### PR TITLE
Add mol-mesh-arm formula

### DIFF
--- a/.beads/formulas/mol-mesh-arm.formula.json
+++ b/.beads/formulas/mol-mesh-arm.formula.json
@@ -1,0 +1,10 @@
+{
+  "formula": "mol-mesh-arm",
+  "vars": {},
+  "steps": [
+    {
+      "id": "arm",
+      "title": "Arm"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add missing mol-mesh-arm formula with a single arm step for mesh vNext

## Validation
- bd cook mol-mesh-run --dry-run (pass)
- bd cook mol-mesh-arm --dry-run (pass)
- Formatter: N/A (no repo formatter tooling found)
- Lint/Typecheck: N/A (no repo lint/typecheck tooling found)
- Build: N/A (no repo build tooling found)
- Tests: N/A (no repo test tooling found)