### PR TITLE
mesh-monitor: add agent status inspector

### DIFF
--- a/codex/AGENTS.md
+++ b/codex/AGENTS.md
@@ -18,6 +18,7 @@ If the command returns any paths, use the `$beads` skill for all bd workflow and
 ## Managing AI-Generated Planning Documents
 
 AI assistants often create planning and design documents during development:
+
 - PLAN.md, IMPLEMENTATION.md, ARCHITECTURE.md
 - DESIGN.md, CODEBASE_SUMMARY.md, INTEGRATION_PLAN.md
 - TESTING_GUIDE.md, TECHNICAL_DESIGN.md, and similar files
@@ -25,18 +26,21 @@ AI assistants often create planning and design documents during development:
 **Best Practice: Use a dedicated directory for these ephemeral files**
 
 **Recommended approach:**
+
 - Create a `history/` directory in the project root
 - Store ALL AI-generated planning/design docs in `history/`
 - Keep the repository root clean and focused on permanent project files
 - Only access `history/` when explicitly asked to review past planning
 
 **Example .gitignore entry (optional):**
+
 ```
 # AI planning documents (ephemeral)
 history/
 ```
 
 **Benefits:**
+
 - ✅ Clean repository root
 - ✅ Clear separation between ephemeral and permanent documentation
 - ✅ Easy to exclude from version control if desired
@@ -70,47 +74,58 @@ For more details, see README.md and QUICKSTART.md.
 - Use `$select` to pick the next bead after `bd ready` using risk-first heuristics (explicit-only).
 
 **Clarification Expert (CE)**
+
 - Trigger: "build a system", "make it better", "optimize this", "how do I", unclear goals, conflicting requirements, vague requests, or missing success criteria.
 - Playbook: exhaustively research codebase (no asking discoverable facts) → maintain a running snapshot of facts/decisions/open questions → ask only judgment-call questions in a numbered "Human Input Required" block → incorporate answers and repeat until no questions remain → generate verbose beads via `bd` → hard-stop (do not begin work).
 
 **Creative Problem Solver (CPS)**
+
 - Trigger: stalled progress, blocked integration, repeated failed attempts, explicit requests for options/alternatives, brainstorming, or tradeoff exploration.
 - Playbook: reframe (inversion/analogy/extremes/first principles) → propose Quick Win, Strategic Play, Advantage Play, Transformative Move, Moonshot (each with expected signal + escape hatch) → close with Insights Summary inviting next action.
 
 **Complexity Mitigator (CM)**
+
 - Trigger: tangled control flow, deep nesting, cross-file hop fatigue, hard-to-parse names.
 - Playbook: identify essential vs incidental complexity → suggest flatten/rename/extract steps ranked by effort/impact → provide a small code sketch → cite TRACE letters satisfied/violated.
 
 **Invariant Ace (IA)**
+
 - Trigger: shaky state validity, nullable surprises, validation clutter, “should never happen” comments.
 - Playbook: name the at-risk invariant and current protection level → propose stronger invariant (construction/compile time) → sketch before/after type or parser → recommend verification (property test or check).
 
 **Prove It (PI)**
+
 - Trigger: absolutes like “always”, “never”, “guaranteed”, “optimal solution”, “prove it”, “devil's advocate”.
 - Playbook: challenge certainty with counterexamples/logic traps → stress test edge cases → synthesis by Oracle → transparent confidence trail.
 
 **Unsoundness Detector (UD)**
+
 - Trigger: crashes, data corruption risk, races, leaks, resource lifetime concerns.
 - Playbook: rank failure modes (crash > corruption > logic) → give concrete counterexample input → smallest sound fix that removes the class → state the new invariant.
 
 **Footgun Detector (FD)**
+
 - Trigger: misuse-prone API, confusing or reordered params, silent failure paths, unexpected defaults.
 - Playbook: list top hazards ordered by likelihood × severity → minimal misuse snippets showing surprise → offer safer signature/naming/typestate choice → add a test/assertion to lock it.
 
 **TRACE (TR)**
+
 - Trigger: review requests, “refactor”, cognitive load concerns, “what is this?” surprises.
 - Playbook: cognitive heat map (🔥/⚪) → TRACE checklist (Type, Readability, Atomic, Cognitive, Essential) → prioritized refactor plan.
 
 **Logophile (LO)**
+
 - Trigger: requests to tighten wording, clarity/brevity complaints, bloated drafts.
 - Playbook: classify text type/audience/goal → prune redundancy → elevate vocabulary and structure (TRACE/E-SDD) → report key edits and word/character delta when shrink >20%.
 
 **Abstraction Archaeologist (AA)**
+
 - Trigger: duplicated code patterns, "this looks like that", refactor discussions, repeated parameter clusters, shape similarity across modules, "we keep doing this".
 - Playbook: gather ≥3 concrete instances before proposing abstraction → identify essential shape (what varies vs what's fixed) → test the seam (can instances evolve independently?) → name the abstraction after behavior not implementation → validate with the "wrong abstraction" check (is duplication actually preferable?) → sketch interface segregated by actual usage patterns.
 - Deliverable: (1) evidence table of instances with shared shape highlighted, (2) essential vs accidental similarity verdict, (3) proposed abstraction with variance points explicit, (4) "break glass" scenario where the abstraction should be abandoned.
 
 **Universalist (UN)**
+
 - Trigger: algebraic-structure cues (sum/product types, map/fmap/fold/reduce, compose, identity/associativity laws, monoid/semigroup hints, functor/monad/applicative talk, universal properties).
 - Playbook: map to the simplest fitting construction → translate into the repo's language → name the governing laws and their safety/duplication benefit → propose one quick law-based check.
 
@@ -119,6 +134,7 @@ For more details, see README.md and QUICKSTART.md.
 - Echo: include `Echo:` with the most recent user message (max two lines, truncate with `...`) in every response. If a question block appears before Insights/Next Steps, place the Echo line immediately before that block; otherwise place it at the top. This requirement applies even when using skills or templates. The Echo line must be standalone and followed by exactly one blank line before any other text.
 
 Example:
+
 ```
 Echo: Most recent user message goes here, truncated to two lines if needed...
 CLARIFICATION EXPERT: HUMAN INPUT REQUIRED
@@ -228,18 +244,18 @@ Adopt the Abstraction Archaeologist discipline when patterns emerge across code 
 1. **Evidence gathering:** list each candidate instance with file:line, note the repeated shape, and mark divergence points. If you can't name three, stop—premature abstraction ahead.
 2. **Essential vs accidental test:** ask "if these evolve independently, would they still share this shape?" Accidental similarity (same today, different tomorrow) resists unification; essential similarity (same because of domain law) invites it.
 3. **Seam analysis:** probe the boundary. Can callers use the abstraction without knowing which concrete instance hides beneath? If implementation details leak, the seam is wrong.
-4. **Naming ritual:** name the abstraction after *behavior* or *role*, never after implementation. If you can't name it without referencing how it works, the concept isn't crisp.
+4. **Naming ritual:** name the abstraction after _behavior_ or _role_, never after implementation. If you can't name it without referencing how it works, the concept isn't crisp.
 5. **Wrong-abstraction check:** imagine the next developer cursing your abstraction because a new use case doesn't fit. What would they have to do—extend, wrap, or rip out? If "rip out" is likely, prefer duplication.
 
 #### Abstraction Shapes to Recognize
 
-| Shape | Signal | Typical Unification |
-|-------|--------|---------------------|
-| **Structural twins** | Same fields, different names | Product type / record |
-| **Behavioral siblings** | Same method signatures, different guts | Interface / trait / protocol |
-| **Pipeline echoes** | Repeated transform → validate → persist | Higher-order function / middleware chain |
-| **Config sprawl** | Same options scattered across call sites | Options struct / builder |
-| **Error déjà vu** | Identical catch/recover blocks | Result type / centralized handler |
+| Shape                   | Signal                                   | Typical Unification                      |
+| ----------------------- | ---------------------------------------- | ---------------------------------------- |
+| **Structural twins**    | Same fields, different names             | Product type / record                    |
+| **Behavioral siblings** | Same method signatures, different guts   | Interface / trait / protocol             |
+| **Pipeline echoes**     | Repeated transform → validate → persist  | Higher-order function / middleware chain |
+| **Config sprawl**       | Same options scattered across call sites | Options struct / builder                 |
+| **Error déjà vu**       | Identical catch/recover blocks           | Result type / centralized handler        |
 
 #### Anti-Patterns to Avoid
 
@@ -301,29 +317,3 @@ Adopt the Footgun Detector checklist when an API feels dangerous to use.
 - **Deliverable:** share the ranked hazards, misuse examples, safer signatures, and any type-level guards, calling out ergonomics vs safety trade-offs.
 - **Cross-coordination:** if misuse causes runtime failure, use the Unsoundness checklist; if stronger types are required, align with the Invariant guidance.
 - **Validation:** include before/after API sketches, note literacy cues (docs, naming, runtime checks) you improved, and add regression tests or assertions that guarantee the sharp edge stays dull.
-
-## Landing the Plane (Session Completion)
-
-**When ending a work session**, you MUST complete ALL steps below. Work is NOT complete until `git push` succeeds.
-
-**MANDATORY WORKFLOW:**
-
-1. **File issues for remaining work** - Create issues for anything that needs follow-up
-2. **Run quality gates** (if code changed) - Tests, linters, builds
-3. **Update issue status** - Close finished work, update in-progress items
-4. **PUSH TO REMOTE** - This is MANDATORY:
-   ```bash
-   git pull --rebase
-   bd sync
-   git push
-   git status  # MUST show "up to date with origin"
-   ```
-5. **Clean up** - Clear stashes, prune remote branches
-6. **Verify** - All changes committed AND pushed
-7. **Hand off** - Provide context for next session
-
-**CRITICAL RULES:**
-- Work is NOT complete until `git push` succeeds
-- NEVER stop before pushing - that leaves work stranded locally
-- NEVER say "ready to push when you are" - YOU must push
-- If push fails, resolve and retry until it succeeds

--- a/codex/skills/mesh/scripts/mesh-bd-ro
+++ b/codex/skills/mesh/scripts/mesh-bd-ro
@@ -13,6 +13,7 @@ Runs: bd --readonly --sandbox <command...>
 
 Global flags (allowlisted):
   -h, --help
+  --allow-stale
   --dry-run
   --json
   -q, --quiet
@@ -56,9 +57,6 @@ deny_disallowed_globals() {
       --profile|--profile=*)
         mesh_die "mesh-bd-ro: disallowed global flag: --profile"
         ;;
-      --allow-stale|--allow-stale=*)
-        mesh_die "mesh-bd-ro: disallowed global flag: --allow-stale"
-        ;;
       --lock-timeout|--lock-timeout=*)
         mesh_die "mesh-bd-ro: disallowed global flag: --lock-timeout"
         ;;
@@ -90,6 +88,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --dry-run)
       want_dry_run=1
+      shift
+      ;;
+    --allow-stale)
+      global_flags+=("$1")
       shift
       ;;
     --json)

--- a/codex/skills/mesh/scripts/mesh-bd-ro
+++ b/codex/skills/mesh/scripts/mesh-bd-ro
@@ -13,6 +13,7 @@ Runs: bd --readonly --sandbox <command...>
 
 Global flags (allowlisted):
   -h, --help
+  --dry-run
   --json
   -q, --quiet
   -v, --verbose
@@ -39,6 +40,8 @@ mesh_require_cmd bd
 
 declare -a global_flags=()
 want_help=0
+want_dry_run=0
+want_json=0
 
 deny_disallowed_globals() {
   local arg
@@ -85,7 +88,16 @@ while [[ $# -gt 0 ]]; do
       global_flags+=("$1")
       shift
       ;;
-    --json|-q|--quiet|-v|--verbose)
+    --dry-run)
+      want_dry_run=1
+      shift
+      ;;
+    --json)
+      want_json=1
+      global_flags+=("$1")
+      shift
+      ;;
+    -q|--quiet|-v|--verbose)
       global_flags+=("$1")
       shift
       ;;
@@ -149,6 +161,8 @@ if [[ $want_help -eq 1 ]]; then
   exit 0
 fi
 
+MESH_JSON=$want_json
+
 deny_disallowed_globals "$@"
 
 case "$path" in
@@ -167,8 +181,15 @@ if [[ -n "$sub" ]]; then
 fi
 cmd_args+=("$@")
 
+render_cmd=(bd --readonly --sandbox)
 if [[ ${#global_flags[@]} -gt 0 ]]; then
-  exec bd --readonly --sandbox "${global_flags[@]}" "${cmd_args[@]}"
+  render_cmd+=("${global_flags[@]}")
+fi
+render_cmd+=("${cmd_args[@]}")
+
+if [[ $want_dry_run -eq 1 ]]; then
+  mesh_emit "dry-run: ${render_cmd[*]}"
+  exit 0
 fi
 
-exec bd --readonly --sandbox "${cmd_args[@]}"
+exec "${render_cmd[@]}"

--- a/codex/skills/mesh/scripts/mesh-monitor
+++ b/codex/skills/mesh/scripts/mesh-monitor
@@ -1,0 +1,341 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=mesh-lib.sh
+source "${SCRIPT_DIR}/mesh-lib.sh"
+
+usage() {
+  cat <<'USAGE'
+Usage: mesh-monitor [GLOBAL_FLAGS] [options] [agent-name...]
+
+Inspect mesh agent hooks, liveness, and workspace presence.
+
+Options:
+  --count N           Agent count when names are not provided (default: MESH_CONCURRENCY or 6)
+  --prefix NAME-      Agent name prefix (default: mesh-)
+  --start N           Agent name start index (default: 1)
+  --watch SECONDS     Poll continuously (disallowed with --json)
+  --allow-stale       Pass --allow-stale to mesh-bd-ro
+  --last-interaction  Show last interaction timestamp (requires rg)
+
+Config:
+  MESH_WORKSPACE_ROOT Workspace root (default: ../workspaces/<repo>)
+
+Global flags:
+  -h, --help     Show help and exit
+  --dry-run      Print intended actions without executing
+  --json         Emit machine-readable JSON output (single object)
+USAGE
+}
+
+mesh_require_cmd bd
+mesh_require_cmd jq
+
+mesh_parse_common_flags "$@"
+
+if [[ ${MESH_HELP} -eq 1 ]]; then
+  usage
+  exit 0
+fi
+
+count="${MESH_CONCURRENCY:-6}"
+prefix="${MESH_AGENT_PREFIX:-mesh-}"
+start="${MESH_AGENT_START:-1}"
+watch=""
+allow_stale=0
+show_last_interaction=0
+names=()
+
+usage_error() {
+  echo "error: $*" >&2
+  usage >&2
+  exit 2
+}
+
+idx=0
+while [[ ${idx} -lt ${#MESH_ARGS[@]} ]]; do
+  arg="${MESH_ARGS[${idx}]}"
+  case "${arg}" in
+    --count)
+      if [[ $((idx + 1)) -ge ${#MESH_ARGS[@]} ]]; then
+        usage_error "mesh-monitor: --count requires a value"
+      fi
+      count="${MESH_ARGS[$((idx + 1))]}"
+      idx=$((idx + 2))
+      ;;
+    --prefix)
+      if [[ $((idx + 1)) -ge ${#MESH_ARGS[@]} ]]; then
+        usage_error "mesh-monitor: --prefix requires a value"
+      fi
+      prefix="${MESH_ARGS[$((idx + 1))]}"
+      idx=$((idx + 2))
+      ;;
+    --start)
+      if [[ $((idx + 1)) -ge ${#MESH_ARGS[@]} ]]; then
+        usage_error "mesh-monitor: --start requires a value"
+      fi
+      start="${MESH_ARGS[$((idx + 1))]}"
+      idx=$((idx + 2))
+      ;;
+    --watch)
+      if [[ $((idx + 1)) -ge ${#MESH_ARGS[@]} ]]; then
+        usage_error "mesh-monitor: --watch requires a value"
+      fi
+      watch="${MESH_ARGS[$((idx + 1))]}"
+      idx=$((idx + 2))
+      ;;
+    --allow-stale)
+      allow_stale=1
+      idx=$((idx + 1))
+      ;;
+    --last-interaction)
+      show_last_interaction=1
+      idx=$((idx + 1))
+      ;;
+    --)
+      idx=$((idx + 1))
+      while [[ ${idx} -lt ${#MESH_ARGS[@]} ]]; do
+        names+=("${MESH_ARGS[${idx}]}")
+        idx=$((idx + 1))
+      done
+      ;;
+    -*)
+      usage_error "mesh-monitor: unknown flag: ${arg}"
+      ;;
+    *)
+      names+=("${arg}")
+      idx=$((idx + 1))
+      ;;
+  esac
+done
+
+if [[ -n "${watch}" && ${MESH_JSON} -eq 1 ]]; then
+  usage_error "mesh-monitor: --watch cannot be combined with --json"
+fi
+
+if [[ -n "${watch}" && ! "${watch}" =~ ^[0-9]+$ ]]; then
+  usage_error "mesh-monitor: --watch must be an integer number of seconds"
+fi
+if ! [[ "${count}" =~ ^[0-9]+$ ]]; then
+  usage_error "mesh-monitor: --count must be an integer"
+fi
+if ! [[ "${start}" =~ ^[0-9]+$ ]]; then
+  usage_error "mesh-monitor: --start must be an integer"
+fi
+
+mesh_agent_pool_script="${SCRIPT_DIR}/mesh-agent-pool"
+mesh_bd_ro_script="${SCRIPT_DIR}/mesh-bd-ro"
+
+mesh_repo_root() {
+  local root
+  root="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+  if [[ -z "${root}" ]]; then
+    mesh_die "mesh-monitor: not inside a git repository"
+  fi
+  printf '%s' "${root}"
+}
+
+mesh_workspace_slug() {
+  local raw="$1"
+  raw="${raw##*/}"
+  raw="$(printf '%s' "${raw}" | sed -E 's/^[.]+//; s/[^A-Za-z0-9._-]+/-/g; s/\.{2,}/-/g; s/[.]+$//; s/^-+//; s/-+$//')"
+  if [[ "${raw}" == *.lock ]]; then
+    raw="${raw%.lock}-lock"
+  fi
+  if [[ -z "${raw}" ]]; then
+    mesh_die "mesh-monitor: invalid bead id: $1"
+  fi
+  printf '%s' "${raw}"
+}
+
+mesh_workspace_path() {
+  local bead_id="$1"
+  local root="${MESH_WORKSPACE_ROOT:-}"
+  if [[ -z "${root}" ]]; then
+    local repo_root
+    repo_root="$(mesh_repo_root)"
+    local repo_name
+    repo_name="$(basename "${repo_root}")"
+    root="${repo_root%/}/../workspaces/${repo_name}"
+  fi
+  root="${root%/}"
+  local slug
+  slug="$(mesh_workspace_slug "${bead_id}")"
+  printf '%s/%s' "${root}" "${slug}"
+}
+
+mesh_epoch_from_iso() {
+  local ts="$1"
+  local clean
+  clean="$(printf '%s' "${ts}" | sed -E 's/\.[0-9]+//; s/([+-][0-9]{2}):([0-9]{2})/\1\2/')"
+  if date -u -j -f "%Y-%m-%dT%H:%M:%S%z" "${clean}" +%s 2>/dev/null; then
+    return 0
+  fi
+  if date -u -d "${ts}" +%s 2>/dev/null; then
+    return 0
+  fi
+  return 1
+}
+
+mesh_agent_process_state() {
+  local token="$1"
+  if ! command -v pgrep >/dev/null 2>&1; then
+    printf '%s' "unknown"
+    return 0
+  fi
+  if pgrep -f "codex.*${token}" >/dev/null 2>&1; then
+    printf '%s' "running"
+    return 0
+  fi
+  printf '%s' "none"
+}
+
+mesh_last_interaction() {
+  local issue_id="$1"
+  if [[ ${show_last_interaction} -ne 1 ]]; then
+    printf '%s' ""
+    return 0
+  fi
+  if ! command -v rg >/dev/null 2>&1; then
+    printf '%s' "rg-missing"
+    return 0
+  fi
+  local line
+  line="$(rg "\"issue_id\":\"${issue_id}\"" .beads/interactions.jsonl | tail -n1 || true)"
+  if [[ -z "${line}" ]]; then
+    printf '%s' ""
+    return 0
+  fi
+  local created
+  created="$(sed -E 's/.*"created_at":"([^"]+)".*/\1/' <<<"${line}")"
+  printf '%s' "${created}"
+}
+
+collect_names() {
+  if [[ ${#names[@]} -gt 0 ]]; then
+    printf '%s\n' "${names[@]}"
+    return 0
+  fi
+  local i
+  for ((i=0; i<count; i++)); do
+    printf '%s\n' "${prefix}$((start + i))"
+  done
+}
+
+emit_table() {
+  printf '%-8s %-12s %-16s %-8s %-20s %-6s %-8s %-10s' \
+    "Agent" "AgentID" "Hook" "State" "LastActivity" "Age" "Proc" "Workspace"
+  if [[ ${show_last_interaction} -eq 1 ]]; then
+    printf ' %-20s' "LastInteraction"
+  fi
+  printf '\n'
+}
+
+render_once() {
+  local timestamp
+  timestamp="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  local -a rows=()
+  local -a json_items=()
+
+  while IFS= read -r name; do
+    [[ -z "${name}" ]] && continue
+    local agent_id=""
+    agent_id="$("${mesh_agent_pool_script}" id "${name}" 2>/dev/null || true)"
+    local hook_bead=""
+    local agent_state=""
+    local last_activity=""
+    local age=""
+    local proc_state=""
+    local ws_path=""
+    local ws_state=""
+    local last_interaction=""
+
+    if [[ -n "${agent_id}" ]]; then
+      local ro_flags=()
+      if [[ ${allow_stale} -eq 1 ]]; then
+        ro_flags+=(--allow-stale)
+      fi
+      local agent_json=""
+      if agent_json="$("${mesh_bd_ro_script}" "${ro_flags[@]}" --json show "${agent_id}" 2>/dev/null)"; then
+        hook_bead="$(jq -r '.[0].hook_bead // empty' <<<"${agent_json}")"
+        agent_state="$(jq -r '.[0].agent_state // empty' <<<"${agent_json}")"
+        last_activity="$(jq -r '.[0].last_activity // empty' <<<"${agent_json}")"
+      fi
+    fi
+
+    if [[ -n "${last_activity}" ]]; then
+      local last_epoch=""
+      if last_epoch="$(mesh_epoch_from_iso "${last_activity}")"; then
+        local now_epoch
+        now_epoch="$(date -u +%s)"
+        age="$((now_epoch - last_epoch))"
+      fi
+    fi
+
+    if [[ -n "${hook_bead}" ]]; then
+      proc_state="$(mesh_agent_process_state "${hook_bead}")"
+      ws_path="$(mesh_workspace_path "${hook_bead}")"
+      if [[ -d "${ws_path}" ]]; then
+        if [[ -d "${ws_path}/.jj" ]]; then
+          ws_state="jj"
+        elif [[ -d "${ws_path}/.git" ]]; then
+          ws_state="git"
+        else
+          ws_state="dir"
+        fi
+      else
+        ws_state="missing"
+      fi
+      last_interaction="$(mesh_last_interaction "${hook_bead}")"
+    fi
+
+    if [[ ${MESH_JSON} -eq 1 ]]; then
+      json_items+=("$(jq -n \
+        --arg agent_name "${name}" \
+        --arg agent_id "${agent_id}" \
+        --arg hook_bead "${hook_bead}" \
+        --arg agent_state "${agent_state}" \
+        --arg last_activity "${last_activity}" \
+        --arg age_seconds "${age}" \
+        --arg process "${proc_state}" \
+        --arg workspace_path "${ws_path}" \
+        --arg workspace_state "${ws_state}" \
+        --arg last_interaction "${last_interaction}" \
+        '{agent_name:$agent_name,agent_id:$agent_id,hook_bead:$hook_bead,agent_state:$agent_state,last_activity:$last_activity,age_seconds:$age_seconds,process:$process,workspace_path:$workspace_path,workspace_state:$workspace_state,last_interaction:$last_interaction}')")
+    else
+      rows+=("$(printf '%-8s %-12s %-16s %-8s %-20s %-6s %-8s %-10s' \
+        "${name}" "${agent_id:-}" "${hook_bead:-}" "${agent_state:-}" "${last_activity:-}" "${age:-}" "${proc_state:-}" "${ws_state:-}")")
+      if [[ ${show_last_interaction} -eq 1 ]]; then
+        rows[-1]+="$(printf ' %-20s' "${last_interaction:-}")"
+      fi
+    fi
+  done < <(collect_names)
+
+  if [[ ${MESH_JSON} -eq 1 ]]; then
+    if [[ ${#json_items[@]} -eq 0 ]]; then
+      jq -n --arg timestamp "${timestamp}" '{ok:true,timestamp:$timestamp,agents:[]}'
+      return 0
+    fi
+    printf '%s\n' "${json_items[@]}" | jq -s --arg timestamp "${timestamp}" '{ok:true,timestamp:$timestamp,agents:.}'
+    return 0
+  fi
+
+  printf 'mesh-monitor: %s\n' "${timestamp}"
+  emit_table
+  local row
+  for row in "${rows[@]}"; do
+    printf '%s\n' "${row}"
+  done
+}
+
+if [[ -z "${watch}" ]]; then
+  render_once
+  exit 0
+fi
+
+while true; do
+  render_once
+  sleep "${watch}"
+  echo ""
+done

--- a/codex/skills/mesh/scripts/mesh-run
+++ b/codex/skills/mesh/scripts/mesh-run
@@ -191,10 +191,11 @@ mesh_epoch_from_iso() {
 
 mesh_agent_process_running() {
   local token="$1"
-  if command -v pgrep >/dev/null 2>&1; then
-    if pgrep -f "codex.*${token}" >/dev/null 2>&1; then
-      return 0
-    fi
+  if ! command -v pgrep >/dev/null 2>&1; then
+    return 0
+  fi
+  if pgrep -f "codex.*${token}" >/dev/null 2>&1; then
+    return 0
   fi
   return 1
 }

--- a/codex/skills/mesh/scripts/mesh-run
+++ b/codex/skills/mesh/scripts/mesh-run
@@ -25,6 +25,7 @@ Config:
   MESH_AGENT_MODEL       Audit model label for agent prompts (default: gpt-5.2-codex)
   MESH_AGENT_PREFIX      Agent name prefix (default: mesh-)
   MESH_AGENT_START       Agent name start index (default: 1)
+  MESH_STALE_HOOK_TTL_SECONDS  Clear agent hooks if idle beyond TTL (default: 3600)
   MESH_WORKSPACE_ROOT    Workspace root (default: ../workspaces/<repo>)
   MESH_CX_EXEC           Override cx-exec.sh path
 
@@ -52,6 +53,7 @@ audit_level=""
 agent_model="${MESH_AGENT_MODEL:-gpt-5.2-codex}"
 agent_prefix="${MESH_AGENT_PREFIX:-mesh-}"
 agent_start="${MESH_AGENT_START:-1}"
+stale_hook_ttl_seconds="${MESH_STALE_HOOK_TTL_SECONDS:-3600}"
 
 mesh_workspace_script="${SCRIPT_DIR}/mesh-workspace"
 mesh_audit_script="${SCRIPT_DIR}/mesh-audit"
@@ -172,6 +174,88 @@ run_write_in_dir() {
     return 0
   fi
   (cd "${dir}" && "$@")
+}
+
+mesh_epoch_from_iso() {
+  local ts="$1"
+  local clean
+  clean="$(printf '%s' "${ts}" | sed -E 's/\.[0-9]+//; s/([+-][0-9]{2}):([0-9]{2})/\1\2/')"
+  if date -u -j -f "%Y-%m-%dT%H:%M:%S%z" "${clean}" +%s 2>/dev/null; then
+    return 0
+  fi
+  if date -u -d "${ts}" +%s 2>/dev/null; then
+    return 0
+  fi
+  return 1
+}
+
+mesh_agent_process_running() {
+  local token="$1"
+  if command -v pgrep >/dev/null 2>&1; then
+    if pgrep -f "codex.*${token}" >/dev/null 2>&1; then
+      return 0
+    fi
+  fi
+  return 1
+}
+
+mesh_cleanup_stale_hooks() {
+  local ttl="$1"
+  if [[ -z "${ttl}" ]]; then
+    return 0
+  fi
+  if ! [[ "${ttl}" =~ ^[0-9]+$ ]]; then
+    usage_error "mesh-run: MESH_STALE_HOOK_TTL_SECONDS must be an integer"
+  fi
+  if [[ "${ttl}" -le 0 ]]; then
+    return 0
+  fi
+
+  local now
+  now="$(date -u +%s)"
+  local idx=0
+  while [[ ${idx} -lt ${concurrency} ]]; do
+    local agent_name="${agent_prefix}$((agent_start + idx))"
+    local agent_id=""
+    if ! agent_id="$("${mesh_agent_pool_script}" id "${agent_name}" 2>/dev/null)"; then
+      idx=$((idx + 1))
+      continue
+    fi
+    local agent_json=""
+    if ! agent_json="$(bd show "${agent_id}" --json 2>/dev/null)"; then
+      idx=$((idx + 1))
+      continue
+    fi
+    local hook_bead=""
+    hook_bead="$(jq -r '.[0].hook_bead // empty' <<<"${agent_json}")"
+    if [[ -z "${hook_bead}" || "${hook_bead}" == "null" ]]; then
+      idx=$((idx + 1))
+      continue
+    fi
+    local last_activity=""
+    last_activity="$(jq -r '.[0].last_activity // empty' <<<"${agent_json}")"
+    if [[ -z "${last_activity}" || "${last_activity}" == "null" ]]; then
+      idx=$((idx + 1))
+      continue
+    fi
+    local last_epoch=""
+    if ! last_epoch="$(mesh_epoch_from_iso "${last_activity}")"; then
+      idx=$((idx + 1))
+      continue
+    fi
+    local age=$((now - last_epoch))
+    if [[ "${age}" -lt "${ttl}" ]]; then
+      idx=$((idx + 1))
+      continue
+    fi
+    if mesh_agent_process_running "${hook_bead}"; then
+      idx=$((idx + 1))
+      continue
+    fi
+
+    run_write "${mesh_agent_pool_script}" release "${agent_name}"
+    idx=$((idx + 1))
+  done
 }
 
 run_read_capture() {
@@ -327,6 +411,7 @@ mesh_audit_prompt() {
 }
 
 mesh_seed_formulas
+run_write bd sync --import-only
 
 target_kind=""
 target_id=""
@@ -416,6 +501,9 @@ if [[ -z "${concurrency}" ]]; then
 fi
 if ! [[ "${concurrency}" =~ ^[0-9]+$ ]] || [[ "${concurrency}" -lt 1 ]]; then
   usage_error "mesh-run: concurrency must be a positive integer"
+fi
+if [[ -n "${stale_hook_ttl_seconds}" && ! "${stale_hook_ttl_seconds}" =~ ^[0-9]+$ ]]; then
+  usage_error "mesh-run: MESH_STALE_HOOK_TTL_SECONDS must be an integer"
 fi
 if [[ -n "${workspace_backend}" && "${workspace_backend}" != "worktree" ]]; then
   usage_error "mesh-run: --workspace-backend must be 'worktree'"
@@ -659,6 +747,7 @@ dispatch_wave() {
   fi
 
   run_write "${mesh_agent_pool_script}" ensure --count "${#wave_ids[@]}" --prefix "${agent_prefix}" --start "${agent_start}"
+  mesh_cleanup_stale_hooks "${stale_hook_ttl_seconds}"
 
   local idx=0
   local id

--- a/codex/skills/mesh/scripts/mesh-workspace
+++ b/codex/skills/mesh/scripts/mesh-workspace
@@ -168,6 +168,16 @@ case "${cmd}" in
     fi
 
     if [[ ${MESH_DRY_RUN} -eq 1 ]]; then
+      mesh_emit "dry-run: init jj repo in ${path}"
+    else
+      if command -v jj >/dev/null 2>&1; then
+        if [[ ! -d "${path}/.jj" ]]; then
+          (cd "${path}" && jj git init --colocate >/dev/null 2>&1 || true)
+        fi
+      fi
+    fi
+
+    if [[ ${MESH_DRY_RUN} -eq 1 ]]; then
       mesh_emit "dry-run: set beads redirect to ${REPO_ROOT}/.beads"
     else
       if [[ -d "${path}/.beads" ]]; then


### PR DESCRIPTION
## Summary
- add `mesh-monitor` to inspect agent hooks, liveness, and workspace presence
- normalize markdown formatting in `codex/AGENTS.md`

## Testing
- `bash -n codex/skills/mesh/scripts/mesh-monitor`