### PR TITLE
Scaffold mesh scripts helpers

### DIFF
--- a/codex/skills/mesh/scripts/mesh-bd-ro
+++ b/codex/skills/mesh/scripts/mesh-bd-ro
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "${SCRIPT_DIR}/mesh-lib.sh"
+
+usage() {
+  cat <<'USAGE'
+Usage: mesh-bd-ro <command...> [--dry-run] [--json]
+
+Read-only wrapper for bd (stub scaffold).
+
+USAGE
+  mesh_common_flags
+}
+
+mesh_parse_common_flags "$@"
+
+if [[ "${MESH_HELP}" -eq 1 ]]; then
+  usage
+  exit 0
+fi
+
+if [[ "${#MESH_ARGS[@]}" -eq 0 ]]; then
+  usage >&2
+  exit 2
+fi
+
+mesh_emit "stub: mesh-bd-ro not implemented"
+exit 2

--- a/codex/skills/mesh/scripts/mesh-lib.sh
+++ b/codex/skills/mesh/scripts/mesh-lib.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+mesh_die() {
+  echo "error: $*" >&2
+  exit 2
+}
+
+mesh_common_flags() {
+  cat <<'USAGE'
+Common flags:
+  -h, --help     Show help and exit
+  --dry-run      Print intended actions without executing
+  --json         Emit machine-readable JSON output
+USAGE
+}
+
+mesh_json_escape() {
+  local s="$1"
+  s=${s//\\/\\\\}
+  s=${s//\"/\\\"}
+  s=${s//$'\n'/\\n}
+  s=${s//$'\r'/\\r}
+  s=${s//$'\t'/\\t}
+  printf '%s' "$s"
+}
+
+mesh_parse_common_flags() {
+  MESH_HELP=0
+  MESH_DRY_RUN=0
+  MESH_JSON=0
+  MESH_ARGS=()
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      -h|--help)
+        MESH_HELP=1
+        shift
+        ;;
+      --dry-run)
+        MESH_DRY_RUN=1
+        shift
+        ;;
+      --json)
+        MESH_JSON=1
+        shift
+        ;;
+      --)
+        shift
+        MESH_ARGS+=("$@")
+        break
+        ;;
+      -* )
+        MESH_ARGS+=("$@")
+        break
+        ;;
+      *)
+        MESH_ARGS+=("$1")
+        shift
+        ;;
+    esac
+  done
+}
+
+mesh_emit() {
+  if [[ "${MESH_JSON}" -eq 1 ]]; then
+    printf '{"ok":true,"message":"%s"}\n' "$(mesh_json_escape "$1")"
+  else
+    echo "$1"
+  fi
+}
+
+mesh_run() {
+  if [[ "${MESH_DRY_RUN}" -eq 1 ]]; then
+    mesh_emit "dry-run: $*"
+    return 0
+  fi
+  "$@"
+}


### PR DESCRIPTION
## Summary
- add mesh scripts scaffold directory with shared helper
- add mesh-bd-ro stub entrypoint with common flag parsing hooks

## Validation
- Lint/typecheck: bash -n codex/skills/mesh/scripts/mesh-lib.sh codex/skills/mesh/scripts/mesh-bd-ro
- Formatter: N/A (no repo formatter configured)
- Build: N/A (no build system configured)
- Tests: N/A (no test suite configured)