### PR TITLE
Adopt canonical ledger artifact roots

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,13 @@ codex/skills/deckset/references/refresh-metadata.json
 **/node_modules
 
 .step/st-plan.jsonl.lock
+.ledger/st/st-plan.jsonl.lock
+.ledger/resolve/c3/
+.ledger/actuating/*/current.json
+.ledger/actuating/*/history/
+.ledger/actuating/**/scratch/
+.ledger/retrace/*
+.ledger/seq/*
 codex/memories/extensions/learnings/resources/latest_learnings_digest.md
 codex/memories/extensions/chronicle/resources/*
 

--- a/.ledger/migration/LEDGER-ARTIFACT-ROOT-v1.receipt.json
+++ b/.ledger/migration/LEDGER-ARTIFACT-ROOT-v1.receipt.json
@@ -1,0 +1,42 @@
+{
+  "schema_version": "MIGRATION-RECEIPT-v1",
+  "receipt_id": "MIGRATION-LEDGER-ARTIFACT-ROOT-v1",
+  "stable_identity": "LEDGER-ARTIFACT-ROOT-v1:.dotfiles:path-default-migration",
+  "spec_id": "LEDGER-ARTIFACT-ROOT-v1",
+  "written_at": "2026-06-25T19:34:31Z",
+  "repository": "/Users/tk/.dotfiles",
+  "base_head": "e79ae0403b3e34f4130ea96274387293f4986ceb",
+  "summary": "Migrated machine-owned workflow artifact defaults and examples to owner namespaces under .ledger/ while preserving explicit legacy read fallbacks for migration windows.",
+  "canonical_owner_namespaces": [
+    ".ledger/plan/",
+    ".ledger/st/",
+    ".ledger/actuating/",
+    ".ledger/resolve/",
+    ".ledger/retrace/",
+    ".ledger/seq/",
+    ".ledger/negative-ledger/",
+    ".ledger/proof/",
+    ".ledger/migration/"
+  ],
+  "legacy_read_fallbacks": [
+    ".step/st-plan.jsonl",
+    ".ledger/c3/state.json",
+    ".step/resolve-c3-st-plan.jsonl"
+  ],
+  "local_runtime_defaults": [
+    ".ledger/st/st-plan.jsonl.lock",
+    ".ledger/resolve/c3/",
+    ".ledger/actuating/*/current.json",
+    ".ledger/actuating/*/history/",
+    ".ledger/actuating/**/scratch/",
+    ".ledger/retrace/*",
+    ".ledger/seq/*"
+  ],
+  "verification": [
+    "sh -n codex/hooks/st_hook_common.sh codex/hooks/st_pre_tool_use.sh codex/hooks/st_session_start.sh codex/hooks/st_stop.sh codex/hooks/tests/test_st_hook_common.sh",
+    "codex/hooks/tests/test_st_hook_common.sh",
+    "uv run python codex/skills/actuating/tests/test_actuating_tools.py",
+    "git diff --name-only -- '*.json' | xargs -r jq empty",
+    "git diff --name-only -- '*.yaml' '*.yml' | xargs -r ruby -e 'require \"yaml\"; ARGV.each { |path| YAML.load_file(path) }'"
+  ]
+}

--- a/codex/hooks/st_hook_common.sh
+++ b/codex/hooks/st_hook_common.sh
@@ -4,7 +4,7 @@ set -eu
 find_st_root() {
   dir="${1:-$PWD}"
   while [ "$dir" != "/" ]; do
-    if [ -f "$dir/.step/st-plan.jsonl" ]; then
+    if [ -f "$dir/.ledger/st/st-plan.jsonl" ] || [ -f "$dir/.step/st-plan.jsonl" ]; then
       printf '%s\n' "$dir"
       return 0
     fi
@@ -13,20 +13,50 @@ find_st_root() {
   return 1
 }
 
+st_plan_rel() {
+  repo_root="${1:?repo root required}"
+  if [ -f "$repo_root/.ledger/st/st-plan.jsonl" ]; then
+    printf '%s\n' ".ledger/st/st-plan.jsonl"
+    return 0
+  fi
+  if [ -f "$repo_root/.step/st-plan.jsonl" ]; then
+    printf '%s\n' ".step/st-plan.jsonl"
+    return 0
+  fi
+  printf '%s\n' ".ledger/st/st-plan.jsonl"
+}
+
+st_plan_write_rel() {
+  printf '%s\n' ".ledger/st/st-plan.jsonl"
+}
+
 st_plan_file() {
-  printf '%s/.step/st-plan.jsonl\n' "$1"
+  printf '%s/%s\n' "$1" "$(st_plan_rel "$1")"
 }
 
 find_c3_root() {
   dir="${1:-$PWD}"
   while [ "$dir" != "/" ]; do
-    if [ -f "$dir/.ledger/c3/state.json" ]; then
+    if [ -f "$dir/.ledger/resolve/c3/state.json" ] || [ -f "$dir/.ledger/c3/state.json" ]; then
       printf '%s\n' "$dir"
       return 0
     fi
     dir=$(dirname "$dir")
   done
   return 1
+}
+
+c3_state_rel() {
+  repo_root="${1:?repo root required}"
+  if [ -f "$repo_root/.ledger/resolve/c3/state.json" ]; then
+    printf '%s\n' ".ledger/resolve/c3/state.json"
+    return 0
+  fi
+  if [ -f "$repo_root/.ledger/c3/state.json" ]; then
+    printf '%s\n' ".ledger/c3/state.json"
+    return 0
+  fi
+  printf '%s\n' ".ledger/resolve/c3/state.json"
 }
 
 resolve_c3_bin() {
@@ -50,7 +80,7 @@ has_non_plan_changes() {
     git -C "$repo_root" diff --name-only
     git -C "$repo_root" diff --cached --name-only
     git -C "$repo_root" ls-files --others --exclude-standard
-  } | awk 'NF' | sort -u | grep -Ev '(^|/)\.step/st-plan\.jsonl(\.lock)?$|(^|/)\.learnings\.jsonl$' | grep -q .
+  } | awk 'NF' | sort -u | grep -Ev '(^|/)(\.ledger/st|\.step)/st-plan\.jsonl(\.lock)?$|(^|/)\.learnings\.jsonl$' | grep -q .
 }
 
 st_supports_command() {

--- a/codex/hooks/st_pre_tool_use.sh
+++ b/codex/hooks/st_pre_tool_use.sh
@@ -15,7 +15,8 @@ if [ -n "${resolve_bin:-}" ]; then
     exit 0
   fi
 elif c3_root=$(find_c3_root "$PWD" || true); [ -n "${c3_root:-}" ]; then
-  reason=$(printf 'Active C³ state exists at %s/.ledger/c3/state.json, but resolve-c3 is unavailable.' "$c3_root")
+  c3_state=$(c3_state_rel "$c3_root")
+  reason=$(printf 'Active C³ state exists at %s/%s, but resolve-c3 is unavailable.' "$c3_root" "$c3_state")
   jq -n --arg reason "$reason" '{continue: true, decision: "block", reason: $reason}'
   exit 0
 fi
@@ -40,10 +41,12 @@ st_bin=$(resolve_st_bin "guard-pre-tool-use" || true)
   exit 0
 }
 
+plan_rel=$(st_plan_rel "$repo_root")
+
 if [ -n "${transcript_path:-}" ]; then
-  output=$(cd "$repo_root" && "$st_bin" guard-pre-tool-use --file .step/st-plan.jsonl --session-id "$session_id" --transcript-path "$transcript_path" 2>/dev/null || true)
+  output=$(cd "$repo_root" && "$st_bin" guard-pre-tool-use --file "$plan_rel" --session-id "$session_id" --transcript-path "$transcript_path" 2>/dev/null || true)
 else
-  output=$(cd "$repo_root" && "$st_bin" guard-pre-tool-use --file .step/st-plan.jsonl --session-id "$session_id" 2>/dev/null || true)
+  output=$(cd "$repo_root" && "$st_bin" guard-pre-tool-use --file "$plan_rel" --session-id "$session_id" 2>/dev/null || true)
 fi
 
 status=$(printf '%s' "$output" | jq -r '.status // "allow"' 2>/dev/null || printf allow)

--- a/codex/hooks/st_session_start.sh
+++ b/codex/hooks/st_session_start.sh
@@ -37,7 +37,8 @@ if [ -n "${resolve_bin:-}" ]; then
     fi
   fi
 elif c3_root=$(find_c3_root "$PWD" || true); [ -n "${c3_root:-}" ]; then
-  resolve_context="Active C³ state exists at $c3_root/.ledger/c3/state.json, but resolve-c3 is unavailable. Install with: brew install tkersey/tap/resolve-c3"
+  c3_state=$(c3_state_rel "$c3_root")
+  resolve_context="Active C³ state exists at $c3_root/$c3_state, but resolve-c3 is unavailable. Install with: brew install tkersey/tap/resolve-c3"
   contexts="${contexts}${resolve_context}
 "
   messages="${messages}Active C³ state found without resolve-c3. "
@@ -47,7 +48,8 @@ repo_root=$(find_st_root "$PWD" || true)
 if [ -n "${repo_root:-}" ] && [ -n "${session_id:-}" ]; then
   st_bin=$(resolve_st_bin "guard-session-start" || true)
   if [ -n "${st_bin:-}" ]; then
-    update_plan_payload=$(cd "$repo_root" && "$st_bin" guard-session-start --file .step/st-plan.jsonl --session-id "$session_id" 2>/dev/null || true)
+    plan_rel=$(st_plan_rel "$repo_root")
+    update_plan_payload=$(cd "$repo_root" && "$st_bin" guard-session-start --file "$plan_rel" --session-id "$session_id" 2>/dev/null || true)
     if [ -n "${update_plan_payload:-}" ]; then
       plan_file=$(st_plan_file "$repo_root")
       st_context=$(cat <<EOF

--- a/codex/hooks/st_stop.sh
+++ b/codex/hooks/st_stop.sh
@@ -29,7 +29,8 @@ if [ -n "${resolve_bin:-}" ]; then
     exit 0
   fi
 elif c3_root=$(find_c3_root "$PWD" || true); [ -n "${c3_root:-}" ]; then
-  reason=$(printf 'Active C³ state exists at %s/.ledger/c3/state.json, but resolve-c3 is unavailable.' "$c3_root")
+  c3_state=$(c3_state_rel "$c3_root")
+  reason=$(printf 'Active C³ state exists at %s/%s, but resolve-c3 is unavailable.' "$c3_root" "$c3_state")
   jq -n --arg reason "$reason" '{continue: true, decision: "block", reason: $reason}'
   exit 0
 fi
@@ -66,9 +67,10 @@ st_bin=$(resolve_st_bin "reconcile-codex" || true)
   exit 0
 }
 
-plan_file=$(st_plan_file "$repo_root")
+plan_rel=$(st_plan_write_rel)
+plan_file="$repo_root/$plan_rel"
 
-if output=$(cd "$repo_root" && "$st_bin" reconcile-codex --file .step/st-plan.jsonl --transcript-path "$transcript_path" 2>&1); then
+if output=$(cd "$repo_root" && "$st_bin" reconcile-codex --file "$plan_rel" --transcript-path "$transcript_path" 2>&1); then
   json_continue
   exit 0
 fi

--- a/codex/hooks/tests/test_st_hook_common.sh
+++ b/codex/hooks/tests/test_st_hook_common.sh
@@ -1,0 +1,52 @@
+#!/bin/sh
+set -eu
+
+script_dir=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+. "$script_dir/st_hook_common.sh"
+
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT INT HUP TERM
+
+assert_eq() {
+  expected="$1"
+  actual="$2"
+  label="$3"
+  if [ "$expected" != "$actual" ]; then
+    printf 'FAIL %s\nexpected: %s\nactual:   %s\n' "$label" "$expected" "$actual" >&2
+    exit 1
+  fi
+}
+
+canonical_repo="$tmp/canonical"
+mkdir -p "$canonical_repo/.ledger/st" "$canonical_repo/nested"
+: >"$canonical_repo/.ledger/st/st-plan.jsonl"
+assert_eq "$canonical_repo" "$(find_st_root "$canonical_repo/nested")" "find canonical st root"
+assert_eq ".ledger/st/st-plan.jsonl" "$(st_plan_rel "$canonical_repo")" "canonical st read path"
+assert_eq ".ledger/st/st-plan.jsonl" "$(st_plan_write_rel)" "canonical st write path"
+
+legacy_repo="$tmp/legacy"
+mkdir -p "$legacy_repo/.step" "$legacy_repo/nested"
+: >"$legacy_repo/.step/st-plan.jsonl"
+assert_eq "$legacy_repo" "$(find_st_root "$legacy_repo/nested")" "find legacy st root"
+assert_eq ".step/st-plan.jsonl" "$(st_plan_rel "$legacy_repo")" "legacy st read fallback"
+assert_eq ".ledger/st/st-plan.jsonl" "$(st_plan_write_rel)" "legacy does not change write path"
+
+both_repo="$tmp/both"
+mkdir -p "$both_repo/.ledger/st" "$both_repo/.step"
+: >"$both_repo/.ledger/st/st-plan.jsonl"
+: >"$both_repo/.step/st-plan.jsonl"
+assert_eq ".ledger/st/st-plan.jsonl" "$(st_plan_rel "$both_repo")" "canonical preferred over legacy"
+
+c3_repo="$tmp/c3"
+mkdir -p "$c3_repo/.ledger/resolve/c3"
+: >"$c3_repo/.ledger/resolve/c3/state.json"
+assert_eq "$c3_repo" "$(find_c3_root "$c3_repo")" "find canonical c3 root"
+assert_eq ".ledger/resolve/c3/state.json" "$(c3_state_rel "$c3_repo")" "canonical c3 state path"
+
+c3_legacy_repo="$tmp/c3-legacy"
+mkdir -p "$c3_legacy_repo/.ledger/c3"
+: >"$c3_legacy_repo/.ledger/c3/state.json"
+assert_eq "$c3_legacy_repo" "$(find_c3_root "$c3_legacy_repo")" "find legacy c3 root"
+assert_eq ".ledger/c3/state.json" "$(c3_state_rel "$c3_legacy_repo")" "legacy c3 read fallback"
+
+printf 'st hook path policy: PASS\n'

--- a/codex/skills/actuating/SKILL.md
+++ b/codex/skills/actuating/SKILL.md
@@ -221,20 +221,20 @@ proof obligations and rollback
 Compatibility path:
 
 ```bash
-st intake scaffold --source decision.json --out .step/st-intake.md
+st intake scaffold --source decision.json --out .ledger/st/intake/st-intake.md
 # Map EPD fields exactly; do not change policy semantics.
 st intake check \
-  --input .step/st-intake.md \
+  --input .ledger/st/intake/st-intake.md \
   --gate implementation-ready \
   --format json
 st intake normalize \
-  --input .step/st-intake.md \
-  --out .step/st-intake.normalized.md
+  --input .ledger/st/intake/st-intake.md \
+  --out .ledger/st/intake/st-intake.normalized.md
 st intake apply \
-  --file .step/st-plan.jsonl \
-  --input .step/st-intake.normalized.md \
+  --file .ledger/st/st-plan.jsonl \
+  --input .ledger/st/intake/st-intake.normalized.md \
   --gate implementation-ready
-st compile aperture --file .step/st-plan.jsonl --limit 7
+st compile aperture --file .ledger/st/st-plan.jsonl --limit 7
 ```
 
 Do not materialize dormant policy branches as ready or blocked tasks.
@@ -326,7 +326,7 @@ python3 codex/skills/actuating/tools/actuation_slice_gate.py slice.json
 python3 codex/skills/actuating/tools/actuation_checkpoint.py \
   write \
   --input slice.json \
-  --root .step/actuating
+  --root .ledger/actuating
 ```
 
 ASL does not duplicate policy state or `$st` task status.

--- a/codex/skills/actuating/assets/actuation-slice.example.json
+++ b/codex/skills/actuating/assets/actuation-slice.example.json
@@ -13,9 +13,9 @@
       "st_plan_fingerprint": "sha256:plan"
     },
     "task_control": {
-      "plan_ref": ".step/st-plan.jsonl",
+      "plan_ref": ".ledger/st/st-plan.jsonl",
       "gcr_id": "GCR-example-001",
-      "gcr_ref": ".step/proof/gcr-example.json",
+      "gcr_ref": ".ledger/proof/gcr-example.json",
       "gcr_seq": 42,
       "gcr_current": "yes",
       "execution_allowed": "yes",
@@ -27,11 +27,11 @@
     },
     "semantic_control": {
       "semantic_route_refs": [
-        ".step/actuating/routes/zsr.json"
+        ".ledger/actuating/routes/zsr.json"
       ],
       "owner": "LoadedSessionImage.validate",
       "invariant": "A loaded session image must bind continuation fields to one authoritative state.",
-      "matrix_ref": ".step/actuating/ACT-example-001/validation-matrix.json",
+      "matrix_ref": ".ledger/actuating/ACT-example-001/validation-matrix.json",
       "selected_rows": [
         "VMX-row-002"
       ],
@@ -97,12 +97,12 @@
       }
     },
     "realization": {
-      "fixed_point_slice_ref": ".step/actuating/ACT-example-001/fps.json",
+      "fixed_point_slice_ref": ".ledger/actuating/ACT-example-001/fps.json",
       "fixed_point_result_ref": null,
       "status": "prepared"
     },
     "proof": {
-      "proof_dag_ref": ".step/actuating/ACT-example-001/proof-dag.json",
+      "proof_dag_ref": ".ledger/actuating/ACT-example-001/proof-dag.json",
       "focused_obligations": [
         "proof-loaded-session-row-002"
       ],
@@ -127,7 +127,7 @@
         "active_clauses": [
           "ZIG-ROUTER-001"
         ],
-        "route_ref": ".step/actuating/routes/zsr.json"
+        "route_ref": ".ledger/actuating/routes/zsr.json"
       }
     ],
     "state": "prepared",

--- a/codex/skills/actuating/assets/actuation-slice.policy.example.json
+++ b/codex/skills/actuating/assets/actuation-slice.policy.example.json
@@ -13,9 +13,9 @@
       "st_plan_fingerprint": "sha256:plan"
     },
     "task_control": {
-      "plan_ref": ".step/st-plan.jsonl",
+      "plan_ref": ".ledger/st/st-plan.jsonl",
       "gcr_id": "GCR-example-001",
-      "gcr_ref": ".step/proof/gcr-example.json",
+      "gcr_ref": ".ledger/proof/gcr-example.json",
       "gcr_seq": 42,
       "gcr_current": "yes",
       "execution_allowed": "yes",
@@ -28,11 +28,11 @@
     },
     "semantic_control": {
       "semantic_route_refs": [
-        ".step/actuating/routes/zsr.json"
+        ".ledger/actuating/routes/zsr.json"
       ],
       "owner": "LoadedSessionImage.validate",
       "invariant": "A loaded session image must bind continuation fields to one authoritative state.",
-      "matrix_ref": ".step/actuating/ACT-example-001/validation-matrix.json",
+      "matrix_ref": ".ledger/actuating/ACT-example-001/validation-matrix.json",
       "selected_rows": [
         "VMX-row-002"
       ],
@@ -98,12 +98,12 @@
       }
     },
     "realization": {
-      "fixed_point_slice_ref": ".step/actuating/ACT-example-001/fps.json",
+      "fixed_point_slice_ref": ".ledger/actuating/ACT-example-001/fps.json",
       "fixed_point_result_ref": null,
       "status": "prepared"
     },
     "proof": {
-      "proof_dag_ref": ".step/actuating/ACT-example-001/proof-dag.json",
+      "proof_dag_ref": ".ledger/actuating/ACT-example-001/proof-dag.json",
       "focused_obligations": [
         "proof-loaded-session-row-002"
       ],
@@ -128,7 +128,7 @@
         "active_clauses": [
           "ZIG-ROUTER-001"
         ],
-        "route_ref": ".step/actuating/routes/zsr.json"
+        "route_ref": ".ledger/actuating/routes/zsr.json"
       }
     ],
     "state": "prepared",

--- a/codex/skills/actuating/assets/afr-v1.example.json
+++ b/codex/skills/actuating/assets/afr-v1.example.json
@@ -12,10 +12,10 @@
       "dirty_fingerprint": "sha256:dirty"
     },
     "graph_binding": {
-      "plan_ref": ".step/st-plan.jsonl",
+      "plan_ref": ".ledger/st/st-plan.jsonl",
       "plan_seq": 42,
       "gcr_id": "GCR-example-001",
-      "gcr_ref": ".step/proof/gcr-42.json",
+      "gcr_ref": ".ledger/proof/gcr-42.json",
       "structure_fingerprint": "sha256:structure",
       "contract_fingerprint": "sha256:contract",
       "coverage_fingerprint": "sha256:coverage",

--- a/codex/skills/actuating/assets/asr-v2.example.json
+++ b/codex/skills/actuating/assets/asr-v2.example.json
@@ -12,7 +12,7 @@
       "dirty_fingerprint": "sha256:clean"
     },
     "control": {
-      "plan_ref": ".step/st-plan.jsonl",
+      "plan_ref": ".ledger/st/st-plan.jsonl",
       "gcr_id": "GCR-example-final",
       "gcr_current": true,
       "execution_allowed": true,
@@ -29,7 +29,7 @@
     },
     "frontiers": {
       "afr_refs": [
-        ".step/actuation/ACT-example-001/slice-001.afr.json"
+        ".ledger/actuating/ACT-example-001/slice-001.afr.json"
       ],
       "terminal": 1,
       "return_to_frontier": 0,

--- a/codex/skills/actuating/references/actuation-slice-contract.md
+++ b/codex/skills/actuating/references/actuation-slice-contract.md
@@ -20,7 +20,7 @@ actuation_slice:
     st_plan_fingerprint:
 
   task_control:
-    plan_ref: .step/st-plan.jsonl
+    plan_ref: .ledger/st/st-plan.jsonl
     gcr_id:
     gcr_ref:
     gcr_seq:
@@ -152,8 +152,8 @@ A new observation that changes owner, invariant, row set, route, or boundary for
 Recommended local path:
 
 ```text
-.step/actuating/<run-id>/current.json
-.step/actuating/<run-id>/history/<timestamp>-<slice-id>.json
+.ledger/actuating/<run-id>/current.json
+.ledger/actuating/<run-id>/history/<timestamp>-<slice-id>.json
 ```
 
 These are workflow-control artifacts, not an alternate task graph.

--- a/codex/skills/actuating/references/decision-contract.yaml
+++ b/codex/skills/actuating/references/decision-contract.yaml
@@ -117,7 +117,7 @@ skill_decision_contract:
         - ACT-SHIP
       required_artifacts:
         - current executable GCR-v1
-        - canonical .step/st-plan.jsonl
+        - canonical .ledger/st/st-plan.jsonl
       success_signals:
         - selected tasks match current policy action/materialization
       failure_signals:

--- a/codex/skills/actuating/references/example-invocations.md
+++ b/codex/skills/actuating/references/example-invocations.md
@@ -17,7 +17,7 @@ proof, and open a ready PR when complete. Do not merge.
 ```text
 Use $actuating.
 
-Resume the existing .step/st-plan.jsonl and .step/actuating checkpoint.
+Resume the existing .ledger/st/st-plan.jsonl and .ledger/actuating checkpoint.
 Verify the current GCR and ASL before mutation. Continue to a ready PR.
 ```
 

--- a/codex/skills/actuating/references/st-control-gate.md
+++ b/codex/skills/actuating/references/st-control-gate.md
@@ -45,7 +45,7 @@ repair intake/graph/proof contract
 recompile
 ```
 
-Do not route around debt with another `.step/*-st-plan.jsonl`.
+Do not route around debt with another `.ledger/st/*-st-plan.jsonl`.
 
 ## Projection
 

--- a/codex/skills/actuating/references/st-handoff.md
+++ b/codex/skills/actuating/references/st-handoff.md
@@ -3,21 +3,21 @@
 ## New material plan
 
 ```bash
-st intake scaffold --source <plan.md> --out .step/st-intake.md
+st intake scaffold --source <plan.md> --out .ledger/st/intake/st-intake.md
 # Agent authors/corrects semantic intake.
-st intake check --input .step/st-intake.md --gate implementation-ready --format json
-st intake normalize --input .step/st-intake.md --out .step/st-intake.normalized.md
+st intake check --input .ledger/st/intake/st-intake.md --gate implementation-ready --format json
+st intake normalize --input .ledger/st/intake/st-intake.md --out .ledger/st/intake/st-intake.normalized.md
 st intake apply \
-  --file .step/st-plan.jsonl \
-  --input .step/st-intake.normalized.md \
+  --file .ledger/st/st-plan.jsonl \
+  --input .ledger/st/intake/st-intake.normalized.md \
   --gate implementation-ready
-st compile aperture --file .step/st-plan.jsonl --limit 7
+st compile aperture --file .ledger/st/st-plan.jsonl --limit 7
 ```
 
 ## Existing graph
 
 ```bash
-st compile aperture --file .step/st-plan.jsonl --limit 7
+st compile aperture --file .ledger/st/st-plan.jsonl --limit 7
 ```
 
 ## Hard rule
@@ -44,18 +44,18 @@ Repeated projection without a graph/GCR change is a projection-inversion warning
 ## Completion
 
 ```bash
-st proof plan --file .step/st-plan.jsonl --scope aperture --format json
+st proof plan --file .ledger/st/st-plan.jsonl --scope aperture --format json
 st proof record \
-  --file .step/st-plan.jsonl \
+  --file .ledger/st/st-plan.jsonl \
   --id <st-id> \
   --obligation <proof-id> \
   --action <proof-action-id> \
   --command "<validation command>" \
   --evidence-ref <proof-log> \
   --artifact-ref "git:<sha-or-working-tree-fingerprint>"
-st complete --file .step/st-plan.jsonl --id <st-id>
-st compile aperture --file .step/st-plan.jsonl --limit 7
-st assert-projection --file .step/st-plan.jsonl
+st complete --file .ledger/st/st-plan.jsonl --id <st-id>
+st compile aperture --file .ledger/st/st-plan.jsonl --limit 7
+st assert-projection --file .ledger/st/st-plan.jsonl
 ```
 
 ASL may reference `$st` IDs and receipts. It may not independently mark `$st` tasks complete.

--- a/codex/skills/actuating/tests/test_actuating_tools.py
+++ b/codex/skills/actuating/tests/test_actuating_tools.py
@@ -138,6 +138,24 @@ def main() -> int:
         assert packet["verdict"] == "pass"
         assert packet["semantic_frontier"]["selected_rows"] == ["VMX-row-002"]
 
+        default_result = subprocess.run(
+            [
+                sys.executable,
+                str(TOOLS / "actuation_checkpoint.py"),
+                "write",
+                "--input",
+                str(ASSETS / "actuation-slice.example.json"),
+            ],
+            cwd=temp,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+            timeout=20,
+        )
+        assert default_result.returncode == 0, default_result.stdout + default_result.stderr
+        assert (temp / ".ledger" / "actuating" / "ACT-example-001" / "current.json").exists()
+
     print("actuating frontier tools: PASS")
     return 0
 

--- a/codex/skills/actuating/tools/actuation_checkpoint.py
+++ b/codex/skills/actuating/tools/actuation_checkpoint.py
@@ -195,17 +195,17 @@ def main() -> int:
 
     p_write = sub.add_parser("write")
     p_write.add_argument("--input", required=True)
-    p_write.add_argument("--root", default=".step/actuating")
+    p_write.add_argument("--root", default=".ledger/actuating")
     p_write.set_defaults(func=write_slice)
 
     p_resume = sub.add_parser("resume")
-    p_resume.add_argument("--root", default=".step/actuating")
+    p_resume.add_argument("--root", default=".ledger/actuating")
     p_resume.add_argument("--run-id", required=True)
     p_resume.add_argument("--repo")
     p_resume.set_defaults(func=resume)
 
     p_check = sub.add_parser("check")
-    p_check.add_argument("--root", default=".step/actuating")
+    p_check.add_argument("--root", default=".ledger/actuating")
     p_check.add_argument("--run-id", required=True)
     p_check.set_defaults(func=check)
 

--- a/codex/skills/cas/SKILL.md
+++ b/codex/skills/cas/SKILL.md
@@ -395,8 +395,8 @@ run_cas_tool review-session start --cwd /path/to/workspace --uncommitted --json
    - Treat `failureCode` as authoritative. CAS never silently falls back to native `codex review`; callers that want a temporary fallback must do it explicitly at their own layer.
 
 4. For swarm-hardening runs, treat `$st` as the durable source of truth before any worker starts.
-   - `st import-orchplan --file .step/st-plan.jsonl --input .step/orchplan.yaml`
-   - `st claim --file .step/st-plan.jsonl --wave w1 --executor codex`
+   - `st import-orchplan --file .ledger/st/st-plan.jsonl --input .ledger/st/orchplan.yaml`
+   - `st claim --file .ledger/st/st-plan.jsonl --wave w1 --executor codex`
    - CAS probes the wave; it does not replace the durable claim ledger.
 
 5. Enforce handshake assumptions when diagnosing failures.

--- a/codex/skills/cas/references/retrace-session-inquiry.md
+++ b/codex/skills/cas/references/retrace-session-inquiry.md
@@ -31,7 +31,7 @@ Preferred command:
 cas session_inquiry run \
   --capsule capsule.json \
   --plan plan.json \
-  --receipt-dir .retrace/<inquiry-id> \
+  --receipt-dir .ledger/retrace/<inquiry-id> \
   --json
 ```
 

--- a/codex/skills/codebase-doctrine/assets/codebase-doctrine.example.json
+++ b/codex/skills/codebase-doctrine/assets/codebase-doctrine.example.json
@@ -216,7 +216,7 @@
         "lane": "history_and_forensics",
         "question_id": "Q-FAILURE",
         "observation": "Two repairs and canonical ledger NEG-0001 identify reader-side tolerance as a failed route.",
-        "evidence_ref": ".ledger/negative-ledger.jsonl#NEG-0001",
+        "evidence_ref": ".ledger/negative-ledger/events.jsonl#NEG-0001",
         "artifact_state_id": "AS-ce619f3a519dcde1",
         "scope": "store",
         "confidence": "high",

--- a/codex/skills/codebase-doctrine/assets/codebase-doctrine.example.yaml
+++ b/codex/skills/codebase-doctrine/assets/codebase-doctrine.example.yaml
@@ -170,7 +170,7 @@ codebase_doctrine:
     question_id: Q-FAILURE
     observation: Two repairs and canonical ledger NEG-0001 identify reader-side tolerance
       as a failed route.
-    evidence_ref: .ledger/negative-ledger.jsonl#NEG-0001
+    evidence_ref: .ledger/negative-ledger/events.jsonl#NEG-0001
     artifact_state_id: AS-ce619f3a519dcde1
     scope: store
     confidence: high

--- a/codex/skills/codebase-doctrine/assets/codebase-doctrine.refreshed.example.yaml
+++ b/codex/skills/codebase-doctrine/assets/codebase-doctrine.refreshed.example.yaml
@@ -170,7 +170,7 @@ codebase_doctrine:
     question_id: Q-FAILURE
     observation: Two repairs and canonical ledger NEG-0001 identify reader-side tolerance
       as a failed route.
-    evidence_ref: .ledger/negative-ledger.jsonl#NEG-0001
+    evidence_ref: .ledger/negative-ledger/events.jsonl#NEG-0001
     artifact_state_id: AS-7edb540f90b51f4b
     scope: store
     confidence: high

--- a/codex/skills/fixed-point-driver/agents/negative-ledger-mapper.md
+++ b/codex/skills/fixed-point-driver/agents/negative-ledger-mapper.md
@@ -7,14 +7,14 @@ description: "Read-only specialist for mapping repo-local ledger records, learni
 
 ## Mission
 
-Prevent repeated semantic dead ends by mapping canonical `.ledger/negative-ledger.jsonl` evidence against the current artifact state.
+Prevent repeated semantic dead ends by mapping canonical `.ledger/negative-ledger/events.jsonl` evidence against the current artifact state.
 
 This specialist is read-only. It never captures ledger events, changes statuses, or writes memory-source notes.
 
 ## Allowed Reads
 
 - `ledger doctor`, `query`, `map`, `handoff`, `show`, and `export`;
-- `.ledger/negative-ledger.jsonl` through the CLI;
+- `.ledger/negative-ledger/events.jsonl` through the CLI;
 - selected `.learnings.jsonl` hits as historical candidate evidence;
 - relevant commits, reverts, reviews, benchmarks, tests, traces, and diffs;
 - the current changed surface needed to judge applicability.

--- a/codex/skills/fixed-point-driver/assets/arh-v1.example.json
+++ b/codex/skills/fixed-point-driver/assets/arh-v1.example.json
@@ -47,6 +47,6 @@
     "proof_obligations": [
       "proof-focused-authority"
     ],
-    "proof_dag_ref": ".step/actuation/ACT-example-001/slice-001.afr.json#/proof_dag"
+    "proof_dag_ref": ".ledger/actuating/ACT-example-001/slice-001.afr.json#/proof_dag"
   }
 }

--- a/codex/skills/fixed-point-driver/assets/fixed-point-result.example.json
+++ b/codex/skills/fixed-point-driver/assets/fixed-point-result.example.json
@@ -36,7 +36,7 @@
       "new_public_symbols": 0
     },
     "proof_refs": [
-      ".step/proof/proof-loaded-session-row-002.json"
+      ".ledger/proof/proof-loaded-session-row-002.json"
     ],
     "obligations_covered": [
       "proof-loaded-session-row-002"

--- a/codex/skills/fixed-point-driver/assets/fixed-point-result.policy.example.json
+++ b/codex/skills/fixed-point-driver/assets/fixed-point-result.policy.example.json
@@ -42,7 +42,7 @@
       "new_public_symbols": 0
     },
     "proof_refs": [
-      ".step/proof/proof-loaded-session-row-002.json"
+      ".ledger/proof/proof-loaded-session-row-002.json"
     ],
     "obligations_covered": [
       "proof-loaded-session-row-002"
@@ -73,7 +73,7 @@
         {
           "observation_id": "OBS-focused-proof",
           "outcome": "pass",
-          "evidence_ref": ".step/proof/proof-loaded-session-row-002.json"
+          "evidence_ref": ".ledger/proof/proof-loaded-session-row-002.json"
         }
       ],
       "prediction_invalidated": false

--- a/codex/skills/fixed-point-driver/assets/fixed-point-slice.example.json
+++ b/codex/skills/fixed-point-driver/assets/fixed-point-slice.example.json
@@ -9,10 +9,10 @@
     "st_task_refs": [
       "st-101"
     ],
-    "graph_control_ref": ".step/proof/gcr-example.json",
-    "actuation_slice_ref": ".step/actuating/ACT-example-001/current.json",
+    "graph_control_ref": ".ledger/proof/gcr-example.json",
+    "actuation_slice_ref": ".ledger/actuating/ACT-example-001/current.json",
     "semantic_route_refs": [
-      ".step/actuating/routes/zsr.json"
+      ".ledger/actuating/routes/zsr.json"
     ],
     "owner": "LoadedSessionImage.validate",
     "invariant": "Current format requires continuation identity.",

--- a/codex/skills/fixed-point-driver/assets/fixed-point-slice.policy.example.json
+++ b/codex/skills/fixed-point-driver/assets/fixed-point-slice.policy.example.json
@@ -9,10 +9,10 @@
     "st_task_refs": [
       "st-101"
     ],
-    "graph_control_ref": ".step/proof/gcr-example.json",
-    "actuation_slice_ref": ".step/actuating/ACT-policy-example-001/current.json",
+    "graph_control_ref": ".ledger/proof/gcr-example.json",
+    "actuation_slice_ref": ".ledger/actuating/ACT-policy-example-001/current.json",
     "semantic_route_refs": [
-      ".step/actuating/routes/zsr.json"
+      ".ledger/actuating/routes/zsr.json"
     ],
     "owner": "LoadedSessionImage.validate",
     "invariant": "Current format requires continuation identity.",

--- a/codex/skills/fixed-point-driver/assets/fpsr-v1.example.json
+++ b/codex/skills/fixed-point-driver/assets/fpsr-v1.example.json
@@ -46,7 +46,7 @@
         "zig build test-session-image --summary all"
       ],
       "evidence_refs": [
-        ".step/proof/session-image-authority.log"
+        ".ledger/proof/session-image-authority.log"
       ],
       "status": "pass"
     },

--- a/codex/skills/memory-source-notes/SKILL.md
+++ b/codex/skills/memory-source-notes/SKILL.md
@@ -37,7 +37,7 @@ source skill or canonical domain store
 ```
 
 - `learnings` owns `.learnings.jsonl` and the admission gate for learning snapshots.
-- `ledger` owns `.ledger/negative-ledger.jsonl` and the admission gate for route state.
+- `ledger` owns `.ledger/negative-ledger/events.jsonl` and the admission gate for route state.
 - `harness-memory` owns durable operating-correction admission.
 - `synesthesia` owns sensory mapping and activation-boundary admission.
 - `memory-note` owns safe immutable transport.
@@ -314,7 +314,7 @@ Do not use this skill to:
 
 - bypass native ad-hoc remember/forget/update behavior;
 - write compiled memory directly;
-- replace `.learnings.jsonl` or `.ledger/negative-ledger.jsonl`;
+- replace `.learnings.jsonl` or `.ledger/negative-ledger/events.jsonl`;
 - decide whether negative evidence blocks a route;
 - infer durable user preferences from assistant prose alone;
 - capture ordinary chronology;

--- a/codex/skills/memory-source-notes/references/extension-payloads.md
+++ b/codex/skills/memory-source-notes/references/extension-payloads.md
@@ -40,7 +40,7 @@ The complete canonical row remains in `.learnings.jsonl`.
 {
   "neg_id": "NEG-000001",
   "record_version": "NER-v2",
-  "ledger_path": ".ledger/negative-ledger.jsonl",
+  "ledger_path": ".ledger/negative-ledger/events.jsonl",
   "projection_fingerprint": "...",
   "status": "active",
   "kind": "realization_route",

--- a/codex/skills/memory-source-notes/references/note-contract.md
+++ b/codex/skills/memory-source-notes/references/note-contract.md
@@ -128,7 +128,7 @@ Phase 2 updates compiled memory surgically. It never deletes source notes.
 
 A note can be authoritative that Phase 2 must consider an event while remaining subordinate to its canonical domain source.
 
-- a negative-ledger note is an exported snapshot; `.ledger/negative-ledger.jsonl` owns route state;
+- a negative-ledger note is an exported snapshot; `.ledger/negative-ledger/events.jsonl` owns route state;
 - a learnings note admits a row; `.learnings.jsonl` owns the full learning;
 - a harness note may itself be canonical when it records explicit operating correction;
 - a Synesthesia note may itself be canonical when it records explicit endorsement, correction, rejection, retraction, reopening, or a durable boundary.

--- a/codex/skills/negative-ledger/SKILL.md
+++ b/codex/skills/negative-ledger/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: negative-ledger
-description: "Durably capture, query, map, transition, compact, export, and hand off witnessed negative evidence in repo-local `.ledger/negative-ledger.jsonl`; selectively admit full ledger projections to Codex memory through memory-source-notes. Use for failed semantic routes, benchmark regressions, no-effect attempts, reverts, route exclusions, reopening, or search-space pruning."
+description: "Durably capture, query, map, transition, compact, export, and hand off witnessed negative evidence in repo-local `.ledger/negative-ledger/events.jsonl`; selectively admit full ledger projections to Codex memory through memory-source-notes. Use for failed semantic routes, benchmark regressions, no-effect attempts, reverts, route exclusions, reopening, or search-space pruning."
 metadata:
   version: "6.0.0"
 ---
@@ -14,7 +14,7 @@ Prune semantic search space without turning stale failures into permanent dogma.
 The operational truth is:
 
 ```text
-<repo>/.ledger/negative-ledger.jsonl
+<repo>/.ledger/negative-ledger/events.jsonl
 ```
 
 The memory-admission channel is:
@@ -41,7 +41,7 @@ Never use memory notes as the operational route gate. For accepted admission, lo
 ## Canonical Store and CLI
 
 ```text
-.ledger/negative-ledger.jsonl
+.ledger/negative-ledger/events.jsonl
 ledger
 ```
 
@@ -197,7 +197,7 @@ Report both layers separately.
 - Do not block from fuzzy matches.
 - Do not use stale benchmarks without current applicability reasoning.
 - Do not treat absence of a ledger entry as novelty proof.
-- Do not hand-edit `.ledger/negative-ledger.jsonl`.
+- Do not hand-edit `.ledger/negative-ledger/events.jsonl`.
 - Do not let memory notes outrank the repo-local ledger.
 - Do not write compiled memory directly.
 - Do not publish incomplete projections to Phase 2.

--- a/codex/skills/negative-ledger/agents/negative-ledger-mapper.md
+++ b/codex/skills/negative-ledger/agents/negative-ledger-mapper.md
@@ -7,14 +7,14 @@ description: "Read-only specialist for mapping repo-local ledger records, learni
 
 ## Mission
 
-Prevent repeated semantic dead ends by mapping canonical `.ledger/negative-ledger.jsonl` evidence against the current artifact state.
+Prevent repeated semantic dead ends by mapping canonical `.ledger/negative-ledger/events.jsonl` evidence against the current artifact state.
 
 This specialist is read-only. It never captures ledger events, changes statuses, or writes memory-source notes.
 
 ## Allowed Reads
 
 - `ledger doctor`, `query`, `map`, `handoff`, `show`, and `export`;
-- `.ledger/negative-ledger.jsonl` through the CLI;
+- `.ledger/negative-ledger/events.jsonl` through the CLI;
 - selected `.learnings.jsonl` hits as historical candidate evidence;
 - relevant commits, reverts, reviews, benchmarks, tests, traces, and diffs;
 - the current changed surface needed to judge applicability.
@@ -46,7 +46,7 @@ This specialist is read-only. It never captures ledger events, changes statuses,
 ```yaml
 negative_evidence_ledger:
   - neg_id: NEG-000001
-    ledger_path: .ledger/negative-ledger.jsonl
+    ledger_path: .ledger/negative-ledger/events.jsonl
     record_version: NER-v2
     status: active | accepted_risk | stale | reopened | superseded | unknown | need-evidence
     route_or_model_id: "..."

--- a/codex/skills/negative-ledger/references/learnings-source.md
+++ b/codex/skills/negative-ledger/references/learnings-source.md
@@ -3,7 +3,7 @@
 `$learnings` supplies historical candidate evidence. The negative ledger owns failed-hypothesis semantics and operational route state in:
 
 ```text
-.ledger/negative-ledger.jsonl
+.ledger/negative-ledger/events.jsonl
 ```
 
 ## Read Path

--- a/codex/skills/negative-ledger/references/negative-ledger-contract.md
+++ b/codex/skills/negative-ledger/references/negative-ledger-contract.md
@@ -56,4 +56,4 @@ A reopened route needs positive proof that at least one reopening criterion is s
 
 ## Memory Projection
 
-Memory admission is a projection of ledger truth, not a second ledger. The projection embeds complete source refs, applicability conditions, exclusion rule, reopening criteria, source event count, and projection fingerprint. Phase 2 may compile it into memory, but route blocking continues to consult `.ledger/negative-ledger.jsonl`.
+Memory admission is a projection of ledger truth, not a second ledger. The projection embeds complete source refs, applicability conditions, exclusion rule, reopening criteria, source event count, and projection fingerprint. Phase 2 may compile it into memory, but route blocking continues to consult `.ledger/negative-ledger/events.jsonl`.

--- a/codex/skills/negative-ledger/references/negative-ledger-jsonl.md
+++ b/codex/skills/negative-ledger/references/negative-ledger-jsonl.md
@@ -3,7 +3,7 @@
 ## Canonical Operational Store
 
 ```text
-<repo>/.ledger/negative-ledger.jsonl
+<repo>/.ledger/negative-ledger/events.jsonl
 ```
 
 Use the `ledger` CLI. Do not hand-edit the store and do not treat `.learnings.jsonl` as the operational negative-ledger authority.
@@ -29,7 +29,7 @@ ledger status --id NEG-000001 --to stale --reason "..."
 ## Operational Versus Memory Authority
 
 ```text
-.ledger/negative-ledger.jsonl
+.ledger/negative-ledger/events.jsonl
   decides current route state
 
 extensions/negative-ledger/notes/*.md

--- a/codex/skills/negative-ledger/references/review-governor-memory.md
+++ b/codex/skills/negative-ledger/references/review-governor-memory.md
@@ -10,7 +10,7 @@ negative_route_gate:
   evidence_source:
     query_or_map: yes
     ledger_cli: ledger
-    store: .ledger/negative-ledger.jsonl
+    store: .ledger/negative-ledger/events.jsonl
     command: "ledger map --route ... --cluster ... --artifact ..."
     exit_code: 0 | 2 | 3
     ledger_available: yes | no

--- a/codex/skills/plan/SKILL.md
+++ b/codex/skills/plan/SKILL.md
@@ -530,7 +530,7 @@ Current compatibility path:
 EPG/current state
 -> EPD-v1 selected action
 -> semantic intake for only the current commitment horizon
--> canonical .step/st-plan.jsonl
+-> canonical .ledger/st/st-plan.jsonl
 -> GCR-v1
 ```
 

--- a/codex/skills/plan/assets/transition-receipt.probe.example.json
+++ b/codex/skills/plan/assets/transition-receipt.probe.example.json
@@ -51,7 +51,7 @@
         {
           "observation_id": "OBS-ROUTE",
           "outcome": "route_a",
-          "evidence_ref": ".step/policy/evidence/cache-comparison.json"
+          "evidence_ref": ".ledger/plan/evidence/cache-comparison.json"
         }
       ],
       "potential_after": {
@@ -66,7 +66,7 @@
         "PROOF-PROBE"
       ],
       "evidence_refs": [
-        ".step/policy/evidence/cache-comparison.json"
+        ".ledger/plan/evidence/cache-comparison.json"
       ],
       "status": "pass"
     },
@@ -94,7 +94,7 @@
     },
     "result": "success",
     "evidence_refs": [
-      ".step/policy/evidence/cache-comparison.json"
+      ".ledger/plan/evidence/cache-comparison.json"
     ]
   }
 }

--- a/codex/skills/plan/references/st-handoff.md
+++ b/codex/skills/plan/references/st-handoff.md
@@ -8,7 +8,7 @@ Current compatibility path:
 EPG + EPS state
 -> EPD selected action
 -> `$st` semantic intake containing exact policy/state/action refs
--> canonical `.step/st-plan.jsonl`
+-> canonical `.ledger/st/st-plan.jsonl`
 -> GCR-v1
 ```
 

--- a/codex/skills/resolve/assets/mbkc-intent-closed-terminal.example.json
+++ b/codex/skills/resolve/assets/mbkc-intent-closed-terminal.example.json
@@ -53,9 +53,9 @@
     },
     "realization": {
       "selected_design_id": "DESIGN-1",
-      "manifest_ref": ".ledger/c3/realization/manifest.json",
-      "construct_map_ref": ".ledger/c3/realization/construct-map.json",
-      "surface_ref": ".ledger/c3/realization/surface.json",
+      "manifest_ref": ".ledger/resolve/c3/realization/manifest.json",
+      "construct_map_ref": ".ledger/resolve/c3/realization/construct-map.json",
+      "surface_ref": ".ledger/resolve/c3/realization/surface.json",
       "verified": "yes",
       "new_observations": []
     },
@@ -78,7 +78,7 @@
       "all_laws_covered": "yes",
       "wound_specific_tests": [],
       "unmapped_proof_actions": [],
-      "basis_ref": ".ledger/c3/proof/basis.json"
+      "basis_ref": ".ledger/resolve/c3/proof/basis.json"
     },
     "terminal_holdout": {
       "novel_in_horizon_counterexamples": 0,

--- a/codex/skills/resolve/references/controller.md
+++ b/codex/skills/resolve/references/controller.md
@@ -33,7 +33,7 @@ Those are controller-derived.
 State root:
 
 ```text
-.ledger/c3/
+.ledger/resolve/c3/
 ```
 
 Local-exclude by default unless the user deliberately versions campaign evidence.

--- a/codex/skills/resolve/references/governor-tooling.md
+++ b/codex/skills/resolve/references/governor-tooling.md
@@ -8,4 +8,4 @@ resolve-c3 mrpc-gate --file <mrpc.json>
 resolve-c3 rdr-gate --file <record.yml>
 ```
 
-The Python governor validators are retired. Current C3 closure uses `resolve-c3` gate subcommands and controller state under `.ledger/c3/`.
+The Python governor validators are retired. Current C3 closure uses `resolve-c3` gate subcommands and controller state under `.ledger/resolve/c3/`.

--- a/codex/skills/resolve/references/mutation-permit-gate.md
+++ b/codex/skills/resolve/references/mutation-permit-gate.md
@@ -14,7 +14,7 @@ The gate checks the literal `RGR-V2-MUTATION-PERMIT:` key and rejects:
 - positive production net without warrant;
 - continue_owner when owner is too coarse or unknown;
 - negative-ledger query_or_map: no;
-- missing `ledger_cli: ledger`, `.ledger/negative-ledger.jsonl` store, or `ledger map` exit code;
+- missing `ledger_cli: ledger`, `.ledger/negative-ledger/events.jsonl` store, or `ledger map` exit code;
 - `ledger_available: no` or `exit_code: 3`;
 - one-test-per-wound without a family matrix;
 - handoff_allowed: no.

--- a/codex/skills/resolve/references/negative-ledger-integration.md
+++ b/codex/skills/resolve/references/negative-ledger-integration.md
@@ -18,4 +18,4 @@ Operational source:
 ledger map --route "<selected-route>" --cluster "<cluster-id>" --artifact "<artifact-state-id>"
 ```
 
-Use `.ledger/negative-ledger.jsonl` through the `ledger` CLI. Do not treat prose or `.learnings.jsonl` recall as an operational route gate.
+Use `.ledger/negative-ledger/events.jsonl` through the `ledger` CLI. Do not treat prose or `.learnings.jsonl` recall as an operational route gate.

--- a/codex/skills/resolve/references/negative-ledger-operational-evidence.md
+++ b/codex/skills/resolve/references/negative-ledger-operational-evidence.md
@@ -11,7 +11,7 @@ negative_route_gate:
     skill_read:
     query_or_map:
     ledger_cli: ledger
-    store: .ledger/negative-ledger.jsonl
+    store: .ledger/negative-ledger/events.jsonl
     command: "ledger map --route ... --cluster ... --artifact ..."
     exit_code: 0 | 2 | 3
     ledger_available: yes | no

--- a/codex/skills/resolve/references/negative-route-gate.md
+++ b/codex/skills/resolve/references/negative-route-gate.md
@@ -6,7 +6,7 @@ Before repeating any route in a hot cluster:
 negative_route_gate:
   query_or_map: yes | no
   ledger_cli: ledger
-  store: .ledger/negative-ledger.jsonl
+  store: .ledger/negative-ledger/events.jsonl
   command: "ledger map --route ... --cluster ... --artifact ..."
   exit_code: 0 | 2 | 3
   ledger_available: yes | no

--- a/codex/skills/resolve/references/negative-route-ratchet.md
+++ b/codex/skills/resolve/references/negative-route-ratchet.md
@@ -6,7 +6,7 @@ Before repeating a route in a hot cluster, check active negative evidence.
 negative_route_gate:
   query_or_map: yes | no
   ledger_cli: ledger
-  store: .ledger/negative-ledger.jsonl
+  store: .ledger/negative-ledger/events.jsonl
   command: "ledger map --route ... --cluster ... --artifact ..."
   exit_code: 0 | 2 | 3
   ledger_available: yes | no

--- a/codex/skills/resolve/references/route-wave-artifact.md
+++ b/codex/skills/resolve/references/route-wave-artifact.md
@@ -5,7 +5,7 @@ Publish route/RCP/RDP/NREC/negative-ledger/universalist decisions into a first-c
 Preferred path:
 
 ```text
-.step/proof/resolve/<resolve-run-id>/review-wave-<n>.route.yml
+.ledger/proof/resolve/<resolve-run-id>/review-wave-<n>.route.yml
 ```
 
 Validate with:

--- a/codex/skills/retrace/SKILL.md
+++ b/codex/skills/retrace/SKILL.md
@@ -320,7 +320,7 @@ See [inquiry-lanes.md](references/inquiry-lanes.md).
 cas session_inquiry run \
   --capsule capsule.json \
   --plan plan.json \
-  --receipt-dir .retrace/<inquiry-id> \
+  --receipt-dir .ledger/retrace/<inquiry-id> \
   --json
 ```
 CAS must prove source lineage, retained anchor, model/provider, permission policy, workspace mode, turn state, and cleanup.
@@ -423,7 +423,7 @@ bounded excerpts and refs
 ```
 Do not use `thread/shellCommand`.
 Do not persist private reasoning.
-Use `.retrace/<inquiry-id>/` only when receipts are required, and local-exclude it by default.
+Use `.ledger/retrace/<inquiry-id>/` only when receipts are required, and local-exclude it by default.
 A blocked replay does not erase deterministic source evidence.
 
 ## Output

--- a/codex/skills/review-compression-compiler/references/route-wave-artifact.md
+++ b/codex/skills/review-compression-compiler/references/route-wave-artifact.md
@@ -5,7 +5,7 @@
 Suggested path:
 
 ```text
-.step/proof/resolve/<resolve-run-id>/review-wave-<n>.route.yml
+.ledger/proof/resolve/<resolve-run-id>/review-wave-<n>.route.yml
 ```
 
 Shape includes:

--- a/codex/skills/seq/references/resolve-c3-audit.md
+++ b/codex/skills/seq/references/resolve-c3-audit.md
@@ -11,8 +11,8 @@ when the installed `seq` supports it.
 Until then, audit:
 
 - `resolve-c3` lifecycle commands;
-- `.ledger/c3/state.json`;
-- `.ledger/c3/events.jsonl`;
+- `.ledger/resolve/c3/state.json`;
+- `.ledger/resolve/c3/events.jsonl`;
 - MRPC-v1 stages;
 - direct delivery mutations between begin and close;
 - candidate tournament size and route diversity;

--- a/codex/skills/st/SKILL.md
+++ b/codex/skills/st/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: st
-description: "Durable graph control, aperture, and proof source for `.step/st-plan.jsonl`. Use for `use $st`, resuming durable work, dependencies, proof-carrying completion, mirroring bounded work into Codex/OpenCode plans, or turning a plan, proposal, issue, spec, markdown document, TODO list, or design into executable tasks. For material work, require a current CLI-emitted GCR-v1 before execution projection."
+description: "Durable graph control, aperture, and proof source for `.ledger/st/st-plan.jsonl`. Use for `use $st`, resuming durable work, dependencies, proof-carrying completion, mirroring bounded work into Codex/OpenCode plans, or turning a plan, proposal, issue, spec, markdown document, TODO list, or design into executable tasks. For material work, require a current CLI-emitted GCR-v1 before execution projection."
 ---
 
 # st
@@ -32,7 +32,7 @@ Use graph mode for material plans with intent atoms, contracted executable items
 Required control command:
 
 ```bash
-st compile aperture --file .step/st-plan.jsonl --limit 7
+st compile aperture --file .ledger/st/st-plan.jsonl --limit 7
 ```
 
 Current `st` also accepts legacy `--parallelism auto` on this command as a no-op compatibility alias; do not write new instructions with that flag.
@@ -77,31 +77,31 @@ Cache that result for the session.
 For a new material plan, use the intake check/apply path:
 
 ```bash
-st intake scaffold --source docs/plan.md --out .step/st-intake.md
+st intake scaffold --source docs/plan.md --out .ledger/st/intake/st-intake.md
 # Agent fills or edits the semantic intake artifact.
-st intake check --input .step/st-intake.md --gate implementation-ready --format json
-st intake normalize --input .step/st-intake.md --out .step/st-intake.normalized.md
-st intake apply --file .step/st-plan.jsonl --input .step/st-intake.normalized.md --gate implementation-ready
-st compile aperture --file .step/st-plan.jsonl --limit 7
+st intake check --input .ledger/st/intake/st-intake.md --gate implementation-ready --format json
+st intake normalize --input .ledger/st/intake/st-intake.md --out .ledger/st/intake/st-intake.normalized.md
+st intake apply --file .ledger/st/st-plan.jsonl --input .ledger/st/intake/st-intake.normalized.md --gate implementation-ready
+st compile aperture --file .ledger/st/st-plan.jsonl --limit 7
 ```
 
 `st intake plan` is a deprecated alias for scaffold. A scaffold is not semantic compilation until the agent-authored intake passes `check` and `apply`.
 
-Intake always applies to the canonical `.step/st-plan.jsonl`. Do not create an alternate durable plan file such as `.step/*-st-plan.jsonl` to bypass existing canonical graph debt; repair the canonical graph with `st` commands or fail with the audit/intake diagnostics.
+Intake always applies to the canonical `.ledger/st/st-plan.jsonl`. Do not create an alternate durable plan file such as `.ledger/st/*-st-plan.jsonl` to bypass existing canonical graph debt; repair the canonical graph with `st` commands or fail with the audit/intake diagnostics.
 
 ## Existing Healthy Graph
 
 For existing healthy graph work, start with:
 
 ```bash
-st compile aperture --file .step/st-plan.jsonl --limit 7
+st compile aperture --file .ledger/st/st-plan.jsonl --limit 7
 ```
 
 Then mirror only the emitted `plan_sync.codex.plan` into `update_plan` or `plan_sync.opencode.todos` into OpenCode.
 
 ## Projection Rules
 
-- Durable source: `.step/st-plan.jsonl`.
+- Durable source: `.ledger/st/st-plan.jsonl`.
 - Do not create sidecar durable plan files to work around canonical graph debt.
 - Native plan tools are projection only.
 - Mutate durable state only through `st` commands.
@@ -116,18 +116,18 @@ Then mirror only the emitted `plan_sync.codex.plan` into `update_plan` or `plan_
 Execute only the selected aperture. After work, record proof at obligation level:
 
 ```bash
-st proof plan --file .step/st-plan.jsonl --scope aperture --format json
+st proof plan --file .ledger/st/st-plan.jsonl --scope aperture --format json
 st proof record \
-  --file .step/st-plan.jsonl \
+  --file .ledger/st/st-plan.jsonl \
   --id st-001 \
   --obligation proof-001 \
   --action proof-action-test-st \
   --command "zig build test-st" \
-  --evidence-ref .step/proof/st-001-proof-001.log \
+  --evidence-ref .ledger/proof/st-001-proof-001.log \
   --artifact-ref "git:<sha-or-working-tree-fingerprint>"
-st complete --file .step/st-plan.jsonl --id st-001
-st compile aperture --file .step/st-plan.jsonl --limit 7
-st assert-projection --file .step/st-plan.jsonl
+st complete --file .ledger/st/st-plan.jsonl --id st-001
+st compile aperture --file .ledger/st/st-plan.jsonl --limit 7
+st assert-projection --file .ledger/st/st-plan.jsonl
 ```
 
 `st set-proof` remains a compatibility convenience. Do not use one ambiguous legacy proof to satisfy several distinct required commands.
@@ -139,22 +139,22 @@ If a local installed `st` rejects a documented proof flag combination, do not sp
 Use graph debt commands when the GCR blocks execution:
 
 ```bash
-st graph debt list --file .step/st-plan.jsonl --format json
-st graph debt waive --file .step/st-plan.jsonl --id debt-... --reason "..." --expires on-next-touch
-st graph debt resolve --file .step/st-plan.jsonl --id debt-...
+st graph debt list --file .ledger/st/st-plan.jsonl --format json
+st graph debt waive --file .ledger/st/st-plan.jsonl --id debt-... --reason "..." --expires on-next-touch
+st graph debt resolve --file .ledger/st/st-plan.jsonl --id debt-...
 ```
 
 For material work, unwaived blocking debt means `execution_allowed: no`.
 
 ## First-Use Storage Policy
 
-Before the first `st init` or mutation in a repo, determine whether `.step/st-plan.jsonl` is shared or local.
+Before the first `st init` or mutation in a repo, determine whether `.ledger/st/st-plan.jsonl` is shared or local.
 
 - If already tracked, respect shared mode.
 - If ignored, respect local mode.
-- If unclear, ask whether `.step/st-plan.jsonl` should be committed for shared review or kept local via `.git/info/exclude`.
-- Shared mode: track `.step/st-plan.jsonl`; ignore `.step/st-plan.jsonl.lock`.
-- Local mode: ignore both `.step/st-plan.jsonl` and `.step/st-plan.jsonl.lock`.
+- If unclear, ask whether `.ledger/st/st-plan.jsonl` should be committed for shared review or kept local via `.git/info/exclude`.
+- Shared mode: track `.ledger/st/st-plan.jsonl`; ignore `.ledger/st/st-plan.jsonl.lock`.
+- Local mode: ignore both `.ledger/st/st-plan.jsonl` and `.ledger/st/st-plan.jsonl.lock`.
 
 ## Final Response
 

--- a/codex/skills/st/references/jsonl-format.md
+++ b/codex/skills/st/references/jsonl-format.md
@@ -208,18 +208,18 @@ Finding shape is `{code,severity,target,message,waived,waiver_id}`.
 - Canonical rewrite shape is two records: one `event` (`op=replace`) and one `checkpoint`, both at the new watermark
 - Checkpoint seq rule: each checkpoint `seq` must equal the watermark immediately before that checkpoint record
 - Replay contract: latest checkpoint + records with `seq` greater than checkpoint `seq` must equal full replay
-- Repair path: `st doctor --file .step/st-plan.jsonl --repair-seq` rewrites a canonical replace+checkpoint stream at the current watermark
+- Repair path: `st doctor --file .ledger/st/st-plan.jsonl --repair-seq` rewrites a canonical replace+checkpoint stream at the current watermark
 
 ## Plan-file storage policy
 
-- The JSONL format is the same whether `.step/st-plan.jsonl` is repo-tracked or locally ignored
-- On first use in a repo, ask which policy should govern `.step/st-plan.jsonl` unless the repo already makes the choice obvious
-- Shared mode: keep `.step/st-plan.jsonl` tracked and ignore only the lock sidecar
-- Local mode: add both `.step/st-plan.jsonl` and `.step/st-plan.jsonl.lock` to `.git/info/exclude`
+- The JSONL format is the same whether `.ledger/st/st-plan.jsonl` is repo-tracked or locally ignored
+- On first use in a repo, ask which policy should govern `.ledger/st/st-plan.jsonl` unless the repo already makes the choice obvious
+- Shared mode: keep `.ledger/st/st-plan.jsonl` tracked and ignore only the lock sidecar
+- Local mode: add both `.ledger/st/st-plan.jsonl` and `.ledger/st/st-plan.jsonl.lock` to `.git/info/exclude`
 
 ## Lock sidecar policy
 
-- Mutation paths acquire a sidecar file lock at `<plan-file>.lock` (for example `.step/st-plan.jsonl.lock`)
+- Mutation paths acquire a sidecar file lock at `<plan-file>.lock` (for example `.ledger/st/st-plan.jsonl.lock`)
 - In git worktrees, mutating commands require that sidecar path to be ignored (`git check-ignore`) before writes proceed
 - Use `.gitignore` for the sidecar in shared mode, or `.git/info/exclude` for both plan and sidecar in local-only mode
 

--- a/codex/skills/st/references/material-plan-intake-template.md
+++ b/codex/skills/st/references/material-plan-intake-template.md
@@ -1,6 +1,6 @@
 # Material Plan Intake Template
 
-Copy this file to `.step/st-intake.md` when the installed `st` binary does not yet provide `st intake plan`.
+Copy this file to `.ledger/st/intake/st-intake.md` when the installed `st` binary does not yet provide `st intake plan`.
 
 ```markdown
 # st graph intake

--- a/codex/skills/st/references/next-cli-patch-spec.md
+++ b/codex/skills/st/references/next-cli-patch-spec.md
@@ -17,8 +17,8 @@ Therefore, reduce the graph path to one obvious intake artifact and one obvious 
 ## Add Commands
 
 ```bash
-st intake plan --file .step/st-plan.jsonl --source <plan.md> --out .step/st-intake.md
-st intake apply --file .step/st-plan.jsonl --input .step/st-intake.md --gate implementation-ready
+st intake plan --file .ledger/st/st-plan.jsonl --source <plan.md> --out .ledger/st/intake/st-intake.md
+st intake apply --file .ledger/st/st-plan.jsonl --input .ledger/st/intake/st-intake.md --gate implementation-ready
 ```
 
 ## Intake Markdown
@@ -38,7 +38,7 @@ st intake apply --file .step/st-plan.jsonl --input .step/st-intake.md --gate imp
 
 `st intake apply` should parse and normalize it into durable `$st` graph state.
 
-Intake must target the canonical `.step/st-plan.jsonl`. If the canonical graph has legacy debt, the CLI should either repair/audit that graph or fail with diagnostics; it must not encourage agents to create alternate durable `.step/*-st-plan.jsonl` sidecars to route around the problem.
+Intake must target the canonical `.ledger/st/st-plan.jsonl`. If the canonical graph has legacy debt, the CLI should either repair/audit that graph or fail with diagnostics; it must not encourage agents to create alternate durable `.ledger/st/*-st-plan.jsonl` sidecars to route around the problem.
 
 ## Graph Debt Warnings
 
@@ -65,7 +65,7 @@ Suggested warning payload:
 Preferred behavior:
 
 ```bash
-st import-proposed-plan --mode graph-intake --input .step/proposed-plan.md
+st import-proposed-plan --mode graph-intake --input .ledger/plan/proposed-plan.md
 ```
 
 or emit:
@@ -73,8 +73,8 @@ or emit:
 ```text
 Imported as draft rows only.
 For material plans, run:
-  st intake plan --source .step/proposed-plan.md --out .step/st-intake.md
-  st intake apply --input .step/st-intake.md --gate implementation-ready
+  st intake plan --source .ledger/plan/proposed-plan.md --out .ledger/st/intake/st-intake.md
+  st intake apply --input .ledger/st/intake/st-intake.md --gate implementation-ready
 ```
 
 ## CLI Shape Compatibility
@@ -83,7 +83,7 @@ Improve or alias common old-style invocations:
 
 ```bash
 st set-status st-001 in_progress
-st set-proof st-001 pass "zig build test-st" .step/proof.log
+st set-proof st-001 pass "zig build test-st" .ledger/proof/st/proof.log
 ```
 
 If not supported, emit precise "did you mean" diagnostics with long-option form.

--- a/codex/skills/verification-closure/SKILL.md
+++ b/codex/skills/verification-closure/SKILL.md
@@ -16,7 +16,7 @@ Decide whether the current artifact is actually ready.
 Require:
 
 ```text
-.ledger/c3/mbkc.json
+.ledger/resolve/c3/mbkc.json
 certificate_version = MBKC-v1
 campaign_base unchanged
 review-ready baseline unchanged


### PR DESCRIPTION
## Summary
- migrate workflow artifact defaults/examples to canonical `.ledger/<owner>/` namespaces
- update Codex hooks to prefer `.ledger/st/st-plan.jsonl` and `.ledger/resolve/c3/state.json`, with explicit legacy read fallbacks
- add canonical runtime ignore rules, a migration receipt, and focused path-selection regression coverage

## Verification
- `sh -n codex/hooks/st_hook_common.sh codex/hooks/st_pre_tool_use.sh codex/hooks/st_session_start.sh codex/hooks/st_stop.sh codex/hooks/tests/test_st_hook_common.sh`
- `codex/hooks/tests/test_st_hook_common.sh`
- `uv run python codex/skills/actuating/tests/test_actuating_tools.py`
- `git diff --name-only -- '*.json' | xargs -r jq empty`
- `git diff --name-only -- '*.yaml' '*.yml' | xargs -r ruby -e 'require "yaml"; ARGV.each { |path| YAML.load_file(path) }'
- `uv run python codex/skills/plan/tests/test_policy_tools.py`
- `uv run python codex/skills/fixed-point-driver/tests/test_fixed_point_tools.py`
- `uv run python codex/skills/retrace/tests/test_retrace_tools.py`
- `uv run python codex/skills/codebase-doctrine/tests/test_doctrine_tools.py && uv run python codex/skills/codebase-doctrine/tests/test_packet_tools.py && uv run python codex/skills/codebase-doctrine/tests/test_mode_and_routing.py`

## Note
- Expanded `uv run python codex/skills/resolve/tests/test_intent_closed_protocol.py && uv run python codex/skills/resolve/tests/test_kernel_tools.py` showed `test_intent_closed_protocol.py` passing and `test_kernel_tools.py` failing on its synthetic MBK fixture schema. The fixture was not touched by this migration; the only changed resolve asset lines are path rewrites from `.ledger/c3/` to `.ledger/resolve/c3/`.