### PR TITLE
mesh: document lock groups and scheduler rule

### DIFF
--- a/codex/AGENTS.md
+++ b/codex/AGENTS.md
@@ -110,6 +110,17 @@ For more details, see README.md and QUICKSTART.md.
 - Trigger: algebraic-structure cues (sum/product types, map/fmap/fold/reduce, compose, identity/associativity laws, monoid/semigroup hints, functor/monad/applicative talk, universal properties).
 - Playbook: map to the simplest fitting construction → translate into the repo's language → name the governing laws and their safety/duplication benefit → propose one quick law-based check.
 
+## Response Format
+
+- Echo: immediately before any question block that appears prior to Insights/Next Steps, include `Echo:` followed by the most recent user message, max two lines (truncate with `...`).
+
+Example:
+```
+Echo: Most recent user message goes here, truncated to two lines if needed...
+CLARIFICATION EXPERT: HUMAN INPUT REQUIRED
+1. ...
+```
+
 ## Tooling Standards
 
 ### GIT

--- a/codex/skills/mesh/SKILL.md
+++ b/codex/skills/mesh/SKILL.md
@@ -214,9 +214,31 @@ ordering with a human override.
    3) Prefer checkpoint/integration beads when Ready.
    4) Manual pick always wins (present the recommendation, then ask to confirm
       or override).
-4. Contention check: if two Ready beads touch the same files, serialize them or
-   explicitly define a lock order. Mention `bd merge-slot` if the team uses it.
+4. Contention check:
+   - Lock groups are label-based: `mesh-lock:<group>`.
+   - Never schedule two Ready beads together if their lock labels overlap.
+   - If lock labels are missing but file overlap is likely, serialize them or
+     explicitly define a lock order. Mention `bd merge-slot` if the team uses it.
 5. Announce the wave + status summary using the template below.
+
+### Lock groups (mesh-lock:<group>)
+
+Lock groups prevent unsafe parallel work by declaring coarse-grained
+contention domains. A bead may carry one or more `mesh-lock:<group>` labels
+(kebab-case). Scheduling rule: **do not** place two Ready beads in the same
+wave if they share any lock group label.
+
+Default lock groups for this repo (initial, conservative):
+- `mesh-lock:core-config` (Brewfile, gitconfig, gitignore, brew-aliases,
+  lazygit/, links.conf, README/AGENTS)
+- `mesh-lock:codex` (codex/)
+- `mesh-lock:editor` (nvim/)
+- `mesh-lock:shell` (fish/)
+- `mesh-lock:terminal` (ghostty/)
+- `mesh-lock:install` (install/, assets/)
+
+If a bead spans multiple domains, add multiple lock labels. If no default fits,
+define a new lock group and keep it narrow.
 
 ### Wave status summary
 

--- a/codex/skills/mesh/SKILL.md
+++ b/codex/skills/mesh/SKILL.md
@@ -230,7 +230,7 @@ wave if they share any lock group label.
 
 Default lock groups for this repo (initial, conservative):
 - `mesh-lock:core-config` (Brewfile, gitconfig, gitignore, brew-aliases,
-  lazygit/, links.conf, README/AGENTS)
+  lazygit/, links.conf, README.md, AGENTS.md)
 - `mesh-lock:codex` (codex/)
 - `mesh-lock:editor` (nvim/)
 - `mesh-lock:shell` (fish/)


### PR DESCRIPTION
## Summary
- Document mesh lock-group convention and scheduling rule.
- Add default lock groups for this repo.

## Verification
- rg -n "mesh-lock" codex/skills/mesh/SKILL.md  # pass

## Validation
- Format: N/A (no repo formatter/entrypoint found)
- Lint/Typecheck: N/A (no repo lint/typecheck entrypoint found)
- Build: N/A (no build entrypoint found)
- Tests: N/A (no test entrypoint found)