### PR TITLE
Implement mesh-bd-ro allowlist wrapper

### DIFF
--- a/codex/skills/mesh/scripts/mesh-bd-ro
+++ b/codex/skills/mesh/scripts/mesh-bd-ro
@@ -2,30 +2,173 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
-# shellcheck source=/dev/null
+# shellcheck source=mesh-lib.sh
 source "${SCRIPT_DIR}/mesh-lib.sh"
 
 usage() {
-  cat <<'USAGE'
-Usage: mesh-bd-ro <command...> [--dry-run] [--json]
+  cat <<'EOF'
+Usage: mesh-bd-ro [GLOBAL_FLAGS] <command> [args...]
 
-Read-only wrapper for bd (stub scaffold).
+Runs: bd --readonly --sandbox <command...>
 
-USAGE
-  mesh_common_flags
+Global flags (allowlisted):
+  -h, --help
+  --json
+  -q, --quiet
+  -v, --verbose
+
+Allowlisted commands:
+  show <id...>
+  list [args...]
+  ready [args...]
+  blocked [args...]
+  search <query>
+  count [args...]
+  status [args...]
+  state [args...]
+  dep list|tree|cycles [args...]
+  mol show|current|progress [args...]
+  swarm status|validate|list [args...]
+  epic status [args...]
+
+Use command-specific help via: mesh-bd-ro <command> --help
+EOF
 }
 
-mesh_parse_common_flags "$@"
+mesh_require_cmd bd
 
-if [[ "${MESH_HELP}" -eq 1 ]]; then
+declare -a global_flags=()
+want_help=0
+
+deny_disallowed_globals() {
+  local arg
+  for arg in "$@"; do
+    case "$arg" in
+      --actor|--actor=*)
+        mesh_die "mesh-bd-ro: disallowed global flag: --actor"
+        ;;
+      --db|--db=*)
+        mesh_die "mesh-bd-ro: disallowed global flag: --db"
+        ;;
+      --profile|--profile=*)
+        mesh_die "mesh-bd-ro: disallowed global flag: --profile"
+        ;;
+      --allow-stale|--allow-stale=*)
+        mesh_die "mesh-bd-ro: disallowed global flag: --allow-stale"
+        ;;
+      --lock-timeout|--lock-timeout=*)
+        mesh_die "mesh-bd-ro: disallowed global flag: --lock-timeout"
+        ;;
+      --no-*)
+        mesh_die "mesh-bd-ro: disallowed global flag: $arg"
+        ;;
+    esac
+  done
+}
+
+require_positional() {
+  local name="$1"
+  shift
+  local arg
+  for arg in "$@"; do
+    if [[ "$arg" != -* ]]; then
+      return 0
+    fi
+  done
+  mesh_die "mesh-bd-ro: ${name} requires at least one positional argument"
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -h|--help)
+      want_help=1
+      global_flags+=("$1")
+      shift
+      ;;
+    --json|-q|--quiet|-v|--verbose)
+      global_flags+=("$1")
+      shift
+      ;;
+    --)
+      shift
+      break
+      ;;
+    -*)
+      mesh_die "mesh-bd-ro: disallowed global flag: $1"
+      ;;
+    *)
+      break
+      ;;
+  esac
+done
+
+if [[ $want_help -eq 1 && $# -eq 0 ]]; then
   usage
   exit 0
 fi
 
-if [[ "${#MESH_ARGS[@]}" -eq 0 ]]; then
+if [[ $# -eq 0 ]]; then
   usage >&2
-  exit 2
+  exit 1
 fi
 
-mesh_emit "stub: mesh-bd-ro not implemented"
-exit 2
+cmd="$1"
+shift
+sub=""
+path="$cmd"
+
+case "$cmd" in
+  dep|mol|swarm|epic)
+    if [[ $# -eq 0 ]]; then
+      mesh_die "mesh-bd-ro: missing subcommand for ${cmd}"
+    fi
+    sub="$1"
+    shift
+    path="${cmd} ${sub}"
+    ;;
+esac
+
+case "$path" in
+  show|list|ready|blocked|search|count|status|state)
+    ;;
+  "dep list"|"dep tree"|"dep cycles")
+    ;;
+  "mol show"|"mol current"|"mol progress")
+    ;;
+  "swarm status"|"swarm validate"|"swarm list")
+    ;;
+  "epic status")
+    ;;
+  *)
+    mesh_die "mesh-bd-ro: disallowed command: ${path}"
+    ;;
+esac
+
+if [[ $want_help -eq 1 ]]; then
+  usage
+  exit 0
+fi
+
+deny_disallowed_globals "$@"
+
+case "$path" in
+  show)
+    require_positional "show" "$@"
+    ;;
+  search)
+    require_positional "search" "$@"
+    ;;
+esac
+
+cmd_args=()
+cmd_args+=("$cmd")
+if [[ -n "$sub" ]]; then
+  cmd_args+=("$sub")
+fi
+cmd_args+=("$@")
+
+if [[ ${#global_flags[@]} -gt 0 ]]; then
+  exec bd --readonly --sandbox "${global_flags[@]}" "${cmd_args[@]}"
+fi
+
+exec bd --readonly --sandbox "${cmd_args[@]}"

--- a/codex/skills/mesh/scripts/mesh-lib.sh
+++ b/codex/skills/mesh/scripts/mesh-lib.sh
@@ -6,6 +6,10 @@ mesh_die() {
   exit 2
 }
 
+mesh_require_cmd() {
+  command -v "$1" >/dev/null 2>&1 || mesh_die "missing required command: $1"
+}
+
 mesh_common_flags() {
   cat <<'USAGE'
 Common flags:


### PR DESCRIPTION
## Summary
- add mesh-bd-ro wrapper to enforce allowlisted read-only bd access
- add mesh-lib.sh helper for mesh scripts

## Testing
- bash -n codex/skills/mesh/scripts/mesh-lib.sh codex/skills/mesh/scripts/mesh-bd-ro (pass)
- codex/skills/mesh/scripts/mesh-bd-ro --help (pass)
- codex/skills/mesh/scripts/mesh-bd-ro show .dotfiles-dsk.3.2 --json (fail: bd DB out of sync; needs bd sync --import-only)
- Formatter/Lint/Build/Tests: N/A (no repo tooling configured)