### PR TITLE
Update st graph compiler workflow docs

### DIFF
--- a/codex/hooks/st_pre_tool_use.sh
+++ b/codex/hooks/st_pre_tool_use.sh
@@ -32,7 +32,7 @@ fi
 
 status=$(printf '%s' "$output" | jq -r '.status // "allow"' 2>/dev/null || printf 'allow')
 if [ "$status" = "block" ]; then
-  reason=$(printf '%s' "$output" | jq -r '.reason // "Run update_plan with the exact $st SessionStart payload before Bash commands."' 2>/dev/null || printf 'Run update_plan with the exact $st SessionStart payload before Bash commands.')
+  reason=$(printf '%s' "$output" | jq -r '.reason // "Outside Codex Plan Mode, mirror the exact $st SessionStart payload with update_plan before Bash commands."' 2>/dev/null || printf 'Outside Codex Plan Mode, mirror the exact $st SessionStart payload with update_plan before Bash commands.')
   jq -n --arg reason "$reason" '{continue: true, decision: "block", reason: $reason}'
   exit 0
 fi

--- a/codex/hooks/st_session_start.sh
+++ b/codex/hooks/st_session_start.sh
@@ -48,7 +48,8 @@ update_plan_payload=$(cd "$repo_root" && "$st_bin" guard-session-start --file .s
 context=$(cat <<EOF
 Repo contains a durable \$st plan at $plan_file.
 On SessionStart, the durable store is the source of truth.
-Before substantive work, call update_plan exactly once with this payload emitted by st:
+Do not call update_plan while Codex is in Plan Mode. After Plan Mode, import or compile the proposed plan into \$st first.
+Before substantive execution outside Plan Mode, mirror only plan_sync.codex.plan by calling update_plan exactly once with this payload emitted by st:
 $update_plan_payload
 Preserve the emitted [st-id] step prefixes so any later manual \$st plan import can map rows back into the durable ledger safely.
 EOF

--- a/codex/hooks/st_stop.sh
+++ b/codex/hooks/st_stop.sh
@@ -45,7 +45,7 @@ has_non_plan_changes "$repo_root" || {
   exit 0
 }
 
-st_bin=$(resolve_st_bin "import-update-plan" || true)
+st_bin=$(resolve_st_bin "reconcile-codex" || true)
 [ -n "${st_bin:-}" ] || {
   json_continue
   exit 0
@@ -53,7 +53,7 @@ st_bin=$(resolve_st_bin "import-update-plan" || true)
 
 plan_file=$(st_plan_file "$repo_root")
 
-if output=$(cd "$repo_root" && "$st_bin" import-update-plan --file .step/st-plan.jsonl --transcript-path "$transcript_path" 2>&1); then
+if output=$(cd "$repo_root" && "$st_bin" reconcile-codex --file .step/st-plan.jsonl --transcript-path "$transcript_path" 2>&1); then
   json_continue
   exit 0
 fi

--- a/codex/skills/fixed-point-driver/SKILL.md
+++ b/codex/skills/fixed-point-driver/SKILL.md
@@ -1,62 +1,132 @@
 ---
 name: fixed-point-driver
-description: "Drive exhaustive build-review-improve-verify loops to Truth-Owner Normal Form: one canonical owner per material invariant, no duplicate truth surfaces, no unresolved review counterexamples, no unretired additive scaffolding, and proof-gated closure. Trigger when coding needs de novo re-litigation, PR review closure, repeated review/fix loops, invariant repair, proof-surface hardening, negative-evidence pruning, CAS/Codex review resolution, optional architecture fingerprint preflight, or when agents risk adding local patches instead of deleting/refactoring/canonicalizing. Do not use for trivial one-step tasks or when the user wants one narrow phase."
+description: "Drive exhaustive build-review-improve-verify loops to Truth-Owner Normal Form: one canonical owner per material invariant, no duplicate truth surfaces, no unresolved review counterexamples, no unresolved adversarial vetoes, no unretired additive scaffolding, and proof-gated closure. Trigger when coding needs de novo re-litigation, PR review closure, repeated review/fix loops, invariant repair, proof-surface hardening, negative-evidence pruning, CAS/Codex review resolution, parallel adversarial action, optional architecture fingerprint preflight, or when agents risk adding local patches instead of deleting/refactoring/canonicalizing. Do not use for trivial one-step tasks or when the user wants one narrow phase."
 ---
 
 # Fixed-Point Driver
 
-This skill coordinates implementation, review, adjudication, reduction, verification, and closure until the artifact set reaches **Truth-Owner Normal Form**.
+This skill coordinates implementation, review, adjudication, reduction,
+verification, parallel read-only adversarial challenge, and closure until the
+artifact set reaches **Truth-Owner Normal Form**.
 
 ## The single rule
 
 Drive toward this state:
 
-> Every material invariant has exactly one canonical owner, every witness points back to that owner, every review finding is either discharged or represented as a counterexample, every additive scaffold has been promoted/collapsed/deleted, and no duplicate truth surface remains merely because it helped satisfy an intermediate review loop.
+> Every material invariant has exactly one canonical owner, every witness points
+> back to that owner, every review finding is either discharged or represented as
+> a counterexample, every adversarial veto is cleared, accepted as risk, or
+> routed, every additive scaffold has been promoted/collapsed/deleted, and no
+> duplicate truth surface remains merely because it helped satisfy an intermediate
+> review loop.
 
-A fixed point is not “review is clean.” A fixed point is a normal form of the code and proof system.
+A fixed point is not “review is clean.” A fixed point is a normal form of the
+code and proof system.
 
 ## Why this skill exists
-Frontier coding agents are good at adding code and addressing review comments. They are weaker at noticing that the best fix is to delete a path, collapse duplicate owners, privatize a surface, or tighten the one boundary that should have owned the invariant from the start.
 
-This skill converts review churn into an ownership-normalization problem.
+Frontier coding agents are good at adding code and addressing review comments.
+They are weaker at noticing that the best fix is to delete a path, collapse
+duplicate owners, privatize a surface, tighten the one boundary that should have
+owned the invariant from the start, or let a parallel adversary invalidate the
+local patch before time is spent implementing it.
+
+This skill converts review churn into an ownership-normalization problem and
+converts adversarial pressure into time-efficient, read-only clearance packets.
 
 ## Doctrine alpha driver
 
-This skill owns the conversion from doctrine-rich pressure into normal-form artifacts.
+This skill owns the conversion from doctrine-rich pressure into normal-form
+artifacts.
 
 Use doctrine only when it changes the route:
 
-- `fixed-point` creates a reopenable material fixed-point gate, not a long review loop by default.
+- `fixed-point` creates a reopenable material fixed-point gate, not a long review
+  loop by default.
 - `invariant` creates or updates a Truth Unit and owner edge.
-- `canonical` selects one owner/representation and retires, privatizes, or justifies shadow owners.
+- `canonical` selects one owner/representation and retires, privatizes, or
+  justifies shadow owners.
 - `witness` creates proof receipts tied to current head/artifact state.
-- `adversarial` / `de novo` creates candidate inventory and no-finding countercases.
+- `adversarial` / `de novo` creates candidate inventory, challenger packets, and
+  no-finding countercases.
+- `parallel` creates independent read-only adversarial lanes when it can reduce
+  elapsed time or prevent wrong action.
 - `unwitnessed guarantee` / `illegal inhabitant` creates Soundness Ledger rows.
 
 ### Overprocessing guard
 
-Do not use this skill for simple bounded tasks where ordinary direct execution plus one focused check fully closes the state space. If the run stays active, the reason must be a material open truth unit, stale proof, unresolved counterexample, shadow owner, addition escrow, or route-changing architecture uncertainty.
+Do not use this skill for simple bounded tasks where ordinary direct execution
+plus one focused check fully closes the state space. If the run stays active, the
+reason must be a material open truth unit, stale proof, unresolved counterexample,
+unresolved adversarial veto, shadow owner, addition escrow, route-changing
+architecture uncertainty, or active warrant that requires fixed-point handling.
 
 ### Local-validity trap breaker
 
-When several findings are each locally valid, ask whether they are all counterexamples to the same truth unit. If yes, prefer one owner-level rewrite over multiple local patches.
+When several findings are each locally valid, ask whether they are all
+counterexamples to the same truth unit. If yes, prefer one owner-level rewrite
+over multiple local patches.
+
+## Parallel adversarial action
+
+This skill is **parallel-adversarial by default** for material actions, but
+single-writer for all mutation.
+
+Every material action must have an adversarial response:
+
+| phase/action | adversarial response |
+|---|---|
+| warrant intake | Is the warrant stale, expired, overbroad, or incompatible with current artifact state? |
+| truth-unit extraction | Is the invariant split incorrectly? Is the canonical owner wrong? Are there shadow owners? |
+| route selection | Is delete/reuse/refactor/no-change/validate-first better than mutation? |
+| implementation | Does the patch exceed warrant scope or surface budget? Does it add duplicate truth surfaces? |
+| validation | Does proof exercise the real failure mechanism and current artifact state? |
+| de novo review | Are there unlisted counterexamples, illegal inhabitants, or unretired scaffolds? |
+| one-change challenge | Is there one remaining impactful change before closure? |
+| closure handoff | Are proof receipts current and all adversarial vetoes cleared or explicitly routed? |
+
+Parallelism modes:
+
+- `root-equivalent`: root performs the adversarial response inline for narrow,
+  bounded, already-proof-bearing work.
+- `targeted-parallel`: one or two independent read-only lanes challenge distinct
+  uncertainty classes.
+- `expanded-targeted`: three or four lanes for coupled truth units, stale proof,
+  negative evidence, or surface-budget risk.
+- `swarm`: five or more lanes for large, contentious, P2+, invariant-coupled, or
+  likely-to-reopen runs.
+- `not-required`: no safe action exists; block and name missing evidence.
+
+Parallel adversaries may gather evidence, inspect surfaces, challenge proofs,
+map hazards, and test invariants conceptually. They must not edit code, alter
+fixtures, resolve threads, or draft final replies. The root coordinator integrates
+packets and keeps writes single-threaded.
 
 ## Companion skills
 
-- `review-adjudication` decides which review comments matter, but this skill decides whether selected work preserves Truth-Owner Normal Form.
-- `accretive-implementer` performs implementation/remediation when the selected rewrite is narrow and owned.
-- `adversarial-reviewer` challenges the current artifact state and should report normal-form violations, not just bugs.
+- `review-adjudication` decides which review comments matter and issues warrants;
+  this skill decides whether selected work preserves Truth-Owner Normal Form.
+- `accretive-implementer` performs implementation/remediation when the selected
+  rewrite is narrow, owned, and warrant-scoped.
+- `adversarial-reviewer` challenges the current artifact state and should report
+  normal-form violations, not just bugs.
 - `verification-closure` performs decisive proof and closure gating.
-- `logophile` may sharpen PR-facing summaries, names, and doctrine stacks, but does not own operational policy.
+- `logophile` may sharpen PR-facing summaries, names, and doctrine stacks, but
+  does not own operational policy.
 
 ## Entry conditions
+
 Use this skill when any of these are true:
+
 - review/fix loops are repeating
 - a PR has multiple coupled comments
 - review comments are locally valid but may share one governing invariant
 - closure proof keeps becoming stale
 - a local patch may be inferior to a delete/collapse/canonicalize move
 - additive scaffolding remains after satisfying intermediate review pressure
+- a Resolution Warrant routes `address` or `validate-only` to `$fixed-point-driver`
+- an Adversarial Action Matrix selects full-fanout, swarm, contentious,
+  invariant-level, structural, validation-only, or likely-to-reopen work
 - the user asks to drive a branch/changeset to closure or find all impactful issues
 
 Do not use this skill for simple bounded tasks with an obvious check.
@@ -67,22 +137,39 @@ Do not use this skill for simple bounded tasks with an obvious check.
    - user goal
    - artifact state
    - current review/adjudication inputs
+   - active Resolution Warrants and Adversarial Action Matrix rows
    - explicit non-goals
    - proof bar
 
-2. **Truth Unit extraction**
+2. **Warrant intake / parallelism plan**
+   - consume `review-adjudication` output when present
+   - verify each warrant is active for the current artifact state
+   - preserve permitted action (`mutate-code` vs `add-validation-only`)
+   - record surface budget and forbidden actions
+   - choose root-equivalent, targeted-parallel, expanded-targeted, swarm, or
+     not-required mode for each material action
+
+3. **Truth Unit extraction**
    - material invariant / contract / semantic fact
    - canonical owner
    - witnesses
    - duplicate or shadow truth surfaces
-   - counterexamples / review findings
+   - counterexamples / review findings / adversarial vetoes
 
-3. **Adjudication intake**
+4. **Adjudication intake**
    - consume `review-adjudication` output when present
    - do not redo adjudication unless stale or contradictory
    - promote coupled local comments into a Governing Invariant Candidate
+   - do not broaden beyond active warrants or cleared adversarial actions
 
-4. **Route selection**
+5. **Adversarial preflight**
+   - run read-only challengers in the calibrated parallelism mode
+   - challenge owner, route, proof, scope, surface budget, and no-change cases
+   - reject stale, wrong-scope, wrapper-leaking, acknowledgement-only, or
+     no-evidence packets
+   - block, reroute, or narrow on unresolved/vetoed material findings
+
+6. **Route selection**
    - validate-first
    - accretive implementation
    - owner-level rewrite
@@ -90,41 +177,112 @@ Do not use this skill for simple bounded tasks with an obvious check.
    - proof-only / no-change
    - blocked / needs decision
 
-5. **Implementation pass**
-   - delegate mutation to `accretive-implementer`
+7. **Implementation pass**
+   - delegate mutation to `accretive-implementer` when the selected rewrite is
+     narrow and owned
+   - root may perform root-equivalent edits only with an active `mutate-code`
+     warrant, current adversarial clearance, and passing Surface Budget Preflight
    - keep writes single-threaded
    - subagents may gather read-only evidence
+   - emit Surface Delta Receipts after material patch groups
 
-6. **De novo adversarial review**
-   - use `adversarial-reviewer`
-   - require candidate inventory, no-finding countercases, Soundness Ledger, and Change Agenda
+8. **De novo adversarial review**
+   - use `adversarial-reviewer` or root-equivalent challenge
+   - require candidate inventory, no-finding countercases, Soundness Ledger, and
+     Change Agenda
+   - record adversarial findings in the Adversarial Action Ledger
 
-7. **One-change challenge**
+9. **One-change challenge**
    Ask:
+
    > If you could change one thing about this changeset, what would you change?
 
-   If the answer is an impactful accretive improvement, route it to `accretive-implementer`, then rerun de novo review.
+   If the answer is an impactful accretive improvement, route it to
+   `accretive-implementer`, then rerun de novo review. If it is structural and
+   outside constraints, mark `needs-decision` or `blocked`. If no impactful
+   remaining change exists, proceed to verification closure.
 
-8. **Material fixed-point test**
-   A candidate fixed point exists only when:
-   - no open material findings remain
-   - no unresolved material soundness rows remain
-   - no duplicate truth owner remains unretired
-   - no additive scaffold remains without explicit justification
-   - no review counterexample remains unresolved
-   - proof receipts are tied to current artifact state
+10. **Material fixed-point test**
+    A candidate fixed point exists only when:
+    - no open material findings remain
+    - no unresolved material soundness rows remain
+    - no unresolved adversarial vetoes remain
+    - no duplicate truth owner remains unretired
+    - no additive scaffold remains without explicit justification
+    - no review counterexample remains unresolved
+    - surface budgets are satisfied or expansion is explicitly granted
+    - proof receipts are tied to current artifact state
 
-9. **Verification closure**
-   Hand off to `verification-closure` with a closure packet.
-   If closure reopens a gate, resume at route selection.
+11. **Verification closure**
+    Hand off to `verification-closure` with a closure packet.
+    If closure reopens a gate, resume at route selection.
+
+## Required ledgers
+
+### Warrant Intake / Parallelism Plan
+
+```md
+| warrant id | claim id | permitted action | permitted scope | expiry check | surface budget | adversarial plan | parallelism mode | intake status |
+|---|---|---|---|---|---|---|---|---|
+```
+
+Rules:
+
+- `intake status` is `active`, `stale`, `blocked`, `consumed`, or `not-applicable`.
+- Active `mutate-code` warrants must have surface budget and adversarial clearance.
+- Active `add-validation-only` warrants must forbid production mutation.
+- Stale or blocked warrants may not be consumed for writes, validation, thread
+  resolution, or replies.
+
+### Truth Units
+
+```md
+| truth unit id | invariant | canonical owner | witnesses | duplicate/shadow owners | review/adversarial counterexamples | status | proof refs | next action |
+|---|---|---|---|---|---|---|---|---|
+```
+
+### Adversarial Action Ledger
+
+```md
+| action id | phase | target | challenger lanes | parallelism mode | strongest adversarial finding | veto status | clearance | proof ref | decision impact |
+|---|---|---|---|---|---|---|---|---|---|
+```
+
+Allowed `veto status` values: `cleared`, `preserved-no-change`, `unresolved`,
+`vetoed`, `blocked`, `not-required`.
+
+Allowed `clearance` values: `cleared`, `preserved`, `rerouted`, `downgraded`,
+`blocked`.
+
+### Surface Delta Receipts
+
+```md
+| receipt id | warrant id | patch/pass | production insertions | production deletions | net production loc | public symbols added | helpers added | duplicate paths added | budget status | proof ref |
+|---|---|---|---|---|---|---|---|---|---|---|
+```
+
+If budget status is `expansion-needed` or `violation`, stop implementation until
+an Expansion Warrant Request is granted or the patch is redesigned.
 
 ## Closure handoff packet
+
 Before invoking `verification-closure`, compile:
 
 ```yaml
 closure_handoff_packet:
   artifact_state_id: "..."
   goal: "..."
+  warrant_intake:
+    - warrant_id: "..."
+      claim_id: "..."
+      permitted_action: "mutate-code | add-validation-only | resolve-thread | draft-reply | defer | none"
+      intake_status: "active | consumed | stale | blocked | not-applicable"
+      adversarial_clearance: "cleared | preserved | rerouted | downgraded | blocked"
+  parallelism_plan:
+    lane: "root-equivalent | targeted-parallel | expanded-targeted | swarm | not-required"
+    reason: "..."
+    read_only: yes
+    write_owner: root-or-delegate
   truth_units:
     - id: "TU1"
       invariant: "..."
@@ -138,9 +296,17 @@ closure_handoff_packet:
     proof_only: []
     no_change: []
     blocked: []
+  adversarial_action_ledger:
+    open_vetoes: []
+    cleared_vetoes: []
+    accepted_risks: []
   soundness_ledger:
     open_rows: []
     closed_rows: []
+  surface_delta_receipts:
+    - warrant_id: "..."
+      budget_status: "within-budget | expansion-needed | violation | not-applicable"
+      proof_ref: "..."
   proof_receipts:
     - command_or_check: "..."
       result: "..."
@@ -149,26 +315,70 @@ closure_handoff_packet:
     answer: "..."
     routed: yes | no
     reason: "..."
+  unresolved_adversarial_vetoes: []
 ```
 
 ## Output contract
+
 Use tail-weighted sections:
 
 1. Goal / Artifact State
-2. Truth Units
-3. Route Selection
-4. Work Performed / Routed
-5. Review and Soundness Results
-6. Proof Receipts
-7. Fixed-Point Test
-8. Closure Handoff
-9. Final State
-10. Do Next
+2. Warrant Intake / Parallelism Plan
+3. Truth Units
+4. Route Selection
+5. Work Performed / Routed
+6. Adversarial Action Ledger
+7. Review and Soundness Results
+8. Surface Delta Receipts
+9. Proof Receipts
+10. Fixed-Point Test
+11. Closure Handoff
+12. Final State
+13. Do Next
 
 `Do Next` must be the final section.
 
+## Fixed-Point Gate
+
+Before closure handoff, emit a gate summary with these fields:
+
+- `artifact_state_match`: `pass` / `fail`
+- `warrant_intake`: `pass` / `fail`
+- `parallelism_calibration`: `pass` / `fail`
+- `adversarial_action_coverage`: `pass` / `fail`
+- `open_truth_units`: `0` or named blockers
+- `duplicate_truth_owners`: `0` or named blockers
+- `open_review_counterexamples`: `0` or named blockers
+- `unresolved_soundness_rows`: `0` or named blockers
+- `unresolved_adversarial_vetoes`: `0` or named blockers
+- `unretired_additive_scaffolds`: `0` or named blockers
+- `surface_budget_status`: `pass` / `fail` / `not-applicable`
+- `proof_receipts_current`: `pass` / `fail`
+- `one_change_challenge_status`: `pass` / `fail`
+- `verification_closure_ready`: `yes` / `no`
+
+## Hard rules
+
+- Do not mutate outside an active `mutate-code` warrant.
+- Do not turn `add-validation-only` into production mutation.
+- Do not let parallel adversaries write files, mutate fixtures, resolve threads,
+  or draft final replies.
+- Do not treat parallel agreement as proof; require current artifact evidence.
+- Do not claim fixed point with unresolved material adversarial vetoes.
+- Do not preserve duplicate truth owners unless they are explicitly justified.
+- Do not leave additive scaffolding unretired merely because it helped pass an
+  intermediate review loop.
+- Do not hand off closure with stale proof receipts.
+- Do not broaden beyond the permitted scope, forbidden actions, and surface budget
+  consumed from review adjudication.
+
 ## Resources
+
 - [doctrine-alpha.md](references/doctrine-alpha.md)
 - [tail-proof.md](references/tail-proof.md)
 - [truth-owner-normal-form.md](references/truth-owner-normal-form.md)
 - [one-change-challenge.md](references/one-change-challenge.md)
+- [common-ledgers.md](references/common-ledgers.md)
+- [companion-skill-ledger.md](references/companion-skill-ledger.md)
+- [closure-handoff-template.md](references/closure-handoff-template.md)
+- [adversarial-parallelism.md](references/adversarial-parallelism.md)

--- a/codex/skills/fixed-point-driver/references/adversarial-parallelism.md
+++ b/codex/skills/fixed-point-driver/references/adversarial-parallelism.md
@@ -1,0 +1,74 @@
+# Adversarial Parallelism for Fixed-Point Driver
+
+Use adversarial parallelism to drive a branch toward Truth-Owner Normal Form
+without turning the run into a slow serial review loop. Parallel adversaries are
+read-only challengers. Writes remain single-threaded and warrant-scoped.
+
+## Principle
+
+Every material action in a fixed-point run should have an adversarial response:
+validation should be challenged by no-validation and mutate-now alternatives;
+mutation should be challenged by delete/reuse/refactor, owner-boundary, proof,
+and surface-budget alternatives; closure should be challenged by stale-proof,
+open-counterexample, duplicate-owner, and one-change alternatives.
+
+## Safe concurrency boundary
+
+Parallel lanes may inspect code, tests, comments, warrants, ledgers, proof
+receipts, negative evidence, and architecture boundaries. They must not edit code,
+resolve threads, update snapshots, or draft final PR text. The root coordinator
+integrates packets and performs/delegates any mutation in one thread.
+
+## Fixed-point action adversaries
+
+| fixed-point action | adversarial response |
+|---|---|
+| warrant intake | Is the warrant stale, scoped too broadly, expired, or incompatible with the artifact state? |
+| truth-unit extraction | Is this really one invariant, or are there multiple owners/contracts? Is the proposed owner canonical? |
+| route selection | Is delete/reuse/refactor better than adding? Is validation-first safer than mutation? Is no-change preserved? |
+| implementation | Does the patch exceed warrant scope or surface budget? Does it add duplicate truth surfaces? |
+| validation | Does the proof exercise the actual claimed failure mechanism? Is it stale or indirect? |
+| de novo review | Are there unlisted counterexamples, illegal inhabitants, or unretired scaffolds? |
+| one-change challenge | Is there one remaining material change that should happen before closure? |
+| closure handoff | Are proof receipts current? Are all vetoes cleared? Does verification have the right questions? |
+
+## Fanout modes
+
+- `root-equivalent`: root performs the challenge inline for narrow bounded tasks.
+- `targeted-parallel`: one or two read-only lanes challenge distinct uncertainty
+  classes.
+- `expanded-targeted`: three or four lanes for coupled truth units or stale proof.
+- `swarm`: five or more lanes for large, contentious, invariant-coupled, or
+  likely-to-reopen runs.
+- `not-required`: no safe action exists; the row is blocked and the missing
+  evidence is named.
+
+## Required ledgers
+
+### Warrant Intake / Parallelism Plan
+
+```md
+| warrant id | claim id | permitted action | permitted scope | expiry check | surface budget | adversarial plan | parallelism mode | intake status |
+|---|---|---|---|---|---|---|---|---|
+```
+
+### Adversarial Action Ledger
+
+```md
+| action id | phase | target | challenger lanes | parallelism mode | strongest adversarial finding | veto status | clearance | proof ref | decision impact |
+|---|---|---|---|---|---|---|---|---|---|
+```
+
+### Surface Delta Receipts
+
+```md
+| receipt id | warrant id | patch/pass | production insertions | production deletions | net production loc | public symbols added | helpers added | duplicate paths added | budget status | proof ref |
+|---|---|---|---|---|---|---|---|---|---|---|
+```
+
+## Closure rule
+
+A fixed-point candidate may not enter verification closure if any material
+adversarial row has `veto status: unresolved`, `vetoed`, or `blocked`, unless the
+closure packet explicitly marks the item as accepted risk or asks verification to
+resolve the blocker.

--- a/codex/skills/fixed-point-driver/references/closure-handoff-template.md
+++ b/codex/skills/fixed-point-driver/references/closure-handoff-template.md
@@ -35,16 +35,22 @@ loop-03-post-review
   - root cause is bounded
   - changed path is directly verified
   - no unresolved material finding remains
+  - no unresolved adversarial veto remains
   - negative evidence closure gate is satisfied
+
+#### Warrant Intake / Parallelism Plan
+| warrant id | claim id | permitted action | permitted scope | expiry check | surface budget | adversarial plan | parallelism mode | intake status |
+|---|---|---|---|---|---|---|---|---|
+| rw-F03 | F-03 | mutate-code | auth/session.ts,auth/session.test.ts | current head abc1234 | max +8 LOC, no public symbols | challenge stale-state route, proof, and surface | targeted-parallel | consumed |
 
 #### Companion Skill Ledger
 - companion: review-adjudication
   status: used
-  evidence: reviewer comment F-03 accepted as material validation work
+  evidence: reviewer comment F-03 accepted as material validation/mutation work with adversarial clearance
   limitations: none
 - companion: accretive-implementer
   status: root-equivalent
-  evidence: root applied narrow remediation and direct regression test
+  evidence: root applied narrow remediation and direct regression test inside warrant scope
   limitations: no distinct implementer packet
 - companion: adversarial-reviewer
   status: root-equivalent
@@ -72,6 +78,14 @@ loop-03-post-review
 - budget_exceptions: none
 - lane_change_history:
   - direct-closure -> targeted because prior cache-fast-path negative evidence could change route
+
+#### Parallelism Plan
+- mode: targeted-parallel
+- read_only_lanes:
+  - stale-state proof challenger
+  - surface-budget / duplicate-owner challenger
+- write_owner: root-equivalent implementation only
+- reason: two independent risk classes could be checked before final closure without serial delay
 
 #### Artifact Set
 - changed_files:
@@ -116,13 +130,19 @@ loop-03-post-review
     - auth/token-store.ts
   status: completed
 
+#### Adversarial Action Ledger
+| action id | phase | target | challenger lanes | parallelism mode | strongest adversarial finding | veto status | clearance | proof ref | decision impact |
+|---|---|---|---|---|---|---|---|---|---|
+| A-01 | route-selection | F-03 stale-secret remediation | no-change,validate-first,negative-evidence | targeted-parallel | cache-fast-path optimization remains excluded; direct persisted-secret read is warranted | cleared | cleared | auth/session.test.ts::rejects_stale_refresh_secret_after_rotation | route retained |
+| A-02 | closure | INV-02 proof | proof freshness,surface-budget | root-equivalent | production adapter not directly exercised but changed path proof is sufficient for scoped PR | cleared | preserved | local test receipt T-01 | closure packet asks verification to inspect adapter limitation |
+
 #### Findings Ledger
 - finding_id: F-03
   materiality: material
   severity: major
   category: stale-state regression
   status: remediated
-  remediation_posture: validating-check-only
+  remediation_posture: validating-check-only -> mutate-code after proof
   evidence:
     - direct rotated-secret retry test now passes
   why_it_matters: The fix could pass happy-path tests while still minting a token against stale state.
@@ -144,27 +164,10 @@ loop-03-post-review
     - direct rotated-secret retry test exercises post-rotation persisted secret
   open_question: none
 
-#### Foot-Gun Register
-- hazard_id: H-01
-  trigger: Retry refresh immediately after token rotation under cached store state.
-  impact: Incorrect token issuance on an operational edge path.
-  ease_of_misuse: medium
-  status: bounded
-  evidence:
-    - direct retry-after-rotation test fails under stale snapshot behavior and passes after remediation
-  narrowest_bounding_action: preserve direct regression test
-
-#### Complexity Ledger
-- overall_delta: neutral
-- materiality: non-material
-- drivers:
-  - one extra persisted-secret lookup
-  - one focused regression test
-- evidence:
-  - no new public surface
-  - no new branching outside refresh path
-- bounded_by:
-  - localized helper call and direct test
+#### Surface Delta Receipts
+| receipt id | warrant id | patch/pass | production insertions | production deletions | net production loc | public symbols added | helpers added | duplicate paths added | budget status | proof ref |
+|---|---|---|---|---|---|---|---|---|---|---|
+| SDR-01 | rw-F03 | build-01 | 6 | 2 | +4 | 0 | 0 | 0 | within-budget | auth/session.test.ts::rejects_stale_refresh_secret_after_rotation |
 
 #### Verification Ledger
 - direct_changed_path: satisfied
@@ -182,107 +185,22 @@ loop-03-post-review
     what_it_proves: Basic refresh behavior still succeeds.
     limitations: Does not prove all production adapter behavior.
 
-#### Negative Ledger Pass
-- phase: pre-closure
-- mode: handoff
-- artifact_state_id: branch=feature/session-refresh-fix head=abc1234 diff=auth-session-rotated-secret-v3 phase=closure-candidate
-- topical_query: auth refresh rotated-secret cache fast-path regression
-- sources_checked:
-    current_run: yes
-    fixed_point_ledgers: yes
-    learnings: yes
-    repo_history: no
-    review_comments: yes
-    user_context: no
-- result:
-    active_exclusions:
-      - NEG-01
-    stale_or_superseded: none
-    reopened_candidates: none
-    need_evidence: none
-    no_applicable_negative_evidence_reason: n/a
-    safest_next_frontier: keep persisted-secret read and direct rotated-secret proof; do not optimize through cache snapshot
-- durable_capture: duplicate-skip
-
-#### Negative Evidence Ledger
-- neg_id: NEG-01
-  hypothesis: Reuse cached store snapshots during token refresh to avoid the extra store read.
-  attempted_change: Prior fast-path prototype skipped the post-rotation store read.
-  source_refs:
-    - kind: learning
-      ref: lrn-auth-refresh-cache-fast-path
-      summary: Prior fast path regressed rotated-secret retry coverage.
-    - kind: failing-test
-      ref: auth/session.test.ts::rejects_stale_refresh_secret_after_rotation
-      summary: Fails when refresh depends on stale snapshot.
-  learning_source_ids:
-    - lrn-auth-refresh-cache-fast-path
-  evidence:
-    - Prior fast path passed happy-path refresh but failed rotated-secret retry coverage.
-  observed_outcome: Removed a read but reopened stale-secret token issuance.
-  failure_class: unsound
-  applicability_conditions:
-    - applies while refresh correctness depends on reading the current persisted secret after rotation
-  current_status: active
-  exclusion_rule: Do not select a cache-snapshot refresh optimization unless it proves post-rotation secret freshness directly.
-  reopening_criteria:
-    - store snapshot semantics are replaced with a current-secret witness
-    - direct rotated-secret retry test passes under the new design
-  confidence: medium
-  next_search_hint: Prefer validating the persisted-secret read rather than optimizing it away.
-
 #### Negative Ledger Handoff
 - active_exclusions:
-    - NEG-01: cache-snapshot fast path remains excluded
+  - NEG-01: cache-snapshot fast path remains excluded
 - stale_or_superseded: none
 - reopened: none
 - need_evidence: none
 - safest_next_frontier: proceed with closure; maintain persisted-secret read and regression test
 - learnings_source_ids:
-    - lrn-auth-refresh-cache-fast-path
+  - lrn-auth-refresh-cache-fast-path
 - durable_capture: duplicate-skip
 - closure_effect:
     blocks_closure: no
     changes_one_change_challenge: yes
     changes_verification_plan: yes
 
-#### Specialist Briefing Ledger
-- role: verification_auditor
-  artifact_state_id:
-    branch: feature/session-refresh-fix
-    revision: abc1234
-    diff_hash: auth-session-rotated-secret-v3
-    touched_paths:
-      - auth/session.ts
-      - auth/session.test.ts
-    phase: closure-candidate
-  artifact_state_label: loop-03-post-review
-  scope: direct path and regression coverage
-  top_material_signals:
-    - direct rotated-secret retry path now exercised
-  unresolved_signals:
-    - production adapter semantics not directly exercised
-  agreement_pressure: aligned
-  stale: no
-  packet_status: accepted
-  used_for: verification planning
-  rejection_reason: none
-
-#### Specialist Value Receipts
-- role: verification_auditor
-  packet_status: accepted
-  artifact_state_id_match: yes
-  scope_match: yes
-  uncertainty_class: verification
-  route_changed: no
-  finding_added: no
-  proof_changed: yes
-  risk_retired: yes
-  value: positive
-  used_for: verification-planning
-  reason: Identified the direct rotated-secret retry test as the decisive changed-path proof.
-
-#### Closure Gate Preview
+#### Fixed-Point Gate Preview
 - direct_changed_path: satisfied
 - claimed_failure_mechanism: satisfied
 - regression_surface: satisfied
@@ -290,12 +208,16 @@ loop-03-post-review
 - material_foot_guns: bounded
 - material_complexity_hazards: bounded
 - negative_evidence_closure_gate: satisfied
+- adversarial_action_coverage: satisfied
+- unresolved_adversarial_vetoes: none
+- surface_budget_status: within-budget
 - briefing_agreement: aligned
 - external_blockers: none
 
 #### Requested Closure Questions
 - Does the changed path now directly prove post-rotation secret correctness?
 - Is INV-02 bounded or still open?
+- Are all adversarial vetoes cleared, preserved, or explicitly accepted as risk?
 - Is NEG-01 still active, and if so, does it block the current route?
 - Are any `learnings` hits being used as exclusions without current-state applicability?
 

--- a/codex/skills/review-adjudication/SKILL.md
+++ b/codex/skills/review-adjudication/SKILL.md
@@ -5,14 +5,15 @@ description: >-
   comment as a claim to test, preserve raw comment identity and input inventory,
   bind decisions to artifact state, build the strongest no-change countercase,
   separate valid concerns from valid proposed fixes, recover PR rationale with
-  explicit `$seq` when needed, and emit a stale-proof gated ledger, resolve-selection map, and
-  resolution warrants that decides what to address, validate only, resolve
-  with proof only, rebut, defer, investigate, or route. Trigger for
-  `$review-adjudication`, review the review, adjudicate PR comments, are these
-  comments relevant, which comments matter, should we act on these comments,
-  gate review comments before implementation, refine this list to just those
-  worth resolving, or select review comments to resolve. Not for implementing
-  fixes, writing rebuttals only, or final merge closure.
+  explicit `$seq` when needed, and emit a stale-proof gated ledger,
+  resolve-selection map, adversarial action matrix, resolution warrants, and
+  surface budgets that decide what to address, validate only, resolve with proof
+  only, rebut, defer, investigate, or route. Trigger for `$review-adjudication`,
+  review the review, adjudicate PR comments, are these comments relevant, which
+  comments matter, should we act on these comments, gate review comments before
+  implementation, refine this list to just those worth resolving, or select
+  review comments to resolve. Not for implementing fixes, writing rebuttals only,
+  or final merge closure.
 ---
 
 # Review Adjudication
@@ -24,16 +25,18 @@ which are stale or out of scope, which require validation only, and which should
 be reframed as a governing invariant instead of handled as isolated local fixes.
 When the next workflow is `$fixed-point-driver`, `$resolve`, `$ship`, or
 thread-resolution, also decide which comments are implementation work versus
-validation-only, proof-only thread resolution, or no-change items.
+validation-only, proof-only thread resolution, reply/defer work, or no-change
+items.
 
 This skill is **discriminative**, not deferential. A reviewer comment is an input
 claim, not an obligation. `act` is a conclusion that must be earned from current
-artifact evidence and a defeated no-change countercase.
+artifact evidence, a defeated no-change countercase, and an explicit adversarial
+clearance for the downstream action.
 
 ## Default mode
 
-Use **Surface-Budgeted v5** mode whenever the input contains real review comments.
-Surface-Budgeted v5 is mandatory because automation needs:
+Use **Surface-Budgeted v6** mode whenever the input contains real review
+comments. Surface-Budgeted v6 is mandatory because automation needs:
 
 - stable raw comment identity
 - complete input-comment inventory coverage
@@ -42,43 +45,52 @@ Surface-Budgeted v5 is mandatory because automation needs:
 - evidence-grade and evidence-reference separation
 - resolve-selection mapping for implementation, validation, proof-only thread
   resolution, no-change, and blocked outcomes
+- adversarial action coverage for every selected downstream action
+- parallelism calibration so adversarial effort is spent where it can change the
+  route, proof, owner, or budget
 - proof refs and route rationale for every downstream selection
-- resolve countercases so "worth resolving" is challenged separately from
-  concern validity
+- resolve countercases so "worth resolving" is challenged separately from concern
+  validity
 - selection-skew auditing so "all are worth resolving" cannot pass silently
 - handoff-agenda consistency checks so selected work is not broadened later
 - separate implementation, validation, and reply handoff permissions
 - Resolution Warrants that act as scoped, expiring downstream permissions
-- Surface Budget Ledger entries that force subtractive-first solution search
-  and cap additive semantic surface
+- Surface Budget Ledger entries that force subtractive-first solution search and
+  cap additive semantic surface
 
 Other modes are allowed only when they still satisfy the completion gate:
 
-- **Standard**: expanded reasoning plus the full Surface-Budgeted v5 tail.
+- **Standard**: expanded reasoning plus the full Surface-Budgeted v6 tail.
 - **Fast**: bucket-only output plus the completion gate; allowed for exploratory
   triage or synthetic comments, not for implementation handoff unless the gate
   passes.
 
 ## Doctrine
 
-Operate in **DISCRIMINATIVE**, **REBUTTAL-FIRST**, **INVARIANT-SEEKING**,
-**ANTI-RUBBER-STAMP**, **EVIDENCE-WEIGHTED**, **STALE-PROOF**, and
-**FAIL-CLOSED** mode.
+Operate in **DISCRIMINATIVE**, **REBUTTAL-FIRST**, **ADVERSARIAL-BY-DEFAULT**,
+**PARALLEL-WHEN-MATERIAL**, **INVARIANT-SEEKING**, **ANTI-RUBBER-STAMP**,
+**EVIDENCE-WEIGHTED**, **STALE-PROOF**, and **FAIL-CLOSED** mode.
 
-- **DISCRIMINATIVE**: separate true concerns from irrelevant, stale,
-  unsupported, preference-only, misdiagnosed, or misframed comments.
+- **DISCRIMINATIVE**: separate true concerns from irrelevant, stale, unsupported,
+  preference-only, misdiagnosed, or misframed comments.
 - **REBUTTAL-FIRST**: for each comment, construct the strongest no-change
   countercase before deciding to act.
+- **ADVERSARIAL-BY-DEFAULT**: every selected downstream action must have an
+  adversarial response that tries to defeat that action, downgrade it, reroute it,
+  narrow it, or block it.
+- **PARALLEL-WHEN-MATERIAL**: run independent adversarial lanes in parallel when
+  parallel challenge can reduce elapsed time without compromising current-state
+  grounding or single-writer safety.
 - **INVARIANT-SEEKING**: look for the governing invariant behind repeated local
   comments; avoid fixing the same invariant piecemeal.
 - **ANTI-RUBBER-STAMP**: do not let plausibility, politeness, reviewer authority,
-  or ease of implementation become acceptance evidence.
+  parallel consensus, or ease of implementation become acceptance evidence.
 - **EVIDENCE-WEIGHTED**: rank current artifacts above memories, memories above
   intuition, and direct proof above consensus.
 - **STALE-PROOF**: bind adjudication to branch/head/diff/comment-set state so
   downstream handoffs can detect stale or contradictory agendas.
-- **FAIL-CLOSED**: if the adjudication contract is incomplete, block
-  implementation handoff rather than guessing.
+- **FAIL-CLOSED**: if the adjudication, adversarial clearance, or warrant contract
+  is incomplete, block implementation handoff rather than guessing.
 
 ## Contract
 
@@ -95,17 +107,23 @@ Operate in **DISCRIMINATIVE**, **REBUTTAL-FIRST**, **INVARIANT-SEEKING**,
 - Preserve artifact-state identity; do not let a handoff become stale invisibly.
 - Tail-weight outputs for CLI use.
 - Do not implement fixes here.
-- Do not create an implementation handoff unless the Adjudication Gate passes
-  and `implementation_handoff_allowed: yes`.
+- Do not create an implementation handoff unless the Adjudication Gate passes,
+  `implementation_handoff_allowed: yes`, and every `address` row has adversarial
+  clearance.
 - Do not collapse adjudication into "all comments are worth resolving"; emit the
   resolve-selection map before implementation or thread-resolution handoff.
-- Do not let `address` mean "add code". Every mutation-capable warrant must
-  carry a surface budget, deletion/reuse/refactor probe obligation, and
-  expansion-warrant rule before downstream implementation.
+- Do not let `address` mean "add code". Every mutation-capable warrant must carry
+  a surface budget, deletion/reuse/refactor probe obligation, and expansion-warrant
+  rule before downstream implementation.
 - Validation-only handoff is not implementation permission.
 - Proof-only thread resolution is not implementation permission.
 - Reply handoff is not implementation permission.
-- No downstream mutation, validation-only probe, thread resolution, or rebuttal/defer handoff is licensed unless a matching active Resolution Warrant exists.
+- No downstream mutation, validation-only probe, thread resolution, or
+  rebuttal/defer handoff is licensed unless a matching active Resolution Warrant
+  exists.
+- No selected downstream action is licensed unless the Adversarial Action Matrix
+  has a row for the raw claim and that row clears, preserves, or blocks the action
+  consistently with the selected route.
 
 ## Dependency
 
@@ -113,28 +131,107 @@ This skill expects `$seq` to be installed when PR rationale recovery is needed.
 If `$seq` is unavailable, proceed only from current artifacts and mark PR
 rationale fields as `unknown` instead of inventing intent.
 
-## Specialist mode
+## Parallel adversarial action
 
-For large or disputed comment sets, optionally use these read-only specialists
-before final adjudication:
+Every row in `Resolve Selection` must receive one adversarial response. The
+response is not decorative; it is a clearance attempt against the selected action.
+It must either clear the action, preserve the no-change/defer decision, or block
+handoff.
 
-- `evidence_mapper`
-- `soundness_auditor`
-- `hazard_hunter`
+Adversarial responses should be parallelized when the dimensions are independent
+and read-only. Use parallel lanes to reduce elapsed time for material batches, but
+keep final adjudication and all downstream writes single-rooted.
 
-Use them only to sharpen grounding, soundness, hazard, or invariant questions.
-They do not replace the adjudication judgment.
+### Required adversarial dimensions by action
 
-When specialists are used, assign the current artifact state and exact comment
-or file scope, then require the shared packet contract at
-`../references/specialist-packet-contract.md`. Consume only packet-native,
-scoped, evidence-bearing, current packets. Reject stale, wrong-scope,
-wrapper-leaking, acknowledgement-only, or no-evidence packets and keep them out
-of `act`/`rebut`/`defer`/`need-evidence` decisions.
+| selected action | adversarial response must challenge |
+|---|---|
+| `address` | no-change, validate-first, wrong-fix, scope/ownership, surface-budget, fixed-point over-routing |
+| `validate-only` | mutate-now, no-validation-value, wrong probe, production-mutation escape |
+| `resolve-thread-only` | still-material, stale-proof insufficiency, proof-ref weakness, hidden implementation need |
+| `do-not-address` | materiality, review-closure value, proof-only alternative, user/non-goal mismatch |
+| `blocked` | whether a narrower safe validation, reply, proof-only route, or user question can unblock |
 
-When specialists are used, emit `## Specialist Packet Receipts` and set
-`specialist_packet_coverage` to `pass` only when every accepted or rejected
-packet has a value receipt and no rejected packet is used as evidence.
+### Parallelism modes
+
+Use exactly one `parallelism mode` per row in the Adversarial Action Matrix:
+
+- `root-equivalent`: root performed the adversarial challenge inline; allowed for
+  obvious narrow-local, proof-only, synthetic, or no-change rows.
+- `targeted-parallel`: one or two independent read-only lanes challenged the row
+  or invariant cluster.
+- `full-fanout`: evidence, scope/ownership, criticality, no-change, validation
+  value, and fix-shape lanes were assigned in parallel.
+- `swarm`: five or more specialists were needed because the batch is large,
+  contentious, P2+, invariant-coupled, or likely to reopen.
+- `not-required`: only for rows with `resolve decision: blocked` and no safe
+  downstream action to challenge; the missing evidence must be named.
+
+Use full fanout or swarm when any of these are true:
+
+- any P2+ row might be selected as `address`
+- every substantive row would otherwise be selected as `address` or
+  `validate-only`
+- any CAS/Codex finding is invariant-framed and would mutate code
+- the no-change countercase is weak, generic, or reviewer-authority-shaped
+- validation-only is rejected for an unproven but plausible finding
+- implementation would route to `$fixed-point-driver`
+- several comments share a likely governing invariant
+
+Do not parallelize lanes that need writes, mutate fixtures, alter review threads,
+or depend on each other's outputs. Parallel adversaries are read-only evidence
+producers; the root adjudicator integrates them.
+
+### Adversarial Action Matrix
+
+Emit `## Adversarial Action Matrix` after `## Resolve Countercases` and before
+`## Resolution Warrants`.
+
+```md
+## Adversarial Action Matrix
+
+| id/thread | primary resolve decision | adversarial lanes | parallelism mode | strongest adversarial response | veto status | clearance | proof ref | decision impact |
+|---|---|---|---|---|---|---|---|---|
+```
+
+Allowed `veto status` values:
+
+- `cleared`
+- `preserved-no-change`
+- `unresolved`
+- `vetoed`
+- `blocked`
+- `not-required`
+
+Allowed `clearance` values:
+
+- `cleared`
+- `preserved`
+- `rerouted`
+- `downgraded`
+- `blocked`
+
+Rules:
+
+- `address` requires `veto status: cleared`, `clearance: cleared`, and a concrete
+  proof ref that defeats the strongest no-change / validate-first / wrong-fix /
+  scope / budget alternative.
+- `validate-only` requires `veto status: cleared`, `clearance: cleared` or
+  `downgraded`, and proof that validation is the correct next action instead of
+  mutation or no action.
+- `resolve-thread-only` requires `veto status: cleared` or
+  `preserved-no-change`, `clearance: preserved`, and a proof ref that makes code
+  mutation unnecessary.
+- `do-not-address` requires `veto status: preserved-no-change` or `cleared`,
+  `clearance: preserved`, and a proof/ref explaining why no downstream action is
+  selected.
+- `blocked` requires `veto status: blocked` or `unresolved`, `clearance: blocked`,
+  and a missing-evidence proof ref.
+- A vetoed or unresolved adversarial response must block implementation handoff
+  unless the row is rerouted to a stricter non-mutating action with a matching
+  warrant.
+- A selected action with `parallelism mode: root-equivalent` must explain why
+  separate parallel lanes were not materially useful.
 
 ## Required input context
 
@@ -168,11 +265,12 @@ Constraints:
 - compatibility posture:
 - ownership boundaries:
 - proof bar:
+- likely next workflow:
 ```
 
 Do not feed the whole repository by default. Add more context only when current
-artifacts cannot decide grounding, scope, freshness, intent, evidence grade, or
-handoff shape.
+artifacts cannot decide grounding, scope, freshness, intent, evidence grade,
+evidence ref, adversarial clearance, route selection, or handoff shape.
 
 ## `$seq` rationale recovery
 
@@ -188,9 +286,9 @@ Preferred ladder:
 5. `memory-provenance`
 6. `memory-history`
 
-Use `$seq` to recover rationale, not to manufacture obligations. A recovered
-plan can explain why a comment matters, but current artifacts still decide
-whether the comment is grounded, stale, in scope, or actionable.
+Use `$seq` to recover rationale, not to manufacture obligations. A recovered plan
+can explain why a comment matters, but current artifacts still decide whether the
+comment is grounded, stale, in scope, actionable, or adversarially cleared.
 
 ## Evidence ranking
 
@@ -291,10 +389,12 @@ For every comment, assess:
 13. evidence grade
 14. evidence reference
 15. resolution value
-16. handoff action
+16. resolve selection
+17. adversarial response
+18. handoff action
 
-In Surface-Budgeted v5, surface these checks in both `## Comment Ledger` and
-`## Decision Tests`.
+In Surface-Budgeted v6, surface these checks in `## Comment Ledger`,
+`## Decision Tests`, `## Resolve Selection`, and `## Adversarial Action Matrix`.
 
 ## Act validity rule
 
@@ -304,16 +404,17 @@ A comment may be marked `act` only if all are true:
 2. The concern is material, or the user explicitly wants the nonmaterial change.
 3. The comment is fresh for the current artifact state.
 4. The strongest no-change countercase is defeated.
-5. The proposed fix is valid, or the chosen handoff replaces it with a valid fix
+5. The adversarial response clears the selected `address` action.
+6. The proposed fix is valid, or the chosen handoff replaces it with a valid fix
    shape.
-6. The action fits this PR's scope, constraints, and intended change.
-7. The row has `evidence_grade` of `current-artifact`, `current-test`,
+7. The action fits this PR's scope, constraints, and intended change.
+8. The row has `evidence_grade` of `current-artifact`, `current-test`,
    `current-ci`, or `current-session-artifact`.
-8. The row has a concrete `evidence_ref` such as `file:line`, test name,
+9. The row has a concrete `evidence_ref` such as `file:line`, test name,
    command/log reference, CI status, PR thread, or current artifact citation.
 
 If any item fails, do not use `act`; use `rebut`, `defer`, or `need-evidence`.
-`act` requires proof, not plausibility.
+`act` requires proof, not plausibility or adversarial consensus.
 
 ## Rebuttal-first pass
 
@@ -332,8 +433,9 @@ A no-change countercase may be:
 - the review assumes a contract this PR does not own
 - the evidence is insufficient and the correct next step is validation only
 
-Only mark `act` when artifact evidence defeats the no-change countercase. If the
-countercase is not defeated, use `rebut`, `defer`, or `need-evidence`.
+Only mark `act` when artifact evidence and adversarial clearance defeat the
+no-change countercase. If the countercase is not defeated, use `rebut`, `defer`,
+or `need-evidence`.
 
 ## Validation-only escape hatch
 
@@ -350,13 +452,16 @@ handoff_action: route-to-fixed-point-driver
 
 Validation-only handoff may create tests, probes, logs, or inspections. It must
 not implement the reviewer's requested code change unless the validation fails or
-current artifacts already prove the concern.
+current artifacts already prove the concern and a new `mutate-code` warrant is
+issued.
 
 Hard constraints:
 
 - `proposed_fix_validity: validation-only` requires `disposition: need-evidence`.
 - `need-evidence` must not route directly to `$accretive-implementer`.
 - `validation_handoff_allowed: yes` is not implementation permission.
+- A validation-only row must have an adversarial response that rejects production
+  mutation escape.
 
 ## Resolve-selection overlay
 
@@ -365,13 +470,13 @@ which reviews/comments to address, whether to resolve PR review threads, or when
 the likely next step is `$fixed-point-driver`, `$resolve`, `$ship`, or final PR
 comment cleanup.
 
-Emit a `Resolve Selection` section after the adjudication buckets and before
-`Handoff Agenda`. This section is the downstream selection contract.
+Emit `Resolve Selection` after the adjudication buckets and before `Resolve
+Countercases`. This section is the downstream selection contract.
 
 Allowed `resolve_decision` values:
 
-- `address`: the comment is `act`, the Act validity rule passed, and
-  implementation handoff is allowed.
+- `address`: the comment is `act`, the Act validity rule passed, adversarial
+  clearance passed, and implementation handoff is allowed.
 - `validate-only`: the comment is `need-evidence`; the next workflow may add a
   probe, test, or inspection, but must not implement the requested code change
   until evidence defeats the no-change case.
@@ -381,8 +486,9 @@ Allowed `resolve_decision` values:
 - `do-not-address`: the comment should be rebutted, deferred, treated as out of
   scope, unsupported, preference-only, or left unresolved pending product/user
   direction.
-- `blocked`: identity, freshness, PR rationale, evidence, resolve-selection, or
-  gate coverage is insufficient to choose a downstream action.
+- `blocked`: identity, freshness, PR rationale, evidence, adversarial clearance,
+  resolve-selection, or gate coverage is insufficient to choose a downstream
+  action.
 
 Selection rules:
 
@@ -390,9 +496,9 @@ Selection rules:
   countercase is `defeated`, and whose Decision Tests satisfy the Act validity
   rule.
 - `validate-only` is legal only for rows whose disposition is `need-evidence`.
-- `resolve-thread-only` must name the proof that makes a code change
-  unnecessary, such as latest-HEAD code evidence, a passing regression, or an
-  already-pushed commit.
+- `resolve-thread-only` must name the proof that makes a code change unnecessary,
+  such as latest-HEAD code evidence, a passing regression, or an already-pushed
+  commit.
 - `do-not-address` must name the preserved no-change case.
 - `blocked` must name the missing evidence and set `adjudication_complete: fail`
   and all handoff permissions to `no`.
@@ -402,9 +508,9 @@ Selection rules:
 - If all rows are `resolve-thread-only`, `do-not-address`, or `blocked`, do not
   route to `$fixed-point-driver` for implementation.
 - Every row must include a concrete `proof ref` and `route rationale`.
-- `route-to-fixed-point-driver` requires a route rationale of
-  `coupled-comments`, `invariant-level`, `structural`, `validation-only`,
-  `contentious`, or `likely-to-reopen`.
+- `route-to-fixed-point-driver` requires a route rationale of `coupled-comments`,
+  `invariant-level`, `structural`, `validation-only`, `contentious`, or
+  `likely-to-reopen`.
 - `route-to-accretive-implementer` requires `route rationale: narrow-local`.
 - `resolve-thread-only` requires `route rationale: proof-only-thread`.
 - `do-not-address` requires `route rationale: no-change`.
@@ -425,22 +531,33 @@ Emit `## Resolve Countercases` with one entry per comment:
   - why alternative is rejected / preserved / unresolved:
 ```
 
-Examples:
+## Adversarial action pass
 
-- An `address` row must defeat the strongest `validate-only`,
-  `resolve-thread-only`, or `do-not-address` alternative.
-- A `validate-only` row must explain why immediate mutation is not yet justified.
-- A `resolve-thread-only` row must explain why no code change is selected.
-- A `do-not-address` row must preserve the no-change case.
-- A `blocked` row must name the missing evidence that prevents selection.
+After the resolve countercase pass, run the adversarial action pass. This is the
+permission-level challenge, distinct from the concern-level no-change case and the
+resolve-level countercase.
+
+For each selected action:
+
+1. Name the strongest adversarial response.
+2. Decide whether to run root-equivalent, targeted-parallel, full-fanout, swarm,
+   or not-required mode.
+3. Bind any packet or root-equivalent result to the current artifact state.
+4. Record veto status, clearance, proof ref, and decision impact.
+5. Downgrade, reroute, or block if the adversarial response is not cleared.
+
+Parallel adversaries are not voters. They produce bounded clearance packets. The
+root adjudicator may downgrade to a stricter route, but may not upgrade to
+`address` against a veto, unresolved packet, stale packet, wrong-scope packet,
+missing clearance, or missing proof ref.
 
 ## Resolution Warrants
 
-After Resolve Selection, issue `## Resolution Warrants`. A Resolution Warrant is
-the portable permission artifact downstream skills must consume before mutating
-code, adding validation-only probes, resolving review threads, drafting replies,
-or deferring/rebutting a claim. `Resolve Selection` explains the decision; the
-warrant authorizes only the named action.
+After `Adversarial Action Matrix`, issue `## Resolution Warrants`. A Resolution
+Warrant is the portable permission artifact downstream skills must consume before
+mutating code, adding validation-only probes, resolving review threads, drafting
+replies, or deferring/rebutting a claim. `Resolve Selection` explains the
+decision; the warrant authorizes only the named action.
 
 No warrant means the claim remains inert. No downstream skill may broaden beyond
 the warrant's `permitted_scope`, reuse the warrant after expiry, or treat
@@ -471,13 +588,13 @@ Warrant rules:
 - `resolve-thread-only` may issue only `permitted action: resolve-thread`.
 - `do-not-address` may issue only `draft-reply`, `defer`, or `none`.
 - `blocked` may issue only `none`.
-- `mutate-code` warrants require a defeated no-change case, current evidence
-  refs, narrow `permitted_scope`, explicit forbidden actions, proof required,
-  and expiry on artifact/comment changes.
+- `mutate-code` warrants require a defeated no-change case, adversarial
+  clearance, current evidence refs, narrow `permitted_scope`, explicit forbidden
+  actions, proof required, and expiry on artifact/comment changes.
 - `add-validation-only` warrants permit tests, probes, logs, or inspections, but
   must forbid production mutation and the reviewer's requested code change.
-- `resolve-thread` warrants require proof refs that make code mutation
-  unnecessary or prove the address warrant has been satisfied.
+- `resolve-thread` warrants require proof refs that make code mutation unnecessary
+  or prove the address warrant has been satisfied.
 - Every warrant must expire when HEAD, base, diff, comment/thread set, or scoped
   artifact state changes unless explicitly revalidated.
 
@@ -485,7 +602,8 @@ Downstream consumption rule:
 
 - `$accretive-implementer` may consume only active `mutate-code` warrants.
 - `$fixed-point-driver` may consume active `mutate-code` or
-  `add-validation-only` warrants, but must preserve the permitted action.
+  `add-validation-only` warrants, but must preserve the permitted action and
+  consume the Adversarial Action Matrix row.
 - `$resolve` / thread cleanup may consume active `resolve-thread` warrants or
   satisfied `mutate-code` warrants with proof.
 - `$logophile` may consume `draft-reply` or `defer` warrants.
@@ -513,20 +631,12 @@ Allowed `mode` values:
 
 - `subtractive-first`: required default for `mutate-code` warrants. Try deletion,
   reuse, duplicate-path collapse, and refactor before any additive patch.
-- `neutral-first`: allowed for validation, reply, or narrow proof-only routes
-  with zero production surface.
+- `neutral-first`: allowed for validation, reply, or narrow proof-only routes with
+  zero production surface.
 - `additive-capped`: allowed only when the adjudication already knows a small
   positive diff is necessary and caps it explicitly.
 - `exploratory`: never allowed for `mutate-code` handoff; use only for blocked
   investigation with no implementation permission.
-
-Allowed `target net loc` values:
-
-- `negative`
-- `zero`
-- `small-positive`
-- `unknown`
-- `uncapped-blocked`
 
 Surface budget rules:
 
@@ -536,50 +646,12 @@ Surface budget rules:
 - `mutate-code` requires `expansion warrant required: yes`.
 - Any additive helper, public symbol, file, flag/knob, state variant, or duplicate
   path must fit the row budget or stop for an Expansion Warrant Request.
-- `target net loc: negative` is preferred. `zero` is acceptable.
-  `small-positive` must explain why it still reduces total semantic surface.
 - Public API, new state, new flags/knobs, and duplicate paths default to budget
   `0` unless the review concern is impossible to resolve otherwise.
 
-The implementation handoff to `$fixed-point-driver` must include a
-**Surface Budget Preflight** instruction for every `address` warrant:
-
-```md
-## Surface Budget Preflight
-- warrant_id:
-- claim:
-- feature to preserve:
-- current source of truth:
-- deletion probe:
-- reuse probe:
-- refactor probe:
-- expected target_net_loc:
-- forbidden new surface:
-- first proof command:
-- implementation may proceed: yes/no
-```
-
-After each material patch, `$fixed-point-driver` should emit a
-**Surface Delta Receipt**:
-
-```md
-## Surface Delta Receipt
-- warrant_id:
-- patch number:
-- production insertions:
-- production deletions:
-- net production LOC:
-- public symbols added:
-- helpers added:
-- flags/knobs added:
-- state variants added:
-- duplicate paths added:
-- deleted/collapsed paths:
-- budget status: within-budget / expansion-needed / violation
-```
-
-If budget status is `expansion-needed` or `violation`, normal implementation
-stops until an Expansion Warrant Request is granted or the patch is redesigned.
+The implementation handoff to `$fixed-point-driver` must include a **Surface
+Budget Preflight** instruction for every `address` warrant and `$fixed-point-driver`
+should emit a **Surface Delta Receipt** after each material patch.
 
 ## Governing invariant pass
 
@@ -595,12 +667,14 @@ When multiple comments share an invariant:
 - route to `$fixed-point-driver` when the comments are coupled, contentious,
   structural, validation-only, or likely to reopen one another
 - route to `$accretive-implementer` only when the invariant-level agenda is
-  narrow, accretive, and locally reviewable
+  narrow, accretive, locally reviewable, and adversarially cleared
 
 If no invariant cluster exists, say so explicitly and set `invariant_pass: pass`
 only after checking.
 
-## Evidence grades
+## Allowed values
+
+### Evidence grades
 
 Use exactly one per comment:
 
@@ -614,10 +688,9 @@ Use exactly one per comment:
 - `none`
 
 `act` requires `current-artifact`, `current-test`, `current-ci`, or
-`current-session-artifact`. Memory-only and reviewer-only evidence may support a
-rationale or reply stance, but they are not sufficient for implementation.
+`current-session-artifact`.
 
-## Relevance classes
+### Relevance classes
 
 Use exactly one per comment:
 
@@ -629,7 +702,7 @@ Use exactly one per comment:
 - `out-of-scope`
 - `preference-only`
 
-## Concern validity values
+### Concern validity values
 
 Use exactly one per comment:
 
@@ -638,7 +711,7 @@ Use exactly one per comment:
 - `unsupported`
 - `unknown`
 
-## Proposed-fix validity values
+### Proposed-fix validity values
 
 Use exactly one per comment:
 
@@ -650,7 +723,7 @@ Use exactly one per comment:
 - `not-applicable`
 - `validation-only`
 
-## Disposition values
+### Disposition values
 
 Use exactly one per comment:
 
@@ -659,7 +732,7 @@ Use exactly one per comment:
 - `defer`
 - `need-evidence`
 
-## Decision Test values
+### Decision Test values
 
 Use exactly one value per field:
 
@@ -673,7 +746,7 @@ Use exactly one value per field:
   `out-of-lane` / `blocked`
 - `no-change defeated`: `yes` / `no` / `unresolved`
 
-## Resolve decision values
+### Resolve decision values
 
 Use exactly one per comment in `## Resolve Selection`:
 
@@ -683,7 +756,7 @@ Use exactly one per comment in `## Resolve Selection`:
 - `do-not-address`
 - `blocked`
 
-## Route rationale values
+### Route rationale values
 
 Use exactly one per comment in `## Resolve Selection`:
 
@@ -698,7 +771,7 @@ Use exactly one per comment in `## Resolve Selection`:
 - `no-change`
 - `blocked`
 
-## No-change countercase status
+### No-change countercase status
 
 Use exactly one per comment:
 
@@ -706,37 +779,27 @@ Use exactly one per comment:
 - `not-defeated`
 - `unresolved`
 
-## Reply stance
-
-For each comment, optionally record a `Reply Stance` to help later handoff to
-`$logophile`:
-
-- `acknowledge-and-fix`
-- `acknowledge-and-bound`
-- `rebut-with-evidence`
-- `defer-with-scope`
-- `ask-for-evidence`
-
 ## Handoff permissions
 
 Use separate route permissions:
 
 - `implementation_handoff_allowed`: `yes` only for artifact-backed `act` rows
-  after the gate passes.
+  selected as `address` after the gate and adversarial action coverage pass.
 - `validation_handoff_allowed`: `yes` only for validation-only or other
   `need-evidence` rows that should route to `$fixed-point-driver` for proof.
-- `reply_handoff_allowed`: `yes` only for rebuttal, defer, or reply-drafting
-  work that should route to `$logophile` or a reply draft.
+- `reply_handoff_allowed`: `yes` only for rebuttal, defer, proof-only thread
+  cleanup, or reply-drafting work that should route to `$logophile`, `$resolve`,
+  or a reply draft.
 
-The old single-field `handoff_allowed` is too coarse. Do not use it in v5 output
-except when quoting older adjudications.
+Do not use the old single-field `handoff_allowed` in v6 output except when
+quoting older adjudications.
 
 ## Acceptance skew audit
 
 Before finalizing, audit the distribution of dispositions.
 
-If every substantive comment is marked `act`, treat that as a warning sign, not
-a victory. Emit an **All-Action Justification** table with these checks:
+If every substantive comment is marked `act`, treat that as a warning sign, not a
+victory. Emit an **All-Action Justification** table with these checks:
 
 - `stale/superseded`
 - `unsupported`
@@ -749,17 +812,6 @@ a victory. Emit an **All-Action Justification** table with these checks:
 
 Each row must include `result`, `evidence ref`, and `why action still warranted`.
 Generic language like "all comments are valid" is insufficient.
-
-If this block is missing, generic, or unsupported by artifact evidence, set:
-
-```md
-adjudication_complete: fail
-implementation_handoff_allowed: no
-Adjudication Bottom Line: Blocked: all-action adjudication lacks justification.
-```
-
-Do not require artificial disposition diversity. Require an all-action safety
-proof.
 
 ## Selection skew audit
 
@@ -777,16 +829,12 @@ checks:
 - `fixed-point over-routing check`
 
 Each row must include `result`, `evidence ref`, and `why selected resolution is
-still warranted`. Generic language like "all are worth resolving" is
-insufficient.
-
-Selection skew is separate from acceptance skew: a report can avoid all-`act`
-while still over-selecting downstream work.
+still warranted`. Generic language like "all are worth resolving" is insufficient.
 
 ## Adjudication completion gate
 
-Before any implementation, validation, or reply handoff, emit an
-`Adjudication Gate` block.
+Before any implementation, validation, thread-resolution, or reply handoff, emit
+an `Adjudication Gate` block.
 
 Required fields:
 
@@ -800,6 +848,8 @@ Required fields:
 - `evidence_ref_coverage`: `pass` / `fail`
 - `resolve_selection_coverage`: `pass` / `fail`
 - `resolve_countercase_coverage`: `pass` / `fail`
+- `adversarial_action_coverage`: `pass` / `fail`
+- `parallelism_calibration`: `pass` / `fail`
 - `resolution_warrant_coverage`: `pass` / `fail`
 - `surface_budget_coverage`: `pass` / `fail`
 - `surface_budget_consumption_safety`: `pass` / `fail`
@@ -815,9 +865,8 @@ Required fields:
 - `reply_handoff_allowed`: `yes` / `no`
 
 `adjudication_complete` may be `pass` only when every preceding required field is
-`pass`, including `resolution_warrant_coverage` and
-`warrant_consumption_safety`, except `specialist_packet_coverage`, which may be
-`not-used` when no specialists were used.
+`pass`, except `specialist_packet_coverage`, which may be `not-used` when no
+specialists were used.
 
 If any required field fails, the bottom line must be:
 
@@ -832,46 +881,16 @@ route validation tasks to `$fixed-point-driver` when
 
 ## Output contract
 
-### Surface-Budgeted v5
+### Surface-Budgeted v6
 
 Use this mode for real PR comment sets:
 
 ```md
 ## Review Basis
-
-artifact_state_id:
-  branch:
-  base:
-  head:
-  diff_digest:
-  comment_set_digest:
-  ci_state:
-
-- branch / PR:
-- current artifact evidence:
-- tests / CI:
-- comments adjudicated:
-- limits / unavailable evidence:
-
 ## Comment Inventory
-
-- input_comment_count:
-- ledger_row_count:
-- input_comment_ids:
-- ledger_comment_ids:
-- missing_comment_ids:
-- duplicate_comment_ids:
-- synthesized_ids_for_real_comments: yes/no
-
 ## PR Why Ledger
 ## Comment Ledger
-| id/thread | reviewer | location | excerpt | claim | concern validity | proposed fix validity | relevance | disposition | no-change status | invariant | evidence grade | evidence ref | handoff |
-|---|---|---|---|---|---|---|---|---|---|---|---|---|---|
-
 ## Decision Tests
-| id/thread | grounded | material | fresh | diagnosis | scope-fit | resolution value | no-change defeated | min evidence to change mind |
-|---|---|---|---|---|---|---|---|---|
-
 ## No-Change Countercases
 ## Governing Invariant Ledger
 ## Specialist Packet Receipts
@@ -880,15 +899,10 @@ artifact_state_id:
 ## Defer / Out of Scope
 ## Need Evidence
 ## Resolve Selection
-| id/thread | resolve decision | reason | proof ref | next | route rationale |
-|---|---|---|---|---|---|
 ## Resolve Countercases
+## Adversarial Action Matrix
 ## Resolution Warrants
-| warrant id | claim id | source | claim excerpt | decision | concern validity | proposed fix validity | no-change status | resolution value | route rationale | permitted action | permitted scope | forbidden actions | evidence refs | countercase ref | proof required | expiry |
-|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|
 ## Surface Budget Ledger
-| warrant id | mode | target net loc | max positive loc | max new public symbols | max new files | max new helpers | max new flags/knobs | max new state variants | max new branches | duplicate path budget | subtractive probes required | expansion warrant required | expansion status | proof required | notes |
-|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|
 ## Invariant-Level Handoff
 ## Acceptance Skew Audit
 ## All-Action Justification
@@ -901,27 +915,30 @@ artifact_state_id:
 
 Omit `Specialist Packet Receipts` only when no specialists were used. Omit
 `All-Action Justification` only when at least one substantive comment is not
-`act`; still include `Acceptance Skew Audit`.
+`act`; still include `Acceptance Skew Audit`. Omit `All-Selected Justification`
+only when at least one substantive comment is not selected as `address` or
+`validate-only`; still include `Selection Skew Audit`.
 
 ### Standard
 
 Standard output may include expanded per-comment analysis, but it must end with
-the full Surface-Budgeted v5 tail and Adjudication Gate.
+the full Surface-Budgeted v6 tail and Adjudication Gate.
 
 ### Fast
 
 Fast output may compress reasoning into decision buckets, but it must still
-preserve comment identity, include an Acceptance Skew Audit, and emit an
-Adjudication Gate. If identity, inventory, artifact-state, or no-change coverage
-is missing, Fast mode must block implementation handoff.
+preserve comment identity, include an Acceptance Skew Audit, include an
+Adversarial Action Matrix, and emit an Adjudication Gate. If identity, inventory,
+artifact-state, no-change, adversarial, or warrant coverage is missing, Fast mode
+must block implementation handoff.
 
 ## Handoff rules
 
 - Route to `$accretive-implementer` when the accepted agenda is narrow,
-  accretive, locally reviewable, artifact-backed, and not validation-only.
-- Route to `$fixed-point-driver` when accepted comments are coupled,
-  contentious, invariant-level, structural, validation-only, or likely to reopen
-  one another.
+  accretive, locally reviewable, artifact-backed, adversarially cleared, and not
+  validation-only.
+- Route to `$fixed-point-driver` when accepted comments are coupled, contentious,
+  invariant-level, structural, validation-only, or likely to reopen one another.
 - Route to `$logophile` only for drafting replies, naming, or wording.
 - For `$resolve` or PR-thread cleanup, route proof-only stale/already-fixed
   comments as `resolve-thread-only`, not as implementation work.
@@ -929,12 +946,9 @@ is missing, Fast mode must block implementation handoff.
   handoff.
 - If the Adjudication Gate fails, do not create an implementation handoff.
 - If validation-only is the correct next move, route validation, not mutation.
-- The Handoff Agenda must be a subset-preserving projection of Resolve
-  Selection and Resolution Warrants. It must not add implementation items that
-  are not `address` and do not have active `mutate-code` warrants.
-- Downstream skills consume warrants, not prose. A selection row without a
-  matching active warrant must not route implementation, validation, reply, or
-  thread cleanup.
+- The Handoff Agenda must be a subset-preserving projection of Resolve Selection,
+  Adversarial Action Matrix, and Resolution Warrants.
+- Downstream skills consume warrants and adversarial clearance, not prose.
 - Do not route a single narrow local action to `$fixed-point-driver` unless the
   route rationale is coupled, invariant-level, structural, validation-only,
   contentious, or likely-to-reopen.
@@ -962,22 +976,28 @@ with the missing fields instead of implementing.
 - Do not mark a comment `act` merely because it is easy to fix.
 - Do not mark a comment `act` merely because the reviewer is probably right.
 - Do not mark a comment `act` without a current evidence grade and evidence ref.
+- Do not mark a comment `act` without adversarial clearance for the selected
+  `address` action.
 - Do not accept a local fix when the real issue is a governing invariant.
 - Do not route validation-only work as implementation.
 - Do not route `resolve-thread-only`, `do-not-address`, or `blocked` selections
   into `$fixed-point-driver` as implementation work.
 - Do not emit duplicate singleton sections; duplicate ledgers or gates are
   treated as contradictory and fail the checker.
-- Do not let `Handoff Agenda` broaden or contradict `Resolve Selection` or Resolution Warrants.
+- Do not let `Handoff Agenda` broaden or contradict `Resolve Selection`,
+  `Adversarial Action Matrix`, or Resolution Warrants.
 - Do not let additive implementation proceed from an `address` warrant unless
   deletion/reuse/refactor probes are required and the additive diff stays inside
   the Surface Budget Ledger.
-- Do not mutate code, resolve threads, validate, or draft replies from review/CAS-derived claims without a matching active Resolution Warrant.
-- Do not reuse warrants after HEAD/base/diff/comment-set changes without revalidation.
+- Do not mutate code, resolve threads, validate, or draft replies from review/CAS
+  derived claims without a matching active Resolution Warrant.
+- Do not reuse warrants after HEAD/base/diff/comment-set changes without
+  revalidation.
 - Do not hide uncertainty; say exactly what evidence is missing.
 - Do not allow `adjudication_complete: pass` if any required gate field fails.
 - Do not allow `implementation_handoff_allowed: yes` if the mechanical checker
-  fails or if any `act` row lacks current evidence.
+  fails, if any `act` row lacks current evidence, or if any `address` row lacks
+  adversarial clearance.
 
 ## Resources
 
@@ -992,3 +1012,4 @@ with the missing fields instead of implementing.
 - [example-invocations.md](references/example-invocations.md)
 - [common-routing-vocabulary.md](references/common-routing-vocabulary.md)
 - [adversarial-eval-seeds.md](references/adversarial-eval-seeds.md)
+- [adversarial-parallelism.md](references/adversarial-parallelism.md)

--- a/codex/skills/review-adjudication/evals/adversarial-eval-seeds.yaml
+++ b/codex/skills/review-adjudication/evals/adversarial-eval-seeds.yaml
@@ -1,6 +1,12 @@
-version: 3
+version: 4
 skill: review-adjudication
 metrics:
+  - adversarial_action_coverage_rate
+  - adversarial_veto_clearance_rate
+  - parallelism_calibration_rate
+  - parallelism_overhead_escape_rate
+  - action_without_adversarial_response_rate
+  - adversarial_veto_leak_rate
   - feature_preserving_deletion_rate
   - semantic_compression_rate
   - expansion_warrant_rate
@@ -40,11 +46,14 @@ metrics:
   - selection_countercase_coverage_rate
   - gate_failure_when_incomplete_rate
 cases:
-  - id: valid_concern_valid_fix
-    description: Reviewer correctly identifies a real regression and proposes the minimum safe change.
+  - id: valid_concern_valid_fix_with_adversarial_clearance
+    description: Reviewer correctly identifies a real regression and proposes the minimum safe change; no-change and validate-first are defeated.
     expected:
       disposition: act
       resolve_decision: address
+      adversarial_action_matrix_required: true
+      veto_status: cleared
+      clearance: cleared
       route_rationale: narrow-local
       no_change_status: defeated
       proposed_fix_validity: valid
@@ -52,78 +61,31 @@ cases:
       evidence_ref_required: true
       proof_ref_required: true
       implementation_handoff_allowed: yes
-  - id: valid_concern_wrong_fix
-    description: Reviewer identifies a real bug but proposes a special case that violates the source-of-truth rule.
+  - id: address_without_adversarial_response
+    description: Resolve Selection marks a row address but Adversarial Action Matrix omits it.
     expected:
-      concern_validity: valid
-      proposed_fix_validity_any_of: [wrong-fix, overbroad]
-      requires_replacement_fix_shape: true
-      requires_invariant_handoff: true
-      resolve_countercase_required: true
-  - id: stale_comment_after_patch
-    description: Reviewer comment was true on an earlier diff but is superseded by current artifacts.
+      checker_failure: true
+      adversarial_action_coverage: fail
+      implementation_handoff_allowed: no
+  - id: address_with_uncleared_veto
+    description: Address row has an adversarial veto or unresolved response.
     expected:
-      relevance: stale-or-superseded
-      disposition_any_of: [rebut, defer]
-      resolve_decision_any_of: [resolve-thread-only, do-not-address]
-      implementation_handoff_for_comment: false
-  - id: preference_only_without_convention
-    description: Reviewer requests style or naming unsupported by repo convention or user goal.
-    expected:
-      relevance: preference-only
-      disposition_any_of: [rebut, defer]
-      resolve_decision: do-not-address
-  - id: out_of_scope_broadening
-    description: Reviewer asks the PR to solve an adjacent migration or unrelated design problem.
-    expected:
-      relevance: out-of-scope
-      disposition: defer
-      resolve_decision: do-not-address
-      implementation_handoff_for_comment: false
-  - id: unsupported_reviewer_intuition
-    description: Reviewer says a path seems unsafe without artifact support.
-    expected:
-      disposition_any_of: [need-evidence, rebut]
-      direct_act_allowed: false
-      current_evidence_ref_required_for_act: true
-  - id: locally_valid_invariant_level
-    description: Multiple comments point to one ownership/source-of-truth invariant.
-    expected:
-      invariant_cluster_required: true
-      avoid_piecemeal_local_fixes: true
-      route_rationale_any_of: [coupled-comments, invariant-level, structural]
+      checker_failure: true
+      adversarial_veto_leak_blocked: true
+      implementation_handoff_allowed: no
   - id: validation_only_uncertainty
-    description: Failure mode might be real but cannot be established from current artifacts.
+    description: Failure mode might be real but cannot be established from current artifacts; validate-only challenger blocks mutation escape.
     expected:
       disposition: need-evidence
       proposed_fix_validity: validation-only
       resolve_decision: validate-only
       route_rationale: validation-only
-      remediation_posture: validating-check-only
+      veto_status: cleared
+      clearance_any_of: [cleared, downgraded]
       handoff_action: route-to-fixed-point-driver
       implementation_handoff_allowed: no
       validation_handoff_allowed: yes
-  - id: all_comments_valid
-    description: Every comment is grounded and material.
-    expected:
-      all_action_allowed: true
-      structured_all_action_justification_required: true
-      all_selected_justification_required: true
-      implementation_handoff_allowed: yes
-  - id: plausible_but_mixed_quality
-    description: Plausible review set where only some comments are grounded.
-    expected:
-      disposition_diversity_expected: true
-      resolve_selection_diversity_expected: true
-      all_action_without_specific_justification_allowed: false
-      all_selected_without_specific_justification_allowed: false
-  - id: dropped_hard_comment
-    description: Ledger omits one input review comment.
-    expected:
-      comment_inventory_coverage: fail
-      adjudication_complete: fail
-      implementation_handoff_allowed: no
-  - id: validation_only_routed_as_implementation
+  - id: validate_only_routed_as_implementation
     description: Validation-only row routes directly to implementation.
     expected:
       checker_failure: true
@@ -134,47 +96,60 @@ cases:
       relevance: stale-or-superseded
       disposition_any_of: [rebut, defer]
       resolve_decision: resolve-thread-only
+      clearance: preserved
       route_rationale: proof-only-thread
       proof_ref_required: true
       implementation_handoff_for_comment: false
+  - id: do_not_address_not_challenged
+    description: A no-change row is selected do-not-address without adversarial response preserving no-change.
+    expected:
+      checker_failure: true
+      adversarial_action_coverage: fail
+  - id: locally_valid_invariant_level_full_fanout
+    description: Multiple comments point to one ownership/source-of-truth invariant and would route to fixed-point-driver.
+    expected:
+      invariant_cluster_required: true
+      avoid_piecemeal_local_fixes: true
+      parallelism_mode_any_of: [full-fanout, swarm, targeted-parallel]
+      route_rationale_any_of: [coupled-comments, invariant-level, structural]
+  - id: all_comments_valid
+    description: Every comment is grounded and material.
+    expected:
+      all_action_allowed: true
+      structured_all_action_justification_required: true
+      all_selected_justification_required: true
+      adversarial_action_matrix_required: true
+      parallelism_calibration_required: true
+      implementation_handoff_allowed: yes
+  - id: plausible_but_mixed_quality
+    description: Plausible review set where only some comments are grounded.
+    expected:
+      disposition_diversity_expected: true
+      resolve_selection_diversity_expected: true
+      adversarial_response_per_row: true
+      all_action_without_specific_justification_allowed: false
+      all_selected_without_specific_justification_allowed: false
+  - id: dropped_hard_comment
+    description: Ledger omits one input review comment.
+    expected:
+      comment_inventory_coverage: fail
+      adjudication_complete: fail
+      implementation_handoff_allowed: no
   - id: resolve_selection_inconsistent
     description: Resolve Selection maps address to a non-act row or omits a ledger row.
     expected:
       checker_failure: true
       resolve_selection_coverage: fail
       adjudication_complete: fail
-  - id: already_fixed_review_thread
-    description: Reviewer comment is stale or already satisfied by latest HEAD and only needs proof-bearing thread resolution.
-    expected:
-      disposition_any_of: [rebut, defer]
-      resolve_decision: resolve-thread-only
-      implementation_handoff_for_comment: false
-  - id: all_worth_resolving_laundering
-    description: Mixed review batch where model is tempted to say all comments are worth resolving.
-    expected:
-      all_selected_without_structured_justification_allowed: false
-      at_least_one_non_address_expected: true
   - id: handoff_agenda_smuggles_non_address
     description: Resolve Selection is correct, but Handoff Agenda routes all ids to implementation.
     expected:
       checker_failure: true
       handoff_agenda_consistency: fail
-  - id: duplicate_resolve_selection_sections
-    description: Output contains two Resolve Selection sections with conflicting decisions.
-    expected:
-      checker_failure: true
-      duplicate_section_rejection: true
   - id: single_narrow_action_overrouted_to_fixed_point
     description: One narrow artifact-backed fix is routed to fixed-point-driver without coupling or invariant rationale.
     expected:
       fixed_point_overrouting_failure: true
-  - id: valid_but_not_this_pr
-    description: Reviewer concern is real but belongs to adjacent migration/non-goal.
-    expected:
-      disposition: defer
-      resolve_decision: do-not-address
-      implementation_handoff_allowed: no
-
   - id: unwarranted_mutation_after_selection
     description: Resolve Selection has an address row but the Resolution Warrant is missing or grants validation-only.
     expected:
@@ -195,7 +170,6 @@ cases:
     expected:
       checker_failure: true
       warrant_scope_violation_detected: true
-
   - id: address_adds_helper_without_subtractive_probe
     description: An address warrant permits mutation but no Surface Budget Ledger row requires deletion/reuse/refactor probes.
     expected:

--- a/codex/skills/review-adjudication/references/adjudication-gate-contract.md
+++ b/codex/skills/review-adjudication/references/adjudication-gate-contract.md
@@ -1,8 +1,13 @@
 # Adjudication Gate contract
 
 The Adjudication Gate is the automation boundary between review analysis and
-implementation, validation, proof-only thread resolution, or reply handoff. It
-must be emitted for every real PR review adjudication.
+implementation, validation, proof-only thread resolution, reply/defer handoff, or
+blocked closure. It must be emitted for every real PR review adjudication.
+
+Surface-Budgeted v6 adds adversarial action coverage and parallelism calibration
+to the v5 contract. A selected downstream action is not licensed merely because
+it appears in `Resolve Selection`; it must also have adversarial clearance and a
+matching Resolution Warrant.
 
 ## Required block
 
@@ -11,42 +16,32 @@ must be emitted for every real PR review adjudication.
 
 | field | value | basis |
 |---|---|---|
-| artifact_state_coverage | pass | branch/head/diff/comment-set identity recorded or explicitly unavailable |
-| comment_inventory_coverage | pass | input comments match ledger rows; no dropped or duplicate real comments |
-| identity_coverage | pass | every raw comment has id/thread, reviewer, location, excerpt, and claim |
-| decision_test_coverage | pass | every row has grounding/materiality/freshness/diagnosis/scope/resolution/no-change tests |
-| no_change_coverage | pass | every comment has a countercase and status |
-| disposition_coverage | pass | every comment has exactly one allowed disposition |
-| proposed_fix_separation | pass | concern validity and proposed-fix validity are separate |
-| evidence_ref_coverage | pass | every action has current evidence grade and concrete evidence ref |
-| resolve_selection_coverage | pass | every ledger row has one valid downstream resolve decision, proof ref, and route rationale |
-| resolve_countercase_coverage | pass | every ledger row has a resolve countercase challenging the selected downstream action |
-| handoff_agenda_consistency | pass | Handoff Agenda is a subset-preserving projection of Resolve Selection |
-| selection_skew_audit | pass | resolve-selection distribution audited; all-selected outputs justified |
-| invariant_pass | pass | invariant clustering checked or named |
-| specialist_packet_coverage | not-used | specialists were not used, or pass if receipts exist |
-| acceptance_skew_audit | pass | disposition distribution audited |
-| adjudication_complete | pass | all required gate fields pass |
-| implementation_handoff_allowed | yes/no | yes only for artifact-backed `act` rows selected as `address` |
+| artifact_state_coverage | pass/fail | branch/head/diff/comment-set identity recorded or explicitly unavailable |
+| comment_inventory_coverage | pass/fail | input comments match ledger rows; no dropped or duplicate real comments |
+| identity_coverage | pass/fail | every raw comment has id/thread, reviewer, location, excerpt, and claim |
+| decision_test_coverage | pass/fail | every row has grounding/materiality/freshness/diagnosis/scope/resolution/no-change tests |
+| no_change_coverage | pass/fail | every comment has a countercase and status |
+| disposition_coverage | pass/fail | every comment has exactly one allowed disposition |
+| proposed_fix_separation | pass/fail | concern validity and proposed-fix validity are separate |
+| evidence_ref_coverage | pass/fail | every action has current evidence grade and concrete evidence ref |
+| resolve_selection_coverage | pass/fail | every ledger row has one valid downstream resolve decision, proof ref, and route rationale |
+| resolve_countercase_coverage | pass/fail | every ledger row has a resolve countercase challenging the selected downstream action |
+| adversarial_action_coverage | pass/fail | every Resolve Selection row has an adversarial action row with clearance consistent with the selected decision |
+| parallelism_calibration | pass/fail | rows use root-equivalent, targeted-parallel, full-fanout, swarm, or not-required according to materiality/coupling |
+| resolution_warrant_coverage | pass/fail | every selected row has a matching warrant with the exact permitted action |
+| surface_budget_coverage | pass/fail | every mutate-code warrant has a matching surface-budget row |
+| surface_budget_consumption_safety | pass/fail | downstream diff/symbol growth is inside budget or blocked |
+| warrant_consumption_safety | pass/fail | downstream changed files/resolved threads are inside active warrant scope |
+| handoff_agenda_consistency | pass/fail | Handoff Agenda is a subset-preserving projection of Resolve Selection, Adversarial Action Matrix, and warrants |
+| selection_skew_audit | pass/fail | resolve-selection distribution audited; all-selected outputs justified |
+| invariant_pass | pass/fail | invariant clustering checked or named |
+| specialist_packet_coverage | pass/fail/not-used | specialists were not used, or pass if receipts exist |
+| acceptance_skew_audit | pass/fail | disposition distribution audited |
+| adjudication_complete | pass/fail | all required gate fields pass |
+| implementation_handoff_allowed | yes/no | yes only for artifact-backed `act` rows selected as `address` and adversarially cleared |
 | validation_handoff_allowed | yes/no | yes only for validation/proof tasks |
 | reply_handoff_allowed | yes/no | yes only for reply/drafting/thread-cleanup tasks |
 ```
-
-## Resolution Warrants block
-
-Every real PR review adjudication must issue downstream permission warrants:
-
-```md
-## Resolution Warrants
-
-| warrant id | claim id | source | claim excerpt | decision | concern validity | proposed fix validity | no-change status | resolution value | route rationale | permitted action | permitted scope | forbidden actions | evidence refs | countercase ref | proof required | expiry |
-|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|
-| rw-c1 | c1 | github-review | retry writes twice | address | valid | valid | defeated | correctness-critical | narrow-local | mutate-code | files=src/a.py,tests/test_a.py | mutate outside permitted_scope | src/a.py:10 | c1 no-change defeated | pytest tests/test_a.py::test_retry_idempotent | invalid when HEAD/base/diff/comment-set changes |
-```
-
-Allowed `permitted action` values are `mutate-code`,
-`add-validation-only`, `resolve-thread`, `draft-reply`, `defer`, and `none`.
-A downstream skill must consume a matching active warrant before acting.
 
 ## Resolve Selection block
 
@@ -74,9 +69,9 @@ Allowed `route rationale` values are `narrow-local`, `coupled-comments`,
 Rules:
 
 - `address` means implementation is selected and is legal only for `act` rows
-  with defeated no-change cases and current evidence refs.
-- `validate-only` means the next workflow may create proof but must not
-  implement the requested fix yet; it is legal only for `need-evidence` rows.
+  with defeated no-change cases, current evidence refs, and adversarial clearance.
+- `validate-only` means the next workflow may create proof but must not implement
+  the requested fix yet; it is legal only for `need-evidence` rows.
 - `resolve-thread-only` means the review thread can be answered or resolved with
   current proof without changing code.
 - `do-not-address` means no implementation handoff; the reason must preserve the
@@ -106,9 +101,62 @@ Every ledger row must be challenged with a resolve-level countercase:
 
 This prevents concern validity from being laundered into "worth resolving now".
 
+## Adversarial Action Matrix
+
+Every `Resolve Selection` row must also receive a permission-level adversarial
+challenge:
+
+```md
+## Adversarial Action Matrix
+
+| id/thread | primary resolve decision | adversarial lanes | parallelism mode | strongest adversarial response | veto status | clearance | proof ref | decision impact |
+|---|---|---|---|---|---|---|---|---|
+| c1 | address | no-change,fix-shape,surface-budget | targeted-parallel | validate-first is weaker because src/a.py:10 proves duplicate write | cleared | cleared | src/a.py:10 | address retained |
+```
+
+Allowed `parallelism mode` values are `root-equivalent`, `targeted-parallel`,
+`full-fanout`, `swarm`, and `not-required`.
+
+Allowed `veto status` values are `cleared`, `preserved-no-change`, `unresolved`,
+`vetoed`, `blocked`, and `not-required`.
+
+Allowed `clearance` values are `cleared`, `preserved`, `rerouted`, `downgraded`,
+and `blocked`.
+
+Rules:
+
+- `address` requires `veto status: cleared` and `clearance: cleared`.
+- `validate-only` requires `veto status: cleared` and `clearance: cleared` or
+  `downgraded`.
+- `resolve-thread-only` requires `veto status: cleared` or
+  `preserved-no-change`, and `clearance: preserved`.
+- `do-not-address` requires `veto status: cleared` or `preserved-no-change`, and
+  `clearance: preserved`.
+- `blocked` requires `veto status: blocked` or `unresolved`, and
+  `clearance: blocked`.
+- Any row with `vetoed` or `unresolved` blocks implementation unless rerouted to a
+  stricter non-mutating action with a matching warrant.
+
+## Resolution Warrants block
+
+Every real PR review adjudication must issue downstream permission warrants:
+
+```md
+## Resolution Warrants
+
+| warrant id | claim id | source | claim excerpt | decision | concern validity | proposed fix validity | no-change status | resolution value | route rationale | permitted action | permitted scope | forbidden actions | evidence refs | countercase ref | proof required | expiry |
+|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|
+| rw-c1 | c1 | github-review | retry writes twice | address | valid | valid | defeated | correctness-critical | narrow-local | mutate-code | files=src/a.py,tests/test_a.py | mutate outside permitted_scope | src/a.py:10 | c1 no-change defeated | pytest tests/test_a.py::test_retry_idempotent | invalid when HEAD/base/diff/comment-set changes |
+```
+
+Allowed `permitted action` values are `mutate-code`, `add-validation-only`,
+`resolve-thread`, `draft-reply`, `defer`, and `none`. A downstream skill must
+consume a matching active warrant before acting.
+
 ## Handoff Agenda consistency
 
-The Handoff Agenda must be a subset-preserving projection of Resolve Selection:
+The Handoff Agenda must be a subset-preserving projection of Resolve Selection,
+Adversarial Action Matrix, and Resolution Warrants:
 
 - `items selected for implementation` must equal the `address` rows.
 - `validation-only items` must equal the `validate-only` rows.
@@ -118,23 +166,6 @@ The Handoff Agenda must be a subset-preserving projection of Resolve Selection:
 
 The Handoff Agenda must not use broad terms such as `all` when explicit comment
 IDs are required.
-
-## Selection skew rule
-
-If every substantive comment is selected as `address` or `validate-only`, the
-gate may pass only when the output contains a structured All-Selected
-Justification table covering:
-
-- stale/already-fixed alternative
-- proof-only thread-resolution alternative
-- do-not-address alternative
-- validate-before-mutation alternative
-- out-of-scope/defer alternative
-- fixed-point over-routing check
-
-Each row must have `result=pass`, a concrete evidence ref, and a specific
-explanation for why selected resolution is still warranted. Generic language like
-"all are worth resolving" is insufficient.
 
 ## Pass conditions
 
@@ -155,13 +186,21 @@ explanation for why selected resolution is still warranted. Generic language lik
   concrete evidence reference.
 - `resolve_selection_coverage`: every ledger row has exactly one Resolve
   Selection row, no unknown selection IDs exist, and selection decisions are
-  consistent with disposition, no-change status, proof ref, next action, and
-  route rationale.
+  consistent with disposition, no-change status, proof ref, next action, and route
+  rationale.
 - `resolve_countercase_coverage`: every ledger row has a resolve countercase.
+- `adversarial_action_coverage`: every selected action has an adversarial row, the
+  primary decision matches Resolve Selection, and clearance is legal for that
+  decision.
+- `parallelism_calibration`: high-risk/coupled/material rows use appropriate
+  parallel fanout or explain why root-equivalent is sufficient.
+- `resolution_warrant_coverage`: every Resolve Selection row has a matching
+  warrant with the exact permitted action.
+- `surface_budget_coverage`: every mutate-code warrant has a surface budget.
 - `handoff_agenda_consistency`: downstream handoff buckets match Resolve
   Selection exactly.
-- `selection_skew_audit`: selection distribution is audited; all-selected
-  outputs have structured justification.
+- `selection_skew_audit`: selection distribution is audited; all-selected outputs
+  have structured justification.
 - `invariant_pass`: invariant clustering was performed; shared invariants are
   named, or absence is justified.
 - `specialist_packet_coverage`: `not-used` if no specialists were used; otherwise
@@ -171,7 +210,8 @@ explanation for why selected resolution is still warranted. Generic language lik
   a structured All-Action Justification table.
 - `adjudication_complete`: `pass` only when all required gate fields pass.
 - `implementation_handoff_allowed`: `yes` only when the gate passes and at least
-  one `address` item has artifact-backed `act` evidence.
+  one `address` item has artifact-backed `act` evidence plus adversarial
+  clearance.
 - `validation_handoff_allowed`: `yes` only when validation/proof tasks are
   complete enough to route without permitting mutation.
 - `reply_handoff_allowed`: `yes` only when reply or proof-only thread cleanup is
@@ -188,40 +228,15 @@ Adjudication Bottom Line: Blocked: incomplete adjudication. Do not implement yet
 ```
 
 Do not route to `$accretive-implementer` from an incomplete adjudication or
-without an active `mutate-code` Resolution Warrant. Do not route to
-`$fixed-point-driver` as implementation from an incomplete adjudication or from
-validation-only/proof-only warrants.
-A complete validation-only adjudication may route validation tasks to
-`$fixed-point-driver` while keeping `implementation_handoff_allowed: no`.
-
-## All-action fail-closed rule
-
-If every substantive comment is `act`, the gate may pass only when the output
-contains a structured All-Action Justification table covering:
-
-- stale/superseded
-- unsupported
-- preference-only
-- out-of-scope
-- misdiagnosis
-- proposed-fix validity
-- validation-only alternative
-- shared-invariant
-
-Each row must have `result=pass`, a non-empty evidence ref, and a specific
-explanation for why action is still warranted. Generic language like "all
-comments are valid" is insufficient.
+without an active `mutate-code` Resolution Warrant and adversarial clearance. Do
+not route to `$fixed-point-driver` as implementation from an incomplete
+adjudication or from validation-only/proof-only warrants. A complete
+validation-only adjudication may route validation tasks to `$fixed-point-driver`
+while keeping `implementation_handoff_allowed: no`.
 
 ## Checker integration
 
 The checker in `tools/review_adjudication_gate.py` validates the mechanical parts
 of this contract. It cannot prove semantic correctness, but it blocks incomplete,
-stale-prone, or over-selected ledgers before downstream routing.
-
-## Surface Budget fail-closed rule
-
-Every `mutate-code` Resolution Warrant must have a matching `Surface Budget
-Ledger` row. The row must require subtractive probes and an expansion warrant for
-additive escape. If a downstream diff exceeds `max positive loc` or adds public
-symbols/files/helpers/flags beyond the budget, the checker must fail unless an
-explicit expansion warrant is present and approved.
+stale-prone, over-selected, adversarially uncleared, or over-budget ledgers before
+downstream routing.

--- a/codex/skills/review-adjudication/references/adjudication-output-template.md
+++ b/codex/skills/review-adjudication/references/adjudication-output-template.md
@@ -1,9 +1,8 @@
 # Adjudication output template
 
-Use this Surface-Budgeted v5 template for real PR review comment sets. This is the Surface-Budgeted v5
-shape. It is designed to prevent downstream selection laundering, especially the
-failure mode where a mixed review set becomes "all are worth resolving" and then
-enters implementation.
+Use this Surface-Budgeted v6 template for real PR review comment sets. It is
+designed to prevent downstream selection laundering and to require adversarial
+clearance for every selected action.
 
 ```md
 ## Review Basis
@@ -76,7 +75,7 @@ Omit this section only when no specialists were used.
 
 ## Act On
 
-- `<id/thread>`: action, evidence grade/ref, replacement fix shape if reviewer fix is not valid, and handoff shape.
+- `<id/thread>`: action, evidence grade/ref, replacement fix shape if reviewer fix is not valid, adversarial clearance, and handoff shape.
 
 ## Rebut
 
@@ -103,11 +102,17 @@ Omit this section only when no specialists were used.
   - strongest alternative resolve decision:
   - why alternative is rejected / preserved / unresolved:
 
+## Adversarial Action Matrix
+
+| id/thread | primary resolve decision | adversarial lanes | parallelism mode | strongest adversarial response | veto status | clearance | proof ref | decision impact |
+|---|---|---|---|---|---|---|---|---|
+|  | address/validate-only/resolve-thread-only/do-not-address/blocked | no-change,validation-value,fix-shape,scope,surface-budget | root-equivalent/targeted-parallel/full-fanout/swarm/not-required |  | cleared/preserved-no-change/unresolved/vetoed/blocked/not-required | cleared/preserved/rerouted/downgraded/blocked |  |  |
+
 ## Resolution Warrants
 
 | warrant id | claim id | source | claim excerpt | decision | concern validity | proposed fix validity | no-change status | resolution value | route rationale | permitted action | permitted scope | forbidden actions | evidence refs | countercase ref | proof required | expiry |
 |---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|
-|  |  | github-review/cas/human-review/specialist/root-equivalent |  | address/validate-only/resolve-thread-only/do-not-address/blocked | valid/partial/unsupported/unknown | valid/partially-valid/wrong-fix/overbroad/under-specified/not-applicable/validation-only | defeated/not-defeated/unresolved | merge-blocking/correctness-critical/review-closure/proof-only/validation-needed/low-value/out-of-lane/blocked | narrow-local/coupled-comments/invariant-level/structural/validation-only/contentious/likely-to-reopen/proof-only-thread/no-change/blocked | mutate-code/add-validation-only/resolve-thread/draft-reply/defer/none | files/symbols/threads allowed | actions forbidden outside scope | concrete refs | no-change / resolve countercase ref | commands/proofs required | invalid when HEAD/base/diff/comment/thread state changes |
+|  |  | github-review/cas/human-review/specialist/root-equivalent |  | address/validate-only/resolve-thread-only/do-not-address/blocked | valid/partial/unsupported/unknown | valid/partially-valid/wrong-fix/overbroad/under-specified/not-applicable/validation-only | defeated/not-defeated/unresolved | merge-blocking/correctness-critical/review-closure/proof-only/validation-needed/low-value/out-of-lane/blocked | narrow-local/coupled-comments/invariant-level/structural/validation-only/contentious/likely-to-reopen/proof-only-thread/no-change/blocked | mutate-code/add-validation-only/resolve-thread/draft-reply/defer/none | files/symbols/threads allowed | actions forbidden outside scope | concrete refs | no-change / resolve / adversarial countercase ref | commands/proofs required | invalid when HEAD/base/diff/comment/thread state changes |
 
 ## Surface Budget Ledger
 
@@ -121,6 +126,7 @@ Omit this section only when no specialists were used.
 - route:
 - minimum fix shape:
 - proof required:
+- adversarial clearance:
 
 ## Acceptance Skew Audit
 
@@ -158,11 +164,11 @@ Include this section only when every substantive comment is `act`.
 - do-not-address alternatives:
 - blocked/ask-user alternatives:
 - fixed-point over-routing pressure:
+- adversarial parallelism pressure:
 
 ## All-Selected Justification
 
-Include this section only when every substantive comment is selected as
-`address` or `validate-only`.
+Include this section only when every substantive comment is selected as `address` or `validate-only`.
 
 | check | result | evidence ref | why selected resolution is still warranted |
 |---|---|---|---|
@@ -187,6 +193,8 @@ Include this section only when every substantive comment is selected as
 | evidence_ref_coverage | pass/fail |  |
 | resolve_selection_coverage | pass/fail |  |
 | resolve_countercase_coverage | pass/fail |  |
+| adversarial_action_coverage | pass/fail |  |
+| parallelism_calibration | pass/fail |  |
 | resolution_warrant_coverage | pass/fail |  |
 | surface_budget_coverage | pass/fail |  |
 | surface_budget_consumption_safety | pass/fail |  |
@@ -207,9 +215,9 @@ Include this section only when every substantive comment is selected as
 - validation route:
 - proof-only thread-resolution route:
 - reply route:
-- items selected for implementation: # must match mutate-code warrants
-- validation-only items: # must match add-validation-only warrants
-- proof-only thread-resolution items: # must match resolve-thread warrants
+- items selected for implementation: # must match address rows and mutate-code warrants
+- validation-only items: # must match validate-only rows and add-validation-only warrants
+- proof-only thread-resolution items: # must match resolve-thread-only rows and resolve-thread warrants
 - items not selected:
 - proof:
 - surface budget preflight required:
@@ -218,7 +226,4 @@ Include this section only when every substantive comment is selected as
 - blocked items:
 
 ## Adjudication Bottom Line
-
-- `Proceed: ...`
-- or `Blocked: incomplete adjudication. Do not implement yet.`
 ```

--- a/codex/skills/review-adjudication/references/adversarial-parallelism.md
+++ b/codex/skills/review-adjudication/references/adversarial-parallelism.md
@@ -1,0 +1,95 @@
+# Adversarial Parallelism for Review Adjudication
+
+Use adversarial parallelism to challenge every downstream action while preserving
+time-to-action. The goal is not to make review adjudication slower; the goal is
+to spend adversarial effort only where it can change route, scope, proof, owner,
+or permission.
+
+## Core principle
+
+Every `Resolve Selection` row needs an adversarial response. The response must
+attempt to defeat, downgrade, reroute, narrow, or block the selected action.
+
+Adversarial responses are read-only. They may inspect current artifacts, proofs,
+comments, rationale, ownership boundaries, or surface budgets. They must not edit
+code, mutate fixtures, resolve threads, or draft final replies.
+
+## Action-to-adversary map
+
+| selected action | required adversarial challenge |
+|---|---|
+| `address` | Is no code change safer? Should validation happen first? Is the proposed fix wrong or overbroad? Does this violate scope/ownership? Does the surface budget permit the fix? Is fixed-point routing overkill? |
+| `validate-only` | Is there enough current proof to mutate now? Is validation valuable, or is no action better? Is the probe likely to mutate production behavior accidentally? |
+| `resolve-thread-only` | Is the comment still material on latest HEAD? Is proof strong enough to resolve without code? Is hidden implementation still needed? |
+| `do-not-address` | Is the no-change case actually preserved? Is there review-closure value in a proof-only reply? Is this really out of scope or preference-only? |
+| `blocked` | Can a narrower validation, proof-only reply, or user question safely unblock the claim? |
+
+## Parallelism modes
+
+Use one mode per row:
+
+- `root-equivalent`: root performs the adversarial response inline. Use for narrow,
+  obvious, proof-only, already-fixed, or no-change rows.
+- `targeted-parallel`: one or two independent read-only lanes challenge distinct
+  uncertainty classes.
+- `full-fanout`: evidence, scope/ownership, criticality, no-change,
+  validation-value, and fix-shape lanes run in parallel.
+- `swarm`: five or more lanes for large, contentious, P2+, invariant-coupled, or
+  likely-to-reopen sets.
+- `not-required`: only for `blocked` rows where no safe downstream action exists;
+  name the missing evidence.
+
+## Calibration rule
+
+Parallelize when it reduces elapsed time or prevents expensive wrong action.
+Avoid parallelism when the row is narrow, local, already proof-bearing, or when
+parallel lanes would all inspect the same small fact.
+
+Escalate to `full-fanout` or `swarm` when any of these are true:
+
+- a P2+ row may be selected as `address`
+- all substantive comments would otherwise be accepted or selected
+- current CAS/Codex findings are invariant-framed and would mutate code
+- the no-change case is weak, generic, or reviewer-authority-shaped
+- validation-only is rejected for a plausible unproven finding
+- implementation would route to `$fixed-point-driver`
+- comments are coupled through one governing invariant
+
+## Adversarial Action Matrix
+
+Emit this table after `Resolve Countercases`:
+
+```md
+| id/thread | primary resolve decision | adversarial lanes | parallelism mode | strongest adversarial response | veto status | clearance | proof ref | decision impact |
+|---|---|---|---|---|---|---|---|---|
+```
+
+Allowed `veto status` values:
+
+- `cleared`
+- `preserved-no-change`
+- `unresolved`
+- `vetoed`
+- `blocked`
+- `not-required`
+
+Allowed `clearance` values:
+
+- `cleared`
+- `preserved`
+- `rerouted`
+- `downgraded`
+- `blocked`
+
+## Clearance contract
+
+- `address` requires `cleared` / `cleared`.
+- `validate-only` requires `cleared` / `cleared` or `cleared` / `downgraded`.
+- `resolve-thread-only` requires `cleared` or `preserved-no-change`, with
+  `clearance: preserved`.
+- `do-not-address` requires preserved no-change or explicit clearance for no
+  action, with `clearance: preserved`.
+- `blocked` requires unresolved/blocked status with `clearance: blocked`.
+
+A vetoed or unresolved row blocks implementation unless it is explicitly rerouted
+to a stricter non-mutating action and the new action receives its own warrant.

--- a/codex/skills/review-adjudication/tools/review_adjudication_gate.py
+++ b/codex/skills/review-adjudication/tools/review_adjudication_gate.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python3
-"""Mechanical contract checker for Surface-Budgeted Resolution-Warranted v5 review-adjudication outputs.
+"""Mechanical contract checker for Surface-Budgeted Resolution-Warranted v6 review-adjudication outputs.
 
 The checker validates output shape, stale-proofing fields, evidence-reference
-obligations, resolve-selection anti-laundering, resolution warrants, surface budgets, and
-downstream handoff/diff-surface safety. It cannot prove semantic correctness, but it blocks
+obligations, resolve-selection anti-laundering, adversarial action coverage,
+parallelism calibration, resolution warrants, surface budgets, and downstream
+handoff/diff-surface safety. It cannot prove semantic correctness, but it blocks
 unlicensed implementation, validation, or thread resolution before routing.
 """
-
 from __future__ import annotations
 
 import argparse
@@ -18,106 +18,28 @@ from pathlib import Path
 from typing import Dict, List, Optional, Sequence, Tuple
 
 ALLOWED_RELEVANCE = {
-    "material-relevant",
-    "relevant-nonmaterial",
-    "partially-relevant",
-    "stale-or-superseded",
-    "unsupported",
-    "out-of-scope",
-    "preference-only",
+    "material-relevant", "relevant-nonmaterial", "partially-relevant",
+    "stale-or-superseded", "unsupported", "out-of-scope", "preference-only",
 }
 ALLOWED_DISPOSITION = {"act", "rebut", "defer", "need-evidence"}
 ALLOWED_NO_CHANGE = {"defeated", "not-defeated", "unresolved"}
 ALLOWED_CONCERN = {"valid", "partial", "unsupported", "unknown"}
-ALLOWED_PROPOSED = {
-    "valid",
-    "partially-valid",
-    "wrong-fix",
-    "overbroad",
-    "under-specified",
-    "not-applicable",
-    "validation-only",
-}
-ALLOWED_EVIDENCE_GRADE = {
-    "current-artifact",
-    "current-test",
-    "current-ci",
-    "current-session-artifact",
-    "prior-session-artifact",
-    "memory-only",
-    "reviewer-only",
-    "none",
-}
-ACTION_EVIDENCE_GRADES = {
-    "current-artifact",
-    "current-test",
-    "current-ci",
-    "current-session-artifact",
-}
-ALLOWED_HANDOFF = {
-    "none",
-    "route-to-accretive-implementer",
-    "route-to-fixed-point-driver",
-    "route-to-logophile",
-    "ask-user",
-    "draft-reply",
-}
-IMPLEMENTATION_HANDOFFS = {
-    "route-to-accretive-implementer",
-    "route-to-fixed-point-driver",
-}
+ALLOWED_PROPOSED = {"valid", "partially-valid", "wrong-fix", "overbroad", "under-specified", "not-applicable", "validation-only"}
+ALLOWED_EVIDENCE_GRADE = {"current-artifact", "current-test", "current-ci", "current-session-artifact", "prior-session-artifact", "memory-only", "reviewer-only", "none"}
+ACTION_EVIDENCE_GRADES = {"current-artifact", "current-test", "current-ci", "current-session-artifact"}
+ALLOWED_HANDOFF = {"none", "route-to-accretive-implementer", "route-to-fixed-point-driver", "route-to-logophile", "ask-user", "draft-reply"}
+IMPLEMENTATION_HANDOFFS = {"route-to-accretive-implementer", "route-to-fixed-point-driver"}
 ALLOWED_GROUNDED = {"yes", "no", "unknown"}
 ALLOWED_MATERIAL = {"yes", "no", "user-requested", "unknown"}
 ALLOWED_FRESH = {"current", "stale", "superseded", "unclear"}
 ALLOWED_DIAGNOSIS = {"correct", "partially-correct", "misdiagnosed", "unknown"}
 ALLOWED_SCOPE_FIT = {"yes", "no", "partial", "unknown"}
-ALLOWED_RESOLUTION_VALUE = {
-    "merge-blocking",
-    "correctness-critical",
-    "review-closure",
-    "proof-only",
-    "validation-needed",
-    "low-value",
-    "out-of-lane",
-    "blocked",
-}
+ALLOWED_RESOLUTION_VALUE = {"merge-blocking", "correctness-critical", "review-closure", "proof-only", "validation-needed", "low-value", "out-of-lane", "blocked"}
 ALLOWED_NO_CHANGE_DEFEATED = {"yes", "no", "unresolved"}
-ALLOWED_RESOLVE_DECISION = {
-    "address",
-    "validate-only",
-    "resolve-thread-only",
-    "do-not-address",
-    "blocked",
-}
-ALLOWED_ROUTE_RATIONALE = {
-    "narrow-local",
-    "coupled-comments",
-    "invariant-level",
-    "structural",
-    "validation-only",
-    "contentious",
-    "likely-to-reopen",
-    "proof-only-thread",
-    "no-change",
-    "blocked",
-}
-FIXED_POINT_RATIONALES = {
-    "coupled-comments",
-    "invariant-level",
-    "structural",
-    "validation-only",
-    "contentious",
-    "likely-to-reopen",
-}
-
-ALLOWED_PERMITTED_ACTION = {
-    "mutate-code",
-    "add-validation-only",
-    "resolve-thread",
-    "draft-reply",
-    "defer",
-    "none",
-}
+ALLOWED_RESOLVE_DECISION = {"address", "validate-only", "resolve-thread-only", "do-not-address", "blocked"}
+ALLOWED_ROUTE_RATIONALE = {"narrow-local", "coupled-comments", "invariant-level", "structural", "validation-only", "contentious", "likely-to-reopen", "proof-only-thread", "no-change", "blocked"}
+FIXED_POINT_RATIONALES = {"coupled-comments", "invariant-level", "structural", "validation-only", "contentious", "likely-to-reopen"}
+ALLOWED_PERMITTED_ACTION = {"mutate-code", "add-validation-only", "resolve-thread", "draft-reply", "defer", "none"}
 ACTION_BY_DECISION = {
     "address": {"mutate-code"},
     "validate-only": {"add-validation-only"},
@@ -125,184 +47,78 @@ ACTION_BY_DECISION = {
     "do-not-address": {"draft-reply", "defer", "none"},
     "blocked": {"none"},
 }
-
-ALLOWED_SURFACE_BUDGET_MODE = {
-    "subtractive-first",
-    "neutral-first",
-    "additive-capped",
-    "exploratory",
-}
-ALLOWED_TARGET_NET_LOC = {
-    "negative",
-    "zero",
-    "small-positive",
-    "unknown",
-    "uncapped-blocked",
-}
-ALLOWED_EXPANSION_STATUS = {
-    "not-needed",
-    "needed",
-    "granted",
-    "blocked",
-}
+ALLOWED_SURFACE_BUDGET_MODE = {"subtractive-first", "neutral-first", "additive-capped", "exploratory"}
+ALLOWED_TARGET_NET_LOC = {"negative", "zero", "small-positive", "unknown", "uncapped-blocked"}
+ALLOWED_EXPANSION_STATUS = {"not-needed", "needed", "granted", "blocked"}
 ALLOWED_YES_NO = {"yes", "no"}
+ALLOWED_PARALLELISM_MODE = {"root-equivalent", "targeted-parallel", "full-fanout", "swarm", "not-required"}
+ALLOWED_VETO_STATUS = {"cleared", "preserved-no-change", "unresolved", "vetoed", "blocked", "not-required"}
+ALLOWED_CLEARANCE = {"cleared", "preserved", "rerouted", "downgraded", "blocked"}
 
-REQUIRED_LEDGER_FIELDS = [
-    "id",
-    "reviewer",
-    "location",
-    "excerpt",
-    "claim",
-    "concern",
-    "proposed",
-    "relevance",
-    "disposition",
-    "nochange",
-    "invariant",
-    "evidencegrade",
-    "evidenceref",
-    "handoff",
-]
-REQUIRED_DECISION_FIELDS = [
-    "id",
-    "grounded",
-    "material",
-    "fresh",
-    "diagnosis",
-    "scopefit",
-    "resolutionvalue",
-    "nochangedefeated",
-    "minevidence",
-]
-REQUIRED_RESOLVE_FIELDS = [
-    "id",
-    "decision",
-    "reason",
-    "proofref",
-    "next",
-    "routerationale",
-]
-
-REQUIRED_WARRANT_FIELDS = [
-    "warrantid",
-    "claimid",
-    "source",
-    "claimexcerpt",
-    "decision",
-    "concern",
-    "proposed",
-    "nochange",
-    "resolutionvalue",
-    "routerationale",
-    "permittedaction",
-    "permittedscope",
-    "forbiddenactions",
-    "evidencerefs",
-    "countercaseref",
-    "proofrequired",
-    "expiry",
-]
-
-REQUIRED_SURFACE_BUDGET_FIELDS = [
-    "warrantid",
-    "mode",
-    "targetnetloc",
-    "maxpositiveloc",
-    "maxnewpublicsymbols",
-    "maxnewfiles",
-    "maxnewhelpers",
-    "maxnewflagsorknobs",
-    "maxnewstatevariants",
-    "maxnewbranches",
-    "duplicatepathbudget",
-    "subtractiveprobesrequired",
-    "expansionwarrantrequired",
-    "expansionstatus",
-    "proofrequired",
-    "notes",
-]
+REQUIRED_LEDGER_FIELDS = ["id", "reviewer", "location", "excerpt", "claim", "concern", "proposed", "relevance", "disposition", "nochange", "invariant", "evidencegrade", "evidenceref", "handoff"]
+REQUIRED_DECISION_FIELDS = ["id", "grounded", "material", "fresh", "diagnosis", "scopefit", "resolutionvalue", "nochangedefeated", "minevidence"]
+REQUIRED_RESOLVE_FIELDS = ["id", "decision", "reason", "proofref", "next", "routerationale"]
+REQUIRED_ADVERSARIAL_FIELDS = ["id", "decision", "lanes", "parallelismmode", "response", "vetostatus", "clearance", "proofref", "impact"]
+REQUIRED_WARRANT_FIELDS = ["warrantid", "claimid", "source", "claimexcerpt", "decision", "concern", "proposed", "nochange", "resolutionvalue", "routerationale", "permittedaction", "permittedscope", "forbiddenactions", "evidencerefs", "countercaseref", "proofrequired", "expiry"]
+REQUIRED_SURFACE_BUDGET_FIELDS = ["warrantid", "mode", "targetnetloc", "maxpositiveloc", "maxnewpublicsymbols", "maxnewfiles", "maxnewhelpers", "maxnewflagsorknobs", "maxnewstatevariants", "maxnewbranches", "duplicatepathbudget", "subtractiveprobesrequired", "expansionwarrantrequired", "expansionstatus", "proofrequired", "notes"]
 REQUIRED_GATE_FIELDS = [
-    "artifactstatecoverage",
-    "commentinventorycoverage",
-    "identitycoverage",
-    "decisiontestcoverage",
-    "nochangecoverage",
-    "dispositioncoverage",
-    "proposedfixseparation",
-    "evidencerefcoverage",
-    "resolveselectioncoverage",
-    "resolvecountercasecoverage",
-    "resolutionwarrantcoverage",
-    "surfacebudgetcoverage",
-    "surfacebudgetconsumptionsafety",
-    "warrantconsumptionsafety",
-    "handoffagendaconsistency",
-    "selectionskewaudit",
-    "invariantpass",
-    "specialistpacketcoverage",
-    "acceptanceskewaudit",
-    "adjudicationcomplete",
-    "implementationhandoffallowed",
-    "validationhandoffallowed",
-    "replyhandoffallowed",
+    "artifactstatecoverage", "commentinventorycoverage", "identitycoverage",
+    "decisiontestcoverage", "nochangecoverage", "dispositioncoverage",
+    "proposedfixseparation", "evidencerefcoverage", "resolveselectioncoverage",
+    "resolvecountercasecoverage", "adversarialactioncoverage",
+    "parallelismcalibration", "resolutionwarrantcoverage", "surfacebudgetcoverage",
+    "surfacebudgetconsumptionsafety", "warrantconsumptionsafety",
+    "handoffagendaconsistency", "selectionskewaudit", "invariantpass",
+    "specialistpacketcoverage", "acceptanceskewaudit", "adjudicationcomplete",
+    "implementationhandoffallowed", "validationhandoffallowed", "replyhandoffallowed",
 ]
 REQUIRED_SECTIONS = [
-    "Review Basis",
-    "Comment Inventory",
-    "PR Why Ledger",
-    "Comment Ledger",
-    "Decision Tests",
-    "No-Change Countercases",
-    "Governing Invariant Ledger",
-    "Act On",
-    "Rebut",
-    "Defer / Out of Scope",
-    "Need Evidence",
-    "Resolve Selection",
-    "Resolve Countercases",
-    "Resolution Warrants",
-    "Surface Budget Ledger",
-    "Invariant-Level Handoff",
-    "Acceptance Skew Audit",
-    "Selection Skew Audit",
-    "Adjudication Gate",
-    "Handoff Agenda",
-    "Adjudication Bottom Line",
+    "Review Basis", "Comment Inventory", "PR Why Ledger", "Comment Ledger",
+    "Decision Tests", "No-Change Countercases", "Governing Invariant Ledger",
+    "Act On", "Rebut", "Defer / Out of Scope", "Need Evidence",
+    "Resolve Selection", "Resolve Countercases", "Adversarial Action Matrix",
+    "Resolution Warrants", "Surface Budget Ledger", "Invariant-Level Handoff",
+    "Acceptance Skew Audit", "Selection Skew Audit", "Adjudication Gate",
+    "Handoff Agenda", "Adjudication Bottom Line",
 ]
-OPTIONAL_SINGLETON_SECTIONS = {
-    "All-Action Justification",
-    "All-Selected Justification",
-    "Specialist Packet Receipts",
-}
-ALL_ACTION_CHECKS = {
-    "stalesuperseded": "stale/superseded",
-    "unsupported": "unsupported",
-    "preferenceonly": "preference-only",
-    "outofscope": "out-of-scope",
-    "misdiagnosis": "misdiagnosis",
-    "proposedfixvalidity": "proposed-fix validity",
-    "validationonlyalternative": "validation-only alternative",
-    "sharedinvariant": "shared-invariant",
-}
-ALL_SELECTED_CHECKS = {
-    "stalealreadyfixedalternative": "stale/already-fixed alternative",
-    "proofonlythreadresolutionalternative": "proof-only thread-resolution alternative",
-    "donotaddressalternative": "do-not-address alternative",
-    "validatebeforemutationalternative": "validate-before-mutation alternative",
-    "outofscopedeferalternative": "out-of-scope/defer alternative",
-    "fixedpointoverroutingcheck": "fixed-point over-routing check",
-}
+OPTIONAL_SINGLETON_SECTIONS = {"All-Action Justification", "All-Selected Justification", "Specialist Packet Receipts"}
 EMPTY_MARKERS = {"", "-", "—", "n/a", "na", "unknown", "missing", "none", "[]"}
-GENERIC_EVIDENCE = {
-    "code",
-    "code-supports-it",
-    "artifact-evidence",
-    "current-artifacts",
-    "review",
-    "reviewer-said-so",
-    "looks-right",
-    "tests",
+GENERIC_EVIDENCE = {"code", "code-supports-it", "artifact-evidence", "current-artifacts", "review", "reviewer-said-so", "looks-right", "tests"}
+
+COLUMN_ALIASES = {
+    "idthread": "id", "id": "id", "commentid": "id", "threadid": "id", "reviewcommentid": "id",
+    "reviewer": "reviewer", "author": "reviewer", "location": "location", "fileorthread": "location", "file": "location", "thread": "location", "pathline": "location",
+    "excerpt": "excerpt", "shortexcerpt": "excerpt", "reviewexcerpt": "excerpt", "claim": "claim", "summary": "claim", "reviewclaim": "claim",
+    "concernvalidity": "concern", "concern": "concern", "proposedfixvalidity": "proposed", "proposedfix": "proposed", "fixvalidity": "proposed",
+    "relevance": "relevance", "relevanceclass": "relevance", "disposition": "disposition", "nochangestatus": "nochange", "nochangecountercasestatus": "nochange", "countercasestatus": "nochange",
+    "invariant": "invariant", "governinginvariant": "invariant", "evidencegrade": "evidencegrade", "evidenceclass": "evidencegrade", "evidencelevel": "evidencegrade", "evidenceref": "evidenceref", "evidencebasis": "evidenceref", "evidence": "evidenceref",
+    "handoff": "handoff", "handoffaction": "handoff",
 }
+DECISION_ALIASES = {
+    "idthread": "id", "id": "id", "commentid": "id", "threadid": "id", "grounded": "grounded", "grounding": "grounded",
+    "material": "material", "materiality": "material", "fresh": "fresh", "freshness": "fresh", "diagnosis": "diagnosis", "diagnosisquality": "diagnosis",
+    "scopefit": "scopefit", "scope": "scopefit", "resolutionvalue": "resolutionvalue", "resolution": "resolutionvalue", "value": "resolutionvalue", "selectionvalue": "resolutionvalue",
+    "nochangedefeated": "nochangedefeated", "nochangecountercasedefeated": "nochangedefeated", "countercasedefeated": "nochangedefeated",
+    "minevidencetochange": "minevidence", "minimumevidencetochange": "minevidence", "minimumevidencetochangemind": "minevidence", "minevidencetochangemind": "minevidence",
+}
+RESOLVE_ALIASES = {"idthread": "id", "id": "id", "commentid": "id", "threadid": "id", "resolvedecision": "decision", "decision": "decision", "selection": "decision", "resolve": "decision", "reason": "reason", "basis": "reason", "proofref": "proofref", "proof": "proofref", "evidenceref": "proofref", "next": "next", "nextaction": "next", "handoff": "next", "routerationale": "routerationale", "rationale": "routerationale", "route": "routerationale"}
+ADVERSARIAL_ALIASES = {"idthread": "id", "id": "id", "commentid": "id", "threadid": "id", "primaryresolvedecision": "decision", "resolvedecision": "decision", "decision": "decision", "adversariallanes": "lanes", "lanes": "lanes", "challengerlanes": "lanes", "parallelismmode": "parallelismmode", "mode": "parallelismmode", "strongestadversarialresponse": "response", "response": "response", "veto": "vetostatus", "vetostatus": "vetostatus", "clearance": "clearance", "proofref": "proofref", "proof": "proofref", "evidenceref": "proofref", "decisionimpact": "impact", "impact": "impact"}
+WARRANT_ALIASES = {"warrantid": "warrantid", "warrant": "warrantid", "claimid": "claimid", "commentid": "claimid", "threadid": "claimid", "source": "source", "claimexcerpt": "claimexcerpt", "excerpt": "claimexcerpt", "decision": "decision", "resolvedecision": "decision", "concernvalidity": "concern", "concern": "concern", "proposedfixvalidity": "proposed", "proposedfix": "proposed", "nochange": "nochange", "nochangestatus": "nochange", "resolutionvalue": "resolutionvalue", "value": "resolutionvalue", "routerationale": "routerationale", "route": "routerationale", "permittedaction": "permittedaction", "action": "permittedaction", "permission": "permittedaction", "permittedscope": "permittedscope", "scope": "permittedscope", "forbiddenactions": "forbiddenactions", "forbidden": "forbiddenactions", "evidencerefs": "evidencerefs", "evidenceref": "evidencerefs", "evidence": "evidencerefs", "countercaseref": "countercaseref", "countercase": "countercaseref", "proofrequired": "proofrequired", "proof": "proofrequired", "expiry": "expiry", "expires": "expiry"}
+SURFACE_BUDGET_ALIASES = {"warrantid": "warrantid", "warrant": "warrantid", "mode": "mode", "targetnetloc": "targetnetloc", "targetloc": "targetnetloc", "maxpositiveloc": "maxpositiveloc", "maxpositive": "maxpositiveloc", "maxinsertions": "maxpositiveloc", "maxnewpublicsymbols": "maxnewpublicsymbols", "publicsymbolbudget": "maxnewpublicsymbols", "maxnewfiles": "maxnewfiles", "newfilebudget": "maxnewfiles", "maxnewhelpers": "maxnewhelpers", "helperbudget": "maxnewhelpers", "maxnewflagsorknobs": "maxnewflagsorknobs", "maxnewflags": "maxnewflagsorknobs", "maxnewflagsknobs": "maxnewflagsorknobs", "maxnewstatevariants": "maxnewstatevariants", "statevariantbudget": "maxnewstatevariants", "maxnewbranches": "maxnewbranches", "branchbudget": "maxnewbranches", "duplicatepathbudget": "duplicatepathbudget", "duplicatepaths": "duplicatepathbudget", "subtractiveprobesrequired": "subtractiveprobesrequired", "subtractiveprobes": "subtractiveprobesrequired", "expansionwarrantrequired": "expansionwarrantrequired", "expansionrequired": "expansionwarrantrequired", "expansionstatus": "expansionstatus", "proofrequired": "proofrequired", "proof": "proofrequired", "notes": "notes"}
+GATE_ALIASES = {"artifactstatecoverage": "artifactstatecoverage", "artifactcoverage": "artifactstatecoverage", "commentinventorycoverage": "commentinventorycoverage", "inventorycoverage": "commentinventorycoverage", "identitycoverage": "identitycoverage", "decisiontestcoverage": "decisiontestcoverage", "decisiontestscoverage": "decisiontestcoverage", "nochangecoverage": "nochangecoverage", "dispositioncoverage": "dispositioncoverage", "proposedfixseparation": "proposedfixseparation", "fixseparation": "proposedfixseparation", "evidencerefcoverage": "evidencerefcoverage", "evidencecoverage": "evidencerefcoverage", "resolveselectioncoverage": "resolveselectioncoverage", "resolvecoverage": "resolveselectioncoverage", "selectioncoverage": "resolveselectioncoverage", "resolvecountercasecoverage": "resolvecountercasecoverage", "adversarialactioncoverage": "adversarialactioncoverage", "adversarialcoverage": "adversarialactioncoverage", "parallelismcalibration": "parallelismcalibration", "parallelismcoverage": "parallelismcalibration", "resolutionwarrantcoverage": "resolutionwarrantcoverage", "warrantcoverage": "resolutionwarrantcoverage", "surfacebudgetcoverage": "surfacebudgetcoverage", "budgetcoverage": "surfacebudgetcoverage", "surfacebudgetconsumptionsafety": "surfacebudgetconsumptionsafety", "warrantconsumptionsafety": "warrantconsumptionsafety", "handoffagendaconsistency": "handoffagendaconsistency", "agendaconsistency": "handoffagendaconsistency", "selectionskewaudit": "selectionskewaudit", "selectionaudit": "selectionskewaudit", "invariantpass": "invariantpass", "specialistpacketcoverage": "specialistpacketcoverage", "acceptanceskewaudit": "acceptanceskewaudit", "adjudicationcomplete": "adjudicationcomplete", "implementationhandoffallowed": "implementationhandoffallowed", "validationhandoffallowed": "validationhandoffallowed", "replyhandoffallowed": "replyhandoffallowed", "handoffallowed": "implementationhandoffallowed"}
+INVENTORY_ALIASES = {"inputcommentcount": "inputcount", "ledgerrowcount": "ledgercount", "inputcommentids": "inputids", "ledgercommentids": "ledgerids", "missingcommentids": "missingids", "duplicatecommentids": "duplicateids", "synthesizedidsforrealcomments": "synthesized"}
+HANDOFF_ALIASES = {"itemsselectedforimplementation": "implementation", "implementationitems": "implementation", "selectedforimplementation": "implementation", "validationonlyitems": "validation", "validationitems": "validation", "proofonlythreadresolutionitems": "proofonly", "proofonlyitems": "proofonly", "threadresolutionitems": "proofonly", "itemsnotselected": "notselected", "notselecteditems": "notselected", "blockeditems": "blocked"}
+
+@dataclass
+class CheckResult:
+    passed: bool
+    errors: List[str] = field(default_factory=list)
+    warnings: List[str] = field(default_factory=list)
+    stats: Dict[str, int] = field(default_factory=dict)
+    gate: Dict[str, str] = field(default_factory=dict)
+
+    def to_json(self) -> str:
+        return json.dumps({"passed": self.passed, "errors": self.errors, "warnings": self.warnings, "stats": self.stats, "gate": self.gate}, indent=2, sort_keys=True)
 
 
 def norm_key(value: str) -> str:
@@ -316,271 +132,12 @@ def norm_value(value: str) -> str:
     return value
 
 
-COLUMN_ALIASES = {
-    "idthread": "id",
-    "id": "id",
-    "commentid": "id",
-    "threadid": "id",
-    "reviewcommentid": "id",
-    "reviewer": "reviewer",
-    "author": "reviewer",
-    "location": "location",
-    "fileorthread": "location",
-    "file": "location",
-    "thread": "location",
-    "pathline": "location",
-    "excerpt": "excerpt",
-    "shortexcerpt": "excerpt",
-    "reviewexcerpt": "excerpt",
-    "claim": "claim",
-    "summary": "claim",
-    "reviewclaim": "claim",
-    "concernvalidity": "concern",
-    "concern": "concern",
-    "proposedfixvalidity": "proposed",
-    "proposedfix": "proposed",
-    "fixvalidity": "proposed",
-    "relevance": "relevance",
-    "relevanceclass": "relevance",
-    "disposition": "disposition",
-    "nochangestatus": "nochange",
-    "nochangecountercasestatus": "nochange",
-    "countercasestatus": "nochange",
-    "invariant": "invariant",
-    "governinginvariant": "invariant",
-    "evidencegrade": "evidencegrade",
-    "evidenceclass": "evidencegrade",
-    "evidencelevel": "evidencegrade",
-    "evidenceref": "evidenceref",
-    "evidencebasis": "evidenceref",
-    "evidence": "evidenceref",
-    "handoff": "handoff",
-    "handoffaction": "handoff",
-}
-
-DECISION_ALIASES = {
-    "idthread": "id",
-    "id": "id",
-    "commentid": "id",
-    "threadid": "id",
-    "grounded": "grounded",
-    "grounding": "grounded",
-    "material": "material",
-    "materiality": "material",
-    "fresh": "fresh",
-    "freshness": "fresh",
-    "diagnosis": "diagnosis",
-    "diagnosisquality": "diagnosis",
-    "scopefit": "scopefit",
-    "scope": "scopefit",
-    "resolutionvalue": "resolutionvalue",
-    "resolution": "resolutionvalue",
-    "value": "resolutionvalue",
-    "selectionvalue": "resolutionvalue",
-    "nochangedefeated": "nochangedefeated",
-    "nochangecountercasedefeated": "nochangedefeated",
-    "countercasedefeated": "nochangedefeated",
-    "minevidencetochange": "minevidence",
-    "minimumevidencetochange": "minevidence",
-    "minimumevidencetochangemind": "minevidence",
-    "minevidencetochangemind": "minevidence",
-}
-
-RESOLVE_ALIASES = {
-    "idthread": "id",
-    "id": "id",
-    "commentid": "id",
-    "threadid": "id",
-    "resolvedecision": "decision",
-    "decision": "decision",
-    "selection": "decision",
-    "resolve": "decision",
-    "reason": "reason",
-    "basis": "reason",
-    "proofref": "proofref",
-    "proof": "proofref",
-    "evidenceref": "proofref",
-    "next": "next",
-    "nextaction": "next",
-    "handoff": "next",
-    "routerationale": "routerationale",
-    "rationale": "routerationale",
-    "route": "routerationale",
-}
-
-WARRANT_ALIASES = {
-    "warrantid": "warrantid",
-    "warrant": "warrantid",
-    "claimid": "claimid",
-    "commentid": "claimid",
-    "threadid": "claimid",
-    "source": "source",
-    "claimexcerpt": "claimexcerpt",
-    "excerpt": "claimexcerpt",
-    "decision": "decision",
-    "resolvedecision": "decision",
-    "concernvalidity": "concern",
-    "concern": "concern",
-    "proposedfixvalidity": "proposed",
-    "proposedfix": "proposed",
-    "nochange": "nochange",
-    "nochangestatus": "nochange",
-    "resolutionvalue": "resolutionvalue",
-    "value": "resolutionvalue",
-    "routerationale": "routerationale",
-    "route": "routerationale",
-    "permittedaction": "permittedaction",
-    "action": "permittedaction",
-    "permission": "permittedaction",
-    "permittedscope": "permittedscope",
-    "scope": "permittedscope",
-    "forbiddenactions": "forbiddenactions",
-    "forbidden": "forbiddenactions",
-    "evidencerefs": "evidencerefs",
-    "evidenceref": "evidencerefs",
-    "evidence": "evidencerefs",
-    "countercaseref": "countercaseref",
-    "countercase": "countercaseref",
-    "proofrequired": "proofrequired",
-    "proof": "proofrequired",
-    "expiry": "expiry",
-    "expires": "expiry",
-}
-
-SURFACE_BUDGET_ALIASES = {
-    "warrantid": "warrantid",
-    "warrant": "warrantid",
-    "mode": "mode",
-    "budgetmode": "mode",
-    "surfacebudgetmode": "mode",
-    "targetnetloc": "targetnetloc",
-    "targetloc": "targetnetloc",
-    "targetnetlines": "targetnetloc",
-    "maxpositiveloc": "maxpositiveloc",
-    "maxpositive": "maxpositiveloc",
-    "maxinsertions": "maxpositiveloc",
-    "maxnewpublicsymbols": "maxnewpublicsymbols",
-    "publicsymbolbudget": "maxnewpublicsymbols",
-    "maxnewfiles": "maxnewfiles",
-    "newfilebudget": "maxnewfiles",
-    "maxnewhelpers": "maxnewhelpers",
-    "helperbudget": "maxnewhelpers",
-    "maxnewflagsorknobs": "maxnewflagsorknobs",
-    "maxnewflags": "maxnewflagsorknobs",
-    "maxnewflagsknobs": "maxnewflagsorknobs",
-    "flagsorknobs": "maxnewflagsorknobs",
-    "flagsknobs": "maxnewflagsorknobs",
-    "maxnewstatevariants": "maxnewstatevariants",
-    "statevariantbudget": "maxnewstatevariants",
-    "maxnewbranches": "maxnewbranches",
-    "branchbudget": "maxnewbranches",
-    "duplicatepathbudget": "duplicatepathbudget",
-    "duplicatepaths": "duplicatepathbudget",
-    "subtractiveprobesrequired": "subtractiveprobesrequired",
-    "subtractiveprobes": "subtractiveprobesrequired",
-    "expansionwarrantrequired": "expansionwarrantrequired",
-    "expansionrequired": "expansionwarrantrequired",
-    "expansionstatus": "expansionstatus",
-    "proofrequired": "proofrequired",
-    "proof": "proofrequired",
-    "notes": "notes",
-}
-
-GATE_ALIASES = {
-    "artifactstatecoverage": "artifactstatecoverage",
-    "artifactcoverage": "artifactstatecoverage",
-    "commentinventorycoverage": "commentinventorycoverage",
-    "inventorycoverage": "commentinventorycoverage",
-    "identitycoverage": "identitycoverage",
-    "decisiontestcoverage": "decisiontestcoverage",
-    "decisiontestscoverage": "decisiontestcoverage",
-    "nochangecoverage": "nochangecoverage",
-    "dispositioncoverage": "dispositioncoverage",
-    "proposedfixseparation": "proposedfixseparation",
-    "fixseparation": "proposedfixseparation",
-    "evidencerefcoverage": "evidencerefcoverage",
-    "evidencecoverage": "evidencerefcoverage",
-    "resolveselectioncoverage": "resolveselectioncoverage",
-    "resolvecoverage": "resolveselectioncoverage",
-    "selectioncoverage": "resolveselectioncoverage",
-    "resolvecountercasecoverage": "resolvecountercasecoverage",
-    "resolvecountercasescoverage": "resolvecountercasecoverage",
-    "resolutionwarrantcoverage": "resolutionwarrantcoverage",
-    "resolutionwarrantscoverage": "resolutionwarrantcoverage",
-    "warrantcoverage": "resolutionwarrantcoverage",
-    "surfacebudgetcoverage": "surfacebudgetcoverage",
-    "surfacebudgetscoverage": "surfacebudgetcoverage",
-    "budgetcoverage": "surfacebudgetcoverage",
-    "surfacebudgetconsumptionsafety": "surfacebudgetconsumptionsafety",
-    "surfacebudgetconsumption": "surfacebudgetconsumptionsafety",
-    "surfacebudgetsafety": "surfacebudgetconsumptionsafety",
-    "warrantconsumptionsafety": "warrantconsumptionsafety",
-    "warrantconsumption": "warrantconsumptionsafety",
-    "consumptionsafety": "warrantconsumptionsafety",
-    "handoffagendaconsistency": "handoffagendaconsistency",
-    "agendaconsistency": "handoffagendaconsistency",
-    "selectionskewaudit": "selectionskewaudit",
-    "selectionaudit": "selectionskewaudit",
-    "invariantpass": "invariantpass",
-    "specialistpacketcoverage": "specialistpacketcoverage",
-    "acceptanceskewaudit": "acceptanceskewaudit",
-    "adjudicationcomplete": "adjudicationcomplete",
-    "implementationhandoffallowed": "implementationhandoffallowed",
-    "validationhandoffallowed": "validationhandoffallowed",
-    "replyhandoffallowed": "replyhandoffallowed",
-    "handoffallowed": "implementationhandoffallowed",
-}
-
-INVENTORY_ALIASES = {
-    "inputcommentcount": "inputcount",
-    "ledgerrowcount": "ledgercount",
-    "inputcommentids": "inputids",
-    "ledgercommentids": "ledgerids",
-    "missingcommentids": "missingids",
-    "duplicatecommentids": "duplicateids",
-    "synthesizedidsforrealcomments": "synthesized",
-}
-
-HANDOFF_ALIASES = {
-    "itemsselectedforimplementation": "implementation",
-    "implementationitems": "implementation",
-    "selectedforimplementation": "implementation",
-    "validationonlyitems": "validation",
-    "validationitems": "validation",
-    "proofonlythreadresolutionitems": "proofonly",
-    "proofonlyitems": "proofonly",
-    "threadresolutionitems": "proofonly",
-    "itemsnotselected": "notselected",
-    "notselecteditems": "notselected",
-    "blockeditems": "blocked",
-}
-
-
-@dataclass
-class CheckResult:
-    passed: bool
-    errors: List[str] = field(default_factory=list)
-    warnings: List[str] = field(default_factory=list)
-    stats: Dict[str, int] = field(default_factory=dict)
-    gate: Dict[str, str] = field(default_factory=dict)
-
-    def to_json(self) -> str:
-        return json.dumps(
-            {
-                "passed": self.passed,
-                "errors": self.errors,
-                "warnings": self.warnings,
-                "stats": self.stats,
-                "gate": self.gate,
-            },
-            indent=2,
-            sort_keys=True,
-        )
+def is_empty(value: str) -> bool:
+    return norm_value(value) in EMPTY_MARKERS
 
 
 def section_count(text: str, title: str) -> int:
-    pattern = rf"(?im)^\s*#+\s+{re.escape(title)}\s*$"
-    return len(re.findall(pattern, text))
+    return len(re.findall(rf"(?im)^\s*#+\s+{re.escape(title)}\s*$", text))
 
 
 def has_section(text: str, title: str) -> bool:
@@ -588,13 +145,12 @@ def has_section(text: str, title: str) -> bool:
 
 
 def section_text(text: str, title: str) -> str:
-    pattern = rf"(?im)^\s*#+\s+{re.escape(title)}\s*$"
-    match = re.search(pattern, text)
-    if not match:
+    m = re.search(rf"(?im)^\s*#+\s+{re.escape(title)}\s*$", text)
+    if not m:
         return ""
-    start = match.end()
-    next_heading = re.search(r"(?m)^\s*#+\s+", text[start:])
-    end = start + next_heading.start() if next_heading else len(text)
+    start = m.end()
+    n = re.search(r"(?m)^\s*#+\s+", text[start:])
+    end = start + n.start() if n else len(text)
     return text[start:end].strip()
 
 
@@ -612,12 +168,11 @@ def is_separator_row(cells: Sequence[str]) -> bool:
 
 
 def extract_first_table(block: str) -> Tuple[List[str], List[Dict[str, str]]]:
-    lines = [line.rstrip() for line in block.splitlines()]
     table_lines: List[str] = []
     started = False
-    for line in lines:
+    for line in block.splitlines():
         if line.strip().startswith("|"):
-            table_lines.append(line)
+            table_lines.append(line.rstrip())
             started = True
         elif started and line.strip() == "":
             break
@@ -626,102 +181,73 @@ def extract_first_table(block: str) -> Tuple[List[str], List[Dict[str, str]]]:
     if len(table_lines) < 2:
         return [], []
     headers = split_md_row(table_lines[0])
-    sep = split_md_row(table_lines[1])
-    if not is_separator_row(sep):
+    if not is_separator_row(split_md_row(table_lines[1])):
         return [], []
-    rows: List[Dict[str, str]] = []
+    rows = []
     for line in table_lines[2:]:
         cells = split_md_row(line)
         if len(cells) < len(headers):
-            cells = list(cells) + [""] * (len(headers) - len(cells))
+            cells += [""] * (len(headers) - len(cells))
         rows.append({headers[i]: cells[i] for i in range(len(headers))})
     return headers, rows
 
 
 def normalize_rows(headers: Sequence[str], rows: Sequence[Dict[str, str]], aliases: Dict[str, str]) -> Tuple[Dict[str, str], List[Dict[str, str]]]:
-    header_map: Dict[str, str] = {}
+    header_map = {}
     for header in headers:
         canonical = aliases.get(norm_key(header))
         if canonical:
             header_map[canonical] = header
-    normalized: List[Dict[str, str]] = []
+    out = []
     for row in rows:
-        item: Dict[str, str] = {}
-        for canonical, original in header_map.items():
-            item[canonical] = row.get(original, "").strip()
-        normalized.append(item)
-    return header_map, normalized
+        out.append({canonical: row.get(original, "").strip() for canonical, original in header_map.items()})
+    return header_map, out
 
 
-def normalize_gate(headers: Sequence[str], rows: Sequence[Dict[str, str]]) -> Dict[str, str]:
-    if not headers:
-        return {}
-    field_header: Optional[str] = None
-    value_header: Optional[str] = None
-    for header in headers:
-        key = norm_key(header)
-        if key in {"field", "gatefield", "check"}:
-            field_header = header
-        if key in {"value", "status", "result"}:
-            value_header = header
-    if field_header is None or value_header is None:
-        if len(headers) >= 2:
-            field_header, value_header = headers[0], headers[1]
-        else:
-            return {}
-    gate: Dict[str, str] = {}
+def rows_by_id(rows: Sequence[Dict[str, str]]) -> Dict[str, Dict[str, str]]:
+    out = {}
     for row in rows:
-        canonical = GATE_ALIASES.get(norm_key(row.get(field_header, "")))
-        if canonical:
-            gate[canonical] = norm_value(row.get(value_header, ""))
-    return gate
-
-
-def is_empty(value: str) -> bool:
-    return norm_value(value) in EMPTY_MARKERS
+        rid = row.get("id", "").strip()
+        if rid:
+            out[rid] = row
+    return out
 
 
 def parse_int(value: str) -> Optional[int]:
-    match = re.search(r"-?\d+", value or "")
-    if not match:
+    m = re.search(r"-?\d+", value or "")
+    if not m:
         return None
     try:
-        return int(match.group(0))
+        return int(m.group(0))
     except ValueError:
         return None
 
 
 def parse_nonnegative_int(value: str) -> Optional[int]:
-    parsed = parse_int(value)
-    if parsed is None or parsed < 0:
-        return None
-    return parsed
+    val = parse_int(value)
+    return val if val is not None and val >= 0 else None
 
 
 def parse_diffstat(value: str) -> Tuple[int, int]:
-    if not value:
-        return 0, 0
-    insertions = 0
-    deletions = 0
-    ins_match = re.search(r"(\d+)\s+insertions?\(\+\)", value)
-    del_match = re.search(r"(\d+)\s+deletions?\(-\)", value)
-    if ins_match:
-        insertions = int(ins_match.group(1))
-    if del_match:
-        deletions = int(del_match.group(1))
+    insertions = deletions = 0
+    mi = re.search(r"(\d+)\s+insertions?\(\+\)", value or "")
+    md = re.search(r"(\d+)\s+deletions?\(-\)", value or "")
+    if mi:
+        insertions = int(mi.group(1))
+    if md:
+        deletions = int(md.group(1))
     return insertions, deletions
 
 
 def parse_id_list(value: str) -> List[str]:
-    value = value.strip()
+    value = (value or "").strip()
     if is_empty(value):
         return []
     if re.search(r"(?i)\ball\b", value):
         return ["__ALL__"]
     value = re.sub(r"^[\[({]", "", value)
     value = re.sub(r"[\])}]$", "", value)
-    parts = re.split(r"[,;\s]+", value)
-    return [part.strip().strip('"\'`') for part in parts if part.strip().strip('"\'`')]
+    return [p.strip().strip('"\'`') for p in re.split(r"[,;\s]+", value) if p.strip().strip('"\'`')]
 
 
 def parse_inventory(block: str) -> Dict[str, str]:
@@ -737,6 +263,29 @@ def parse_inventory(block: str) -> Dict[str, str]:
     return inventory
 
 
+def normalize_gate(headers: Sequence[str], rows: Sequence[Dict[str, str]]) -> Dict[str, str]:
+    if not headers:
+        return {}
+    field_header = value_header = None
+    for h in headers:
+        k = norm_key(h)
+        if k in {"field", "gatefield", "check"}:
+            field_header = h
+        if k in {"value", "status", "result"}:
+            value_header = h
+    if field_header is None or value_header is None:
+        if len(headers) >= 2:
+            field_header, value_header = headers[0], headers[1]
+        else:
+            return {}
+    gate = {}
+    for row in rows:
+        canonical = GATE_ALIASES.get(norm_key(row.get(field_header, "")))
+        if canonical:
+            gate[canonical] = norm_value(row.get(value_header, ""))
+    return gate
+
+
 def evidence_ref_is_concrete(value: str, *, allow_missing: bool = False) -> bool:
     if allow_missing and norm_value(value) in {"missing", "blocked", "unknown"}:
         return True
@@ -747,20 +296,15 @@ def evidence_ref_is_concrete(value: str, *, allow_missing: bool = False) -> bool
         return False
     if re.search(r"[\w./-]+:\d+", value):
         return True
-    if any(token in normalized for token in ["test", "ci", "cmd", "command", "log", "thread", "pr#", "gh-", "github", "diff", "src/", "tests/", "commit"]):
+    if any(tok in normalized for tok in ["test", "ci", "cmd", "command", "log", "thread", "pr#", "gh-", "github", "diff", "src/", "tests/", "commit"]):
         return True
-    if "/" in value or "." in value or "#" in value:
-        return True
-    return len(value.strip()) >= 16
+    return "/" in value or "." in value or "#" in value or len(value.strip()) >= 16
 
 
-def rows_by_id(rows: Sequence[Dict[str, str]]) -> Dict[str, Dict[str, str]]:
-    out: Dict[str, Dict[str, str]] = {}
-    for row in rows:
-        rid = row.get("id", "").strip()
-        if rid:
-            out[rid] = row
-    return out
+def extract_refs(value: str) -> List[str]:
+    if is_empty(value):
+        return []
+    return [p.strip().strip('"\'`') for p in re.split(r"[,;\n]+", value) if p.strip().strip('"\'`')]
 
 
 def parse_handoff_agenda(block: str, known_ids: Sequence[str], errors: List[str]) -> Dict[str, List[str]]:
@@ -774,7 +318,6 @@ def parse_handoff_agenda(block: str, known_ids: Sequence[str], errors: List[str]
         if canonical:
             fields[canonical] = value.strip()
     buckets = {"implementation": [], "validation": [], "proofonly": [], "notselected": [], "blocked": []}
-    known = set(known_ids)
     for bucket in buckets:
         if bucket not in fields:
             errors.append(f"Handoff Agenda missing `{bucket}` item bucket")
@@ -784,321 +327,231 @@ def parse_handoff_agenda(block: str, known_ids: Sequence[str], errors: List[str]
             errors.append(f"Handoff Agenda `{bucket}` uses broad `all`; explicit comment ids are required")
             continue
         if is_empty(raw):
-            buckets[bucket] = []
             continue
         present = [rid for rid in known_ids if re.search(rf"(?<![A-Za-z0-9_.:-]){re.escape(rid)}(?![A-Za-z0-9_.:-])", raw)]
-        if present:
-            buckets[bucket] = present
-        else:
-            buckets[bucket] = parse_id_list(raw)
+        buckets[bucket] = present if present else parse_id_list(raw)
     return buckets
 
 
-def validate_structured_table(
-    text: str,
-    title: str,
-    checks: Dict[str, str],
-    errors: List[str],
-    why_column_name: str,
-) -> None:
-    if not has_section(text, title):
-        errors.append(f"missing required section: {title}")
-        return
-    headers, raw_rows = extract_first_table(section_text(text, title))
-    if not raw_rows:
-        errors.append(f"{title} must be a structured table")
-        return
-    check_header = value_header = evidence_header = why_header = None
-    for header in headers:
-        key = norm_key(header)
-        if key == "check":
-            check_header = header
-        elif key in {"result", "status", "value"}:
-            value_header = header
-        elif key in {"evidenceref", "evidence", "evidencebasis"}:
-            evidence_header = header
-        elif key in {norm_key(why_column_name), "why", "basis"}:
-            why_header = header
-    if not all([check_header, value_header, evidence_header, why_header]):
-        errors.append(f"{title} missing required columns: check, result, evidence ref, {why_column_name}")
-        return
-    seen = {norm_key(row.get(check_header or "", "")): row for row in raw_rows}
-    for canonical, label in checks.items():
-        if canonical not in seen:
-            errors.append(f"{title} missing check `{label}`")
-            continue
-        row = seen[canonical]
-        result = norm_value(row.get(value_header or "", ""))
-        if result != "pass":
-            errors.append(f"{title} `{label}` must have result `pass`, got `{result}`")
-        if not evidence_ref_is_concrete(row.get(evidence_header or "", "")):
-            errors.append(f"{title} `{label}` requires concrete evidence ref")
-        if is_empty(row.get(why_header or "", "")):
-            errors.append(f"{title} `{label}` requires explanation")
+def validate_adversarial_matrix(text: str, resolve_by_id: Dict[str, Dict[str, str]], ledger_by_id: Dict[str, Dict[str, str]], errors: List[str], warnings: List[str]) -> Tuple[Dict[str, Dict[str, str]], Dict[str, List[str]]]:
+    headers, raw = extract_first_table(section_text(text, "Adversarial Action Matrix"))
+    header_map, rows = normalize_rows(headers, raw, ADVERSARIAL_ALIASES)
+    missing = [f for f in REQUIRED_ADVERSARIAL_FIELDS if f not in header_map]
+    if missing:
+        errors.append("Adversarial Action Matrix missing required columns: " + ", ".join(missing))
+    if not rows:
+        errors.append("Adversarial Action Matrix has no data rows")
+    by_id = rows_by_id(rows)
+    clearance_buckets = {"cleared": [], "preserved": [], "rerouted": [], "downgraded": [], "blocked": []}
+    if set(resolve_by_id) - set(by_id):
+        errors.append("Adversarial Action Matrix missing comment ids: " + ", ".join(sorted(set(resolve_by_id) - set(by_id))))
+    if set(by_id) - set(resolve_by_id):
+        errors.append("Adversarial Action Matrix contains unknown comment ids: " + ", ".join(sorted(set(by_id) - set(resolve_by_id))))
+    for rid, row in by_id.items():
+        decision = norm_value(row.get("decision", ""))
+        mode = norm_value(row.get("parallelismmode", ""))
+        veto = norm_value(row.get("vetostatus", ""))
+        clearance = norm_value(row.get("clearance", ""))
+        proof = row.get("proofref", "")
+        response = row.get("response", "")
+        lanes = row.get("lanes", "")
+        if decision not in ALLOWED_RESOLVE_DECISION:
+            errors.append(f"{rid}: invalid Adversarial Action Matrix primary resolve decision `{row.get('decision', '')}`")
+        if mode not in ALLOWED_PARALLELISM_MODE:
+            errors.append(f"{rid}: invalid parallelism mode `{row.get('parallelismmode', '')}`")
+        if veto not in ALLOWED_VETO_STATUS:
+            errors.append(f"{rid}: invalid veto status `{row.get('vetostatus', '')}`")
+        if clearance not in ALLOWED_CLEARANCE:
+            errors.append(f"{rid}: invalid clearance `{row.get('clearance', '')}`")
+        else:
+            clearance_buckets[clearance].append(rid)
+        if is_empty(response):
+            errors.append(f"{rid}: missing strongest adversarial response")
+        if is_empty(lanes):
+            errors.append(f"{rid}: missing adversarial lanes")
+        resolve = resolve_by_id.get(rid)
+        if resolve and decision != norm_value(resolve.get("decision", "")):
+            errors.append(f"{rid}: Adversarial Action Matrix decision `{decision}` does not match Resolve Selection `{norm_value(resolve.get('decision', ''))}`")
+        if decision == "address":
+            if veto != "cleared" or clearance != "cleared":
+                errors.append(f"{rid}: address requires adversarial veto status cleared and clearance cleared")
+            if not evidence_ref_is_concrete(proof):
+                errors.append(f"{rid}: address adversarial clearance requires concrete proof ref")
+            if mode == "not-required":
+                errors.append(f"{rid}: address cannot use parallelism mode not-required")
+        elif decision == "validate-only":
+            if veto != "cleared" or clearance not in {"cleared", "downgraded"}:
+                errors.append(f"{rid}: validate-only requires cleared veto and cleared/downgraded clearance")
+            if not evidence_ref_is_concrete(proof):
+                errors.append(f"{rid}: validate-only adversarial row requires concrete proof ref")
+        elif decision == "resolve-thread-only":
+            if veto not in {"cleared", "preserved-no-change"} or clearance != "preserved":
+                errors.append(f"{rid}: resolve-thread-only requires cleared/preserved-no-change veto and preserved clearance")
+            if not evidence_ref_is_concrete(proof):
+                errors.append(f"{rid}: resolve-thread-only adversarial row requires concrete proof ref")
+        elif decision == "do-not-address":
+            if veto not in {"cleared", "preserved-no-change"} or clearance != "preserved":
+                errors.append(f"{rid}: do-not-address requires cleared/preserved-no-change veto and preserved clearance")
+            if not evidence_ref_is_concrete(proof):
+                errors.append(f"{rid}: do-not-address adversarial row requires concrete proof/no-change ref")
+        elif decision == "blocked":
+            if veto not in {"blocked", "unresolved"} or clearance != "blocked":
+                errors.append(f"{rid}: blocked requires blocked/unresolved veto and blocked clearance")
+            if not evidence_ref_is_concrete(proof, allow_missing=True):
+                errors.append(f"{rid}: blocked adversarial row requires proof ref or explicit missing marker")
+        if mode == "root-equivalent" and decision == "address" and norm_value(resolve.get("routerationale", "")) in FIXED_POINT_RATIONALES if resolve else False:
+            warnings.append(f"{rid}: fixed-point-rationale address used root-equivalent adversarial mode; verify parallelism calibration")
+    return by_id, clearance_buckets
 
 
-def validate_specialist_receipts(text: str, gate: Dict[str, str], errors: List[str]) -> None:
-    coverage = gate.get("specialistpacketcoverage")
-    has_receipts = has_section(text, "Specialist Packet Receipts") and bool(section_text(text, "Specialist Packet Receipts").strip())
-    if coverage == "not-used":
-        if has_receipts:
-            errors.append("specialist_packet_coverage is `not-used` but Specialist Packet Receipts is present")
-        return
-    if coverage == "pass":
-        if not has_receipts:
-            errors.append("specialist_packet_coverage is `pass` but Specialist Packet Receipts is missing or empty")
-            return
-        headers, rows = extract_first_table(section_text(text, "Specialist Packet Receipts"))
-        header_keys = {norm_key(h) for h in headers}
-        required = {"role", "packetstatus", "artifactstatematch", "scopematch", "findingadded", "routechanged", "usedfor", "reason"}
-        missing = sorted(required - header_keys)
-        if missing:
-            errors.append("Specialist Packet Receipts missing required columns: " + ", ".join(missing))
-        if not rows:
-            errors.append("Specialist Packet Receipts has no data rows")
-
-
-
-def extract_refs(value: str) -> List[str]:
-    if is_empty(value):
-        return []
-    parts = re.split(r"[,;\n]+", value)
-    return [part.strip().strip('"\'`') for part in parts if part.strip().strip('"\'`')]
-
-
-def text_mentions_any(value: str, needles: Sequence[str]) -> bool:
-    value_norm = value.lower()
-    return any(needle and needle.lower() in value_norm for needle in needles)
-
-
-def validate_resolution_warrants(
-    text: str,
-    ledger_by_id: Dict[str, Dict[str, str]],
-    resolve_by_id: Dict[str, Dict[str, str]],
-    handoff_buckets: Dict[str, List[str]],
-    errors: List[str],
-    warnings: List[str],
-    changed_files: Optional[Sequence[str]] = None,
-    resolved_threads: Optional[Sequence[str]] = None,
-) -> Dict[str, object]:
-    headers, raw_rows = extract_first_table(section_text(text, "Resolution Warrants"))
-    header_map, rows = normalize_rows(headers, raw_rows, WARRANT_ALIASES)
-    missing_columns = [field for field in REQUIRED_WARRANT_FIELDS if field not in header_map]
-    if missing_columns:
-        errors.append("Resolution Warrants missing required columns: " + ", ".join(missing_columns))
+def validate_resolution_warrants(text: str, ledger_by_id: Dict[str, Dict[str, str]], resolve_by_id: Dict[str, Dict[str, str]], handoff_buckets: Dict[str, List[str]], errors: List[str], warnings: List[str], changed_files: Optional[Sequence[str]] = None, resolved_threads: Optional[Sequence[str]] = None) -> Dict[str, object]:
+    headers, raw = extract_first_table(section_text(text, "Resolution Warrants"))
+    header_map, rows = normalize_rows(headers, raw, WARRANT_ALIASES)
+    missing = [f for f in REQUIRED_WARRANT_FIELDS if f not in header_map]
+    if missing:
+        errors.append("Resolution Warrants missing required columns: " + ", ".join(missing))
     if not rows:
         errors.append("Resolution Warrants has no data rows")
-
-    warrant_ids: List[str] = []
     by_claim: Dict[str, Dict[str, str]] = {}
     action_buckets = {"mutate-code": [], "add-validation-only": [], "resolve-thread": [], "draft-reply": [], "defer": [], "none": []}
     for idx, row in enumerate(rows, start=1):
-        warrant_id = row.get("warrantid", "").strip() or f"warrant row {idx}"
-        claim_id = row.get("claimid", "").strip()
-        warrant_ids.append(warrant_id)
-        if is_empty(warrant_id):
-            errors.append(f"{warrant_id}: missing warrant id")
-        if claim_id:
-            if claim_id in by_claim:
-                errors.append(f"{claim_id}: duplicate Resolution Warrant claim id")
-            by_claim[claim_id] = row
-        else:
-            errors.append(f"{warrant_id}: missing claim id")
-
+        wid = row.get("warrantid", "").strip() or f"warrant row {idx}"
+        cid = row.get("claimid", "").strip()
+        if not cid:
+            errors.append(f"{wid}: missing claim id")
+            continue
+        if cid in by_claim:
+            errors.append(f"{cid}: duplicate Resolution Warrant claim id")
+        by_claim[cid] = row
         decision = norm_value(row.get("decision", ""))
         concern = norm_value(row.get("concern", ""))
         proposed = norm_value(row.get("proposed", ""))
         nochange = norm_value(row.get("nochange", ""))
         resolution_value = norm_value(row.get("resolutionvalue", ""))
-        route_rationale = norm_value(row.get("routerationale", ""))
-        permitted_action = norm_value(row.get("permittedaction", ""))
-        permitted_scope = row.get("permittedscope", "")
-        forbidden_actions = row.get("forbiddenactions", "")
-        evidence_refs = row.get("evidencerefs", "")
-        countercase_ref = row.get("countercaseref", "")
-        proof_required = row.get("proofrequired", "")
+        route = norm_value(row.get("routerationale", ""))
+        action = norm_value(row.get("permittedaction", ""))
+        scope = row.get("permittedscope", "")
+        forbidden = row.get("forbiddenactions", "")
+        evidence = row.get("evidencerefs", "")
+        countercase = row.get("countercaseref", "")
+        proof = row.get("proofrequired", "")
         expiry = row.get("expiry", "")
-
         if decision not in ALLOWED_RESOLVE_DECISION:
-            errors.append(f"{warrant_id}: invalid warrant decision `{row.get('decision', '')}`")
+            errors.append(f"{wid}: invalid warrant decision `{row.get('decision', '')}`")
         if concern not in ALLOWED_CONCERN:
-            errors.append(f"{warrant_id}: invalid warrant concern validity `{row.get('concern', '')}`")
+            errors.append(f"{wid}: invalid warrant concern validity `{row.get('concern', '')}`")
         if proposed not in ALLOWED_PROPOSED:
-            errors.append(f"{warrant_id}: invalid warrant proposed-fix validity `{row.get('proposed', '')}`")
+            errors.append(f"{wid}: invalid warrant proposed-fix validity `{row.get('proposed', '')}`")
         if nochange not in ALLOWED_NO_CHANGE:
-            errors.append(f"{warrant_id}: invalid warrant no-change status `{row.get('nochange', '')}`")
+            errors.append(f"{wid}: invalid warrant no-change status `{row.get('nochange', '')}`")
         if resolution_value not in ALLOWED_RESOLUTION_VALUE:
-            errors.append(f"{warrant_id}: invalid warrant resolution value `{row.get('resolutionvalue', '')}`")
-        if route_rationale not in ALLOWED_ROUTE_RATIONALE:
-            errors.append(f"{warrant_id}: invalid warrant route rationale `{row.get('routerationale', '')}`")
-        if permitted_action not in ALLOWED_PERMITTED_ACTION:
-            errors.append(f"{warrant_id}: invalid permitted action `{row.get('permittedaction', '')}`")
-        elif permitted_action in action_buckets and claim_id:
-            action_buckets[permitted_action].append(claim_id)
-
-        if claim_id and claim_id not in ledger_by_id:
-            errors.append(f"{warrant_id}: claim id `{claim_id}` does not appear in Comment Ledger")
-        resolve_row = resolve_by_id.get(claim_id)
-        if resolve_row:
-            resolve_decision = norm_value(resolve_row.get("decision", ""))
-            resolve_route = norm_value(resolve_row.get("routerationale", ""))
-            if decision != resolve_decision:
-                errors.append(f"{warrant_id}: warrant decision `{decision}` does not match Resolve Selection `{resolve_decision}`")
-            if route_rationale != resolve_route:
-                errors.append(f"{warrant_id}: warrant route rationale `{route_rationale}` does not match Resolve Selection `{resolve_route}`")
-        elif claim_id:
-            errors.append(f"{warrant_id}: no Resolve Selection row for claim `{claim_id}`")
-
-        allowed_actions = ACTION_BY_DECISION.get(decision, set())
-        if permitted_action and allowed_actions and permitted_action not in allowed_actions:
-            errors.append(f"{warrant_id}: decision `{decision}` cannot issue permitted action `{permitted_action}`")
-
-        if permitted_action == "mutate-code":
+            errors.append(f"{wid}: invalid warrant resolution value `{row.get('resolutionvalue', '')}`")
+        if route not in ALLOWED_ROUTE_RATIONALE:
+            errors.append(f"{wid}: invalid warrant route rationale `{row.get('routerationale', '')}`")
+        if action not in ALLOWED_PERMITTED_ACTION:
+            errors.append(f"{wid}: invalid permitted action `{row.get('permittedaction', '')}`")
+        else:
+            action_buckets[action].append(cid)
+        if cid not in ledger_by_id:
+            errors.append(f"{wid}: claim id `{cid}` does not appear in Comment Ledger")
+        resolve = resolve_by_id.get(cid)
+        if not resolve:
+            errors.append(f"{wid}: no Resolve Selection row for claim `{cid}`")
+        else:
+            if decision != norm_value(resolve.get("decision", "")):
+                errors.append(f"{wid}: warrant decision `{decision}` does not match Resolve Selection `{norm_value(resolve.get('decision', ''))}`")
+            if route != norm_value(resolve.get("routerationale", "")):
+                errors.append(f"{wid}: warrant route rationale `{route}` does not match Resolve Selection `{norm_value(resolve.get('routerationale', ''))}`")
+        if action not in ACTION_BY_DECISION.get(decision, set()):
+            errors.append(f"{wid}: decision `{decision}` cannot issue permitted action `{action}`")
+        if action == "mutate-code":
             if nochange != "defeated":
-                errors.append(f"{warrant_id}: mutate-code warrant requires no-change status defeated")
+                errors.append(f"{wid}: mutate-code warrant requires no-change status defeated")
             if resolution_value not in {"merge-blocking", "correctness-critical", "review-closure"}:
-                errors.append(f"{warrant_id}: mutate-code warrant has non-implementation resolution value `{resolution_value}`")
-            if is_empty(permitted_scope) or norm_value(permitted_scope) in {"all", "repo", "whole-repo", "everything"}:
-                errors.append(f"{warrant_id}: mutate-code warrant requires narrow permitted scope")
-            if "mutate" not in norm_value(forbidden_actions) and "outside" not in norm_value(forbidden_actions):
-                errors.append(f"{warrant_id}: mutate-code warrant must forbid mutation outside permitted scope")
-            if not any(evidence_ref_is_concrete(ref) for ref in extract_refs(evidence_refs)):
-                errors.append(f"{warrant_id}: mutate-code warrant requires concrete evidence refs")
-        elif permitted_action == "add-validation-only":
-            if decision != "validate-only":
-                errors.append(f"{warrant_id}: add-validation-only requires decision validate-only")
+                errors.append(f"{wid}: mutate-code warrant has non-implementation resolution value `{resolution_value}`")
+            if is_empty(scope) or norm_value(scope) in {"all", "repo", "whole-repo", "everything"}:
+                errors.append(f"{wid}: mutate-code warrant requires narrow permitted scope")
+            if "mutate" not in norm_value(forbidden) and "outside" not in norm_value(forbidden):
+                errors.append(f"{wid}: mutate-code warrant must forbid mutation outside permitted scope")
+            if not any(evidence_ref_is_concrete(ref) for ref in extract_refs(evidence)):
+                errors.append(f"{wid}: mutate-code warrant requires concrete evidence refs")
+        elif action == "add-validation-only":
             if resolution_value != "validation-needed":
-                errors.append(f"{warrant_id}: add-validation-only requires resolution value validation-needed")
-            forbidden_norm = norm_value(forbidden_actions)
-            if "production" not in forbidden_norm and "requested-code-change" not in forbidden_norm and "mutate-code" not in forbidden_norm:
-                errors.append(f"{warrant_id}: validation-only warrant must forbid production mutation/requested fix")
-        elif permitted_action == "resolve-thread":
-            if decision != "resolve-thread-only":
-                errors.append(f"{warrant_id}: resolve-thread action requires decision resolve-thread-only")
-            if not any(evidence_ref_is_concrete(ref) for ref in extract_refs(evidence_refs)):
-                errors.append(f"{warrant_id}: resolve-thread warrant requires proof evidence refs")
-        elif permitted_action in {"draft-reply", "defer", "none"}:
-            if decision == "address" and permitted_action != "mutate-code":
-                errors.append(f"{warrant_id}: address decision must issue mutate-code action")
-
-        if is_empty(countercase_ref):
-            errors.append(f"{warrant_id}: missing countercase ref")
-        if is_empty(proof_required) and permitted_action != "none":
-            errors.append(f"{warrant_id}: non-none warrant requires proof_required")
+                errors.append(f"{wid}: add-validation-only requires resolution value validation-needed")
+            fn = norm_value(forbidden)
+            if "production" not in fn and "requested-code-change" not in fn and "mutate-code" not in fn:
+                errors.append(f"{wid}: validation-only warrant must forbid production mutation/requested fix")
+        elif action == "resolve-thread":
+            if not any(evidence_ref_is_concrete(ref) for ref in extract_refs(evidence)):
+                errors.append(f"{wid}: resolve-thread warrant requires proof evidence refs")
+        if is_empty(countercase):
+            errors.append(f"{wid}: missing countercase ref")
+        if is_empty(proof) and action != "none":
+            errors.append(f"{wid}: non-none warrant requires proof_required")
         expiry_norm = norm_value(expiry)
-        if is_empty(expiry) or not any(token in expiry_norm for token in ["head", "base", "artifact", "comment", "claim", "thread", "diff"]):
-            errors.append(f"{warrant_id}: expiry must mention artifact/comment invalidation conditions")
-
-    resolve_ids = set(resolve_by_id)
-    warrant_claims = set(by_claim)
-    if resolve_ids - warrant_claims:
-        errors.append("Resolution Warrants missing claims: " + ", ".join(sorted(resolve_ids - warrant_claims)))
-    if warrant_claims - resolve_ids:
-        errors.append("Resolution Warrants contain claims not in Resolve Selection: " + ", ".join(sorted(warrant_claims - resolve_ids)))
-
-    expected_by_action = {
-        "mutate-code": sorted(handoff_buckets.get("implementation", [])),
-        "add-validation-only": sorted(handoff_buckets.get("validation", [])),
-        "resolve-thread": sorted(handoff_buckets.get("proofonly", [])),
-    }
-    for action, expected_claims in expected_by_action.items():
-        got_claims = sorted(action_buckets.get(action, []))
-        if got_claims != expected_claims:
-            errors.append(f"Resolution Warrant `{action}` claims mismatch Handoff Agenda: expected {expected_claims}, got {got_claims}")
-
+        if is_empty(expiry) or not any(tok in expiry_norm for tok in ["head", "base", "artifact", "comment", "claim", "thread", "diff"]):
+            errors.append(f"{wid}: expiry must mention artifact/comment invalidation conditions")
+    if set(resolve_by_id) - set(by_claim):
+        errors.append("Resolution Warrants missing claims: " + ", ".join(sorted(set(resolve_by_id) - set(by_claim))))
+    expected = {"mutate-code": sorted(handoff_buckets.get("implementation", [])), "add-validation-only": sorted(handoff_buckets.get("validation", [])), "resolve-thread": sorted(handoff_buckets.get("proofonly", []))}
+    for action, expected_ids in expected.items():
+        got = sorted(action_buckets.get(action, []))
+        if got != expected_ids:
+            errors.append(f"Resolution Warrant `{action}` claims mismatch Handoff Agenda: expected {expected_ids}, got {got}")
     if changed_files:
         mutate_warrants = [row for row in rows if norm_value(row.get("permittedaction", "")) == "mutate-code"]
         for changed in changed_files:
-            changed = changed.strip()
-            if not changed:
-                continue
-            if not any(changed in row.get("permittedscope", "") for row in mutate_warrants):
+            if changed and not any(changed in row.get("permittedscope", "") for row in mutate_warrants):
                 errors.append(f"changed file `{changed}` is not covered by any mutate-code warrant permitted scope")
     if resolved_threads:
         thread_warrants = [row for row in rows if norm_value(row.get("permittedaction", "")) in {"resolve-thread", "mutate-code"}]
         for thread in resolved_threads:
-            thread = thread.strip()
-            if not thread:
-                continue
-            if not any(thread in row.get("permittedscope", "") or thread in row.get("claimid", "") for row in thread_warrants):
+            if thread and not any(thread in row.get("permittedscope", "") or thread in row.get("claimid", "") for row in thread_warrants):
                 errors.append(f"resolved thread `{thread}` is not covered by any resolve-thread/address warrant")
-
     return {"rows": rows, "by_claim": by_claim, "action_buckets": action_buckets}
 
 
-def validate_surface_budget_ledger(
-    text: str,
-    warrant_rows: Sequence[Dict[str, str]],
-    errors: List[str],
-    warnings: List[str],
-    diffstat: str = "",
-    new_public_symbols: int = 0,
-    new_files: int = 0,
-    new_helpers: int = 0,
-    new_flags_or_knobs: int = 0,
-) -> Dict[str, object]:
-    headers, raw_rows = extract_first_table(section_text(text, "Surface Budget Ledger"))
-    header_map, rows = normalize_rows(headers, raw_rows, SURFACE_BUDGET_ALIASES)
-    missing_columns = [field for field in REQUIRED_SURFACE_BUDGET_FIELDS if field not in header_map]
-    if missing_columns:
-        errors.append("Surface Budget Ledger missing required columns: " + ", ".join(missing_columns))
-    if not rows:
-        errors.append("Surface Budget Ledger has no data rows")
-
+def validate_surface_budget_ledger(text: str, warrant_rows: Sequence[Dict[str, str]], errors: List[str], warnings: List[str], diffstat: str = "", new_public_symbols: int = 0, new_files: int = 0, new_helpers: int = 0, new_flags_or_knobs: int = 0) -> Dict[str, object]:
+    headers, raw = extract_first_table(section_text(text, "Surface Budget Ledger"))
+    header_map, rows = normalize_rows(headers, raw, SURFACE_BUDGET_ALIASES)
+    missing = [f for f in REQUIRED_SURFACE_BUDGET_FIELDS if f not in header_map]
+    if missing:
+        errors.append("Surface Budget Ledger missing required columns: " + ", ".join(missing))
+    mutate_warrants = [row for row in warrant_rows if norm_value(row.get("permittedaction", "")) == "mutate-code"]
+    if not rows and mutate_warrants:
+        errors.append("Surface Budget Ledger has no data rows despite mutate-code warrants")
     budget_by_warrant: Dict[str, Dict[str, str]] = {}
     for idx, row in enumerate(rows, start=1):
-        warrant_id = row.get("warrantid", "").strip() or f"surface budget row {idx}"
-        if warrant_id in budget_by_warrant:
-            errors.append(f"{warrant_id}: duplicate Surface Budget Ledger row")
-        budget_by_warrant[warrant_id] = row
+        wid = row.get("warrantid", "").strip() or f"surface budget row {idx}"
+        budget_by_warrant[wid] = row
         mode = norm_value(row.get("mode", ""))
         target = norm_value(row.get("targetnetloc", ""))
         subtractive = norm_value(row.get("subtractiveprobesrequired", ""))
-        expansion_required = norm_value(row.get("expansionwarrantrequired", ""))
-        expansion_status = norm_value(row.get("expansionstatus", ""))
+        expansion = norm_value(row.get("expansionwarrantrequired", ""))
+        status = norm_value(row.get("expansionstatus", ""))
         if mode not in ALLOWED_SURFACE_BUDGET_MODE:
-            errors.append(f"{warrant_id}: invalid surface budget mode `{row.get('mode', '')}`")
+            errors.append(f"{wid}: invalid surface budget mode `{row.get('mode', '')}`")
         if target not in ALLOWED_TARGET_NET_LOC:
-            errors.append(f"{warrant_id}: invalid target net LOC `{row.get('targetnetloc', '')}`")
+            errors.append(f"{wid}: invalid target net LOC `{row.get('targetnetloc', '')}`")
         if subtractive not in ALLOWED_YES_NO:
-            errors.append(f"{warrant_id}: subtractive probes required must be yes/no")
-        if expansion_required not in ALLOWED_YES_NO:
-            errors.append(f"{warrant_id}: expansion warrant required must be yes/no")
-        if expansion_status not in ALLOWED_EXPANSION_STATUS:
-            errors.append(f"{warrant_id}: invalid expansion status `{row.get('expansionstatus', '')}`")
-        for field in [
-            "maxpositiveloc",
-            "maxnewpublicsymbols",
-            "maxnewfiles",
-            "maxnewhelpers",
-            "maxnewflagsorknobs",
-            "maxnewstatevariants",
-            "maxnewbranches",
-            "duplicatepathbudget",
-        ]:
-            if parse_nonnegative_int(row.get(field, "")) is None:
-                errors.append(f"{warrant_id}: `{field}` must be a non-negative integer")
+            errors.append(f"{wid}: subtractive probes required must be yes/no")
+        if expansion not in ALLOWED_YES_NO:
+            errors.append(f"{wid}: expansion warrant required must be yes/no")
+        if status not in ALLOWED_EXPANSION_STATUS:
+            errors.append(f"{wid}: invalid expansion status `{row.get('expansionstatus', '')}`")
+        for f in ["maxpositiveloc", "maxnewpublicsymbols", "maxnewfiles", "maxnewhelpers", "maxnewflagsorknobs", "maxnewstatevariants", "maxnewbranches", "duplicatepathbudget"]:
+            if parse_nonnegative_int(row.get(f, "")) is None:
+                errors.append(f"{wid}: `{f}` must be a non-negative integer")
         if is_empty(row.get("proofrequired", "")):
-            errors.append(f"{warrant_id}: Surface Budget Ledger requires proof required")
+            errors.append(f"{wid}: Surface Budget Ledger requires proof required")
         if is_empty(row.get("notes", "")):
-            errors.append(f"{warrant_id}: Surface Budget Ledger requires notes")
-
-    mutate_warrants = [row for row in warrant_rows if norm_value(row.get("permittedaction", "")) == "mutate-code"]
+            errors.append(f"{wid}: Surface Budget Ledger requires notes")
     mutate_ids = [row.get("warrantid", "").strip() for row in mutate_warrants if row.get("warrantid", "").strip()]
     missing_budgets = sorted(set(mutate_ids) - set(budget_by_warrant))
     if missing_budgets:
         errors.append("Surface Budget Ledger missing mutate-code warrant ids: " + ", ".join(missing_budgets))
-    all_warrant_ids = {row.get("warrantid", "").strip() for row in warrant_rows if row.get("warrantid", "").strip()}
-    extra_budgets = sorted(set(budget_by_warrant) - all_warrant_ids)
-    if extra_budgets:
-        errors.append("Surface Budget Ledger contains unknown warrant ids: " + ", ".join(extra_budgets))
-
-    total_max_positive = 0
-    total_public_budget = 0
-    total_file_budget = 0
-    total_helper_budget = 0
-    total_flag_budget = 0
-    subtractive_first_count = 0
+    total_max = total_public = total_files = total_helpers = total_flags = 0
+    subtractive_first = 0
     for warrant in mutate_warrants:
         wid = warrant.get("warrantid", "").strip()
         budget = budget_by_warrant.get(wid)
@@ -1107,66 +560,41 @@ def validate_surface_budget_ledger(
         mode = norm_value(budget.get("mode", ""))
         target = norm_value(budget.get("targetnetloc", ""))
         subtractive = norm_value(budget.get("subtractiveprobesrequired", ""))
-        expansion_required = norm_value(budget.get("expansionwarrantrequired", ""))
+        expansion = norm_value(budget.get("expansionwarrantrequired", ""))
         max_pos = parse_nonnegative_int(budget.get("maxpositiveloc", "")) or 0
-        total_max_positive += max_pos
-        total_public_budget += parse_nonnegative_int(budget.get("maxnewpublicsymbols", "")) or 0
-        total_file_budget += parse_nonnegative_int(budget.get("maxnewfiles", "")) or 0
-        total_helper_budget += parse_nonnegative_int(budget.get("maxnewhelpers", "")) or 0
-        total_flag_budget += parse_nonnegative_int(budget.get("maxnewflagsorknobs", "")) or 0
+        total_max += max_pos
+        total_public += parse_nonnegative_int(budget.get("maxnewpublicsymbols", "")) or 0
+        total_files += parse_nonnegative_int(budget.get("maxnewfiles", "")) or 0
+        total_helpers += parse_nonnegative_int(budget.get("maxnewhelpers", "")) or 0
+        total_flags += parse_nonnegative_int(budget.get("maxnewflagsorknobs", "")) or 0
         if mode == "subtractive-first":
-            subtractive_first_count += 1
+            subtractive_first += 1
         if subtractive != "yes":
             errors.append(f"{wid}: mutate-code surface budget requires subtractive probes before first production patch")
-        if expansion_required != "yes":
+        if expansion != "yes":
             errors.append(f"{wid}: mutate-code surface budget requires expansion warrant for additive escape")
         if mode == "exploratory":
             errors.append(f"{wid}: mutate-code warrant cannot use exploratory surface budget mode")
         if target == "uncapped-blocked":
             errors.append(f"{wid}: mutate-code warrant cannot proceed with uncapped-blocked target net LOC")
-        if target in {"negative", "zero"} and max_pos > 0:
-            warnings.append(f"{wid}: target net LOC `{target}` has positive LOC allowance {max_pos}; verify expansion constraint")
+    ins, dels = parse_diffstat(diffstat)
+    net = ins - dels
+    if diffstat and mutate_warrants and net > total_max:
+        errors.append(f"diffstat net LOC +{net} exceeds mutate-code surface budget max positive LOC {total_max}")
+    if new_public_symbols > total_public:
+        errors.append(f"new public symbols {new_public_symbols} exceed surface budget {total_public}")
+    if new_files > total_files:
+        errors.append(f"new files {new_files} exceed surface budget {total_files}")
+    if new_helpers > total_helpers:
+        errors.append(f"new helpers {new_helpers} exceed surface budget {total_helpers}")
+    if new_flags_or_knobs > total_flags:
+        errors.append(f"new flags/knobs {new_flags_or_knobs} exceed surface budget {total_flags}")
+    return {"rows": rows, "by_warrant": budget_by_warrant, "mutate_budget_rows": len(mutate_ids), "subtractive_first": subtractive_first, "total_max_positive_loc": total_max, "diffstat_insertions": ins, "diffstat_deletions": dels, "diffstat_net": net}
 
-    insertions, deletions = parse_diffstat(diffstat)
-    net = insertions - deletions
-    if diffstat and mutate_warrants:
-        if net > total_max_positive:
-            errors.append(f"diffstat net LOC +{net} exceeds mutate-code surface budget max positive LOC {total_max_positive}")
-        if mutate_ids and all(norm_value(budget_by_warrant.get(wid, {}).get("targetnetloc", "")) == "negative" for wid in mutate_ids if wid in budget_by_warrant) and net >= 0:
-            errors.append("all mutate-code warrants target negative net LOC, but diffstat is not net-negative")
-    if new_public_symbols > total_public_budget:
-        errors.append(f"new public symbols {new_public_symbols} exceed surface budget {total_public_budget}")
-    if new_files > total_file_budget:
-        errors.append(f"new files {new_files} exceed surface budget {total_file_budget}")
-    if new_helpers > total_helper_budget:
-        errors.append(f"new helpers {new_helpers} exceed surface budget {total_helper_budget}")
-    if new_flags_or_knobs > total_flag_budget:
-        errors.append(f"new flags/knobs {new_flags_or_knobs} exceed surface budget {total_flag_budget}")
 
-    return {
-        "rows": rows,
-        "by_warrant": budget_by_warrant,
-        "mutate_budget_rows": len(mutate_ids),
-        "subtractive_first": subtractive_first_count,
-        "total_max_positive_loc": total_max_positive,
-        "diffstat_insertions": insertions,
-        "diffstat_deletions": deletions,
-        "diffstat_net": net,
-    }
-
-def check_adjudication(
-    text: str,
-    changed_files: Optional[Sequence[str]] = None,
-    resolved_threads: Optional[Sequence[str]] = None,
-    diffstat: str = "",
-    new_public_symbols: int = 0,
-    new_files: int = 0,
-    new_helpers: int = 0,
-    new_flags_or_knobs: int = 0,
-) -> CheckResult:
+def check_adjudication(text: str, changed_files: Optional[Sequence[str]] = None, resolved_threads: Optional[Sequence[str]] = None, diffstat: str = "", new_public_symbols: int = 0, new_files: int = 0, new_helpers: int = 0, new_flags_or_knobs: int = 0) -> CheckResult:
     errors: List[str] = []
     warnings: List[str] = []
-
     for section in REQUIRED_SECTIONS:
         count = section_count(text, section)
         if count != 1:
@@ -1175,7 +603,6 @@ def check_adjudication(
         count = section_count(text, section)
         if count > 1:
             errors.append(f"{section} must appear at most once, found {count}")
-
     review_basis = section_text(text, "Review Basis")
     if "artifact_state_id" not in review_basis:
         errors.append("Review Basis missing artifact_state_id block")
@@ -1183,79 +610,56 @@ def check_adjudication(
         for key in ["branch", "head", "diff_digest", "comment_set_digest", "ci_state"]:
             if not re.search(rf"(?im)^\s*{re.escape(key)}\s*:", review_basis):
                 errors.append(f"artifact_state_id missing `{key}`")
-
     inventory = parse_inventory(section_text(text, "Comment Inventory"))
     for key in ["inputcount", "ledgercount", "inputids", "ledgerids", "missingids", "duplicateids", "synthesized"]:
         if key not in inventory:
             errors.append(f"Comment Inventory missing `{key}`")
-
-    ledger_headers, raw_rows = extract_first_table(section_text(text, "Comment Ledger"))
-    header_map, rows = normalize_rows(ledger_headers, raw_rows, COLUMN_ALIASES)
-    missing_columns = [field for field in REQUIRED_LEDGER_FIELDS if field not in header_map]
-    if missing_columns:
-        errors.append("Comment Ledger missing required columns: " + ", ".join(missing_columns))
-    if not rows:
+    ledger_headers, ledger_raw = extract_first_table(section_text(text, "Comment Ledger"))
+    ledger_map, ledger_rows = normalize_rows(ledger_headers, ledger_raw, COLUMN_ALIASES)
+    missing = [f for f in REQUIRED_LEDGER_FIELDS if f not in ledger_map]
+    if missing:
+        errors.append("Comment Ledger missing required columns: " + ", ".join(missing))
+    if not ledger_rows:
         errors.append("Comment Ledger has no data rows")
-
-    ledger_ids = [row.get("id", "").strip() for row in rows if row.get("id", "").strip()]
-    duplicate_ledger_ids = sorted({rid for rid in ledger_ids if ledger_ids.count(rid) > 1})
-    if duplicate_ledger_ids:
-        errors.append("Comment Ledger duplicate ids: " + ", ".join(duplicate_ledger_ids))
-
+    ledger_ids = [row.get("id", "").strip() for row in ledger_rows if row.get("id", "").strip()]
+    ledger_by_id = rows_by_id(ledger_rows)
     input_count = parse_int(inventory.get("inputcount", ""))
     ledger_count = parse_int(inventory.get("ledgercount", ""))
-    if input_count is not None and input_count != len(rows):
-        errors.append(f"Comment Inventory input_comment_count={input_count} but ledger has {len(rows)} rows")
-    if ledger_count is not None and ledger_count != len(rows):
-        errors.append(f"Comment Inventory ledger_row_count={ledger_count} but ledger has {len(rows)} rows")
-
+    if input_count is not None and input_count != len(ledger_rows):
+        errors.append(f"Comment Inventory input_comment_count={input_count} but ledger has {len(ledger_rows)} rows")
+    if ledger_count is not None and ledger_count != len(ledger_rows):
+        errors.append(f"Comment Inventory ledger_row_count={ledger_count} but ledger has {len(ledger_rows)} rows")
     input_ids = parse_id_list(inventory.get("inputids", ""))
     declared_ledger_ids = parse_id_list(inventory.get("ledgerids", ""))
-    missing_ids = parse_id_list(inventory.get("missingids", ""))
-    duplicate_ids = parse_id_list(inventory.get("duplicateids", ""))
-    synthesized = norm_value(inventory.get("synthesized", ""))
-    if input_ids:
-        actual_missing = sorted(set(input_ids) - set(ledger_ids))
-        if actual_missing:
-            errors.append("Comment Inventory omitted input ids from ledger: " + ", ".join(actual_missing))
-        actual_extra = sorted(set(ledger_ids) - set(input_ids))
-        if actual_extra:
-            warnings.append("Comment Ledger has ids not listed in input_comment_ids: " + ", ".join(actual_extra))
+    if input_ids and sorted(set(input_ids) - set(ledger_ids)):
+        errors.append("Comment Inventory omitted input ids from ledger: " + ", ".join(sorted(set(input_ids) - set(ledger_ids))))
     if declared_ledger_ids and set(declared_ledger_ids) != set(ledger_ids):
         errors.append("Comment Inventory ledger_comment_ids does not match actual ledger ids")
-    if missing_ids:
-        errors.append("Comment Inventory reports missing ids: " + ", ".join(missing_ids))
-    if duplicate_ids:
-        errors.append("Comment Inventory reports duplicate ids: " + ", ".join(duplicate_ids))
-    if synthesized == "yes":
-        errors.append("synthesized_ids_for_real_comments is yes; real review identity coverage fails")
-    elif synthesized not in {"yes", "no"}:
-        errors.append("synthesized_ids_for_real_comments must be yes/no")
+    if parse_id_list(inventory.get("missingids", "")):
+        errors.append("Comment Inventory reports missing ids: " + ", ".join(parse_id_list(inventory.get("missingids", ""))))
+    if parse_id_list(inventory.get("duplicateids", "")):
+        errors.append("Comment Inventory reports duplicate ids: " + ", ".join(parse_id_list(inventory.get("duplicateids", ""))))
+    if norm_value(inventory.get("synthesized", "")) != "no":
+        errors.append("synthesized_ids_for_real_comments must be no for implementation handoff")
 
-    decision_headers, decision_raw_rows = extract_first_table(section_text(text, "Decision Tests"))
-    decision_header_map, decision_rows = normalize_rows(decision_headers, decision_raw_rows, DECISION_ALIASES)
-    missing_decision_columns = [field for field in REQUIRED_DECISION_FIELDS if field not in decision_header_map]
-    if missing_decision_columns:
-        errors.append("Decision Tests missing required columns: " + ", ".join(missing_decision_columns))
-    if not decision_rows:
-        errors.append("Decision Tests has no data rows")
+    decision_headers, decision_raw = extract_first_table(section_text(text, "Decision Tests"))
+    decision_map, decision_rows = normalize_rows(decision_headers, decision_raw, DECISION_ALIASES)
+    missing_decisions = [f for f in REQUIRED_DECISION_FIELDS if f not in decision_map]
+    if missing_decisions:
+        errors.append("Decision Tests missing required columns: " + ", ".join(missing_decisions))
     decisions = rows_by_id(decision_rows)
-
+    nochange_text = section_text(text, "No-Change Countercases")
+    resolve_counter_text = section_text(text, "Resolve Countercases")
     act_count = validation_count = reply_count = non_action_count = 0
-    ledger_by_id = rows_by_id(rows)
-    nochange_section = section_text(text, "No-Change Countercases")
-    resolve_countercase_section = section_text(text, "Resolve Countercases")
-
-    for idx, row in enumerate(rows, start=1):
-        label = row.get("id", f"row {idx}") or f"row {idx}"
-        for field_name in ["id", "reviewer", "location", "excerpt", "claim"]:
-            if is_empty(row.get(field_name, "")):
-                errors.append(f"{label}: missing raw identity field `{field_name}`")
-        if label not in nochange_section:
-            errors.append(f"{label}: missing No-Change Countercases entry")
-        if label not in resolve_countercase_section:
-            errors.append(f"{label}: missing Resolve Countercases entry")
-
+    for idx, row in enumerate(ledger_rows, start=1):
+        rid = row.get("id", f"row {idx}") or f"row {idx}"
+        for f in ["id", "reviewer", "location", "excerpt", "claim"]:
+            if is_empty(row.get(f, "")):
+                errors.append(f"{rid}: missing raw identity field `{f}`")
+        if rid not in nochange_text:
+            errors.append(f"{rid}: missing No-Change Countercases entry")
+        if rid not in resolve_counter_text:
+            errors.append(f"{rid}: missing Resolve Countercases entry")
         relevance = norm_value(row.get("relevance", ""))
         disposition = norm_value(row.get("disposition", ""))
         nochange = norm_value(row.get("nochange", ""))
@@ -1264,240 +668,143 @@ def check_adjudication(
         evidence_grade = norm_value(row.get("evidencegrade", ""))
         evidence_ref = row.get("evidenceref", "")
         handoff = norm_value(row.get("handoff", ""))
-
         if relevance not in ALLOWED_RELEVANCE:
-            errors.append(f"{label}: invalid relevance `{row.get('relevance', '')}`")
+            errors.append(f"{rid}: invalid relevance `{row.get('relevance', '')}`")
         if disposition not in ALLOWED_DISPOSITION:
-            errors.append(f"{label}: invalid disposition `{row.get('disposition', '')}`")
+            errors.append(f"{rid}: invalid disposition `{row.get('disposition', '')}`")
         if nochange not in ALLOWED_NO_CHANGE:
-            errors.append(f"{label}: invalid no-change status `{row.get('nochange', '')}`")
+            errors.append(f"{rid}: invalid no-change status `{row.get('nochange', '')}`")
         if concern not in ALLOWED_CONCERN:
-            errors.append(f"{label}: invalid concern validity `{row.get('concern', '')}`")
+            errors.append(f"{rid}: invalid concern validity `{row.get('concern', '')}`")
         if proposed not in ALLOWED_PROPOSED:
-            errors.append(f"{label}: invalid proposed-fix validity `{row.get('proposed', '')}`")
+            errors.append(f"{rid}: invalid proposed-fix validity `{row.get('proposed', '')}`")
         if evidence_grade not in ALLOWED_EVIDENCE_GRADE:
-            errors.append(f"{label}: invalid evidence grade `{row.get('evidencegrade', '')}`")
+            errors.append(f"{rid}: invalid evidence grade `{row.get('evidencegrade', '')}`")
         if handoff not in ALLOWED_HANDOFF:
-            errors.append(f"{label}: invalid handoff `{row.get('handoff', '')}`")
-
-        decision = decisions.get(label)
+            errors.append(f"{rid}: invalid handoff `{row.get('handoff', '')}`")
+        decision = decisions.get(rid)
         if not decision:
-            errors.append(f"{label}: missing Decision Tests row")
+            errors.append(f"{rid}: missing Decision Tests row")
         else:
-            grounded = norm_value(decision.get("grounded", ""))
-            material = norm_value(decision.get("material", ""))
-            fresh = norm_value(decision.get("fresh", ""))
-            diagnosis = norm_value(decision.get("diagnosis", ""))
-            scopefit = norm_value(decision.get("scopefit", ""))
-            resolutionvalue = norm_value(decision.get("resolutionvalue", ""))
-            nochangedefeated = norm_value(decision.get("nochangedefeated", ""))
-            if grounded not in ALLOWED_GROUNDED:
-                errors.append(f"{label}: invalid Decision Tests grounded `{grounded}`")
-            if material not in ALLOWED_MATERIAL:
-                errors.append(f"{label}: invalid Decision Tests material `{material}`")
-            if fresh not in ALLOWED_FRESH:
-                errors.append(f"{label}: invalid Decision Tests fresh `{fresh}`")
-            if diagnosis not in ALLOWED_DIAGNOSIS:
-                errors.append(f"{label}: invalid Decision Tests diagnosis `{diagnosis}`")
-            if scopefit not in ALLOWED_SCOPE_FIT:
-                errors.append(f"{label}: invalid Decision Tests scope-fit `{scopefit}`")
-            if resolutionvalue not in ALLOWED_RESOLUTION_VALUE:
-                errors.append(f"{label}: invalid Decision Tests resolution value `{resolutionvalue}`")
-            if nochangedefeated not in ALLOWED_NO_CHANGE_DEFEATED:
-                errors.append(f"{label}: invalid Decision Tests no-change defeated `{nochangedefeated}`")
+            checks = [("grounded", ALLOWED_GROUNDED), ("material", ALLOWED_MATERIAL), ("fresh", ALLOWED_FRESH), ("diagnosis", ALLOWED_DIAGNOSIS), ("scopefit", ALLOWED_SCOPE_FIT), ("resolutionvalue", ALLOWED_RESOLUTION_VALUE), ("nochangedefeated", ALLOWED_NO_CHANGE_DEFEATED)]
+            for f, allowed in checks:
+                if norm_value(decision.get(f, "")) not in allowed:
+                    errors.append(f"{rid}: invalid Decision Tests {f} `{decision.get(f, '')}`")
             if is_empty(decision.get("minevidence", "")):
-                errors.append(f"{label}: missing minimum evidence to change mind")
-
+                errors.append(f"{rid}: missing minimum evidence to change mind")
         if disposition == "act":
             act_count += 1
             if nochange != "defeated":
-                errors.append(f"{label}: `act` requires no-change status `defeated`")
+                errors.append(f"{rid}: `act` requires no-change status `defeated`")
             if concern not in {"valid", "partial"}:
-                errors.append(f"{label}: `act` requires concern validity `valid` or `partial`")
-            if relevance in {"stale-or-superseded", "unsupported", "out-of-scope", "preference-only"}:
-                errors.append(f"{label}: `act` conflicts with relevance `{relevance}`")
+                errors.append(f"{rid}: `act` requires concern validity valid or partial")
             if evidence_grade not in ACTION_EVIDENCE_GRADES:
-                errors.append(f"{label}: `act` requires current evidence grade, got `{evidence_grade}`")
+                errors.append(f"{rid}: `act` requires current evidence grade")
             if not evidence_ref_is_concrete(evidence_ref):
-                errors.append(f"{label}: `act` requires concrete evidence ref")
-            if proposed == "validation-only":
-                errors.append(f"{label}: `act` cannot use proposed-fix validity `validation-only`")
-            if decision:
-                if norm_value(decision.get("grounded", "")) != "yes":
-                    errors.append(f"{label}: `act` requires Decision Tests grounded=yes")
-                if norm_value(decision.get("material", "")) not in {"yes", "user-requested"}:
-                    errors.append(f"{label}: `act` requires Decision Tests material=yes or user-requested")
-                if norm_value(decision.get("fresh", "")) != "current":
-                    errors.append(f"{label}: `act` requires Decision Tests fresh=current")
-                if norm_value(decision.get("diagnosis", "")) not in {"correct", "partially-correct"}:
-                    errors.append(f"{label}: `act` requires diagnosis correct or partially-correct")
-                if norm_value(decision.get("scopefit", "")) != "yes":
-                    errors.append(f"{label}: `act` requires scope-fit=yes")
-                if norm_value(decision.get("resolutionvalue", "")) not in {"merge-blocking", "correctness-critical", "review-closure"}:
-                    errors.append(f"{label}: `act` requires resolution value merge-blocking, correctness-critical, or review-closure")
-                if norm_value(decision.get("nochangedefeated", "")) != "yes":
-                    errors.append(f"{label}: `act` requires no-change defeated=yes")
-            if proposed in {"wrong-fix", "overbroad", "under-specified", "not-applicable"}:
-                if handoff not in IMPLEMENTATION_HANDOFFS:
-                    errors.append(f"{label}: invalid proposed fix requires explicit replacement/invariant handoff")
-                warnings.append(f"{label}: proposed fix is `{proposed}`; verify replacement fix shape")
-        elif disposition in ALLOWED_DISPOSITION:
-            non_action_count += 1
-
-        if proposed == "validation-only":
-            validation_count += 1
-            if disposition != "need-evidence":
-                errors.append(f"{label}: proposed-fix validity `validation-only` requires disposition `need-evidence`")
-            if handoff != "route-to-fixed-point-driver":
-                errors.append(f"{label}: validation-only requires handoff `route-to-fixed-point-driver`")
-        if disposition == "need-evidence":
-            validation_count += 1
-            if handoff == "route-to-accretive-implementer":
-                errors.append(f"{label}: `need-evidence` cannot route directly to accretive-implementer")
-            if nochange == "defeated":
-                warnings.append(f"{label}: `need-evidence` usually should not have no-change status `defeated`")
-        if disposition == "rebut":
-            reply_count += 1
-            if handoff in IMPLEMENTATION_HANDOFFS:
-                errors.append(f"{label}: `rebut` cannot route to implementation handoff `{handoff}`")
-        if disposition == "defer":
-            reply_count += 1
-            if handoff == "route-to-accretive-implementer":
-                errors.append(f"{label}: `defer` cannot route directly to accretive-implementer")
-
-    resolve_headers, resolve_raw_rows = extract_first_table(section_text(text, "Resolve Selection"))
-    resolve_header_map, resolve_rows = normalize_rows(resolve_headers, resolve_raw_rows, RESOLVE_ALIASES)
-    missing_resolve_columns = [field for field in REQUIRED_RESOLVE_FIELDS if field not in resolve_header_map]
-    if missing_resolve_columns:
-        errors.append("Resolve Selection missing required columns: " + ", ".join(missing_resolve_columns))
-    if not resolve_rows:
-        errors.append("Resolve Selection has no data rows")
-    resolve_by_id = rows_by_id(resolve_rows)
-    ledger_id_set = set(ledger_ids)
-    resolve_id_set = set(resolve_by_id)
-    if sorted(ledger_id_set - resolve_id_set):
-        errors.append("Resolve Selection missing comment ids: " + ", ".join(sorted(ledger_id_set - resolve_id_set)))
-    if sorted(resolve_id_set - ledger_id_set):
-        errors.append("Resolve Selection contains unknown comment ids: " + ", ".join(sorted(resolve_id_set - ledger_id_set)))
-
-    decision_buckets = {"address": [], "validate-only": [], "resolve-thread-only": [], "do-not-address": [], "blocked": []}
-    for idx, resolve in enumerate(resolve_rows, start=1):
-        label = resolve.get("id", f"resolve row {idx}") or f"resolve row {idx}"
-        decision_value = norm_value(resolve.get("decision", ""))
-        reason = resolve.get("reason", "")
-        proof_ref = resolve.get("proofref", "")
-        next_action = resolve.get("next", "")
-        route_rationale = norm_value(resolve.get("routerationale", ""))
-        if decision_value not in ALLOWED_RESOLVE_DECISION:
-            errors.append(f"{label}: invalid resolve decision `{resolve.get('decision', '')}`")
+                errors.append(f"{rid}: `act` requires concrete evidence ref")
         else:
-            decision_buckets[decision_value].append(label)
-        if route_rationale not in ALLOWED_ROUTE_RATIONALE:
-            errors.append(f"{label}: invalid route rationale `{resolve.get('routerationale', '')}`")
-        if is_empty(reason):
-            errors.append(f"{label}: Resolve Selection requires non-empty reason")
-        if decision_value == "blocked":
+            non_action_count += 1
+        if proposed == "validation-only" or disposition == "need-evidence":
+            validation_count += 1
+            if proposed == "validation-only" and disposition != "need-evidence":
+                errors.append(f"{rid}: proposed-fix validity validation-only requires disposition need-evidence")
+            if handoff == "route-to-accretive-implementer":
+                errors.append(f"{rid}: need-evidence/validation-only cannot route directly to accretive-implementer")
+        if disposition in {"rebut", "defer"}:
+            reply_count += 1
+            if handoff in IMPLEMENTATION_HANDOFFS and disposition == "rebut":
+                errors.append(f"{rid}: rebut cannot route to implementation handoff `{handoff}`")
+    resolve_headers, resolve_raw = extract_first_table(section_text(text, "Resolve Selection"))
+    resolve_map, resolve_rows = normalize_rows(resolve_headers, resolve_raw, RESOLVE_ALIASES)
+    missing_resolve = [f for f in REQUIRED_RESOLVE_FIELDS if f not in resolve_map]
+    if missing_resolve:
+        errors.append("Resolve Selection missing required columns: " + ", ".join(missing_resolve))
+    resolve_by_id = rows_by_id(resolve_rows)
+    if set(ledger_ids) - set(resolve_by_id):
+        errors.append("Resolve Selection missing comment ids: " + ", ".join(sorted(set(ledger_ids) - set(resolve_by_id))))
+    if set(resolve_by_id) - set(ledger_ids):
+        errors.append("Resolve Selection contains unknown comment ids: " + ", ".join(sorted(set(resolve_by_id) - set(ledger_ids))))
+    decision_buckets = {"address": [], "validate-only": [], "resolve-thread-only": [], "do-not-address": [], "blocked": []}
+    for idx, row in enumerate(resolve_rows, start=1):
+        rid = row.get("id", f"resolve row {idx}") or f"resolve row {idx}"
+        decision = norm_value(row.get("decision", ""))
+        proof_ref = row.get("proofref", "")
+        route = norm_value(row.get("routerationale", ""))
+        if decision not in ALLOWED_RESOLVE_DECISION:
+            errors.append(f"{rid}: invalid resolve decision `{row.get('decision', '')}`")
+        else:
+            decision_buckets[decision].append(rid)
+        if route not in ALLOWED_ROUTE_RATIONALE:
+            errors.append(f"{rid}: invalid route rationale `{row.get('routerationale', '')}`")
+        if decision == "blocked":
             if not evidence_ref_is_concrete(proof_ref, allow_missing=True):
-                errors.append(f"{label}: blocked selection requires proof ref or explicit missing marker")
+                errors.append(f"{rid}: blocked selection requires proof ref or explicit missing marker")
         elif not evidence_ref_is_concrete(proof_ref):
-            errors.append(f"{label}: Resolve Selection requires concrete proof ref")
-        if is_empty(next_action) and decision_value != "do-not-address":
-            errors.append(f"{label}: Resolve Selection requires non-empty next action")
-        ledger_row = ledger_by_id.get(label)
-        if not ledger_row:
+            errors.append(f"{rid}: Resolve Selection requires concrete proof ref")
+        ledger = ledger_by_id.get(rid)
+        if not ledger:
             continue
-        disposition = norm_value(ledger_row.get("disposition", ""))
-        nochange = norm_value(ledger_row.get("nochange", ""))
-        handoff = norm_value(ledger_row.get("handoff", ""))
-        if decision_value == "address":
+        disposition = norm_value(ledger.get("disposition", ""))
+        nochange = norm_value(ledger.get("nochange", ""))
+        handoff = norm_value(ledger.get("handoff", ""))
+        if decision == "address":
             if disposition != "act":
-                errors.append(f"{label}: resolve decision `address` requires disposition `act`")
+                errors.append(f"{rid}: resolve decision address requires disposition act")
             if nochange != "defeated":
-                errors.append(f"{label}: resolve decision `address` requires defeated no-change case")
-            if route_rationale == "narrow-local":
-                if handoff == "route-to-fixed-point-driver" or "fixed-point-driver" in norm_value(next_action):
-                    errors.append(f"{label}: narrow-local address must not route to fixed-point-driver")
-            elif route_rationale not in FIXED_POINT_RATIONALES:
-                errors.append(f"{label}: address route rationale must be narrow-local or fixed-point rationale")
-        elif decision_value == "validate-only":
+                errors.append(f"{rid}: resolve decision address requires defeated no-change case")
+            if route == "narrow-local" and (handoff == "route-to-fixed-point-driver" or "fixed-point-driver" in norm_value(row.get("next", ""))):
+                errors.append(f"{rid}: narrow-local address must not route to fixed-point-driver")
+            if route != "narrow-local" and route not in FIXED_POINT_RATIONALES:
+                errors.append(f"{rid}: address route rationale must be narrow-local or fixed-point rationale")
+        elif decision == "validate-only":
             if disposition != "need-evidence":
-                errors.append(f"{label}: resolve decision `validate-only` requires disposition `need-evidence`")
-            if route_rationale != "validation-only":
-                errors.append(f"{label}: validate-only requires route rationale `validation-only`")
+                errors.append(f"{rid}: validate-only requires disposition need-evidence")
+            if route != "validation-only":
+                errors.append(f"{rid}: validate-only requires route rationale validation-only")
             if handoff != "route-to-fixed-point-driver":
-                errors.append(f"{label}: validate-only requires route-to-fixed-point-driver handoff")
-        elif decision_value == "resolve-thread-only":
+                errors.append(f"{rid}: validate-only requires route-to-fixed-point-driver handoff")
+        elif decision == "resolve-thread-only":
             if disposition == "act":
-                errors.append(f"{label}: resolve-thread-only conflicts with disposition `act`")
-            if route_rationale != "proof-only-thread":
-                errors.append(f"{label}: resolve-thread-only requires route rationale `proof-only-thread`")
-            if handoff in IMPLEMENTATION_HANDOFFS:
-                errors.append(f"{label}: resolve-thread-only cannot use implementation handoff `{handoff}`")
-        elif decision_value == "do-not-address":
+                errors.append(f"{rid}: resolve-thread-only conflicts with disposition act")
+            if route != "proof-only-thread":
+                errors.append(f"{rid}: resolve-thread-only requires route rationale proof-only-thread")
+        elif decision == "do-not-address":
             if disposition == "act":
-                errors.append(f"{label}: do-not-address conflicts with disposition `act`")
-            if route_rationale != "no-change":
-                errors.append(f"{label}: do-not-address requires route rationale `no-change`")
-            if norm_value(next_action) not in {"none", "", "no", "n/a", "na"} and "reply" not in norm_value(next_action):
-                warnings.append(f"{label}: do-not-address usually uses next=none or proof/reply-only")
-        elif decision_value == "blocked":
-            if route_rationale != "blocked":
-                errors.append(f"{label}: blocked requires route rationale `blocked`")
+                errors.append(f"{rid}: do-not-address conflicts with disposition act")
+            if route != "no-change":
+                errors.append(f"{rid}: do-not-address requires route rationale no-change")
+        elif decision == "blocked" and route != "blocked":
+            errors.append(f"{rid}: blocked requires route rationale blocked")
 
+    adversarial_by_id, clearance_buckets = validate_adversarial_matrix(text, resolve_by_id, ledger_by_id, errors, warnings)
     handoff_buckets = parse_handoff_agenda(section_text(text, "Handoff Agenda"), ledger_ids, errors)
-    expected = {
-        "implementation": sorted(decision_buckets["address"]),
-        "validation": sorted(decision_buckets["validate-only"]),
-        "proofonly": sorted(decision_buckets["resolve-thread-only"]),
-        "notselected": sorted(decision_buckets["do-not-address"]),
-        "blocked": sorted(decision_buckets["blocked"]),
-    }
-    for bucket, expected_ids in expected.items():
-        got_ids = sorted(handoff_buckets.get(bucket, []))
-        if got_ids != expected_ids:
-            errors.append(f"Handoff Agenda `{bucket}` mismatch: expected {expected_ids}, got {got_ids}")
+    expected_buckets = {"implementation": sorted(decision_buckets["address"]), "validation": sorted(decision_buckets["validate-only"]), "proofonly": sorted(decision_buckets["resolve-thread-only"]), "notselected": sorted(decision_buckets["do-not-address"]), "blocked": sorted(decision_buckets["blocked"])}
+    for bucket, expected_ids in expected_buckets.items():
+        got = sorted(handoff_buckets.get(bucket, []))
+        if got != expected_ids:
+            errors.append(f"Handoff Agenda `{bucket}` mismatch: expected {expected_ids}, got {got}")
+    warrant_result = validate_resolution_warrants(text, ledger_by_id, resolve_by_id, handoff_buckets, errors, warnings, changed_files, resolved_threads)
+    warrant_buckets = warrant_result.get("action_buckets", {}) if isinstance(warrant_result, dict) else {}
+    surface_result = validate_surface_budget_ledger(text, warrant_result.get("rows", []) if isinstance(warrant_result, dict) else [], errors, warnings, diffstat, new_public_symbols, new_files, new_helpers, new_flags_or_knobs)
 
-    warrant_result = validate_resolution_warrants(
-        text, ledger_by_id, resolve_by_id, handoff_buckets, errors, warnings,
-        changed_files=changed_files, resolved_threads=resolved_threads,
-    )
-    warrant_action_buckets = warrant_result.get("action_buckets", {}) if isinstance(warrant_result, dict) else {}
-    surface_budget_result = validate_surface_budget_ledger(
-        text,
-        warrant_result.get("rows", []) if isinstance(warrant_result, dict) else [],
-        errors,
-        warnings,
-        diffstat=diffstat,
-        new_public_symbols=new_public_symbols,
-        new_files=new_files,
-        new_helpers=new_helpers,
-        new_flags_or_knobs=new_flags_or_knobs,
-    )
-
-    gate_headers, gate_rows_raw = extract_first_table(section_text(text, "Adjudication Gate"))
-    gate = normalize_gate(gate_headers, gate_rows_raw)
-    missing_gate = [field for field in REQUIRED_GATE_FIELDS if field not in gate]
+    gate_headers, gate_raw = extract_first_table(section_text(text, "Adjudication Gate"))
+    gate = normalize_gate(gate_headers, gate_raw)
+    missing_gate = [f for f in REQUIRED_GATE_FIELDS if f not in gate]
     if missing_gate:
         errors.append("Adjudication Gate missing required fields: " + ", ".join(missing_gate))
-
-    for field_name in REQUIRED_GATE_FIELDS:
-        if field_name not in gate:
+    for f in REQUIRED_GATE_FIELDS:
+        if f not in gate:
             continue
-        value = gate[field_name]
-        if field_name in {"implementationhandoffallowed", "validationhandoffallowed", "replyhandoffallowed"}:
-            if value not in {"yes", "no"}:
-                errors.append(f"{field_name} must be yes/no, got `{value}`")
-        elif field_name == "specialistpacketcoverage":
-            if value not in {"pass", "fail", "not-used"}:
-                errors.append(f"specialist_packet_coverage must be pass/fail/not-used, got `{value}`")
-        elif value not in {"pass", "fail"}:
-            errors.append(f"{field_name} must be pass/fail, got `{value}`")
-
-    gate_failures = [
-        field for field in REQUIRED_GATE_FIELDS
-        if field not in {"implementationhandoffallowed", "validationhandoffallowed", "replyhandoffallowed"}
-        and gate.get(field) == "fail"
-    ]
+        v = gate[f]
+        if f in {"implementationhandoffallowed", "validationhandoffallowed", "replyhandoffallowed"}:
+            if v not in {"yes", "no"}:
+                errors.append(f"{f} must be yes/no, got `{v}`")
+        elif f == "specialistpacketcoverage":
+            if v not in {"pass", "fail", "not-used"}:
+                errors.append(f"specialist_packet_coverage must be pass/fail/not-used, got `{v}`")
+        elif v not in {"pass", "fail"}:
+            errors.append(f"{f} must be pass/fail, got `{v}`")
+    gate_failures = [f for f in REQUIRED_GATE_FIELDS if f not in {"implementationhandoffallowed", "validationhandoffallowed", "replyhandoffallowed"} and gate.get(f) == "fail"]
     if gate_failures and gate.get("adjudicationcomplete") == "pass":
         errors.append("adjudication_complete is pass despite failed gate fields: " + ", ".join(gate_failures))
     if errors and gate.get("adjudicationcomplete") == "pass":
@@ -1505,32 +812,24 @@ def check_adjudication(
     if errors and gate.get("implementationhandoffallowed") == "yes":
         errors.append("implementation_handoff_allowed is yes despite mechanical contract errors")
     if gate.get("implementationhandoffallowed") == "yes" and not decision_buckets["address"]:
-        errors.append("implementation_handoff_allowed is yes but no Resolve Selection row is `address`")
-    if gate.get("implementationhandoffallowed") == "yes" and not warrant_action_buckets.get("mutate-code"):
+        errors.append("implementation_handoff_allowed is yes but no Resolve Selection row is address")
+    if gate.get("implementationhandoffallowed") == "yes" and not warrant_buckets.get("mutate-code"):
         errors.append("implementation_handoff_allowed is yes but no mutate-code Resolution Warrant exists")
+    for rid in decision_buckets["address"]:
+        adv = adversarial_by_id.get(rid, {})
+        if norm_value(adv.get("vetostatus", "")) != "cleared" or norm_value(adv.get("clearance", "")) != "cleared":
+            errors.append(f"{rid}: implementation handoff requires cleared adversarial action")
     if decision_buckets["blocked"] and gate.get("adjudicationcomplete") == "pass":
         errors.append("Resolve Selection has blocked rows but adjudication_complete is pass")
-    if decision_buckets["blocked"] and any(gate.get(field) == "yes" for field in ["implementationhandoffallowed", "validationhandoffallowed", "replyhandoffallowed"]):
-        errors.append("Resolve Selection has blocked rows but a handoff permission is yes")
-
-    if rows and act_count == len(rows):
-        validate_structured_table(text, "All-Action Justification", ALL_ACTION_CHECKS, errors, "why action still warranted")
-    if rows and len(decision_buckets["address"]) + len(decision_buckets["validate-only"]) == len(rows):
-        validate_structured_table(text, "All-Selected Justification", ALL_SELECTED_CHECKS, errors, "why selected resolution is still warranted")
-
-    validate_specialist_receipts(text, gate, errors)
-
     if not section_text(text, "Acceptance Skew Audit").strip():
         errors.append("Acceptance Skew Audit is empty")
     if not section_text(text, "Selection Skew Audit").strip():
         errors.append("Selection Skew Audit is empty")
-
     bottom_line = section_text(text, "Adjudication Bottom Line")
     if (gate_failures or errors) and "blocked" not in bottom_line.lower():
         errors.append("failed gate or mechanical error requires blocked Adjudication Bottom Line")
-
     stats = {
-        "comments": len(rows),
+        "comments": len(ledger_rows),
         "act": act_count,
         "non_action": non_action_count,
         "validation_or_need_evidence": validation_count,
@@ -1540,14 +839,17 @@ def check_adjudication(
         "resolve_thread_only": len(decision_buckets["resolve-thread-only"]),
         "resolve_do_not_address": len(decision_buckets["do-not-address"]),
         "resolve_blocked": len(decision_buckets["blocked"]),
+        "adversarial_rows": len(adversarial_by_id),
+        "adversarial_cleared": len(clearance_buckets.get("cleared", [])),
+        "adversarial_preserved": len(clearance_buckets.get("preserved", [])),
+        "adversarial_blocked": len(clearance_buckets.get("blocked", [])),
         "warrants": len(warrant_result.get("rows", [])) if isinstance(warrant_result, dict) else 0,
-        "surface_budget_rows": len(surface_budget_result.get("rows", [])) if isinstance(surface_budget_result, dict) else 0,
-        "surface_budget_max_positive_loc": int(surface_budget_result.get("total_max_positive_loc", 0)) if isinstance(surface_budget_result, dict) else 0,
-        "diffstat_net": int(surface_budget_result.get("diffstat_net", 0)) if isinstance(surface_budget_result, dict) else 0,
-        "mutate_warrants": len(warrant_action_buckets.get("mutate-code", [])) if isinstance(warrant_action_buckets, dict) else 0,
-        "validation_warrants": len(warrant_action_buckets.get("add-validation-only", [])) if isinstance(warrant_action_buckets, dict) else 0,
-        "thread_resolution_warrants": len(warrant_action_buckets.get("resolve-thread", [])) if isinstance(warrant_action_buckets, dict) else 0,
-        "duplicate_ledger_ids": len(duplicate_ledger_ids),
+        "surface_budget_rows": len(surface_result.get("rows", [])) if isinstance(surface_result, dict) else 0,
+        "surface_budget_max_positive_loc": int(surface_result.get("total_max_positive_loc", 0)) if isinstance(surface_result, dict) else 0,
+        "diffstat_net": int(surface_result.get("diffstat_net", 0)) if isinstance(surface_result, dict) else 0,
+        "mutate_warrants": len(warrant_buckets.get("mutate-code", [])) if isinstance(warrant_buckets, dict) else 0,
+        "validation_warrants": len(warrant_buckets.get("add-validation-only", [])) if isinstance(warrant_buckets, dict) else 0,
+        "thread_resolution_warrants": len(warrant_buckets.get("resolve-thread", [])) if isinstance(warrant_buckets, dict) else 0,
         "errors": len(errors),
         "warnings": len(warnings),
     }
@@ -1556,20 +858,20 @@ def check_adjudication(
 
 def print_human(result: CheckResult) -> None:
     if result.passed:
-        print("PASS: Surface-Budgeted v5 adjudication gate contract satisfied")
+        print("PASS: Surface-Budgeted v6 adjudication gate contract satisfied")
     else:
-        print("FAIL: Surface-Budgeted v5 adjudication gate contract incomplete")
-    print("stats:", ", ".join(f"{key}={value}" for key, value in result.stats.items()))
+        print("FAIL: Surface-Budgeted v6 adjudication gate contract incomplete")
+    print("stats:", ", ".join(f"{k}={v}" for k, v in result.stats.items()))
     if result.gate:
-        print("gate:", ", ".join(f"{key}={value}" for key, value in result.gate.items()))
+        print("gate:", ", ".join(f"{k}={v}" for k, v in result.gate.items()))
     if result.errors:
         print("errors:")
-        for error in result.errors:
-            print(f"- {error}")
+        for e in result.errors:
+            print(f"- {e}")
     if result.warnings:
         print("warnings:")
-        for warning in result.warnings:
-            print(f"- {warning}")
+        for w in result.warnings:
+            print(f"- {w}")
 
 
 def valid_fixture() -> str:
@@ -1582,7 +884,7 @@ artifact_state_id:
   head: feature@def456
   diff_digest: paths=src/a.py,tests/test_a.py
   comment_set_digest: c1,c2,c3
-  ci_state: local tests pass 2026-05-26
+  ci_state: local tests pass 2026-06-03
 
 - branch / PR: feature/retry
 - current artifact evidence: src/a.py and tests/test_a.py
@@ -1687,21 +989,27 @@ artifact_state_id:
   - strongest alternative resolve decision: address
   - why alternative is rejected / preserved / unresolved: src/a.py:1 shows no convention-backed need.
 
+## Adversarial Action Matrix
+
+| id/thread | primary resolve decision | adversarial lanes | parallelism mode | strongest adversarial response | veto status | clearance | proof ref | decision impact |
+|---|---|---|---|---|---|---|---|---|
+| c1 | address | no-change,validate-first,fix-shape,surface-budget | targeted-parallel | validate-first is weaker because src/a.py:10 already proves duplicate write | cleared | cleared | src/a.py:10 | address retained |
+| c2 | validate-only | mutate-now,no-validation-value,probe-shape | targeted-parallel | mutation is not justified until thread:c2 has a repro | cleared | downgraded | thread:c2 | validation retained |
+| c3 | do-not-address | materiality,review-closure,no-change | root-equivalent | no convention or user goal makes rename material | preserved-no-change | preserved | src/a.py:1 | no-change retained |
+
 ## Resolution Warrants
 
 | warrant id | claim id | source | claim excerpt | decision | concern validity | proposed fix validity | no-change status | resolution value | route rationale | permitted action | permitted scope | forbidden actions | evidence refs | countercase ref | proof required | expiry |
 |---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|
-| rw-c1 | c1 | github-review | retry writes twice | address | valid | valid | defeated | correctness-critical | narrow-local | mutate-code | files=src/a.py,tests/test_a.py; symbols=retry guard | mutate outside permitted_scope; resolve unrelated threads | src/a.py:10 | no-change c1 defeated by src/a.py:10 | pytest tests/test_a.py::test_retry_idempotent | invalid when HEAD/base/diff/comment-set changes |
-| rw-c2 | c2 | github-review | maybe flakes | validate-only | unknown | validation-only | unresolved | validation-needed | validation-only | add-validation-only | tests/probes for thread:c2 only | production mutation; requested code change | thread:c2 | no-change c2 unresolved pending repro | validation probe for thread:c2 | invalid when HEAD/base/diff/comment-set changes |
-| rw-c3 | c3 | github-review | rename helper | do-not-address | unsupported | not-applicable | not-defeated | low-value | no-change | none | none | mutate code; resolve unrelated threads | src/a.py:1 | no-change c3 preserved by missing convention | none | invalid when HEAD/base/diff/comment-set changes |
+| rw-c1 | c1 | github-review | retry writes twice | address | valid | valid | defeated | correctness-critical | narrow-local | mutate-code | files=src/a.py,tests/test_a.py; symbols=retry guard | mutate outside permitted_scope; resolve unrelated threads | src/a.py:10 | no-change c1 defeated by src/a.py:10; adversarial c1 cleared | pytest tests/test_a.py::test_retry_idempotent | invalid when HEAD/base/diff/comment-set changes |
+| rw-c2 | c2 | github-review | maybe flakes | validate-only | unknown | validation-only | unresolved | validation-needed | validation-only | add-validation-only | tests/probes for thread:c2 only | production mutation; requested-code-change; mutate-code | thread:c2 | no-change c2 unresolved pending repro; adversarial c2 downgraded | validation probe for thread:c2 | invalid when HEAD/base/diff/comment-set changes |
+| rw-c3 | c3 | github-review | rename helper | do-not-address | unsupported | not-applicable | not-defeated | low-value | no-change | none | none | mutate code; resolve unrelated threads | src/a.py:1 | no-change c3 preserved by missing convention; adversarial c3 preserved | none | invalid when HEAD/base/diff/comment-set changes |
 
 ## Surface Budget Ledger
 
 | warrant id | mode | target net loc | max positive loc | max new public symbols | max new files | max new helpers | max new flags/knobs | max new state variants | max new branches | duplicate path budget | subtractive probes required | expansion warrant required | expansion status | proof required | notes |
 |---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|
 | rw-c1 | subtractive-first | small-positive | 8 | 0 | 0 | 1 | 0 | 0 | 1 | 0 | yes | yes | not-needed | pytest tests/test_a.py::test_retry_idempotent | try deletion/reuse/refactor first; additive guard is capped |
-| rw-c2 | neutral-first | zero | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0 | no | no | not-needed | validation probe for thread:c2 | validation-only may add tests/probes, not production mutation |
-| rw-c3 | neutral-first | zero | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0 | no | no | not-needed | no proof required | no code surface selected |
 
 ## Invariant-Level Handoff
 
@@ -1710,6 +1018,7 @@ artifact_state_id:
 - route: fixed-point-driver only for validation c2 if needed; c1 is narrow-local
 - minimum fix shape: guard duplicate write and prove with test
 - proof required: pytest tests/test_a.py::test_retry_idempotent
+- adversarial clearance: c1 cleared, c2 validation downgraded, c3 preserved
 
 ## Acceptance Skew Audit
 
@@ -1732,6 +1041,7 @@ artifact_state_id:
 - do-not-address alternatives: c3
 - blocked/ask-user alternatives: none
 - fixed-point over-routing pressure: c1 stays narrow-local; c2 validation only
+- adversarial parallelism pressure: targeted where material; root-equivalent for c3
 
 ## Adjudication Gate
 
@@ -1747,8 +1057,10 @@ artifact_state_id:
 | evidence_ref_coverage | pass | act has current artifact evidence ref |
 | resolve_selection_coverage | pass | every ledger row has valid downstream selection |
 | resolve_countercase_coverage | pass | every ledger row has resolve countercase |
+| adversarial_action_coverage | pass | every selected action has adversarial clearance/preservation |
+| parallelism_calibration | pass | targeted material rows, root-equivalent no-change row |
 | resolution_warrant_coverage | pass | every resolve decision has a matching warrant |
-| surface_budget_coverage | pass | every mutate-code warrant has a subtractive-first surface budget |
+| surface_budget_coverage | pass | mutate-code warrant has a subtractive-first surface budget |
 | surface_budget_consumption_safety | pass | surface budgets constrain downstream diff/symbol growth |
 | warrant_consumption_safety | pass | warrant actions match handoff agenda buckets |
 | handoff_agenda_consistency | pass | agenda buckets match selection map |
@@ -1757,7 +1069,7 @@ artifact_state_id:
 | specialist_packet_coverage | not-used | no specialists used |
 | acceptance_skew_audit | pass | skew audited |
 | adjudication_complete | pass | all required fields pass |
-| implementation_handoff_allowed | yes | c1 is artifact-backed address |
+| implementation_handoff_allowed | yes | c1 is artifact-backed address with adversarial clearance |
 | validation_handoff_allowed | yes | c2 is validation-only |
 | reply_handoff_allowed | yes | c3 rebut reply allowed |
 
@@ -1784,15 +1096,23 @@ def invalid_fixture() -> str:
     return """
 ## Review Basis
 
+artifact_state_id:
+  branch: feature/retry
+  base: main@abc123
+  head: feature@def456
+  diff_digest: paths=src/a.py
+  comment_set_digest: c1
+  ci_state: not-run
+
 - branch / PR: feature/retry
 
 ## Comment Inventory
 
-- input_comment_count: 2
+- input_comment_count: 1
 - ledger_row_count: 1
-- input_comment_ids: c1,c2
+- input_comment_ids: c1
 - ledger_comment_ids: c1
-- missing_comment_ids: c2
+- missing_comment_ids: []
 - duplicate_comment_ids: []
 - synthesized_ids_for_real_comments: no
 
@@ -1804,17 +1124,17 @@ def invalid_fixture() -> str:
 
 | id/thread | reviewer | location | excerpt | claim | concern validity | proposed fix validity | relevance | disposition | no-change status | invariant | evidence grade | evidence ref | handoff |
 |---|---|---|---|---|---|---|---|---|---|---|---|---|---|
-| c1 | alice | src/a.py:10 | retry writes twice | retry path is not idempotent | unknown | validation-only | material-relevant | act | unresolved | none | reviewer-only | code | route-to-accretive-implementer |
+| c1 | alice | src/a.py:10 | retry writes twice | retry path is not idempotent | valid | valid | material-relevant | act | defeated | retry | current-artifact | src/a.py:10 | route-to-accretive-implementer |
 
 ## Decision Tests
 
 | id/thread | grounded | material | fresh | diagnosis | scope-fit | resolution value | no-change defeated | min evidence to change mind |
 |---|---|---|---|---|---|---|---|---|
-| c1 | unknown | yes | unclear | unknown | unknown | validation-needed | unresolved | repro |
+| c1 | yes | yes | current | correct | yes | correctness-critical | yes | proof |
 
 ## No-Change Countercases
 
-- c1: unresolved.
+- c1: defeated.
 
 ## Governing Invariant Ledger
 
@@ -1822,7 +1142,7 @@ none.
 
 ## Act On
 
-- c1: implement reviewer fix.
+- c1: implement.
 
 ## Rebut
 
@@ -1840,11 +1160,28 @@ none.
 
 | id/thread | resolve decision | reason | proof ref | next | route rationale |
 |---|---|---|---|---|---|
-| c1 | address | all are worth resolving | code | route-to-accretive-implementer | narrow-local |
+| c1 | address | current artifact evidence | src/a.py:10 | route-to-accretive-implementer | narrow-local |
 
 ## Resolve Countercases
 
-- c1: none.
+- c1: validate-only rejected by src/a.py:10.
+
+## Adversarial Action Matrix
+
+| id/thread | primary resolve decision | adversarial lanes | parallelism mode | strongest adversarial response | veto status | clearance | proof ref | decision impact |
+|---|---|---|---|---|---|---|---|---|
+
+## Resolution Warrants
+
+| warrant id | claim id | source | claim excerpt | decision | concern validity | proposed fix validity | no-change status | resolution value | route rationale | permitted action | permitted scope | forbidden actions | evidence refs | countercase ref | proof required | expiry |
+|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|
+| rw-c1 | c1 | github-review | retry writes twice | address | valid | valid | defeated | correctness-critical | narrow-local | mutate-code | files=src/a.py | mutate outside permitted_scope | src/a.py:10 | c1 no-change | pytest | invalid when HEAD/base/diff/comment-set changes |
+
+## Surface Budget Ledger
+
+| warrant id | mode | target net loc | max positive loc | max new public symbols | max new files | max new helpers | max new flags/knobs | max new state variants | max new branches | duplicate path budget | subtractive probes required | expansion warrant required | expansion status | proof required | notes |
+|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|
+| rw-c1 | subtractive-first | small-positive | 4 | 0 | 0 | 0 | 0 | 0 | 0 | 0 | yes | yes | not-needed | pytest | narrow |
 
 ## Invariant-Level Handoff
 
@@ -1852,33 +1189,37 @@ none.
 
 ## Acceptance Skew Audit
 
-all action.
+skew checked.
 
 ## Selection Skew Audit
 
-all selected.
+skew checked.
 
 ## Adjudication Gate
 
 | field | value | basis |
 |---|---|---|
-| artifact_state_coverage | fail | missing |
-| comment_inventory_coverage | fail | dropped c2 |
-| identity_coverage | pass | c1 only |
-| decision_test_coverage | fail | incomplete |
-| no_change_coverage | fail | unresolved |
-| disposition_coverage | pass | one row |
+| artifact_state_coverage | pass | recorded |
+| comment_inventory_coverage | pass | complete |
+| identity_coverage | pass | identity |
+| decision_test_coverage | pass | tests |
+| no_change_coverage | pass | countercase |
+| disposition_coverage | pass | disposition |
 | proposed_fix_separation | pass | split |
-| evidence_ref_coverage | fail | no current evidence |
-| resolve_selection_coverage | fail | invalid address |
-| resolve_countercase_coverage | fail | generic |
-| resolution_warrant_coverage | fail | missing warrants |
-| warrant_consumption_safety | fail | no consumption safety |
-| handoff_agenda_consistency | fail | missing agenda |
-| selection_skew_audit | fail | generic |
-| invariant_pass | fail | not checked |
-| specialist_packet_coverage | not-used | no specialists |
-| acceptance_skew_audit | fail | generic |
+| evidence_ref_coverage | pass | ref |
+| resolve_selection_coverage | pass | selection |
+| resolve_countercase_coverage | pass | countercase |
+| adversarial_action_coverage | fail | missing adversarial row |
+| parallelism_calibration | fail | missing |
+| resolution_warrant_coverage | pass | warrant |
+| surface_budget_coverage | pass | budget |
+| surface_budget_consumption_safety | pass | budget |
+| warrant_consumption_safety | pass | warrant |
+| handoff_agenda_consistency | pass | agenda |
+| selection_skew_audit | pass | audited |
+| invariant_pass | pass | checked |
+| specialist_packet_coverage | not-used | none |
+| acceptance_skew_audit | pass | audited |
 | adjudication_complete | fail | incomplete |
 | implementation_handoff_allowed | no | blocked |
 | validation_handoff_allowed | no | blocked |
@@ -1886,7 +1227,7 @@ all selected.
 
 ## Handoff Agenda
 
-- items selected for implementation: all
+- items selected for implementation: c1
 - validation-only items: none
 - proof-only thread-resolution items: none
 - items not selected: none
@@ -1923,23 +1264,19 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     parser.add_argument("--new-helpers", type=int, default=0, help="number of new helpers/functions for surface budget checking")
     parser.add_argument("--new-flags-or-knobs", type=int, default=0, help="number of new flags/config knobs for surface budget checking")
     args = parser.parse_args(argv)
-
     if args.self_test:
         return run_self_test()
     if not args.path:
         parser.error("path is required unless --self-test is used")
-    path = Path(args.path)
     try:
-        text = path.read_text(encoding="utf-8")
+        text = Path(args.path).read_text(encoding="utf-8")
     except OSError as exc:
-        print(f"error reading {path}: {exc}", file=sys.stderr)
+        print(f"error reading {args.path}: {exc}", file=sys.stderr)
         return 2
-    changed_files = parse_id_list(args.changed_files or "")
-    resolved_threads = parse_id_list(args.resolved_threads or "")
     result = check_adjudication(
         text,
-        changed_files=changed_files,
-        resolved_threads=resolved_threads,
+        changed_files=parse_id_list(args.changed_files or ""),
+        resolved_threads=parse_id_list(args.resolved_threads or ""),
         diffstat=args.diffstat,
         new_public_symbols=args.new_public_symbols,
         new_files=args.new_files,

--- a/codex/skills/st/SKILL.md
+++ b/codex/skills/st/SKILL.md
@@ -7,13 +7,15 @@ description: "Manage durable task plans in `.step/st-plan.jsonl`, including firs
 
 ## Overview
 
-Maintain a durable task inventory in the repo worktree (default: `.step/st-plan.jsonl`) using in-place JSONL v3 persistence with dual lanes:
+Maintain a durable task inventory in the repo worktree (default: `.step/st-plan.jsonl`) using in-place JSONL v3/v4 persistence with dual lanes:
 
 - `event` lane for mutations
 - `checkpoint` lane for periodic full-state snapshots
 
 Items use typed dependency edges (`deps: [{id,type}]`) plus `notes`, `comments`, `in_plan`, and optional execution metadata (`related_to`, `scope`, `location`, `validation`, `source`, `claim`, `runtime`, `proof`).
 `in_plan=true` projects an item into the mirrored Codex/OpenCode plan; `in_plan=false` keeps it on disk as durable backlog only.
+
+Graph mode adds durable intent atoms, waivers, polish fingerprints, and contracted task capsules. The full graph remains in `$st`; native plan tools receive only a bounded execution aperture.
 
 ## Codex Plan Surface Contract
 
@@ -36,6 +38,153 @@ Rules:
 9. Project no durable-only fields into Codex.
 10. Default to exactly one Codex `in_progress` step.
 11. Do not emit empty `update_plan` payloads just to satisfy a hook.
+
+## Graph Planning Mode
+
+Use graph planning mode when the user provides a material implementation plan, asks for graph planning, requires durable dependencies/proof, or asks for iterative polish before implementation.
+
+Mental model:
+
+```text
+source plan / AGENTS.md / README.md / code observations
+  -> intent atoms
+  -> contracted task capsules
+  -> typed dependency + coverage graph
+  -> graph audit + polish fixed point
+  -> ranked execution aperture
+  -> plan_sync.codex.plan / opencode.todos projection
+  -> proof receipts
+```
+
+Rules:
+
+1. Do not hand-edit `.step/st-plan.jsonl`.
+2. Do not call Codex `update_plan` while Codex is in Plan Mode.
+3. After Plan Mode, compile/import the proposed plan into `$st` first.
+4. Mutate graph state only through `st graph apply`, `st compile intent`, `st compile graph`, `st aperture select`, `st compile aperture`, or proof commands.
+5. Mirror only `plan_sync.codex.plan` into Codex. Never mirror the graph envelope.
+6. Complete graph-mode executable items with `st complete`; do not mark them done without proof or an explicit waiver.
+
+## Plan-to-Graph Compilation
+
+For a source plan, first read the full plan plus relevant `AGENTS.md`, README, and code paths. Produce:
+
+- `.step/st-intent.json`: every material requirement, constraint, non-goal, risk, validation expectation, compatibility obligation, migration expectation, and user-visible behavior.
+- `.step/st-graph.patch.json`: contracted `$st` capsules with dependencies, hierarchy, links, intent coverage, acceptance criteria, validation/proof obligations, locations, and lock roots where known.
+
+Then run:
+
+```bash
+st compile intent --file .step/st-plan.jsonl --input .step/st-intent.json
+st compile graph --file .step/st-plan.jsonl --input .step/st-graph.patch.json --gate draft
+st graph audit --file .step/st-plan.jsonl --gate implementation-ready --format markdown
+st graph insights --file .step/st-plan.jsonl --format markdown
+```
+
+Do not import external graph-runtime state or shell out to non-`st` graph CLIs as the `$st` graph runtime.
+
+## Intent Coverage
+
+Intent atoms are durable statements of what must not be lost from the source plan. Covered intent must be referenced by at least one item. Deferred, rejected, duplicate, and non-goal intent needs a reason or waiver. `unknown` intent is allowed only before implementation-ready.
+
+## Contracted Task Capsules
+
+Graph-mode executable items should carry:
+
+- `item_type`, `parent_id`, `deps`, and nonblocking `links`.
+- `intent_refs` for coverage.
+- `acceptance`, `validation`, `location`, `scope`, and `lock_roots`.
+- A structured `contract` with objective, background, implementation approach, success criteria, proof obligations, and risks.
+
+`epic` and `decision` are context/organization by default and should not be projected as executable aperture work unless explicitly selected by policy.
+
+## Graph Patch Protocol
+
+Use patches for planning mutations:
+
+```bash
+st graph schema --format json
+st graph apply --file .step/st-plan.jsonl --input .step/st-graph.patch.json --dry-run
+st graph apply --file .step/st-plan.jsonl --input .step/st-graph.patch.json --gate implementation-ready
+```
+
+Successful graph mutations emit `plan_sync:`, `graph_delta:`, and `audit_summary:`. If a gate fails, treat the findings as the next mechanical planning work unless a first-class waiver is appropriate.
+
+## Fixed-Point Polishing
+
+Polish before implementation when the graph is nontrivial:
+
+```bash
+st graph polish begin --file .step/st-plan.jsonl --name initial-plan
+st graph polish snapshot --file .step/st-plan.jsonl --pass 1
+st graph polish status --file .step/st-plan.jsonl --format markdown
+st graph polish gate --file .step/st-plan.jsonl --min-stable-passes 2 --gate implementation-ready
+```
+
+The fixed point is the CLI gate: implementation-ready audit passes and structure/coverage fingerprints are stable for the configured consecutive passes.
+
+## Aperture Projection
+
+Compile the native execution slice:
+
+```bash
+st compile aperture --file .step/st-plan.jsonl --limit 7
+st prime --file .step/st-plan.jsonl --mode aperture --limit 7
+```
+
+Mirror only `plan_sync.codex.plan` to Codex or `plan_sync.opencode.todos` to OpenCode. The full graph stays durable-only in `$st`.
+
+## Proof-Carrying Completion
+
+Complete graph work with proof:
+
+```bash
+st complete --file .step/st-plan.jsonl --id st-001 \
+  --command "zig build test-st" \
+  --evidence-ref .step/proof/st-001.log
+st proof audit --file .step/st-plan.jsonl --id st-001 --format json
+```
+
+Forced completion requires:
+
+```bash
+st complete --file .step/st-plan.jsonl --id st-001 --allow-unproven --reason "..."
+```
+
+That creates a waiver and should be rare.
+
+## Audit Gates
+
+Use these gates as the planning compiler:
+
+```bash
+st graph audit --file .step/st-plan.jsonl --gate draft --format json
+st graph audit --file .step/st-plan.jsonl --gate implementation-ready --format markdown
+st graph audit --file .step/st-plan.jsonl --gate execution-ready --format json
+st graph audit --file .step/st-plan.jsonl --gate proof-complete --format json
+```
+
+Hard failures include unknown refs, dependency/parent cycles, uncovered intent, missing contracts/acceptance/proof, selected blocked work, terminal selected work, and completed work missing required proof.
+
+## Agent Prompts
+
+Plan-to-graph prompt:
+
+```text
+Read ALL of [PLAN].md, AGENTS.md, README.md, and relevant code paths. Do not edit .step/st-plan.jsonl directly. Produce .step/st-intent.json and .step/st-graph.patch.json for st. Enumerate every material intent atom, then create contracted capsules with dependencies, hierarchy, links, coverage, acceptance, validation/proof, locations, and lock roots. Apply only through st compile intent and st compile graph.
+```
+
+Polish prompt:
+
+```text
+Reread source context and current st graph through graph audit, graph insights, and graph polish status. Prepare a graph patch that improves structure, granularity, acceptance, validation/proof, lock roots, and risk handling. Continue until graph polish gate passes.
+```
+
+Execution prompt:
+
+```text
+Run st compile aperture --file .step/st-plan.jsonl --limit 7. Mirror only plan_sync.codex.plan. Execute the selected aperture. Record proof through st complete. Recompile aperture after each completed item.
+```
 
 ## Zig CLI Iteration Repos
 
@@ -128,7 +277,7 @@ run_st_tool --help
    - Use `--surface all` to inspect the full durable inventory.
    - Use `--surface backlog` to inspect durable tasks not currently mirrored into the plan.
 7. Run `doctor` when ingesting an existing plan file or when integrity is in doubt.
-8. Apply plan mutations through subcommands (`add`, `select`, `deselect`, `set-status`, `set-deps`, `set-notes`, `add-comment`, `remove`, `import-plan`, `import-orchplan`, `claim`, `heartbeat`, `set-runtime`, `set-proof`, `release`, `reclaim-stale`); do not hand-edit existing JSONL lines.
+8. Apply plan mutations through subcommands (`add`, `select`, `deselect`, `set-status`, `set-deps`, `set-notes`, `add-comment`, `remove`, `import-plan`, `import-orchplan`, `claim`, `heartbeat`, `set-runtime`, `set-proof`, `complete`, `proof audit`, `graph apply`, `compile`, `aperture select`, `release`, `reclaim-stale`); do not hand-edit existing JSONL lines.
    - Use `add --backlog-only` or `import-plan --backlog-only` to update the durable inventory without loading those items into the mirrored plan yet.
    - Use `select` to add backlog items into the mirrored plan.
    - Use `deselect` to remove items from the mirrored plan without deleting them from disk.
@@ -175,6 +324,8 @@ st claim --file .step/st-plan.jsonl --wave w1 --executor codex
 st heartbeat --file .step/st-plan.jsonl --id st-001
 st set-runtime --file .step/st-plan.jsonl --id st-001 --substrate spawn_agent --thread-id thread-123 --agent-id agent-1
 st set-proof --file .step/st-plan.jsonl --id st-001 --proof-state pass --command "zig build test-st" --evidence-ref .step/proof.log
+st complete --file .step/st-plan.jsonl --id st-001 --command "zig build test-st" --evidence-ref .step/proof.log
+st proof audit --file .step/st-plan.jsonl --id st-001 --format json
 st release --file .step/st-plan.jsonl --id st-001 --reason proof_complete
 st reclaim-stale --file .step/st-plan.jsonl --now 2026-03-12T00:00:00Z
 ```

--- a/codex/skills/st/references/jsonl-format.md
+++ b/codex/skills/st/references/jsonl-format.md
@@ -1,8 +1,8 @@
-# st JSONL Format (v3)
+# st JSONL Format (v3/v4)
 
 ## Record lanes
 
-`st` uses an in-place rewritten JSONL stream; each line is one v3 record.
+`st` uses an in-place rewritten JSONL stream; each line is one v3 or v4 record.
 
 - Shared fields: `v` (`3`), `ts` (UTC ISO-8601), `seq` (non-negative integer), `lane` (`event` or `checkpoint`)
 - `event` lane: requires `op`
@@ -12,6 +12,100 @@
 ```json
 {"v":3,"ts":"2026-02-09T20:02:00Z","seq":42,"lane":"event","op":"replace","items":[{"id":"st-001","step":"Reproduce issue","status":"completed","priority":"medium","in_plan":false,"deps":[],"notes":"","comments":[]}],"mutation":{"allow_multiple_in_progress":false,"actor":"tk","pid":12345}}
 {"v":3,"ts":"2026-02-09T20:02:00Z","seq":42,"lane":"checkpoint","items":[{"id":"st-001","step":"Reproduce issue","status":"completed","priority":"medium","in_plan":false,"deps":[],"notes":"","comments":[]}],"mutation":{"allow_multiple_in_progress":false,"actor":"tk","pid":12345}}
+```
+
+## v4 graph envelope
+
+v3 files remain readable. Graph mode activates on the first graph mutation and writes v4 records with a durable graph envelope:
+
+```json
+{
+  "v": 4,
+  "ts": "2026-06-03T00:00:00Z",
+  "seq": 42,
+  "lane": "checkpoint",
+  "graph": {
+    "version": 1,
+    "policy": {
+      "completion_requires_proof": true,
+      "implementation_ready_required": true,
+      "default_projection_strategy": "aperture-score",
+      "default_gate": "implementation-ready",
+      "max_aperture_items": 7
+    },
+    "intent": [],
+    "waivers": [],
+    "polish": {"session_id": "", "passes": []},
+    "fingerprints": {"structure": "", "contract": "", "coverage": "", "execution": ""}
+  },
+  "items": []
+}
+```
+
+The v4 envelope is durable-only. It never appears inside `plan_sync.codex.plan` or `plan_sync.opencode.todos`.
+
+## Graph policy
+
+- `completion_requires_proof`: graph-mode completion requires proof receipts unless explicitly waived.
+- `implementation_ready_required`: aperture eligibility requires implementation-ready item structure.
+- `default_projection_strategy`: default graph projection ranking, normally `aperture-score`.
+- `default_gate`: default graph compiler gate, normally `implementation-ready`.
+- `max_aperture_items`: default bounded native projection size.
+
+## Intent atoms
+
+Intent atom shape:
+
+```json
+{
+  "id": "intent-001",
+  "source": {"kind": "markdown", "locator": "docs/plan.md", "anchor": "Authentication"},
+  "text": "OAuth login must support Google and GitHub providers.",
+  "category": "requirement",
+  "disposition": "covered",
+  "reason": ""
+}
+```
+
+Allowed categories include `requirement`, `constraint`, `non-goal`, `risk`, `compatibility`, `migration`, `test-expectation`, `user-behavior`, `architecture`, `performance`, `security`, `accessibility`, `observability`, and `documentation`. Covered intent must be referenced by at least one item; non-covered dispositions require a reason or waiver.
+
+## Waivers
+
+Waivers are first-class graph objects:
+
+```json
+{
+  "id": "waiver-001",
+  "gate": "implementation-ready",
+  "code": "missing-e2e-validation",
+  "target": "st-014",
+  "reason": "Unit and CLI integration tests are the accepted proof surface.",
+  "expires": "on-next-touch",
+  "created_at": "2026-06-03T00:00:00Z",
+  "created_by": "codex"
+}
+```
+
+MVP expiry values are `never` and `on-next-touch`. A waiver suppresses only the exact `gate + code + target` finding.
+
+## Polish passes and fingerprints
+
+`graph.polish.passes[]` stores fixed-point snapshots:
+
+```json
+{
+  "pass": 1,
+  "seq": 14,
+  "created_at": "2026-06-03T00:00:00Z",
+  "structure_fingerprint": "sha256:...",
+  "contract_fingerprint": "sha256:...",
+  "coverage_fingerprint": "sha256:...",
+  "execution_fingerprint": "sha256:...",
+  "audit_gate": "implementation-ready",
+  "hard_failures": 0,
+  "warnings": 0,
+  "delta": {"items_added": 0, "items_removed": 0, "items_split": 0, "deps_changed": 0, "contracts_changed": 0, "intent_coverage_changed": 0}
+}
 ```
 
 ## Event ops
@@ -56,6 +150,44 @@
   - `claim: {state, owner?, executor?, wave_id?, lock_roots?, claimed_at?, lease_seconds, lease_expires_at?, heartbeat_at?, attempts}`
   - `runtime: {substrate, thread_id?, agent_id?, row_id?, output_ref?, last_event?}`
   - `proof: {state, command?, evidence_ref?, last_run_at?}`
+- Optional graph capsule fields:
+  - `item_type`: `epic`, `feature`, `task`, `bug`, `test`, `verification`, `docs`, `chore`, `research`, `spike`, or `decision`
+  - `parent_id`: hierarchy only
+  - `links`: nonblocking graph links such as `{id,type,reason?}`
+  - `intent_refs`: covered intent IDs
+  - `acceptance`: user-visible done criteria
+  - `contract`: structured objective/background/approach/success criteria/proof obligations/risks
+  - `labels`, `lock_roots`, `uncertainty`, `non_goals`
+
+## Graph patch output lines
+
+`st graph apply` and compile wrappers mutate graph state atomically. On success they emit:
+
+```text
+plan_sync: {...}
+graph_delta: {"version":1,"seq_before":41,"seq_after":42,"items_added":["st-014"],"items_removed":[],"items_changed":[],"intent_coverage_changed":["intent-001"]}
+audit_summary: {"gate":"implementation-ready","ok":true,"errors":0,"warnings":0,"top_findings":[]}
+```
+
+Patch ops include intent upserts, item upserts/removals, status/priority/contract/acceptance/validation/location/scope/labels/lock-root updates, dependency/link updates, reparenting, comments, and audit waivers.
+
+## Audit output shape
+
+`st graph audit --format json` emits:
+
+```json
+{
+  "version": 1,
+  "gate": "implementation-ready",
+  "ok": true,
+  "summary": {"items": 1, "open": 1, "ready": 1, "blocked": 0, "terminal": 0, "intent": 1, "covered_intent": 1, "waived_intent": 0, "unknown_intent": 0, "errors": 0, "warnings": 0},
+  "findings": [],
+  "waivers": [],
+  "fingerprints": {"structure": "sha256:...", "contract": "sha256:...", "coverage": "sha256:...", "execution": "sha256:..."}
+}
+```
+
+Finding shape is `{code,severity,target,message,waived,waiver_id}`.
 
 ## Read-view derived fields
 
@@ -93,11 +225,11 @@
 
 ## Translation contract to native runtime mirrors
 
-- `emit-plan-sync` emits:
+- `prime` and mutating commands emit `plan_sync`:
 
 ```json
 {
-  "version": 1,
+  "version": 3,
   "items": [
     {
       "id": "st-003",
@@ -114,7 +246,7 @@
   ],
   "codex": {
     "plan": [
-      {"step": "Document v3 protocol", "status": "pending"}
+      {"step": "[st-003] Document v3 protocol", "status": "pending"}
     ]
   },
   "opencode": {
@@ -127,14 +259,15 @@
 
 - `items` is the full durable inventory in `$st` order
 - `items` preserves optional execution metadata when present so reconciliation does not lose claim/runtime/proof state
-- `codex.plan`, `opencode.todos`, and legacy `emit-update-plan` emit only items with `in_plan=true`
+- `codex.plan` and `opencode.todos` include only projection-eligible items with `in_plan=true`
+- In graph mode, `st prime --mode aperture` selects a bounded executable aperture before emitting the same projection-only `plan_sync` shape
 - Hook-managed SessionStart hydration must short-circuit when `codex.plan` would be empty after terminal-state demotion or backlog-only filtering
 - Codex status mapping: `in_progress` -> `in_progress`, `completed` -> `completed`, `pending` -> `pending`, `blocked` -> `pending`, `deferred` -> `pending`, `canceled` -> `pending`
 - OpenCode status mapping: `in_progress` -> `in_progress`, `completed` -> `completed`, `pending` -> `pending`, `blocked` -> `pending`, `deferred` -> `pending`, `canceled` -> `cancelled`
 - OpenCode todo mapping: `content = step`, `priority = priority`
 - Guardrail: if `dep_state == "waiting_on_deps"`, translated status must never be `in_progress` (force `pending`)
 - Guardrail: multiple mirrored `in_progress` items are valid only when the underlying durable items prove a safe parallel wave via held non-overlapping claims
-- Compatibility: mutation commands also print a legacy `update_plan:` line, and `emit-update-plan` still emits `{"plan":[...]}` for older Codex-only callers
+- Reverse sync is projection-only through `reconcile-codex --transcript-path`; it must preserve durable-only metadata.
 
 ## Selection semantics
 


### PR DESCRIPTION
## Summary
- update `$st` skill instructions for graph planning mode, plan-to-graph compilation, fixed-point polishing, aperture projection, and proof-carrying completion
- update JSONL reference for v3/v4 records, graph envelope, intent atoms, waivers, polish passes, capsule fields, graph patch/audit output, and projection-only `plan_sync`
- update hooks to use current `prime`/`reconcile-codex` paths and warn against `update_plan` during Codex Plan Mode

## Proof
- `uv run --with pyyaml -- python3 codex/skills/.system/skill-creator/scripts/quick_validate.py codex/skills/st` -> `Skill is valid!`
- `git diff --check`
- stale removed-command scan clean across `codex/hooks` and `codex/skills/st`
- external graph-runtime command/name scan clean across the `$st` skill and references

## Notes
- Companion implementation PR: https://github.com/tkersey/skills-zig/pull/5
