### PR TITLE
Update st skill for graph control receipts

### DIFF
--- a/codex/hooks/st_hook_common.sh
+++ b/codex/hooks/st_hook_common.sh
@@ -37,6 +37,9 @@ has_non_plan_changes() {
 st_supports_command() {
   bin="${1:?binary required}"
   command_name="${2:?command required}"
+  if "$bin" capabilities --format json 2>/dev/null | jq -e '.st_capabilities.version' >/dev/null 2>&1; then
+    return 0
+  fi
   "$bin" --help 2>/dev/null | grep -Fq "$command_name"
 }
 

--- a/codex/hooks/st_session_start.sh
+++ b/codex/hooks/st_session_start.sh
@@ -49,7 +49,9 @@ context=$(cat <<EOF
 Repo contains a durable \$st plan at $plan_file.
 On SessionStart, the durable store is the source of truth.
 Do not call update_plan while Codex is in Plan Mode. After Plan Mode, import or compile the proposed plan into \$st first.
-Before substantive execution outside Plan Mode, mirror only plan_sync.codex.plan by calling update_plan exactly once with this payload emitted by st:
+Before substantive execution outside Plan Mode, mirror only the exact native projection payload emitted by st.
+If material graph work has no current GCR-v1 for the durable seq/fingerprints, run st compile aperture before execution.
+Mirror plan_sync.codex.plan by calling update_plan exactly once with this payload emitted by st:
 $update_plan_payload
 Preserve the emitted [st-id] step prefixes so any later manual \$st plan import can map rows back into the durable ledger safely.
 EOF

--- a/codex/skills/st/SKILL.md
+++ b/codex/skills/st/SKILL.md
@@ -1,650 +1,171 @@
 ---
 name: st
-description: "Durable graph-planning and execution-aperture manager for `.step/st-plan.jsonl`. Use for `use $st`, resuming durable work, dependencies, proof-carrying completion, mirroring bounded work into Codex/OpenCode plans, or turning a plan, proposal, issue, spec, markdown document, TODO list, or design into executable tasks. For material plans, compile intent and graph capsules before selecting an aperture; skip straight to `prime`/`complete` only for healthy existing `$st` graphs or explicitly simple work."
+description: "Durable graph control, aperture, and proof source for `.step/st-plan.jsonl`. Use for `use $st`, resuming durable work, dependencies, proof-carrying completion, mirroring bounded work into Codex/OpenCode plans, or turning a plan, proposal, issue, spec, markdown document, TODO list, or design into executable tasks. For material work, require a current CLI-emitted GCR-v1 before execution projection."
 ---
 
 # st
 
 ## Mental Model
 
-`$st` is the durable source of truth for agentic work in the current repository.
+`$st` is durable work truth. Native plans are projections.
 
-The native plan surface (`update_plan` in Codex or `TodoWrite` in OpenCode) is not the durable plan. It is a **bounded execution aperture**: the small executable slice selected from the durable graph right now.
-
-Core invariant:
+Canonical material loop:
 
 ```text
-source plan / issue / spec / user request
-        -> intent coverage
-        -> self-contained task graph
-        -> graph audit
-        -> execution aperture
-        -> native plan projection
-        -> proof-carrying completion
+Compile intent into durable graph state.
+Audit it.
+Compile one bounded safe aperture and GCR.
+Project only the aperture.
+Execute.
+Record obligation-level proof.
+Recompile.
 ```
 
-Do not use prose, memory, or `update_plan` as durable task state. Keep the durable source in `.step/st-plan.jsonl` and mutate it only through `st` commands.
+Do not invent critical paths, proof cuts, safe parallel width, or graph debt in prose. Only CLI-emitted `GCR-v1` facts count as graph-control evidence.
 
-## Mode Selection
+## Modes
 
-Choose a mode before doing work.
+### Graph Mode
 
-### Execution Mode
+Use graph mode for material plans with intent atoms, contracted executable items, hard dependency edges, proof obligations, graph lineage, and implementation-ready audit.
 
-Use execution mode when the repo already has a durable `$st` plan/graph and the user asks to continue, resume, implement, finish, verify, or execute known work.
-
-Primary commands:
+Required control command:
 
 ```bash
-st prime --file .step/st-plan.jsonl --mode aperture --limit 7
-st compile aperture --file .step/st-plan.jsonl --limit 7
-st complete --file .step/st-plan.jsonl --id st-001 --command "<validation command>" --evidence-ref .step/proof/st-001.log
+st compile aperture --file .step/st-plan.jsonl --limit 7 --parallelism auto
+```
+
+For material graph work, do not execute or project a native plan without a current `GCR-v1`. Current means the receipt seq and fingerprints match the durable plan state being projected.
+
+### Degraded Graph Mode
+
+If graph state exists but blocking graph debt remains, aperture preview may be useful, but delivery mutation and completion claims are blocked unless an exact active waiver exists. The GCR must show the mode, debt, waiver, and gate decision.
+
+### Ledger/Simple Mode
+
+Use simple ledger commands only for small bounded work or legacy v3 state:
+
+```bash
+st add ...
+st set-status ...
+st set-proof ...
+st complete ...
+```
+
+Do not silently route a material plan through simple-task mode. If no graph was compiled, say exactly:
+
+```text
+Graph not compiled; proceeding in ledger mode.
+```
+
+## Capability Surface
+
+Assume the documented current CLI. Do not proactively call several `--help` surfaces.
+
+Use one probe only when version is genuinely uncertain or an unknown-command error occurs:
+
+```bash
+st capabilities --format json
+```
+
+Cache that result for the session.
+
+## Material Intake
+
+For a new material plan, use the intake check/apply path:
+
+```bash
+st intake scaffold --source docs/plan.md --out .step/st-intake.md
+# Agent fills or edits the semantic intake artifact.
+st intake check --input .step/st-intake.md --gate implementation-ready --format json
+st intake normalize --input .step/st-intake.md --out .step/st-intake.normalized.md
+st intake apply --file .step/st-plan.jsonl --input .step/st-intake.normalized.md --gate implementation-ready
+st compile aperture --file .step/st-plan.jsonl --limit 7 --parallelism auto
+```
+
+`st intake plan` is a deprecated alias for scaffold. A scaffold is not semantic compilation until the agent-authored intake passes `check` and `apply`.
+
+## Existing Healthy Graph
+
+For existing healthy graph work, start with:
+
+```bash
+st compile aperture --file .step/st-plan.jsonl --limit 7 --parallelism auto
+```
+
+Then mirror only the emitted `plan_sync.codex.plan` into `update_plan` or `plan_sync.opencode.todos` into OpenCode.
+
+## Projection Rules
+
+- Durable source: `.step/st-plan.jsonl`.
+- Native plan tools are projection only.
+- Mutate durable state only through `st` commands.
+- Project only `plan_sync.codex.plan` or `plan_sync.opencode.todos`, never the full `plan_sync` object.
+- Preserve `[st-id]` as the first token of each Codex-visible step.
+- Keep durable-only fields out of native plans.
+- Keep exactly one Codex `in_progress` row unless the current GCR proves a selected safe parallel wave.
+- Waiting-on-deps items must not be mirrored as `in_progress`.
+
+## Execution And Proof
+
+Execute only the selected aperture. After work, record proof at obligation level:
+
+```bash
+st proof plan --file .step/st-plan.jsonl --scope aperture --format json
+st proof record \
+  --file .step/st-plan.jsonl \
+  --id st-001 \
+  --obligation proof-001 \
+  --action proof-action-test-st \
+  --command "zig build test-st" \
+  --evidence-ref .step/proof/st-001-proof-001.log \
+  --artifact-ref "git:<sha-or-working-tree-fingerprint>"
+st complete --file .step/st-plan.jsonl --id st-001
+st compile aperture --file .step/st-plan.jsonl --limit 7 --parallelism auto
 st assert-projection --file .step/st-plan.jsonl
 ```
 
-### Planning / Intake Mode
-
-Use planning/intake mode when the user asks to:
-
-- turn a plan into tasks;
-- break a proposal/spec/markdown/issue into steps;
-- create implementation tasks;
-- make a TODO graph;
-- convert a document into work;
-- plan material multi-step work before implementation;
-- preserve requirements that could be lost.
-
-For material plans, do **not** start with `st add`, `st import-proposed-plan`, `st prime`, or `st complete`.
-
-Start with intake:
-
-```bash
-st intake plan --file .step/st-plan.jsonl --source <plan.md> --out .step/st-intake.md
-st intake apply --file .step/st-plan.jsonl --input .step/st-intake.md --gate implementation-ready
-st graph audit --file .step/st-plan.jsonl --gate implementation-ready --format markdown
-st compile aperture --file .step/st-plan.jsonl --limit 7
-```
-
-If `st intake` is not available in the installed binary, use the fallback in [Material Plan Intake Fallback](#material-plan-intake-fallback) and clearly record graph debt rather than pretending the graph was compiled.
-
-### Simple Task Mode
-
-Use simple task mode only when the user request is small, local, and obviously bounded.
-
-A simple task usually has all of these properties:
-
-- 1–2 steps;
-- no meaningful dependency graph;
-- no source plan/spec whose requirements could be lost;
-- no cross-session coordination need;
-- no need for multiple agents;
-- no separate proof obligation beyond the immediate validation command.
-
-Simple tasks may use ordinary `st add` / `st set-status` / `st complete` without full intake, but still preserve durable state when the task spans turns.
-
-## Capability Probe
-
-Before invoking advanced graph/intake commands in a repo or session where capability is uncertain, probe once:
-
-```bash
-st --help
-st prime --help
-st complete --help
-```
-
-If using graph/intake mode, also probe:
-
-```bash
-st intake --help || true
-st graph --help || true
-st compile --help || true
-```
-
-Do not repeatedly spam `--help`. After discovering a missing command, choose the documented fallback and proceed.
-
-## Plan Surface Contract
-
-- Durable source: `.step/st-plan.jsonl`.
-- Proposed plan: Codex Plan Mode output or markdown plan text.
-- Native projection: Codex `update_plan` or OpenCode `TodoWrite`.
-- Backlog: durable items with `in_plan=false`.
-- Aperture/frontier: selected executable items with `in_plan=true`.
-
-Rules:
-
-1. Never call `update_plan` while Codex is in Plan Mode.
-2. After leaving Plan Mode, import or intake the final proposed plan into `$st` before execution.
-3. Treat `.step/st-plan.jsonl` as the source of truth.
-4. Treat native plan tools as display/projection only.
-5. Project only `plan_sync.codex.plan` or `plan_sync.opencode.todos`, never the full `plan_sync` object.
-6. Preserve `[st-id]` as the first token in every Codex-visible step.
-7. Project no durable-only fields into the native plan.
-8. Do not emit empty native plan payloads just to satisfy a hook.
-9. Keep exactly one Codex `in_progress` row unless `$st` proves a safe parallel wave.
-10. Waiting-on-deps items must never be mirrored as `in_progress`.
-
-## First-Use Storage Policy
-
-Before the first `st init` or mutation in a repo, determine the plan-file storage policy.
-
-- If `.step/st-plan.jsonl` is already tracked, respect shared mode.
-- If `.step/st-plan.jsonl` is already ignored, respect local mode.
-- If the choice is not obvious, ask one targeted question: should `.step/st-plan.jsonl` be committed for shared review, or kept local via `.git/info/exclude`?
-- Shared mode: keep `.step/st-plan.jsonl` tracked; ignore only `.step/st-plan.jsonl.lock`.
-- Local mode: add both `.step/st-plan.jsonl` and `.step/st-plan.jsonl.lock` to `.git/info/exclude`.
-
-Mutating commands require the lock sidecar to be ignored inside git repos.
-
-## Material Plan Funnel
-
-Healthy trace for material plans:
-
-```text
-intake -> audit -> aperture -> complete
-```
-
-Preferred command trace:
-
-```bash
-st intake plan --file .step/st-plan.jsonl --source <plan.md> --out .step/st-intake.md
-st intake apply --file .step/st-plan.jsonl --input .step/st-intake.md --gate implementation-ready
-st graph audit --file .step/st-plan.jsonl --gate implementation-ready --format markdown
-st compile aperture --file .step/st-plan.jsonl --limit 7
-st complete --file .step/st-plan.jsonl --id <st-id> --command "<validation>" --evidence-ref <proof-log>
-```
-
-Bad trace for material plans:
-
-```text
-import-proposed-plan -> prime --mode aperture -> complete
-```
-
-That skips intent coverage and graph audit. Use it only for simple plans or when graph/intake commands are unavailable and graph debt is explicitly recorded.
-
-## Material Plan Intake
-
-Material plan intake converts a user plan/spec/issue/markdown document into a self-contained `$st` graph.
-
-The intake artifact is `.step/st-intake.md`. Prefer this over separate JSON intent and graph patch files because agents reliably produce and review Markdown.
-
-### Intake Plan Command
-
-When available:
-
-```bash
-st intake plan --file .step/st-plan.jsonl --source <plan.md> --out .step/st-intake.md
-```
-
-The command should scaffold or normalize a Markdown intake file.
-
-### Intake Apply Command
-
-When available:
-
-```bash
-st intake apply --file .step/st-plan.jsonl --input .step/st-intake.md --gate implementation-ready
-```
-
-Expected behavior:
-
-- parse `.step/st-intake.md`;
-- create intent atoms;
-- create self-contained graph capsules;
-- validate dependency references;
-- validate acceptance/proof/test coverage;
-- emit `plan_sync:`;
-- emit an intake receipt;
-- fail with actionable findings if the implementation-ready gate is not met.
-
-### Intake Template
-
-Use this shape when creating `.step/st-intake.md`:
-
-```markdown
-# st graph intake
-
-Source: docs/plan.md
-
-## Intent
-
-- intent-001 | requirement | covered
-  Text: OAuth login must support Google and GitHub.
-  Source: docs/plan.md#authentication
-
-- intent-002 | test-expectation | covered
-  Text: The OAuth flow must have e2e coverage.
-  Source: docs/plan.md#testing
-
-## Items
-
-### st-001 | feature | high
-
-Step: Implement OAuth login for Google and GitHub
-
-Covers:
-- intent-001
-
-Depends:
-- none
-
-Locations:
-- src/auth
-- tests/e2e/auth
-
-Acceptance:
-- User can authenticate through Google.
-- User can authenticate through GitHub.
-- Session is created and cleared correctly.
-
-Validation:
-- npm run test:e2e -- auth-oauth
-
-Proof:
-- proof-001 | e2e | npm run test:e2e -- auth-oauth
-
-Contract:
-Background:
-The source plan requires low-friction external-provider authentication.
-
-Objective:
-Add OAuth provider login.
-
-Implementation Approach:
-Use the existing auth boundary and add provider configuration, callback handling, and session validation.
-
-Risks:
-- Provider callback misconfiguration.
-- Session persistence regression.
-```
-
-Every material intake item should include:
-
-- stable ID;
-- type;
-- priority;
-- step;
-- intent coverage;
-- dependencies;
-- locations/lock roots when known;
-- acceptance criteria;
-- validation command(s);
-- proof obligation(s);
-- background;
-- objective;
-- implementation approach;
-- risks/considerations.
-
-## Material Plan Intake Fallback
-
-Use this only when `st intake` is not available in the installed binary.
-
-1. Create `.step/st-intake.md` manually using the intake template.
-2. If `st graph apply` exists, convert the intake into `.step/st-graph.patch.json` and apply it:
-
-```bash
-st graph apply --file .step/st-plan.jsonl --input .step/st-graph.patch.json --gate implementation-ready
-```
-
-3. If graph apply is also unavailable, create durable items with existing commands:
-
-```bash
-st init --file .step/st-plan.jsonl
-st add --file .step/st-plan.jsonl --id st-001 --step "Implement OAuth login for Google and GitHub" --priority high --backlog-only
-st set-notes --file .step/st-plan.jsonl --id st-001 --notes "$(cat .step/st-001-notes.md)"
-st set-deps --file .step/st-plan.jsonl --id st-001 --deps ""
-```
-
-4. Record graph debt in notes or comments:
-
-```bash
-st add-comment --file .step/st-plan.jsonl --id st-001 --author codex --text "graph_debt: material plan intake used fallback because st intake/graph apply was unavailable; intent coverage and implementation-ready audit were not machine-checked."
-```
-
-5. Do not claim that graph audit passed if it did not run.
-
-6. Before final response, say graph intake was approximated and name the missing CLI capability.
+`st set-proof` remains a compatibility convenience. Do not use one ambiguous legacy proof to satisfy several distinct required commands.
 
 ## Graph Debt
 
-Graph debt means `$st` is being used for execution without the material plan having been compiled/audited as a graph.
+Use graph debt commands when the GCR blocks execution:
 
-Graph debt examples:
+```bash
+st graph debt list --file .step/st-plan.jsonl --format json
+st graph debt waive --file .step/st-plan.jsonl --id debt-... --reason "..." --expires on-next-touch
+st graph debt resolve --file .step/st-plan.jsonl --id debt-...
+```
+
+For material work, unwaived blocking debt means `execution_allowed: no`.
+
+## First-Use Storage Policy
+
+Before the first `st init` or mutation in a repo, determine whether `.step/st-plan.jsonl` is shared or local.
+
+- If already tracked, respect shared mode.
+- If ignored, respect local mode.
+- If unclear, ask whether `.step/st-plan.jsonl` should be committed for shared review or kept local via `.git/info/exclude`.
+- Shared mode: track `.step/st-plan.jsonl`; ignore `.step/st-plan.jsonl.lock`.
+- Local mode: ignore both `.step/st-plan.jsonl` and `.step/st-plan.jsonl.lock`.
+
+## Final Response
+
+For material `$st` work, report:
+
+- GCR id;
+- mode: graph, degraded, or ledger;
+- ready frontier;
+- blocked frontier;
+- selected wave;
+- critical path/depth;
+- safe parallel decision;
+- proof basis and proof status;
+- graph debt;
+- projection assertion.
+
+If no graph was compiled, include exactly:
 
 ```text
-graph_debt:intent_coverage_missing
-graph_debt:implementation_ready_audit_missing
-graph_debt:material_plan_not_compiled
-graph_debt:proof_obligations_missing
+Graph not compiled; proceeding in ledger mode.
 ```
-
-If `st prime --mode aperture` or `st compile aperture` emits graph-debt warnings, do not ignore them.
-
-Remediation:
-
-```bash
-st intake plan --file .step/st-plan.jsonl --source <plan.md> --out .step/st-intake.md
-st intake apply --file .step/st-plan.jsonl --input .step/st-intake.md --gate implementation-ready
-st graph audit --file .step/st-plan.jsonl --gate implementation-ready --format markdown
-```
-
-If the CLI lacks intake/audit support, record the debt with comments and disclose it in final output.
-
-## Importing Proposed Plans
-
-`st import-proposed-plan` is acceptable for simple plans and Plan Mode markdown, but it is not a substitute for material graph intake.
-
-Preferred for material plans:
-
-```bash
-st intake plan --file .step/st-plan.jsonl --source .step/proposed-plan.md --out .step/st-intake.md
-st intake apply --file .step/st-plan.jsonl --input .step/st-intake.md --gate implementation-ready
-```
-
-If using `import-proposed-plan` on a material plan because intake is unavailable, immediately record graph debt and run the strongest available audit/checks.
-
-```bash
-st import-proposed-plan --file .step/st-plan.jsonl --input .step/proposed-plan.md --select-ready
-st add-comment --file .step/st-plan.jsonl --id st-001 --author codex --text "graph_debt: imported proposed plan directly; material intent coverage was not compiled."
-```
-
-## Aperture Workflow
-
-Use aperture for execution selection, not plan creation.
-
-```bash
-st prime --file .step/st-plan.jsonl --mode aperture --limit 7
-```
-
-or:
-
-```bash
-st compile aperture --file .step/st-plan.jsonl --limit 7
-```
-
-Then mirror only the emitted `plan_sync.codex.plan` into Codex `update_plan`.
-
-If the aperture payload includes graph-debt warnings, repair the graph before implementation unless the work is simple or the user explicitly directs execution despite debt.
-
-Aperture eligibility:
-
-- item is pending;
-- blocking dependencies are complete;
-- item is not terminal;
-- item is not stale-claimed;
-- item is executable, not an epic/decision placeholder;
-- item has adequate proof/validation metadata for graph-mode work.
-
-## Proof-Carrying Completion
-
-Prefer `st complete` over direct `set-status completed` when available.
-
-```bash
-mkdir -p .step/proof
-<validation command> 2>&1 | tee .step/proof/st-001.log
-st complete --file .step/st-plan.jsonl --id st-001 --command "<validation command>" --evidence-ref .step/proof/st-001.log
-```
-
-Rules:
-
-- Do not mark graph-mode items complete without proof or explicit waiver.
-- If validation cannot run, do not fake proof. Record a waiver or leave the item pending/blocked.
-- After completion, recompile/prime the aperture and mirror the new projection.
-
-Fallback if `st complete` is unavailable:
-
-```bash
-<validation command> 2>&1 | tee .step/proof/st-001.log
-st set-proof --file .step/st-plan.jsonl --id st-001 --proof-state pass --command "<validation command>" --evidence-ref .step/proof/st-001.log
-st set-status --file .step/st-plan.jsonl --id st-001 --status completed
-```
-
-## Command Shape Rules
-
-Prefer explicit long-option form. It is the least ambiguous and most stable.
-
-Good:
-
-```bash
-st set-status --file .step/st-plan.jsonl --id st-001 --status in_progress
-st set-proof --file .step/st-plan.jsonl --id st-001 --proof-state pass --command "zig build test-st" --evidence-ref .step/proof/st-001.log
-```
-
-Avoid old positional forms unless the installed binary explicitly supports them:
-
-```bash
-st set-status st-001 in_progress
-st set-proof st-001 pass "zig build test-st" .step/proof/st-001.log
-```
-
-If a command fails due to shape, retry once with long options. Do not repeatedly call `--help`.
-
-## Projection Sync Checklist
-
-After every mutating `st` command:
-
-1. Capture the emitted `plan_sync: {...}`.
-2. If `plan_sync.codex.plan` is nonempty, mirror it with Codex `update_plan`.
-3. Preserve `[st-id]` prefixes exactly.
-4. Do not project durable-only fields.
-5. Do not emit empty update payloads.
-6. If no payload is available, run:
-
-```bash
-st prime --file .step/st-plan.jsonl
-```
-
-Before final response after `$st` mutations:
-
-```bash
-st assert-projection --file .step/st-plan.jsonl
-```
-
-## Receipts and Telemetry
-
-When the CLI emits receipts, preserve and surface important ones.
-
-Expected receipt kinds:
-
-```text
-st_receipt: {"kind":"graph_intake",...}
-st_receipt: {"kind":"graph_debt",...}
-st_receipt: {"kind":"aperture_compiled",...}
-st_receipt: {"kind":"proof_complete",...}
-```
-
-Use receipts to make final responses concrete:
-
-- graph intake applied or approximated;
-- graph debt remaining;
-- aperture selected;
-- proof completed;
-- projection asserted.
-
-## Graph Audit
-
-When available, run graph audit before aperture selection for material plans:
-
-```bash
-st graph audit --file .step/st-plan.jsonl --gate implementation-ready --format markdown
-```
-
-If audit fails:
-
-- fix by editing intake/graph patch and applying through `st`;
-- do not skip to aperture unless user explicitly asks;
-- use waivers only with explicit reasons.
-
-If audit is unavailable:
-
-- record graph debt;
-- use the best available `st show`, `st ready`, `st blocked`, and `st doctor` checks;
-- disclose that graph audit could not run.
-
-## Graph Polishing
-
-Graph polishing is valuable but secondary to first-pass intake adoption.
-
-Use a polishing loop when the plan is material, broad, risky, or swarm-bound:
-
-```bash
-st graph polish begin --file .step/st-plan.jsonl --name <name>
-st graph audit --file .step/st-plan.jsonl --gate implementation-ready --format markdown
-st graph insights --file .step/st-plan.jsonl --format markdown
-# apply improvements through st intake/apply or graph apply
-st graph polish snapshot --file .step/st-plan.jsonl --pass 1
-st graph polish gate --file .step/st-plan.jsonl --min-stable-passes 2 --gate implementation-ready
-```
-
-Do not block simple execution on multi-pass polishing.
-
-## Ready/Blocked Inspection
-
-Use these when deciding next work:
-
-```bash
-st show --file .step/st-plan.jsonl --surface all --format markdown
-st ready --file .step/st-plan.jsonl --format markdown
-st blocked --file .step/st-plan.jsonl --surface all --format markdown
-```
-
-Prefer aperture compilation for execution selection:
-
-```bash
-st compile aperture --file .step/st-plan.jsonl --limit 7
-```
-
-## Existing Commands
-
-Common commands:
-
-```bash
-st init --file .step/st-plan.jsonl
-st add --file .step/st-plan.jsonl --id st-001 --step "Reproduce issue" --priority high
-st add --file .step/st-plan.jsonl --id st-002 --step "Patch core logic" --deps "st-001" --backlog-only
-st select --file .step/st-plan.jsonl --ids "st-002"
-st deselect --file .step/st-plan.jsonl --ids "st-002"
-st set-status --file .step/st-plan.jsonl --id st-001 --status in_progress
-st set-priority --file .step/st-plan.jsonl --id st-002 --priority medium
-st set-deps --file .step/st-plan.jsonl --id st-002 --deps "st-001:blocks"
-st set-notes --file .step/st-plan.jsonl --id st-002 --notes "Need regression proof"
-st add-comment --file .step/st-plan.jsonl --id st-002 --text "Pausing until CI clears" --author codex
-st remove --file .step/st-plan.jsonl --id st-002
-st doctor --file .step/st-plan.jsonl
-st prime --file .step/st-plan.jsonl
-st prime --file .step/st-plan.jsonl --mode aperture --limit 7
-st compile aperture --file .step/st-plan.jsonl --limit 7
-st assert-projection --file .step/st-plan.jsonl
-st reconcile-codex --file .step/st-plan.jsonl --input .step/update-plan.json
-st reconcile-codex --file .step/st-plan.jsonl --transcript-path /path/to/session.jsonl
-st import-proposed-plan --file .step/st-plan.jsonl --input .step/proposed-plan.md --select-ready
-st export --file .step/st-plan.jsonl --output .step/st-plan.snapshot.json
-st import-plan --file .step/st-plan.jsonl --input .step/st-plan.snapshot.json --replace
-st claim --file .step/st-plan.jsonl --wave w1 --executor codex
-st heartbeat --file .step/st-plan.jsonl --id st-001
-st set-runtime --file .step/st-plan.jsonl --id st-001 --substrate spawn_agent --thread-id thread-123
-st set-proof --file .step/st-plan.jsonl --id st-001 --proof-state pass --command "zig build test-st" --evidence-ref .step/proof/st-001.log
-st complete --file .step/st-plan.jsonl --id st-001 --command "zig build test-st" --evidence-ref .step/proof/st-001.log
-st release --file .step/st-plan.jsonl --id st-001 --reason proof_complete
-st reclaim-stale --file .step/st-plan.jsonl
-```
-
-Do not use removed legacy commands such as:
-
-```text
-emit-plan-sync
-emit-update-plan
-import-update-plan
-```
-
-Use `prime` and `reconcile-codex` instead.
-
-## Final Response Requirements
-
-When `$st` was used, final response should include:
-
-- what durable state changed;
-- current aperture/projection status;
-- proof command(s) run and result;
-- whether graph debt remains;
-- exact next move if any.
-
-For material planning tasks, explicitly state whether the plan went through:
-
-```text
-intake -> audit -> aperture
-```
-
-If it did not, say why.
-
-## Validation
-
-Lightweight validation:
-
-```bash
-st --help
-st doctor --file .step/st-plan.jsonl
-st show --file .step/st-plan.jsonl --surface all --format json
-st prime --file .step/st-plan.jsonl
-st assert-projection --file .step/st-plan.jsonl
-```
-
-Material graph validation when supported:
-
-```bash
-st intake apply --file .step/st-plan.jsonl --input .step/st-intake.md --gate implementation-ready
-st graph audit --file .step/st-plan.jsonl --gate implementation-ready --format json
-st graph insights --file .step/st-plan.jsonl --format json
-st compile aperture --file .step/st-plan.jsonl --limit 7
-```
-
-## Troubleshooting
-
-### `st intake` is missing
-
-Use [Material Plan Intake Fallback](#material-plan-intake-fallback). Record `graph_debt:material_plan_not_compiled`.
-
-### `st graph audit` is missing
-
-Use:
-
-```bash
-st doctor --file .step/st-plan.jsonl
-st show --file .step/st-plan.jsonl --surface all --format json
-st ready --file .step/st-plan.jsonl --format markdown
-st blocked --file .step/st-plan.jsonl --surface all --format markdown
-```
-
-Record `graph_debt:implementation_ready_audit_missing`.
-
-### `st complete` is missing
-
-Use:
-
-```bash
-st set-proof --file .step/st-plan.jsonl --id <id> --proof-state pass --command "<cmd>" --evidence-ref <log>
-st set-status --file .step/st-plan.jsonl --id <id> --status completed
-```
-
-### Command shape fails
-
-Retry once with explicit long options.
-
-### Aperture warns about graph debt
-
-Do not ignore it for material plans. Run intake/audit or explicitly disclose the debt.
-
-### Projection drift
-
-Run:
-
-```bash
-st reconcile-codex --file .step/st-plan.jsonl --transcript-path /path/to/session.jsonl
-st prime --file .step/st-plan.jsonl
-st assert-projection --file .step/st-plan.jsonl
-```
-
-## References
-
-- `references/material-plan-intake-template.md`
-- `references/next-cli-patch-spec.md`
-- `references/jsonl-format.md`

--- a/codex/skills/st/agents/openai.yaml
+++ b/codex/skills/st/agents/openai.yaml
@@ -2,5 +2,9 @@ policy:
   allow_implicit_invocation: true
 interface:
   display_name: "st"
-  short_description: "Durable repo JSONL step manager and Codex projection source"
-  default_prompt: "Use $st as the durable step source of truth in `.step/st-plan.jsonl`; prime Codex with `st prime`, mirror only `plan_sync.codex.plan` through Codex `update_plan`, and mutate durable state only through `st` commands."
+  short_description: "Durable graph control, aperture, and proof source"
+  default_prompt: >
+    Use $st as durable work truth. For material work, require a current CLI-emitted
+    GCR-v1 before execution: compile intent, audit the graph, select one safe bounded
+    aperture, project only plan_sync.codex.plan, record obligation-level proof, and
+    recompile after durable mutations.


### PR DESCRIPTION
## Summary
- rewrite the st skill around the GCR-centered material workflow
- update agent metadata for graph control, aperture, and proof authority
- make st hook command discovery prefer st capabilities and update SessionStart GCR/projection guidance

## Validation
- uv run --with pyyaml -- python3 codex/skills/.system/skill-creator/scripts/quick_validate.py codex/skills/st
- sh -n codex/hooks/st_*.sh