### PR TITLE
Document st proof recording fallback

### DIFF
--- a/codex/skills/actuating/references/st-handoff.md
+++ b/codex/skills/actuating/references/st-handoff.md
@@ -14,9 +14,19 @@ st compile aperture --file .step/st-plan.jsonl --limit 7
 ## Completion trace
 
 ```bash
-st complete --file .step/st-plan.jsonl --id <st-id> --command "<validation command>" --evidence-ref <proof-log>
+st proof record \
+  --file .step/st-plan.jsonl \
+  --id <st-id> \
+  --obligation <proof-id> \
+  --action <proof-action-id> \
+  --command "<validation command>" \
+  --evidence-ref <proof-log> \
+  --artifact-ref "git:<sha-or-working-tree-fingerprint>"
+st complete --file .step/st-plan.jsonl --id <st-id>
 st assert-projection --file .step/st-plan.jsonl
 ```
+
+If the installed `st` build rejects a documented proof flag combination, keep the graph status aligned with the smallest accepted `st complete` command and track the parser mismatch as a tool fix. Do not create sidecar proof state outside `$st`.
 
 ## Fallback when intake/graph commands are missing
 

--- a/codex/skills/st/SKILL.md
+++ b/codex/skills/st/SKILL.md
@@ -129,6 +129,8 @@ st assert-projection --file .step/st-plan.jsonl
 
 `st set-proof` remains a compatibility convenience. Do not use one ambiguous legacy proof to satisfy several distinct required commands.
 
+If a local installed `st` rejects a documented proof flag combination, do not spend the shipping loop on parser archaeology. Prefer the canonical `st proof record` form above when it accepts the obligation/action/command flags. If this installed build only accepts the smaller completion surface, keep graph status aligned with the minimal accepted `st complete` command and record the parser mismatch as a follow-up tool fix rather than inventing sidecar proof state.
+
 ## Graph Debt
 
 Use graph debt commands when the GCR blocks execution:


### PR DESCRIPTION
## Summary
- make `$actuating` handoff record obligation-level proof before completion
- keep `$st` guidance canonical on `st proof record`
- document the safe fallback when an installed `st` parser rejects a documented proof flag combination

## Validation
- `rg -n "st proof record|set-proof|complete" codex/skills/st codex/skills/actuating/references/st-handoff.md`
- `git diff --check`

## Proof
- paired with tkersey/skills-zig#24 for the CLI parser/diagnostic fix