### PR TITLE
Require three clean CAS reviews for actuating review closure

### DIFF
--- a/codex/skills/actuating/SKILL.md
+++ b/codex/skills/actuating/SKILL.md
@@ -99,7 +99,8 @@ When the user asks for review, review closure, code review, CAS review, review r
 4. Implement only accepted code-change liabilities.
 5. Preserve no-code dispositions: `reject`, `proof-only`, `follow-up`, and `ask-human`.
 6. Prefer `refactor-kernel` when several findings share one owner boundary.
-7. Close with `$evidence-fold` and `$proof-patch`.
+7. Run three consecutive clean normalized `$cas` review passes on the same artifact scope.
+8. Close with `$evidence-fold` and `$proof-patch`.
 
 Do not treat `resolve-and-fix` as one patch per comment.
 
@@ -120,7 +121,7 @@ $cas review
 -> stop
 ```
 
-Do not call `$goal-grind`.
+Do not call `$goal-grind`. The three-clean-review closure bar does not apply unless the user explicitly asks for exhaustive review certification.
 
 #### Resolve-only
 
@@ -140,7 +141,7 @@ $cas review or existing review findings
 -> stop
 ```
 
-Do not call `$goal-grind`.
+Do not call `$goal-grind`. The three-clean-review closure bar does not apply because no remediation has occurred.
 
 #### Resolve-and-fix
 
@@ -158,11 +159,30 @@ $cas review
 -> resolve pass
 -> $goal-grind accepted liabilities only
 -> $evidence-fold
+-> 3 clean normalized $cas review runs
 -> $proof-patch
 ```
 
 Only accepted code-change liabilities may reach implementation.
 Raw review prose never reaches implementation directly.
+
+#### Three clean normalized CAS review runs
+
+For `resolve-and-fix` and exhaustive review, completion requires three consecutive clean normalized `$cas` review runs against the same current artifact scope unless the user explicitly lowers the review bar.
+
+A clean normalized CAS run means `$cas` produces no new in-scope accepted liability after `$review-fold` and the resolve pass. The run is not made dirty by findings that are duplicate, rejected, out-of-scope, already-proven proof-only, deferred follow-up, or already-resolved by the current refactor kernel.
+
+Reset the clean-run counter to zero when:
+
+```text
+code changes
+review scope changes
+base/head/diff changes
+accepted proof bar changes
+CAS lane/session changes in a way that invalidates continuity
+```
+
+Stop with `actuation verdict: cas-review-blocked` when `$cas` cannot run or the three-clean-run bar cannot be reached because of resource limits.
 
 ### Dry actuation plan
 
@@ -271,6 +291,7 @@ scope, non-goals, compatibility, or proof bar are unresolved
 review findings expand product/API scope
 raw review text has not been reduced to dispositions
 review is required but $cas review is unavailable or not run
+three clean normalized $cas review runs are required but cannot be completed
 $st authority is required but absent
 verification regresses and the next action is not isolate/revert/prove
 public tracker or PR side effects would occur without explicit intent
@@ -284,6 +305,7 @@ Actuating:
 - authority source:
 - mode / persistence:
 - review source / CAS verdict, if required:
+- normalized CAS clean runs: 0|1|2|3|not-required
 - goal contract / work list:
 - review-fold disposition:
 - execution owner: goal-grind | st/fixed-point-driver | none
@@ -305,6 +327,12 @@ actuation verdict: st-authority-blocked
 ```
 
 If review is required but CAS review is unavailable or not run, say:
+
+```text
+actuation verdict: cas-review-blocked
+```
+
+If three clean normalized CAS runs are required but unavailable, say:
 
 ```text
 actuation verdict: cas-review-blocked

--- a/codex/skills/goal-actuating/SKILL.md
+++ b/codex/skills/goal-actuating/SKILL.md
@@ -52,7 +52,7 @@ goal_actuating_mode:
 - `direct-goal`: execute a goal that already has outcome, constraints, and proof checks.
 - `review-only`: classify review findings and stop without mutation.
 - `resolve-only`: classify findings and produce a closure agenda without mutation.
-- `resolve-and-fix`: default review mode; resolve findings, then implement accepted liabilities only.
+- `resolve-and-fix`: default review mode; resolve findings, implement accepted liabilities only, and require three clean normalized CAS review runs before completion.
 - `dry-plan`: show the goal contract and work list only; do not mutate.
 - `st-governed`: hand off to `$st` and `$fixed-point-driver` when durable coordination owns the work.
 
@@ -69,7 +69,8 @@ goal_actuating_mode:
 9. Execute one useful action at a time with `$goal-grind`, unless `$st` owns execution.
 10. Fold verification and review results with `$evidence-fold`.
 11. Use `$failure-memory` when failures or review classes repeat.
-12. Close with `$proof-patch`, or hand off to `$ship` only when publication is requested and ready.
+12. For `resolve-and-fix` and exhaustive review, require three consecutive clean normalized `$cas` review runs on the same artifact scope before completion.
+13. Close with `$proof-patch`, or hand off to `$ship` only when publication is requested and ready.
 
 ## Spec to goal contract
 
@@ -120,6 +121,7 @@ $cas review
 -> resolve pass
 -> $goal-grind accepted liabilities only
 -> $evidence-fold
+-> 3 clean normalized $cas review runs
 -> $proof-patch
 ```
 
@@ -140,6 +142,26 @@ Prefer no-code outcomes when they are correct: `reject`, `proof-only`, `follow-u
 Prefer `refactor-kernel` when several findings share one missing abstraction, invariant, canonical owner, state transition, or proof surface.
 
 Exhaustive review is not optional once requested or required. `$review-fold` controls which findings become code changes; it must not remove the CAS review gate.
+
+## Three clean normalized CAS review runs
+
+For `resolve-and-fix` and exhaustive review, completion requires three consecutive clean normalized `$cas` review runs against the same artifact scope unless the user explicitly lowers the review bar.
+
+A clean normalized CAS run means `$cas` produces no new in-scope accepted liability, unresolved proof gap, unresolved refactor-kernel candidate, or human-owned blocker after `$review-fold` and the resolve pass.
+
+Do not reset the clean-run counter for findings that are duplicate, rejected, out-of-scope, already-proven proof-only, follow-up, or already resolved by the current implementation.
+
+Reset the clean-run counter to zero when:
+
+```text
+code changes
+review scope changes
+base/head/diff changes
+accepted proof bar changes
+CAS lane/session continuity is lost
+```
+
+If `$cas` cannot run, or the three-clean-run bar cannot be reached because of resource limits, stop with `actuation verdict: cas-review-blocked`.
 
 ## Resolve pass
 
@@ -164,6 +186,11 @@ Use `$resolve` as a handoff only when review findings require a dedicated closur
 review_resolution:
   mode: review-only|resolve-only|resolve-and-fix
   source: cas-review|existing-review|human-review
+  clean_cas_runs:
+    required: yes|no
+    count: 0|1|2|3
+    artifact_scope:
+    reset_reason:
   accepted_liabilities:
     - id:
       reason:
@@ -213,6 +240,7 @@ verification regresses
 proof is stale or not bound to the current artifact
 public tracker side effect would be needed without explicit intent
 review is required but $cas review is unavailable or not run
+three clean normalized $cas review runs are required but cannot be completed
 ```
 
 ## Output
@@ -222,6 +250,7 @@ Goal Actuation:
 - source: accepted spec | direct goal | plan handoff | review
 - mode / persistence:
 - review source / CAS verdict, if required:
+- clean normalized CAS review runs: 0|1|2|3|not-required
 - goal contract summary:
 - work list / next action:
 - review-fold disposition, if any:

--- a/codex/skills/review-fold/SKILL.md
+++ b/codex/skills/review-fold/SKILL.md
@@ -36,6 +36,8 @@ resolve pass = closure agenda compiler
 $goal-grind = implementation engine for accepted liabilities
 ```
 
+For `resolve-and-fix` and exhaustive review, final completion requires three consecutive clean normalized `$cas` review runs after implementation. `$review-fold` decides whether each CAS run is normalized clean.
+
 ## Review source rule
 
 ```text
@@ -58,6 +60,10 @@ review_fold:
       mode: none|cas-probe|cas-lane|cas-exhaustive
       verdict_ref:
       lane_ref:
+      clean_run:
+        normalized_clean: yes|no
+        resets_counter: yes|no
+        reason:
   intent_anchor:
     original_goal:
     accepted_scope:
@@ -86,6 +92,11 @@ review_fold:
     no_code_modifier_detected: yes|no
     accepted_liability_count:
     refactor_kernel_candidate_count:
+    clean_cas_runs:
+      required: yes|no
+      current_count: 0|1|2|3
+      normalized_clean_this_run: yes|no
+      reset_reason:
   action_plan:
     mode: adjudicate-only|proof-only|minimal-fix|refactor-kernel|branch-race|st-governed
     work_nodes: []
@@ -108,7 +119,7 @@ review_fold:
 
 - `review-only`: classify findings and stop without a remediation agenda.
 - `resolve-only`: classify findings and produce a closure agenda without implementation.
-- `resolve-and-fix`: default `$actuating` review mode; implement only accepted code-change liabilities after the resolve pass.
+- `resolve-and-fix`: default `$actuating` review mode; implement only accepted code-change liabilities after the resolve pass, then require three clean normalized CAS review runs before completion.
 
 ### `adjudicate-only`
 
@@ -139,11 +150,14 @@ Hand off to `$st` when review remediation requires durable resource claims, exte
 When the source is `cas-exhaustive`, do not treat review as optional or merely advisory. Continue review/fix/fold cycles until one of these holds:
 
 ```text
-CAS review is clean
-all CAS findings are dispositioned with current-artifact proof
+three consecutive clean normalized CAS review runs are complete
 CAS review is blocked and the blocker is reported
 user explicitly lowers the review proof bar
 ```
+
+A clean normalized CAS run means no new in-scope accepted liability, unresolved proof gap, unresolved refactor-kernel candidate, or human-owned blocker remains after `$review-fold` and the resolve pass. Duplicate, rejected, out-of-scope, already-proven proof-only, follow-up, or already-resolved findings do not make the run dirty.
+
+Reset the clean-run counter to zero when code changes, review scope changes, base/head/diff changes, the proof bar changes, or CAS lane continuity is lost.
 
 `$review-fold` may reject or mark findings proof-only, but it must not convert an exhaustive review gate into a no-review closure.
 
@@ -157,13 +171,15 @@ user explicitly lowers the review proof bar
 6. Decide whether each finding's proper response is no code, proof, local fix, refactor, branch race, ask, or follow-up.
 7. Produce a small work graph only for accepted liabilities.
 8. Hand off to `$goal-grind` for implementation and `$evidence-fold` for proof only after a resolve pass accepts code-change liabilities.
-9. Preserve reviewer response drafts as drafts; do not post public comments unless explicitly asked.
+9. For post-implementation CAS runs, mark whether the normalized result is clean and whether the clean-run counter resets.
+10. Preserve reviewer response drafts as drafts; do not post public comments unless explicitly asked.
 
 ## Default behavior in `$actuating`
 
 When called by `$actuating`:
 
 - default to `resolve-and-fix` for review requests;
+- require three consecutive clean normalized `$cas` review runs before completing `resolve-and-fix` or exhaustive review;
 - use `review-only` only when the user explicitly asks for no implementation or classification only;
 - use `resolve-only` only when the user explicitly asks for a plan/agenda without implementation;
 - preserve no-code dispositions for rejected, proof-only, follow-up, or human-owned findings;
@@ -188,4 +204,5 @@ no changes
 - Do not accept scope expansion without user authority.
 - Do not miss the refactor when many comments share one owner boundary.
 - Do not replace a requested or required CAS review with non-CAS critique.
+- Do not claim review closure before three clean normalized CAS runs when `resolve-and-fix` or exhaustive review requires them.
 - Do not resolve or reply to PR threads without explicit public-side-effect intent.


### PR DESCRIPTION
## Summary

Updates the `$actuating` review workflow so default review remediation closes only after three consecutive clean normalized `$cas` review runs.

Changes:

- `resolve-and-fix` remains the default for review requests when the user does not explicitly ask for no implementation.
- `review-only` and `resolve-only` remain no-code modes.
- `resolve-and-fix` and exhaustive review require three clean normalized CAS review runs on the same artifact scope before completion.
- Clean runs are normalized after `$review-fold` and the resolve pass, so duplicate/rejected/out-of-scope/already-proven/follow-up findings do not reset the counter.
- The clean-run counter resets when code, review scope, base/head/diff, proof bar, or CAS lane continuity changes.

## Simplest usage

For an existing PR:

```text
/goal $actuating review and fix PR #<number>
```

or, when already operating inside the PR context:

```text
/goal $actuating review and fix this PR
```

This means: run CAS review, fold findings, resolve the closure agenda, fix accepted liabilities only, verify, then require three clean normalized CAS review runs before proof-patch closure.

## Verification

- Compared branch against `main`; only `$actuating`, `$goal-actuating`, and `$review-fold` skill docs changed.
- No runtime tests were run; this is a workflow-doc/skill-contract change.