### PR TITLE
Address late resolve-c3 review findings

### DIFF
--- a/.step/proof/resolve-c3-st-r3-007.log
+++ b/.step/proof/resolve-c3-st-r3-007.log
@@ -13,3 +13,5 @@ error: --mode body matched 2 distinct skill blocks; narrow with --history latest
 failed command: cd /Users/tk/workspace/tk/skills-zig/apps/seq && ./../../.zig-cache/o/1cfb91dbe37e65cba6094dacb0b5d7fb/test --cache-dir=./../../.zig-cache --seed=0x54215567 --listen=-
 
 Skill is valid!
+command_exit=0
+note=test-seq stderr above is expected negative-case fixture output; the aggregate proof command completed successfully.

--- a/codex/hooks/st_hook_common.sh
+++ b/codex/hooks/st_hook_common.sh
@@ -17,6 +17,25 @@ st_plan_file() {
   printf '%s/.step/st-plan.jsonl\n' "$1"
 }
 
+find_c3_root() {
+  dir="${1:-$PWD}"
+  while [ "$dir" != "/" ]; do
+    if [ -f "$dir/.ledger/c3/state.json" ]; then
+      printf '%s\n' "$dir"
+      return 0
+    fi
+    dir=$(dirname "$dir")
+  done
+  return 1
+}
+
+resolve_c3_bin() {
+  candidate=$(command -v resolve-c3 2>/dev/null || true)
+  [ -n "${candidate:-}" ] || return 1
+  [ -x "$candidate" ] || return 1
+  printf '%s\n' "$candidate"
+}
+
 json_continue() {
   jq -n '{continue: true}'
 }

--- a/codex/hooks/st_pre_tool_use.sh
+++ b/codex/hooks/st_pre_tool_use.sh
@@ -5,15 +5,19 @@ set -eu
 
 payload=$(cat)
 
-resolve_tool="$HOME/.dotfiles/codex/skills/resolve/tools/review_compile.py"
-if [ -f "$resolve_tool" ]; then
-  resolve_output=$(printf '%s' "$payload" | python3 "$resolve_tool" guard-hook --cwd "$PWD" 2>/dev/null || true)
+resolve_bin=$(resolve_c3_bin || true)
+if [ -n "${resolve_bin:-}" ]; then
+  resolve_output=$(printf '%s' "$payload" | "$resolve_bin" guard-hook --cwd "$PWD" 2>/dev/null || true)
   resolve_status=$(printf '%s' "$resolve_output" | jq -r '.status // "allow"' 2>/dev/null || printf allow)
   if [ "$resolve_status" = "block" ]; then
     reason=$(printf '%s' "$resolve_output" | jq -r '.reason // "C³ blocked a direct delivery mutation."' 2>/dev/null || printf 'C³ blocked a direct delivery mutation.')
     jq -n --arg reason "$reason" '{continue: true, decision: "block", reason: $reason}'
     exit 0
   fi
+elif c3_root=$(find_c3_root "$PWD" || true); [ -n "${c3_root:-}" ]; then
+  reason=$(printf 'Active C³ state exists at %s/.ledger/c3/state.json, but resolve-c3 is unavailable.' "$c3_root")
+  jq -n --arg reason "$reason" '{continue: true, decision: "block", reason: $reason}'
+  exit 0
 fi
 
 session_id=$(printf '%s' "$payload" | jq -r '.session_id // ""')

--- a/codex/hooks/st_session_start.sh
+++ b/codex/hooks/st_session_start.sh
@@ -24,9 +24,9 @@ esac
 contexts=""
 messages=""
 
-resolve_tool="$HOME/.dotfiles/codex/skills/resolve/tools/review_compile.py"
-if [ -f "$resolve_tool" ]; then
-  resolve_output=$(python3 "$resolve_tool" hook-context --cwd "$PWD" 2>/dev/null || true)
+resolve_bin=$(resolve_c3_bin || true)
+if [ -n "${resolve_bin:-}" ]; then
+  resolve_output=$("$resolve_bin" hook-context --cwd "$PWD" 2>/dev/null || true)
   resolve_active=$(printf '%s' "$resolve_output" | jq -r '.active // false' 2>/dev/null || printf false)
   if [ "$resolve_active" = "true" ]; then
     resolve_context=$(printf '%s' "$resolve_output" | jq -r '.context // ""' 2>/dev/null || true)
@@ -36,6 +36,11 @@ if [ -f "$resolve_tool" ]; then
       messages="${messages}Hydrating active C³ review compiler state. "
     fi
   fi
+elif c3_root=$(find_c3_root "$PWD" || true); [ -n "${c3_root:-}" ]; then
+  resolve_context="Active C³ state exists at $c3_root/.ledger/c3/state.json, but resolve-c3 is unavailable. Install with: brew install tkersey/tap/resolve-c3"
+  contexts="${contexts}${resolve_context}
+"
+  messages="${messages}Active C³ state found without resolve-c3. "
 fi
 
 repo_root=$(find_st_root "$PWD" || true)

--- a/codex/hooks/st_stop.sh
+++ b/codex/hooks/st_stop.sh
@@ -19,15 +19,19 @@ mode="${ST_STOP_MODE:-block}"
   exit 0
 }
 
-resolve_tool="$HOME/.dotfiles/codex/skills/resolve/tools/review_compile.py"
-if [ -f "$resolve_tool" ]; then
-  resolve_output=$(printf '%s' "$payload" | python3 "$resolve_tool" stop-guard --cwd "$PWD" 2>/dev/null || true)
+resolve_bin=$(resolve_c3_bin || true)
+if [ -n "${resolve_bin:-}" ]; then
+  resolve_output=$(printf '%s' "$payload" | "$resolve_bin" stop-guard --cwd "$PWD" 2>/dev/null || true)
   resolve_status=$(printf '%s' "$resolve_output" | jq -r '.status // "allow"' 2>/dev/null || printf allow)
   if [ "$resolve_status" = "block" ]; then
     reason=$(printf '%s' "$resolve_output" | jq -r '.reason // "C³ run is not closed."' 2>/dev/null || printf 'C³ run is not closed.')
     jq -n --arg reason "$reason" '{continue: true, decision: "block", reason: $reason}'
     exit 0
   fi
+elif c3_root=$(find_c3_root "$PWD" || true); [ -n "${c3_root:-}" ]; then
+  reason=$(printf 'Active C³ state exists at %s/.ledger/c3/state.json, but resolve-c3 is unavailable.' "$c3_root")
+  jq -n --arg reason "$reason" '{continue: true, decision: "block", reason: $reason}'
+  exit 0
 fi
 
 repo_root=$(find_st_root "$PWD" || true)

--- a/codex/skills/resolve/SKILL.md
+++ b/codex/skills/resolve/SKILL.md
@@ -71,6 +71,13 @@ Use:
 resolve-c3 ...
 ```
 
+If the controller is missing, install and verify it before starting C³:
+
+```bash
+brew install tkersey/tap/resolve-c3
+resolve-c3 doctor
+```
+
 Canonical repo-local state:
 
 ```text

--- a/codex/skills/seq/references/resolve-c3-audit.md
+++ b/codex/skills/seq/references/resolve-c3-audit.md
@@ -10,9 +10,9 @@ when the installed `seq` supports it.
 
 Until then, audit:
 
-- `review_compile.py` lifecycle commands;
-- `.resolve-c3/state.json`;
-- `.resolve-c3/events.jsonl`;
+- `resolve-c3` lifecycle commands;
+- `.ledger/c3/state.json`;
+- `.ledger/c3/events.jsonl`;
 - MRPC-v1 stages;
 - direct delivery mutations between begin and close;
 - candidate tournament size and route diversity;

--- a/codex/skills/verification-closure/SKILL.md
+++ b/codex/skills/verification-closure/SKILL.md
@@ -29,7 +29,7 @@ rollback/abort posture
 Require:
 
 ```text
-.resolve-c3/mrpc.json
+.ledger/c3/mrpc.json
 certificate_version = MRPC-v1
 stage = pushed or closed
 immutable base matches run


### PR DESCRIPTION
Follow-up for late review comments on merged PR #44.\n\nSummary:\n- route C³ hooks through the released resolve-c3 controller instead of the removed review_compile.py script\n- update closure/audit docs to canonical .ledger/c3 artifacts\n- document resolve-c3 Homebrew install/doctor bootstrap\n- mark the st-r3-007 proof log with command_exit=0 so expected negative-case stderr is not ambiguous\n\nProof:\n- resolve-c3 0.1.2 installed from tkersey/tap/resolve-c3\n- resolve-c3 run-proof --root /Users/tk/.dotfiles --input .ledger/c3/proof-plan.json\n- resolve-c3 mrpc-gate --file .ledger/c3/mrpc.json\n- sh -n codex/hooks/st_hook_common.sh codex/hooks/st_pre_tool_use.sh codex/hooks/st_session_start.sh codex/hooks/st_stop.sh\n- python3 codex/skills/.system/scripts/quick_validate.py codex/skills/resolve\n- python3 codex/skills/.system/scripts/quick_validate.py codex/skills/verification-closure\n- python3 codex/skills/.system/scripts/quick_validate.py codex/skills/seq\n- targeted rg stale-reference audits\n- hook-context/pre-tool/stop hook smoke checks\n- git diff --check