### PR TITLE
Refine tk into a heuristic-first contract

### DIFF
--- a/codex/skills/tk/SKILL.md
+++ b/codex/skills/tk/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tk
-description: "Software surgery protocol for proof-backed, minimal-diff implementation: Contract to Invariants to Creative Frame to inevitable incision to Proof. Use when users say \"run $tk\", \"patch-first\", \"keep the diff small\", \"state contract + invariants\", \"one clear incision\", \"fix it with a validation signal\", or orchestration cues like \"workers use $tk\" / \"internally use $tk\"."
+description: "Heuristic-first software surgery for proof-backed, minimal-diff implementation: Contract to Invariants to Cut Rationale to inevitable incision to Proof. Use when users say \"run $tk\", \"patch-first\", \"keep the diff small\", \"state contract + invariants\", \"one clear incision\", \"fix it with a validation signal\", or orchestration cues like \"workers use $tk\" / \"internally use $tk\"."
 ---
 
 # TK (Surgeon's Principle)
@@ -15,6 +15,7 @@ TK is a task-to-incision protocol for writing the *fundamental expression* of a 
 - The patch is as small as correctness allows, and obviously correct.
 - Cleverness is allowed only when it reduces risk and branching.
 - Creativity is deliberate: once seams are named, use reframing + techniques to explore cuts before choosing the incision.
+- The visible output should mimic code-shape judgment, not prose voice.
 
 TK optimizes for:
 - Correctness: illegal states are unrepresentable (or rejected at the boundary).
@@ -45,12 +46,13 @@ Output-contract precedence (required):
 - Do not treat invocation text alone (`$tk` inside prompts/wrappers) as proof that TK output format was executed.
 - When output-shape and code-shape preferences conflict, preserve the outer artifact contract and keep TK's seam/shape discipline internal.
 - Decision order for conflicts: outer artifact contract -> explicit task envelope/write scope -> stable boundary/invariants -> repo dialect. See `references/style-precedence-matrix.md`.
+- Creative Frame remains required internally after Contract + Invariants, but it is no longer a mandatory visible heading unless the user explicitly asks for options, tradeoffs, or cut-space reasoning.
 
 Advice mode (no code change requested):
-- Output exactly: Contract, Invariants, Creative Frame, Why This Solution.
+- Output exactly: Contract, Invariants, Cut Rationale, Proof Plan.
 
 Implementation mode (code change requested):
-- Output: Contract, Invariants, Creative Frame, Why This Solution, Incision, Proof.
+- Output: Contract, Invariants, Cut Rationale, Incision, Proof.
 - Incision is the code change you made: minimal diff, meaningful changes, no churn.
   - Report it as an excellent change summary (not a diff):
     - Lead with the meaningful changes (behavior/invariants/API/tests), not a file inventory.
@@ -61,12 +63,13 @@ Implementation mode (code change requested):
 - Proof includes at least one executed signal (test/typecheck/build/run).
   - If execution is impossible: give exact commands and define "pass".
   - If the chosen incision changes representation or introduces constructors/eliminators, normalization, or combine operations, add the lightest fitting structural check (for example exhaustive handling, round-trip/idempotence, identity/associativity, or constructor/eliminator sanity).
-- If blocked on requirements: output Contract, Invariants, Creative Frame, Why This Solution, Question (no Incision/Proof yet).
+- If blocked on requirements: output Contract, Invariants, Cut Rationale, Question (no Incision/Proof yet).
 
 Template compliance (order is mandatory):
-- Contract → Invariants → Creative Frame → Why This Solution → Incision → Proof (default mode).
+- Advice mode: Contract → Invariants → Cut Rationale → Proof Plan.
+- Contract → Invariants → Cut Rationale → Incision → Proof (default mode).
 - Strict-output override: follow the required external artifact format and keep TK sections internal.
-- If blocked: Contract → Invariants → Creative Frame → Why This Solution → Question.
+- If blocked: Contract → Invariants → Cut Rationale → Question.
 
 **Contract**
 - One sentence: what “working” means (include success criteria / proof target when possible).
@@ -74,13 +77,15 @@ Template compliance (order is mandatory):
 **Invariants**
 - What must remain true; what becomes impossible.
 
-**Creative Frame**
-- Reframe: <Inversion / Analogy transfer / Constraint extremes / First principles>
-- Technique: <one named technique from the creative-problem-solver picker; use the picker name verbatim and include one-line why>
-- Representation shift: <one sentence (or “N/A: no shift needed”)>
-
-**Why This Solution**
-- Argue inevitability: name the stable boundary, rule out at least one smaller and one larger tier, and state the proof signal.
+**Cut Rationale**
+- Surface the seam choice directly:
+  - Stable boundary: <where the rule belongs and why>
+  - Not smaller: <why at least one smaller cut fails invariants>
+  - Not larger: <why at least one larger cut is unnecessary or unsafe today>
+  - Proof signal / Proof plan: <the fastest credible executed check, or the exact next check if execution is impossible>
+  - (Optional) Reversibility: <escape hatch / rollback lever>
+  - (Optional) Residual risk: <what you still don’t know>
+- Run Creative Frame internally before this section is written; emit the visible cut rationale, not the internal ideation transcript.
 
 Everything else (full portfolio, scorecards, scope fence, refactors) happens internally unless the user asks for options/tradeoffs (or you're blocked and must surface the portfolio).
 
@@ -112,6 +117,7 @@ These biases keep TK effective when you control the shape.
 - Gate: no code until Contract + Invariants are written.
 - After Contract + Invariants, run a quick signal check: if the problem is really about variants, repeated validation, shared-key agreement, behavior-as-branching, syntax/execution separation, or lawful combine/identity, consult `$universalist` internally before choosing the cut.
 - Choose the fastest credible proof signal you can actually run (existing unit test > typecheck > targeted script > integration test).
+- Prefer the repo's existing seam before inventing a new helper or wrapper; widen only when the boundary cut removes the bug class more cleanly than the smallest textual diff.
 - Cut the incision at the stable boundary; avoid scattering checks through callers.
 - Close the loop: run the proof signal; iterate until it passes; report the result.
 - In wave-oriented execution paired with `$fix`, a wave is done only after `$tk -> $fix -> validation` and immediate delivery:
@@ -245,7 +251,7 @@ Selection bias:
 Creative frame (required):
 - Reframe used: Inversion / Analogy transfer / Constraint extremes / First principles.
 - Technique used: pick 1 technique using the `$creative-problem-solver` skill’s **Technique selection** section; consult the matching technique reference in that skill.
-  - Use the picker name verbatim in TK output; do not invent or rename technique labels.
+  - Use the picker name verbatim whenever Creative Frame is surfaced; do not invent or rename technique labels.
   - If the technique is Lotus Blossom, apply the TK-specific petals from this skill’s **Creative Techniques** reference.
 - Representation shift: one sentence describing the model/representation change (or “N/A: no shift needed”) that makes the choice feel forced.
   - If no Aha (no meaningful representation shift), pick 1 different technique from a different picker row (max 2) and regenerate.
@@ -303,6 +309,7 @@ TK is calm execution under constraints.
 - **Incision**: the smallest correct patch.
 - **Boundary (stable boundary)**: the interface where validity/effects enter; prefer enforcing the rule once here.
 - **Seam**: an enabling point to substitute/redirect behavior safely.
+- **Cut rationale**: the visible seam-choice argument that survives after internal ideation is compressed away.
 - **Creative Frame**: the reframe + technique + representation shift used to widen the cut-space after seams are named.
 - **Lotus blossom**: breadth-first ideation: center the boundary/contract, expand 8 TK-native petals, then turn petals into candidate incisions.
 - **Proof signal**: the concrete check that makes the change trustworthy (test/typecheck/log/law/diagram).
@@ -319,19 +326,16 @@ Advice mode (no code changes): output exactly:
 **Invariants**
 - <bullet list>
 
-**Creative Frame**
-- Reframe: <Inversion / Analogy transfer / Constraint extremes / First principles>
-- Technique: <one named technique from the creative-problem-solver picker; use the picker name verbatim and include one-line why>
-- Representation shift: <one sentence (or “N/A: no shift needed”)>
-
-**Why This Solution**
+**Cut Rationale**
 - Stable boundary: <where the rule belongs and why>
 - Not smaller: <why at least one smaller-tier cut fails invariants>
 - Not larger: <why at least one larger-tier cut is unnecessary or unsafe today>
-- Proof signal: <what test/typecheck/log/law/diagram check makes this trustworthy>
+- Proof plan: <what test/typecheck/log/law/diagram check would make this trustworthy>
 - (Optional) Reversibility: <escape hatch / rollback lever>
 - (Optional) Residual risk: <what you still don’t know>
-- If `$universalist` was consulted, name the smallest fitting construction inside these existing bullets; do not add a new section.
+
+**Proof Plan**
+- <exact command(s) or check(s) you would run, and what pass means>
 
 Implementation mode (code changes): output exactly:
 
@@ -341,12 +345,7 @@ Implementation mode (code changes): output exactly:
 **Invariants**
 - <bullet list>
 
-**Creative Frame**
-- Reframe: <Inversion / Analogy transfer / Constraint extremes / First principles>
-- Technique: <one named technique from the creative-problem-solver picker; use the picker name verbatim and include one-line why>
-- Representation shift: <one sentence (or “N/A: no shift needed”)>
-
-**Why This Solution**
+**Cut Rationale**
 - Stable boundary: <where the rule belongs and why>
 - Not smaller: <why at least one smaller-tier cut fails invariants>
 - Not larger: <why at least one larger-tier cut is unnecessary or unsafe today>

--- a/codex/skills/tk/agents/openai.yaml
+++ b/codex/skills/tk/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "tk"
+  short_description: "Heuristic-first minimal-incision coding via trusted seams and fast proof"
+  default_prompt: "Use $tk to write the smallest boundary-owned patch, reuse the existing repo seam before inventing a helper, and prove it with the fastest credible executed check."

--- a/codex/skills/tk/references/creative-techniques.md
+++ b/codex/skills/tk/references/creative-techniques.md
@@ -3,7 +3,7 @@
 ## Technique selection (canonical: creative-problem-solver)
 - Pick 1 technique using the `$creative-problem-solver` skill’s **Technique selection** section.
 - Then consult the matching technique reference in that skill.
-- Use the picker name verbatim in TK output so evals can detect off-picker drift.
+- Use the picker name verbatim whenever TK surfaces Creative Frame so evals can detect off-picker drift.
 - If no Aha (no meaningful representation shift), pick 1 more technique from a different picker row (max 2).
 - This file exists for TK-specific Lotus Blossom petals + tier mapping.
 

--- a/codex/skills/tk/references/eval/replay-suite.yaml
+++ b/codex/skills/tk/references/eval/replay-suite.yaml
@@ -19,9 +19,14 @@ cases:
         value:
           - "**Contract**"
           - "**Invariants**"
-          - "**Creative Frame**"
-          - "**Why This Solution**"
-      - type: technique_from_picker
+          - "**Cut Rationale**"
+          - "**Proof Plan**"
+      - type: not_contains
+        value: "**Creative Frame**"
+      - type: not_contains
+        value: "**Why This Solution**"
+      - type: regex
+        value: Proof plan
       - type: regex
         value: stable boundary
       - type: regex
@@ -43,9 +48,14 @@ cases:
         value:
           - "**Contract**"
           - "**Invariants**"
-          - "**Creative Frame**"
-          - "**Why This Solution**"
-      - type: technique_from_picker
+          - "**Cut Rationale**"
+          - "**Proof Plan**"
+      - type: not_contains
+        value: "**Creative Frame**"
+      - type: not_contains
+        value: "**Why This Solution**"
+      - type: regex
+        value: Proof plan
       - type: regex
         value: enum|tag|variant
       - type: regex
@@ -67,9 +77,14 @@ cases:
         value:
           - "**Contract**"
           - "**Invariants**"
-          - "**Creative Frame**"
-          - "**Why This Solution**"
-      - type: technique_from_picker
+          - "**Cut Rationale**"
+          - "**Proof Plan**"
+      - type: not_contains
+        value: "**Creative Frame**"
+      - type: not_contains
+        value: "**Why This Solution**"
+      - type: regex
+        value: Proof plan
       - type: regex
         value: delete|remove|collapse|consolidate
       - type: regex
@@ -91,9 +106,14 @@ cases:
         value:
           - "**Contract**"
           - "**Invariants**"
-          - "**Creative Frame**"
-          - "**Why This Solution**"
-      - type: technique_from_picker
+          - "**Cut Rationale**"
+          - "**Proof Plan**"
+      - type: not_contains
+        value: "**Creative Frame**"
+      - type: not_contains
+        value: "**Why This Solution**"
+      - type: regex
+        value: Proof plan
       - type: regex
         value: normalize_tags|normal form|canonical
       - type: regex
@@ -115,9 +135,14 @@ cases:
         value:
           - "**Contract**"
           - "**Invariants**"
-          - "**Creative Frame**"
-          - "**Why This Solution**"
-      - type: technique_from_picker
+          - "**Cut Rationale**"
+          - "**Proof Plan**"
+      - type: not_contains
+        value: "**Creative Frame**"
+      - type: not_contains
+        value: "**Why This Solution**"
+      - type: regex
+        value: Proof plan
       - type: regex
         value: accountid.Parse|stable boundary|canonical
       - type: regex
@@ -186,11 +211,15 @@ cases:
         value:
           - "**Contract**"
           - "**Invariants**"
-          - "**Creative Frame**"
-          - "**Why This Solution**"
+          - "**Cut Rationale**"
           - "**Incision**"
           - "**Proof**"
-      - type: technique_from_picker
+      - type: not_contains
+        value: "**Creative Frame**"
+      - type: not_contains
+        value: "**Why This Solution**"
+      - type: regex
+        value: Proof signal
       - type: regex
         value: parse_token|refined value|normalized
       - type: not_contains

--- a/codex/skills/tk/references/tk-exemplars.md
+++ b/codex/skills/tk/references/tk-exemplars.md
@@ -31,12 +31,7 @@ Keep these synthetic; real session transcripts belong in `references/eval/`, not
 - Downstream code only sees trimmed, lowercased emails (no re-validation).
 - Invalid emails never reach `userService.createUser`.
 
-**Creative Frame**
-- Reframe: First principles
-- Technique: Lotus Blossom (why: structured combinations across seams)
-- Representation shift: Replace `string` email with refined `Email` at the boundary.
-
-**Why This Solution**
+**Cut Rationale**
 - Stable boundary: `src/routes/signup.ts` is where untrusted input enters.
 - Not smaller: Another inline `if (...)` check keeps validation scattered and inconsistent.
 - Not larger: Making every email in the repo a branded type is a rewrite; this keeps the cut local.
@@ -63,12 +58,7 @@ Keep these synthetic; real session transcripts belong in `references/eval/`, not
 - Callers receive one canonical representation.
 - Comments do not restate cleanup rules that the code can encode directly.
 
-**Creative Frame**
-- Reframe: First principles
-- Technique: SCAMPER (why: simplify by removing helper layers before adding new ones)
-- Representation shift: Replace three cleanup helpers with one boundary-owned normal form.
-
-**Why This Solution**
+**Cut Rationale**
 - Stable boundary: `normalize_header(raw)` already sits at ingress for the request path.
 - Not smaller: Adding a fourth alias helper preserves the same drift under a new name.
 - Not larger: A `HeaderNormalizer` class is ceremony when the rule is one pure transform.
@@ -95,12 +85,7 @@ Keep these synthetic; real session transcripts belong in `references/eval/`, not
 - Handlers never pass raw account ID strings deeper into the core.
 - Lean code does not mean bypassing the repo's canonical boundary.
 
-**Creative Frame**
-- Reframe: Inversion
-- Technique: TRIZ (why: remove the contradiction between "fewer lines here" and "one rule owner overall")
-- Representation shift: Treat the existing parser package as the lean path because it already owns the invariant.
-
-**Why This Solution**
+**Cut Rationale**
 - Stable boundary: `accountid.Parse` is the repo's shared ingress for account ID validity.
 - Not smaller: Inline `strings.TrimSpace` plus a regex is a second policy path, not a simplification.
 - Not larger: Rebuilding the parser package or changing every caller is unnecessary.
@@ -129,12 +114,7 @@ Lean note:
 - Production default is system time.
 - Tests can freeze time without sleeping.
 
-**Creative Frame**
-- Reframe: Inversion
-- Technique: SCAMPER (why: mutate the current approach without redesigning)
-- Representation shift: Replace implicit global time with an explicit dependency.
-
-**Why This Solution**
+**Cut Rationale**
 - Stable boundary: Time is an effect; a `Clock` seam isolates it.
 - Not smaller: Adding sleeps/retries makes tests slower and still flaky.
 - Not larger: A full scheduler/state-machine refactor is unnecessary for determinism.
@@ -160,12 +140,7 @@ Lean note:
 - Output is sorted, unique, lowercased.
 - Idempotence: `normalizeTags(normalizeTags(x))` equals `normalizeTags(x)`.
 
-**Creative Frame**
-- Reframe: Constraint extremes
-- Technique: Morphological Analysis (why: explore combinations across canonicalization dimensions)
-- Representation shift: Represent tags as a canonical list (normal form), not "whatever the caller sends".
-
-**Why This Solution**
+**Cut Rationale**
 - Stable boundary: The boundary is the constructor/normalizer; everything downstream can assume the invariant.
 - Not smaller: Sprinkling `trim()/toLowerCase()` in callers guarantees drift.
 - Not larger: A dedicated class + fluent API is ceremony until there are 3+ distinct operations.
@@ -189,16 +164,11 @@ Lean note:
 - Rounding happens in one place (no per-call-site rounding).
 - Totals are deterministic across services and platforms.
 
-**Creative Frame**
-- Reframe: First principles
-- Technique: TRIZ (why: resolve a contradiction cleanly)
-- Representation shift: Treat money as integer cents end-to-end; choose rounding only at the parse/boundary.
-
-**Why This Solution**
+**Cut Rationale**
 - Stable boundary: The money parser/constructor is where the rounding rule belongs.
 - Not smaller: Tweaking one caller fixes a symptom and keeps the bug class alive.
 - Not larger: A full money library migration is too much until we agree on semantics.
-- Proof signal: Characterization tests against a handful of real invoices (including half-cent cases).
+- Proof plan: Characterization tests against a handful of real invoices (including half-cent cases).
 
 **Question**
 - For half-way values (e.g., 1.005), do we want half-up (recommended default) or half-even (banker's rounding)?
@@ -215,12 +185,7 @@ Lean note:
 - New core uses one parser (`parsePhoneNumber`) for validity + normalization.
 - Migration leash: `normalizePhone(raw)` equals `legacyNormalizePhone(raw)` for representative inputs.
 
-**Creative Frame**
-- Reframe: Analogy transfer
-- Technique: TRIZ (why: keep legacy API stable while strengthening invariants)
-- Representation shift: Keep the old API stable; migrate by commuting adapters.
-
-**Why This Solution**
+**Cut Rationale**
 - Stable boundary: `normalizePhone` is the boundary that all callers already use.
 - Not smaller: Tweaking a couple of call sites won't stop drift; the rule must live at the boundary.
 - Not larger: Changing every call site to a new type is a repo-wide rewrite.
@@ -256,5 +221,5 @@ diff --git a/src/slug.py b/src/slug.py
 ````
 
 Notes:
-- TK still runs internally here (Contract -> Invariants -> Creative Frame -> Why This Solution).
+- TK still runs internal cut selection before this external contract is emitted.
 - The external contract wins, so only the patch artifact is emitted.

--- a/codex/skills/tk/scripts/lint_tk_skill_contract.py
+++ b/codex/skills/tk/scripts/lint_tk_skill_contract.py
@@ -20,16 +20,20 @@ REQUIRED_SKILL_PHRASES = [
     "Prefer the highest provable tier, not merely the smallest safe tier.",
     "Selection bias:",
     "Replay suite + shadow-mode notes live under `references/eval/`.",
-    "Use the picker name verbatim in TK output; do not invent or rename technique labels.",
+    "Use the picker name verbatim whenever Creative Frame is surfaced; do not invent or rename technique labels.",
+    "Creative Frame remains required internally after Contract + Invariants, but it is no longer a mandatory visible heading unless the user explicitly asks for options, tradeoffs, or cut-space reasoning.",
+    "Output exactly: Contract, Invariants, Cut Rationale, Proof Plan.",
+    "Output: Contract, Invariants, Cut Rationale, Incision, Proof.",
 ]
 
 REQUIRED_EXEMPLAR_PHRASES = [
     "Keep these synthetic; real session transcripts belong in `references/eval/`, not here.",
     "Strict-output worker mode",
+    "**Cut Rationale**",
 ]
 
 REQUIRED_TECHNIQUE_PHRASES = [
-    "Use the picker name verbatim in TK output so evals can detect off-picker drift.",
+    "Use the picker name verbatim whenever TK surfaces Creative Frame so evals can detect off-picker drift.",
     "Compare candidates first on seam choice, abstraction level, blast radius, and proof posture.",
     "Only use wording/readability as a tie-breaker after the code-shape decision is settled.",
 ]
@@ -136,12 +140,11 @@ def main() -> int:
     require_regex(
         skill_text, r"Output-contract precedence \(required\):", "SKILL.md", errors
     )
+    require_regex(skill_text, r"\*\*Cut Rationale\*\*", "SKILL.md", errors)
+    require_regex(skill_text, r"\*\*Proof Plan\*\*", "SKILL.md", errors)
     require_regex(skill_text, r"\*\*Incision\*\*", "SKILL.md", errors)
     require_regex(skill_text, r"\*\*Proof\*\*", "SKILL.md", errors)
     require_regex(suite_text, r"source_session:", "replay-suite.yaml", errors)
-    require_regex(
-        suite_text, r"type: technique_from_picker", "replay-suite.yaml", errors
-    )
     require_regex(suite_text, r"type: diff_block_count", "replay-suite.yaml", errors)
     require_regex(suite_text, r"type: max_nonempty_lines", "replay-suite.yaml", errors)
 


### PR DESCRIPTION
## Summary
- change `$tk`'s visible contract to `Contract -> Invariants -> Cut Rationale -> Proof Plan` for advice mode and `Contract -> Invariants -> Cut Rationale -> Incision -> Proof` for implementation mode
- keep Creative Frame internal, add seam-first guidance, and add `codex/skills/tk/agents/openai.yaml`
- align exemplars, replay cases, and the TK lint with the new visible headings and worker/local behavior

## Validation
- `uv run --with pyyaml -- python3 codex/skills/.system/skill-creator/scripts/quick_validate.py codex/skills/tk`
- `uv run python codex/skills/tk/scripts/lint_tk_skill_contract.py`
- `uv run --with pyyaml python codex/skills/tk/scripts/tk_replay_benchmark.py --suite codex/skills/tk/references/eval/replay-suite.yaml --dry-run`
- `uv run --with pyyaml python codex/skills/tk/scripts/tk_replay_benchmark.py --suite codex/skills/tk/references/eval/replay-suite.yaml --case replay-canonical-seam-over-raw-primitive --timeout-seconds 60`
- `uv run --with pyyaml python codex/skills/tk/scripts/tk_replay_benchmark.py --suite codex/skills/tk/references/eval/replay-suite.yaml --case replay-worker-patch-first --timeout-seconds 60`
- `git diff --check -- codex/skills/tk`
