### PR TITLE
Fix spec-pipeline lane default for plan-ready specs

### DIFF
--- a/codex/skills/spec-pipeline/PATCH_NOTES.md
+++ b/codex/skills/spec-pipeline/PATCH_NOTES.md
@@ -1,26 +1,35 @@
 # Patch Notes
 
-Version: `2.1.0`
+Version: `2.1.1`
 
-Adds automatic same-turn `$plan` handoff when `$spec-pipeline` recommends it.
+Clarifies lane selection for automatic same-turn `$plan` handoff.
 
-Key change:
+Key correction:
 
 ```text
-SGR-v2 complete + lane=spec_to_plan + plan_allowed=yes + lint pass
-+ execution_handoff.next_owner=$plan + no blockers
-= same-turn $plan tail-call
+explicit $spec-pipeline invocation
+!= spec_only request
 ```
 
-The change is fail-closed:
+In `full` mode, default to `lane=spec_to_plan` unless the user explicitly asks
+for spec-only/no-plan output or a material gate blocks planning. A successful,
+plan-ready SGR-v2 must tail-call `$plan` or emit `AUTO_PLAN_HANDOFF_REQUIRED` if
+same-turn loading is unavailable.
+
+This prevents the regression where an assistant chooses `spec_only` because the
+user invoked `$spec-pipeline` rather than separately invoking `$plan`.
+
+Retains the existing fail-closed rules:
 
 - no `<proposed_plan>` from `$spec-pipeline`;
 - no auto-plan from gate-only, challenge-only, or lint-only modes;
-- no auto-plan with drift, open material questions, failed lint, open subagents, or `do_not_execute_before` blockers;
-- if the runtime cannot load `$plan`, emit `AUTO_PLAN_HANDOFF_REQUIRED` rather than silently stopping.
+- no auto-plan with drift, open material questions, failed lint, open subagents,
+  or `do_not_execute_before` blockers;
+- if the runtime cannot load `$plan`, emit `AUTO_PLAN_HANDOFF_REQUIRED` rather
+  than silently stopping or converting to `spec_only`.
 
 Adds:
 
-- `references/auto-plan-tail-call.md`
-- `tools/auto_plan_handoff_gate.py`
-- fixtures and tests for eligible and blocked handoffs
+- `references/lane-selection.md`
+- clarified `references/auto-plan-tail-call.md`
+- updated OpenAI metadata prompt with the `spec_to_plan` default rule

--- a/codex/skills/spec-pipeline/agents/openai.yaml
+++ b/codex/skills/spec-pipeline/agents/openai.yaml
@@ -6,10 +6,13 @@ interface:
   default_prompt: >-
     Use $spec-pipeline. Select full, gate-only, challenge-only, lint-only, or
     repair mode; emit exactly one SGR-v2 governance receipt; never emit
-    <proposed_plan>. In full or fully repaired repair mode, when SGR-v2 and the
-    Execution Handoff say the spec is complete, lane=spec_to_plan, planning is
-    allowed, lint passed, no blockers remain, next_owner=$plan, and
-    auto_plan_handoff.eligible=yes, immediately tail-call $plan in the same
-    turn using the final implementation spec and SGR-v2 as the source contract.
-    Do not ask the user to invoke $plan separately. If the runtime cannot load
-    $plan, emit AUTO_PLAN_HANDOFF_REQUIRED with the reason.
+    <proposed_plan>. In full mode, do not treat explicit $spec-pipeline
+    invocation as spec-only. Default lane=spec_to_plan unless the user explicitly
+    requests spec-only/no-plan output or a material gate blocks planning. In full
+    or fully repaired repair mode, when SGR-v2 and the Execution Handoff say the
+    spec is complete, lane=spec_to_plan, planning is allowed, lint passed, no
+    blockers remain, next_owner=$plan, and auto_plan_handoff.eligible=yes,
+    immediately tail-call $plan in the same turn using the final implementation
+    spec and SGR-v2 as the source contract. Do not ask the user to invoke $plan
+    separately. If the runtime cannot load $plan, emit AUTO_PLAN_HANDOFF_REQUIRED
+    with the reason; do not silently convert to spec_only.

--- a/codex/skills/spec-pipeline/references/auto-plan-tail-call.md
+++ b/codex/skills/spec-pipeline/references/auto-plan-tail-call.md
@@ -4,6 +4,18 @@
 owns execution-policy synthesis. This reference makes the seam automatic without
 letting `$spec-pipeline` emit plan artifacts.
 
+## Lane selection before the predicate
+
+Before the final SGR-v2 exists, choose the lane with the rule in
+[lane-selection.md](lane-selection.md): in `full` mode, default to `spec_to_plan`
+unless the user explicitly requested spec-only output or a material gate blocks
+planning.
+
+Explicit `$spec-pipeline` invocation is not a request for `spec_only`. If the
+run completes with a plan-ready governed spec, the lane must remain
+`spec_to_plan` and this tail-call predicate decides whether same-turn `$plan`
+runs.
+
 ## Predicate
 
 Run `$plan` immediately after the final SGR-v2 only when every predicate holds:
@@ -58,17 +70,17 @@ PSR-v1 synthesis receipt, and `.ledger/st` handoff.
 
 Do not auto-run `$plan` when:
 
-- user requested `spec_only` or `do not plan`;
+- user explicitly requested `spec_only`, `spec only`, `no plan`, or equivalent;
 - mode is `gate-only`, `challenge-only`, or `lint-only`;
 - status is `blocked`, `drift`, `audit-only`, or `partial`;
-- lane is not `spec_to_plan`;
+- lane is not `spec_to_plan` for a legal blocker recorded in the receipt;
 - material questions remain;
 - lint failed, was skipped when required, or blocked handoff;
 - fresh-eyes returned to grill or detected drift;
 - any subagent remains open;
 - `next_owner` is not `$plan`;
 - `do_not_execute_before` is non-empty;
-- `auto_plan_handoff.eligible = no`.
+- `auto_plan_handoff.eligible = no` with a concrete blocker other than “the user did not separately ask for `$plan`.”
 
 If same-turn loading of `$plan` is unavailable, emit:
 
@@ -79,6 +91,8 @@ next_owner: $plan
 ```
 
 That marker means automation failed; it does not authorize implementation.
+It must not be replaced with `spec_only` merely because the tail-call could not
+run.
 
 ## Validator
 

--- a/codex/skills/spec-pipeline/references/lane-selection.md
+++ b/codex/skills/spec-pipeline/references/lane-selection.md
@@ -1,0 +1,94 @@
+# Lane Selection
+
+`$spec-pipeline` must not treat an explicit `$spec-pipeline` invocation as a request for `spec_only`.
+
+## Governing rule
+
+For `full` mode, the default lane is:
+
+```text
+spec_to_plan
+```
+
+unless the user explicitly requests spec-only output or a material gate blocks downstream planning.
+
+A user saying `$spec-pipeline`, `make a spec`, `write the spec`, `produce the governed spec`, or equivalent is not, by itself, a spec-only instruction. It asks the spec workflow to run. If the workflow finishes complete and plan-ready, planning authority transfers to `$plan` through the SGR-v2 and Execution Handoff.
+
+## Legal `spec_only` reasons
+
+Use `spec_only` only when at least one is true:
+
+```text
+user explicitly requested spec-only/no-plan/no-handoff output
+mode is gate-only/challenge-only/lint-only
+status is blocked, drift, audit-only, or partial
+material user judgment remains unresolved
+Gate Result has plan_allowed=no
+lint failed, was skipped when required, or blocked handoff
+fresh-eyes returned to grill or detected drift
+execution_handoff.ready_for_plan=no
+execution_handoff.next_owner is not $plan
+do_not_execute_before is non-empty
+runtime cannot load or invoke $plan, in which case emit AUTO_PLAN_HANDOFF_REQUIRED rather than silently converting to spec_only
+```
+
+## Illegal `spec_only` reasons
+
+Do not select `spec_only` because:
+
+```text
+the user invoked `$spec-pipeline` rather than `$plan`
+the user did not separately say "run `$plan`"
+the assistant wants to be conservative after the spec succeeds
+the final implementation should be done later by another turn
+the handoff would require a same-turn tail-call
+```
+
+Those are not semantic blockers. They are routing assumptions. If the final SGR-v2 says the spec is complete and plan-ready, the correct lane is `spec_to_plan`.
+
+## Receipt requirements
+
+When choosing `spec_only`, record the concrete blocker in both places:
+
+```yaml
+spec_governance_receipt:
+  lane: spec_only
+  gate:
+    reason: "..."
+  execution_handoff:
+    ready_for_plan: no
+    next_owner: spec-pipeline | grill-me | spec-retro | none
+  auto_plan_handoff:
+    eligible: no
+    reason: "specific blocker, not merely explicit spec-pipeline invocation"
+```
+
+When the only reason would be "the user did not ask for `$plan` separately," set:
+
+```yaml
+lane: spec_to_plan
+auto_plan_handoff:
+  eligible: yes
+  invocation: same_turn_tail_call
+```
+
+or, if the runtime cannot load `$plan`:
+
+```text
+AUTO_PLAN_HANDOFF_REQUIRED
+reason: same-turn tail-call unavailable in this runtime
+next_owner: $plan
+```
+
+## Regression witness
+
+The failure this prevents is:
+
+```text
+explicit `$spec-pipeline` invocation
+-> assistant selects spec_only before final receipt
+-> final receipt says auto_plan_handoff.eligible=no because user did not request same-turn planning
+-> no `$plan` execution even though no spec/governance blocker existed
+```
+
+That is a routing error. Explicit `$spec-pipeline` is not an opt-out from `$plan` when the final governed spec is plan-ready.


### PR DESCRIPTION
## Summary

- add `references/lane-selection.md` documenting that explicit `$spec-pipeline` is not a `spec_only` request
- clarify `references/auto-plan-tail-call.md` so full-mode plan-ready runs keep `lane=spec_to_plan`
- update OpenAI metadata prompt with the default `spec_to_plan` rule
- document the regression fix in `PATCH_NOTES.md`

## Rationale

A recent seq report showed the assistant selected `spec_only` before the final SGR-v2 solely because the user invoked `$spec-pipeline` and did not separately request `$plan`. That was not forced by the skill contract. If a full `$spec-pipeline` run completes and the final SGR-v2/Execution Handoff are plan-ready, the correct route is `spec_to_plan` followed by same-turn `$plan`, or `AUTO_PLAN_HANDOFF_REQUIRED` if the runtime cannot load `$plan`.

## Verification

- Fetched `references/lane-selection.md` on the branch and confirmed it encodes the governing rule plus legal/illegal `spec_only` reasons.
- Fetched `agents/openai.yaml` on the branch and confirmed the metadata prompt now forbids converting explicit `$spec-pipeline` to `spec_only`.
- Compared branch against `main`; diff is limited to spec-pipeline documentation/metadata and one new lane-selection reference.