### PR TITLE
[codex] Add actuating terminal closure gate

### DIFF
--- a/codex/skills/actuating/SKILL.md
+++ b/codex/skills/actuating/SKILL.md
@@ -71,6 +71,7 @@ The workflow performs:
 9. Execute accepted work through $goal-grind, bounded subagents, or $st-governed slices.
 10. Fold evidence after material verification.
 11. Emit proof-patch or explicit $ship handoff.
+12. Run ATCG-v1 terminal closure gate before any completion claim.
 ```
 
 ### Scheme-planning handoff
@@ -298,6 +299,7 @@ accepted disjoint liabilities -> optional patch-fanout
 work list -> $goal-grind next action
 verification output -> $evidence-fold verdict
 completion -> $proof-patch or $ship handoff
+terminal closure -> ATCG-v1 decision
 ```
 
 ## CAS review mandate
@@ -346,6 +348,25 @@ Switch to `branch-race` when local fix and refactor-kernel are both plausible an
 Switch to `st-governed` only when durable claims, fencing, worktrees, or serialized integration are required.
 Switch to `ship-handoff` only when PR/publication intent is explicit or inherited from the accepted spec.
 
+## Terminal closure gate
+
+Before `$actuating` may report completion or call `update_goal complete`, run
+ATCG-v1 over the current branch/head/diff, evidence-fold verdict, proof-patch
+state, CAS clean-run state, ADD-v1 delivery decision, and ship result when
+publication is required.
+
+Completion is legal only when:
+
+```text
+ATCG-v1 verdict = complete
+ATCG-v1 can_mark_goal_complete = yes
+```
+
+If ATCG-v1 returns `continue`, continue with `next_owner`. If it returns
+`blocked`, report the blocked actuation verdict and reasons. Do not substitute
+local proof, proof-complete graph state, cached CAS receipts, or ADD-v1
+`handoff_to_ship` for terminal completion.
+
 ## Stop rules
 
 Stop rather than implement when:
@@ -361,6 +382,7 @@ $st authority is required but absent
 parallel fanout would cross shared invariants or conflicting resources
 verification regresses and the next action is not isolate/revert/prove
 public tracker or PR side effects would occur without explicit intent
+ATCG-v1 does not return can_mark_goal_complete=yes
 ```
 
 ## Final report
@@ -388,6 +410,7 @@ Actuating:
 - execution owner: goal-grind | st-bounded-slice | none
 - evidence-fold verdict:
 - proof-patch / ship handoff:
+- ATCG-v1 verdict / next owner:
 - blockers / residual risk:
 ```
 

--- a/codex/skills/actuating/assets/atcg-v1.complete.example.json
+++ b/codex/skills/actuating/assets/atcg-v1.complete.example.json
@@ -1,0 +1,24 @@
+{
+  "actuation_terminal_decision": {
+    "decision_version": "ATCG-v1",
+    "verdict": "complete",
+    "can_mark_goal_complete": "yes",
+    "issued_at": "2026-07-01T00:00:00Z",
+    "run_id": "ACT-terminal-proof-only",
+    "source": "accepted_spec",
+    "closure_candidate": "proof-patch",
+    "next_owner": "none",
+    "blocked_reasons": [],
+    "continue_reasons": [],
+    "current_artifact_binding": {
+      "repo": "tkersey/example",
+      "branch": "feature/example",
+      "head_sha": "abc123",
+      "diff_fingerprint": "diff:clean",
+      "dirty_state": "clean"
+    },
+    "required_receipts": [
+      "proof_patch"
+    ]
+  }
+}

--- a/codex/skills/actuating/assets/terminal-context.proof-only.example.json
+++ b/codex/skills/actuating/assets/terminal-context.proof-only.example.json
@@ -1,0 +1,53 @@
+{
+  "actuation_terminal_context": {
+    "run_id": "ACT-terminal-proof-only",
+    "source": "accepted_spec",
+    "closure_candidate": "proof-patch",
+    "artifact_scope": {
+      "repo": "tkersey/example",
+      "branch": "feature/example",
+      "head_sha": "abc123",
+      "diff_fingerprint": "diff:clean",
+      "dirty_state": "clean"
+    },
+    "local_proof": {
+      "evidence_fold_verdict": "done",
+      "commands": [
+        "uv run python codex/skills/actuating/tests/test_actuation_terminal_gate.py"
+      ]
+    },
+    "proof_patch": {
+      "required": "yes",
+      "present": "yes",
+      "current": "yes",
+      "ref": "proof-patch:abc123"
+    },
+    "cas_review": {
+      "required": "no",
+      "clean_runs_required": 0,
+      "clean_runs_count": 0,
+      "independent_fresh_runs": "no",
+      "tuple_bound": "no",
+      "tuple": {}
+    },
+    "delivery": {
+      "pr_intent": "no",
+      "publication_required": "no",
+      "add_v1_decision": {
+        "verdict": "shipping_not_requested",
+        "ref": "add-v1:none"
+      },
+      "ship_result": {
+        "present": "no",
+        "current": "unknown",
+        "pr_url": "",
+        "ref": ""
+      }
+    },
+    "final_report_fields": {
+      "normalized_cas_clean_runs": "not-required",
+      "proof_patch_or_ship_handoff": "proof-patch",
+      "blockers_residual_risk": "none"
+    }
+  }
+}

--- a/codex/skills/actuating/assets/terminal-context.regression.example.json
+++ b/codex/skills/actuating/assets/terminal-context.regression.example.json
@@ -1,0 +1,59 @@
+{
+  "actuation_terminal_context": {
+    "run_id": "ACT-terminal-regression",
+    "source": "accepted_spec",
+    "closure_candidate": "ship-complete",
+    "artifact_scope": {
+      "repo": "tkersey/world-host",
+      "branch": "main",
+      "head_sha": "abc123",
+      "diff_fingerprint": "diff:capability-plane",
+      "dirty_state": "clean"
+    },
+    "local_proof": {
+      "evidence_fold_verdict": "done",
+      "commands": [
+        "bun test",
+        "bun run proof"
+      ]
+    },
+    "proof_patch": {
+      "required": "yes",
+      "present": "no",
+      "current": "no",
+      "ref": ""
+    },
+    "cas_review": {
+      "required": "yes",
+      "reason": "proof-patch or ship-handoff would rely on review claim",
+      "clean_runs_required": 3,
+      "clean_runs_count": 0,
+      "independent_fresh_runs": "no",
+      "tuple_bound": "no",
+      "tuple": {
+        "base_sha": "",
+        "head_sha": "",
+        "target_fingerprint": ""
+      }
+    },
+    "delivery": {
+      "pr_intent": "yes",
+      "publication_required": "yes",
+      "add_v1_decision": {
+        "verdict": "missing",
+        "ref": ""
+      },
+      "ship_result": {
+        "present": "no",
+        "current": "unknown",
+        "pr_url": "",
+        "ref": ""
+      }
+    },
+    "final_report_fields": {
+      "normalized_cas_clean_runs": 0,
+      "proof_patch_or_ship_handoff": "not completed",
+      "blockers_residual_risk": "none"
+    }
+  }
+}

--- a/codex/skills/actuating/assets/terminal-context.ship-continue.example.json
+++ b/codex/skills/actuating/assets/terminal-context.ship-continue.example.json
@@ -1,0 +1,60 @@
+{
+  "actuation_terminal_context": {
+    "run_id": "ACT-terminal-ship-continue",
+    "source": "accepted_spec",
+    "closure_candidate": "ship-complete",
+    "artifact_scope": {
+      "repo": "tkersey/example",
+      "branch": "feature/example",
+      "head_sha": "abc123",
+      "diff_fingerprint": "diff:ship",
+      "dirty_state": "clean"
+    },
+    "local_proof": {
+      "evidence_fold_verdict": "done",
+      "commands": [
+        "uv run python codex/skills/actuating/tests/test_actuation_delivery_gate.py"
+      ]
+    },
+    "proof_patch": {
+      "required": "yes",
+      "present": "yes",
+      "current": "yes",
+      "ref": "proof-patch:abc123"
+    },
+    "cas_review": {
+      "required": "no",
+      "clean_runs_required": 0,
+      "clean_runs_count": 0,
+      "independent_fresh_runs": "no",
+      "tuple_bound": "no",
+      "tuple": {}
+    },
+    "delivery": {
+      "pr_intent": "yes",
+      "publication_required": "yes",
+      "add_v1_decision": {
+        "decision_version": "ADD-v1",
+        "verdict": "handoff_to_ship",
+        "ref": "add-v1:handoff",
+        "target_head": "abc123",
+        "ship_handoff": {
+          "ship_input": {
+            "head_sha": "abc123"
+          }
+        }
+      },
+      "ship_result": {
+        "present": "no",
+        "current": "unknown",
+        "pr_url": "",
+        "ref": ""
+      }
+    },
+    "final_report_fields": {
+      "normalized_cas_clean_runs": "not-required",
+      "proof_patch_or_ship_handoff": "ship-handoff",
+      "blockers_residual_risk": "none"
+    }
+  }
+}

--- a/codex/skills/actuating/references/terminal-closure-gate.md
+++ b/codex/skills/actuating/references/terminal-closure-gate.md
@@ -1,0 +1,115 @@
+# Actuating Terminal Closure Gate
+
+## Purpose
+
+ATCG-v1 prevents `$actuating` from treating local verification as terminal
+completion when proof-patch, CAS review, delivery, or ship evidence is still
+required.
+
+The gate enforces this separation:
+
+```text
+local proof passed
+!= proof-patch complete
+!= ship handoff complete
+!= actuation complete
+```
+
+## ATCG-v1
+
+```yaml
+actuation_terminal_decision:
+  decision_version: ATCG-v1
+  verdict: complete | continue | blocked
+  can_mark_goal_complete: yes | no
+  run_id:
+  source: accepted_spec | direct_goal | review | st_handoff
+  closure_candidate: proof-patch | ship-handoff | ship-complete | blocked
+  next_owner: none | $cas | $proof-patch | $ship | $goal-grind | human
+  blocked_reasons: []
+  continue_reasons: []
+  current_artifact_binding:
+    repo:
+    branch:
+    head_sha:
+    diff_fingerprint:
+    dirty_state: clean | tracked-dirty | unknown
+  required_receipts: []
+```
+
+## Handoff rule
+
+Before `$actuating` or `$goal-actuating` may report completion or call
+`update_goal complete`, ATCG-v1 must return:
+
+```text
+verdict = complete
+can_mark_goal_complete = yes
+```
+
+Any other verdict keeps the actuation run active or reports the specific blocked
+state. A local verifier pass, proof-complete graph, or ADD-v1
+`handoff_to_ship` result is not enough by itself.
+
+## Inputs
+
+ATCG-v1 consumes current receiver-owned evidence:
+
+```text
+current branch/head/diff binding
+evidence-fold verdict and proof commands
+proof-patch presence/currentness
+CAS requirement, tuple, freshness, and clean-run count
+ADD-v1 delivery decision
+ship result receipt when publication is required
+final report field values
+```
+
+It does not run CAS, create proof-patch output, call `$ship`, publish PRs, or
+mutate workspace state.
+
+## Common outcomes
+
+```text
+CAS required + clean runs < required -> blocked, next_owner=$cas
+CAS required + clean_runs_required <= 0 -> blocked, next_owner=$cas
+CAS required + final report clean runs < required -> blocked, next_owner=$cas
+proof-patch required + missing/stale -> continue, next_owner=$proof-patch
+proof-patch closure + missing proof-patch receipt -> continue, next_owner=$proof-patch
+ADD-v1 handoff + ship result missing -> continue, next_owner=$ship
+ship-complete closure + missing delivery evidence -> blocked, next_owner=$ship
+ship-complete closure + missing ADD-v1 or ship receipt -> invalid decision
+wrapped ADD-v1 delivery decision -> accepted as delivery evidence
+ADD-shaped handoff without decision_version=ADD-v1 -> blocked
+ADD-v1 target_head or ship_input.head_sha mismatches current artifact -> blocked
+complete + closure_candidate=ship-handoff|blocked -> invalid decision
+artifact binding missing/stale -> blocked, next_owner=$goal-grind
+continue|blocked + next_owner=none -> invalid decision
+evidence-fold refactor-kernel -> continue, next_owner=$goal-grind
+all required receipts current -> complete
+tracked-dirty artifact + current proof-patch receipt -> may complete
+tracked-dirty artifact without proof-patch receipt -> blocked
+```
+
+## Validator
+
+```bash
+uv run python codex/skills/actuating/tools/actuation_terminal_gate.py \
+  decide \
+  --context .ledger/actuating/<run-id>/terminal-context.json \
+  --out .ledger/actuating/<run-id>/terminal-decision.json
+
+uv run python codex/skills/actuating/tools/actuation_terminal_gate.py \
+  check \
+  --decision .ledger/actuating/<run-id>/terminal-decision.json
+```
+
+## Falsifier
+
+The gate is working when future actuation reports show:
+
+```text
+local_proof_passed_but_goal_complete = 0
+cas_required_with_zero_clean_runs_complete = 0
+add_v1_handoff_without_ship_result_complete = 0
+```

--- a/codex/skills/actuating/tests/test_actuating_tools.py
+++ b/codex/skills/actuating/tests/test_actuating_tools.py
@@ -88,6 +88,11 @@ def main() -> int:
         "proof-dag.example.json",
         "proof_dag_gate",
     )
+    quick = run("quick_validate.py")
+    assert quick.returncode == 0, quick.stdout + quick.stderr
+    quick_body = json.loads(quick.stdout)["actuating_quick_validate"]
+    quick_paths = {row["path"] for row in quick_body["tests"]}
+    assert "tests/test_actuation_terminal_gate.py" in quick_paths
 
     with tempfile.TemporaryDirectory() as td:
         temp = Path(td)

--- a/codex/skills/actuating/tests/test_actuation_terminal_gate.py
+++ b/codex/skills/actuating/tests/test_actuation_terminal_gate.py
@@ -1,0 +1,414 @@
+#!/usr/bin/env -S uv run python
+from __future__ import annotations
+
+from copy import deepcopy
+import importlib.util
+import json
+from pathlib import Path
+import tempfile
+import unittest
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "tools" / "actuation_terminal_gate.py"
+ASSETS = ROOT / "assets"
+SPEC = importlib.util.spec_from_file_location("actuation_terminal_gate", SCRIPT)
+assert SPEC and SPEC.loader
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+class ActuationTerminalGateTests(unittest.TestCase):
+    def context(self, name: str = "terminal-context.proof-only.example.json"):
+        return json.loads((ASSETS / name).read_text())["actuation_terminal_context"]
+
+    def decision(self, name: str):
+        return json.loads((ASSETS / name).read_text())
+
+    def test_proof_only_context_can_complete(self) -> None:
+        decision = MODULE.make_decision(self.context())
+        body = decision["actuation_terminal_decision"]
+        self.assertEqual(body["verdict"], "complete")
+        self.assertEqual(body["can_mark_goal_complete"], "yes")
+        self.assertEqual(body["next_owner"], "none")
+
+    def test_current_proof_patch_allows_tracked_dirty_binding(self) -> None:
+        context = deepcopy(self.context())
+        context["artifact_scope"]["dirty_state"] = "tracked-dirty"
+        decision = MODULE.make_decision(context)
+        body = decision["actuation_terminal_decision"]
+        self.assertEqual(body["verdict"], "complete")
+        self.assertEqual(body["current_artifact_binding"]["dirty_state"], "tracked-dirty")
+
+    def test_original_regression_is_blocked(self) -> None:
+        decision = MODULE.make_decision(self.context("terminal-context.regression.example.json"))
+        body = decision["actuation_terminal_decision"]
+        self.assertEqual(body["verdict"], "blocked")
+        self.assertEqual(body["can_mark_goal_complete"], "no")
+        self.assertEqual(body["next_owner"], "$cas")
+        self.assertIn("cas.clean_runs:0-of-3", body["blocked_reasons"])
+        self.assertIn("final_report.normalized_cas_clean_runs:not-satisfied", body["blocked_reasons"])
+
+    def test_proof_patch_closure_requires_proof_patch_receipt(self) -> None:
+        context = deepcopy(self.context())
+        context["proof_patch"] = {}
+        decision = MODULE.make_decision(context)
+        body = decision["actuation_terminal_decision"]
+        self.assertEqual(body["verdict"], "continue")
+        self.assertEqual(body["next_owner"], "$proof-patch")
+        self.assertIn("proof_patch.required:missing-for-proof-patch-closure", body["continue_reasons"])
+
+    def test_ship_complete_requires_delivery_evidence(self) -> None:
+        context = deepcopy(self.context())
+        context["closure_candidate"] = "ship-complete"
+        context["delivery"] = {}
+        decision = MODULE.make_decision(context)
+        body = decision["actuation_terminal_decision"]
+        self.assertEqual(body["verdict"], "blocked")
+        self.assertEqual(body["next_owner"], "$ship")
+        self.assertIn("delivery.pr_intent:missing-for-ship-complete", body["blocked_reasons"])
+
+    def test_ship_complete_accepts_wrapped_add_v1_handoff(self) -> None:
+        context = deepcopy(self.context())
+        context["closure_candidate"] = "ship-complete"
+        context["delivery"] = {
+            "pr_intent": "yes",
+            "publication_required": "yes",
+            "add_v1_decision": json.loads((ASSETS / "add-v1.handoff.example.json").read_text()),
+            "ship_result": {
+                "present": "yes",
+                "current": "yes",
+                "pr_url": "https://github.com/tkersey/example/pull/1",
+                "ref": "ship:example",
+            },
+        }
+        decision = MODULE.make_decision(context)
+        body = decision["actuation_terminal_decision"]
+        self.assertEqual(body["verdict"], "complete")
+        self.assertIn("add_v1_delivery_decision", body["required_receipts"])
+        self.assertIn("ship_result", body["required_receipts"])
+
+    def test_ship_complete_rejects_stale_wrapped_add_v1_handoff(self) -> None:
+        add_v1 = json.loads((ASSETS / "add-v1.handoff.example.json").read_text())
+        add_v1["actuation_delivery_decision"]["target_head"] = "stale-head"
+        add_v1["actuation_delivery_decision"]["ship_handoff"]["ship_input"]["head_sha"] = "stale-head"
+        context = deepcopy(self.context())
+        context["closure_candidate"] = "ship-complete"
+        context["delivery"] = {
+            "pr_intent": "yes",
+            "publication_required": "yes",
+            "add_v1_decision": add_v1,
+            "ship_result": {
+                "present": "yes",
+                "current": "yes",
+                "pr_url": "https://github.com/tkersey/example/pull/1",
+                "ref": "ship:example",
+            },
+        }
+        decision = MODULE.make_decision(context)
+        body = decision["actuation_terminal_decision"]
+        self.assertEqual(body["verdict"], "blocked")
+        self.assertIn("delivery.add_v1_decision.target_head:artifact-mismatch", body["blocked_reasons"])
+        self.assertIn("delivery.add_v1_decision.ship_input.head_sha:artifact-mismatch", body["blocked_reasons"])
+
+    def test_ship_complete_rejects_add_shaped_stub_without_add_v1_version(self) -> None:
+        context = deepcopy(self.context())
+        context["closure_candidate"] = "ship-complete"
+        context["delivery"] = {
+            "pr_intent": "yes",
+            "publication_required": "yes",
+            "add_v1_decision": {
+                "verdict": "handoff_to_ship",
+                "target_head": "abc123",
+                "ship_handoff": {
+                    "ship_input": {
+                        "head_sha": "abc123",
+                    }
+                },
+            },
+            "ship_result": {
+                "present": "yes",
+                "current": "yes",
+                "pr_url": "https://github.com/tkersey/example/pull/1",
+                "ref": "ship:example",
+            },
+        }
+        decision = MODULE.make_decision(context)
+        body = decision["actuation_terminal_decision"]
+        self.assertEqual(body["verdict"], "blocked")
+        self.assertIn("delivery.add_v1_decision.decision_version:invalid", body["blocked_reasons"])
+
+    def test_cached_cas_receipt_does_not_count_as_fresh_clean_run(self) -> None:
+        context = self.context("terminal-context.proof-only.example.json")
+        context["cas_review"] = {
+            "required": "yes",
+            "clean_runs_required": 3,
+            "clean_runs_count": 3,
+            "independent_fresh_runs": "no",
+            "tuple_bound": "yes",
+            "tuple": {
+                "base_sha": "base123",
+                "head_sha": "head123",
+                "target_fingerprint": "diff:clean",
+            },
+        }
+        context["final_report_fields"]["normalized_cas_clean_runs"] = 3
+        decision = MODULE.make_decision(context)
+        body = decision["actuation_terminal_decision"]
+        self.assertEqual(body["verdict"], "blocked")
+        self.assertIn("cas.clean_runs:not-independent", body["blocked_reasons"])
+
+    def test_cas_tuple_must_match_current_artifact(self) -> None:
+        context = self.context("terminal-context.proof-only.example.json")
+        context["cas_review"] = {
+            "required": "yes",
+            "clean_runs_required": 3,
+            "clean_runs_count": 3,
+            "independent_fresh_runs": "yes",
+            "tuple_bound": "yes",
+            "tuple": {
+                "base_sha": "base123",
+                "head_sha": "stale-head",
+                "target_fingerprint": "stale-diff",
+            },
+        }
+        context["final_report_fields"]["normalized_cas_clean_runs"] = 3
+        decision = MODULE.make_decision(context)
+        body = decision["actuation_terminal_decision"]
+        self.assertEqual(body["verdict"], "blocked")
+        self.assertIn("cas.tuple.head_sha:artifact-mismatch", body["blocked_reasons"])
+        self.assertIn("cas.tuple.target_fingerprint:artifact-mismatch", body["blocked_reasons"])
+
+    def test_cas_required_rejects_nonpositive_or_bool_required_clean_runs(self) -> None:
+        for value in (0, False):
+            with self.subTest(value=value):
+                context = deepcopy(self.context("terminal-context.proof-only.example.json"))
+                context["cas_review"] = {
+                    "required": "yes",
+                    "clean_runs_required": value,
+                    "clean_runs_count": 0,
+                    "independent_fresh_runs": "yes",
+                    "tuple_bound": "yes",
+                    "tuple": {
+                        "base_sha": "base123",
+                        "head_sha": "abc123",
+                        "target_fingerprint": "diff:clean",
+                    },
+                }
+                context["final_report_fields"]["normalized_cas_clean_runs"] = 1
+                decision = MODULE.make_decision(context)
+                body = decision["actuation_terminal_decision"]
+                self.assertEqual(body["verdict"], "blocked")
+                self.assertIn("cas.clean_runs_required:invalid", body["blocked_reasons"])
+
+    def test_cas_required_rejects_insufficient_final_report_clean_runs(self) -> None:
+        context = deepcopy(self.context("terminal-context.proof-only.example.json"))
+        context["cas_review"] = {
+            "required": "yes",
+            "clean_runs_required": 3,
+            "clean_runs_count": 3,
+            "independent_fresh_runs": "yes",
+            "tuple_bound": "yes",
+            "tuple": {
+                "base_sha": "base123",
+                "head_sha": "abc123",
+                "target_fingerprint": "diff:clean",
+            },
+        }
+        context["final_report_fields"]["normalized_cas_clean_runs"] = 2
+        decision = MODULE.make_decision(context)
+        body = decision["actuation_terminal_decision"]
+        self.assertEqual(body["verdict"], "blocked")
+        self.assertIn("final_report.normalized_cas_clean_runs:not-satisfied", body["blocked_reasons"])
+
+    def test_cas_required_accepts_matching_final_report_clean_runs(self) -> None:
+        context = deepcopy(self.context("terminal-context.proof-only.example.json"))
+        context["cas_review"] = {
+            "required": "yes",
+            "clean_runs_required": 3,
+            "clean_runs_count": 3,
+            "independent_fresh_runs": "yes",
+            "tuple_bound": "yes",
+            "tuple": {
+                "base_sha": "base123",
+                "head_sha": "abc123",
+                "target_fingerprint": "diff:clean",
+            },
+        }
+        context["final_report_fields"]["normalized_cas_clean_runs"] = "3"
+        decision = MODULE.make_decision(context)
+        body = decision["actuation_terminal_decision"]
+        self.assertEqual(body["verdict"], "complete")
+
+    def test_publication_required_requires_pr_intent_and_ship_evidence(self) -> None:
+        context = deepcopy(self.context())
+        context["delivery"]["publication_required"] = "yes"
+        context["delivery"]["pr_intent"] = "no"
+        decision = MODULE.make_decision(context)
+        body = decision["actuation_terminal_decision"]
+        self.assertEqual(body["verdict"], "blocked")
+        self.assertIn("delivery.pr_intent:missing-with-publication-required", body["blocked_reasons"])
+
+    def test_ship_handoff_without_ship_result_continues(self) -> None:
+        decision = MODULE.make_decision(self.context("terminal-context.ship-continue.example.json"))
+        body = decision["actuation_terminal_decision"]
+        self.assertEqual(body["verdict"], "continue")
+        self.assertEqual(body["next_owner"], "$ship")
+        self.assertIn("ship_result:missing", body["continue_reasons"])
+
+    def test_missing_artifact_binding_blocks(self) -> None:
+        context = deepcopy(self.context())
+        context["artifact_scope"]["head_sha"] = ""
+        decision = MODULE.make_decision(context)
+        body = decision["actuation_terminal_decision"]
+        self.assertEqual(body["verdict"], "blocked")
+        self.assertIn("artifact_scope.head_sha:missing", body["blocked_reasons"])
+
+    def test_artifact_blocker_owner_precedes_cas_blocker(self) -> None:
+        context = deepcopy(self.context("terminal-context.regression.example.json"))
+        context["artifact_scope"]["head_sha"] = ""
+        decision = MODULE.make_decision(context)
+        body = decision["actuation_terminal_decision"]
+        self.assertEqual(body["verdict"], "blocked")
+        self.assertEqual(body["next_owner"], "$goal-grind")
+        self.assertIn("artifact_scope.head_sha:missing", body["blocked_reasons"])
+        self.assertIn("cas.clean_runs:0-of-3", body["blocked_reasons"])
+
+    def test_blocked_artifact_owner_not_overridden_by_pending_proof_patch(self) -> None:
+        context = deepcopy(self.context())
+        context["artifact_scope"]["head_sha"] = ""
+        context["proof_patch"] = {}
+        decision = MODULE.make_decision(context)
+        body = decision["actuation_terminal_decision"]
+        self.assertEqual(body["verdict"], "blocked")
+        self.assertEqual(body["next_owner"], "$goal-grind")
+        self.assertIn("artifact_scope.head_sha:missing", body["blocked_reasons"])
+
+    def test_incomplete_local_proof_routes_to_goal_grind(self) -> None:
+        context = deepcopy(self.context())
+        context["local_proof"]["evidence_fold_verdict"] = "continue"
+        decision = MODULE.make_decision(context)
+        body = decision["actuation_terminal_decision"]
+        self.assertEqual(body["verdict"], "continue")
+        self.assertEqual(body["next_owner"], "$goal-grind")
+        self.assertIn("local_proof.evidence_fold_verdict:continue", body["continue_reasons"])
+
+    def test_refactor_kernel_local_proof_routes_to_goal_grind(self) -> None:
+        context = deepcopy(self.context())
+        context["local_proof"]["evidence_fold_verdict"] = "refactor-kernel"
+        decision = MODULE.make_decision(context)
+        body = decision["actuation_terminal_decision"]
+        self.assertEqual(body["verdict"], "continue")
+        self.assertEqual(body["next_owner"], "$goal-grind")
+        self.assertIn("local_proof.evidence_fold_verdict:refactor-kernel", body["continue_reasons"])
+
+    def test_blocked_local_proof_is_terminal_blocker(self) -> None:
+        context = deepcopy(self.context())
+        context["local_proof"]["evidence_fold_verdict"] = "blocked"
+        decision = MODULE.make_decision(context)
+        body = decision["actuation_terminal_decision"]
+        self.assertEqual(body["verdict"], "blocked")
+        self.assertEqual(body["next_owner"], "$goal-grind")
+        self.assertIn("local_proof.evidence_fold_verdict:blocked", body["blocked_reasons"])
+
+    def test_ask_human_local_proof_routes_to_human(self) -> None:
+        context = deepcopy(self.context())
+        context["local_proof"]["evidence_fold_verdict"] = "ask-human"
+        decision = MODULE.make_decision(context)
+        body = decision["actuation_terminal_decision"]
+        self.assertEqual(body["verdict"], "continue")
+        self.assertEqual(body["next_owner"], "human")
+
+    def test_check_valid_complete_decision(self) -> None:
+        result = MODULE.validate_decision(self.decision("atcg-v1.complete.example.json"))
+        self.assertEqual(result["actuation_terminal_gate"]["verdict"], "pass")
+        self.assertEqual(result["actuation_terminal_gate"]["can_mark_goal_complete"], "yes")
+
+    def test_check_rejects_complete_without_artifact_binding(self) -> None:
+        decision = self.decision("atcg-v1.complete.example.json")
+        decision["actuation_terminal_decision"]["current_artifact_binding"]["head_sha"] = ""
+        with self.assertRaisesRegex(MODULE.TerminalGateError, "complete.current_artifact_binding.head_sha"):
+            MODULE.validate_decision(decision)
+
+    def test_check_rejects_dirty_complete_without_proof_patch_receipt(self) -> None:
+        decision = self.decision("atcg-v1.complete.example.json")
+        decision["actuation_terminal_decision"]["current_artifact_binding"]["dirty_state"] = "tracked-dirty"
+        decision["actuation_terminal_decision"]["required_receipts"] = []
+        with self.assertRaisesRegex(MODULE.TerminalGateError, "complete.current_artifact_binding.dirty_state"):
+            MODULE.validate_decision(decision)
+
+    def test_check_rejects_proof_patch_complete_without_required_receipt(self) -> None:
+        decision = self.decision("atcg-v1.complete.example.json")
+        decision["actuation_terminal_decision"]["required_receipts"] = []
+        with self.assertRaisesRegex(MODULE.TerminalGateError, "complete.required_receipts.proof_patch"):
+            MODULE.validate_decision(decision)
+
+    def test_check_rejects_ship_complete_without_ship_receipt(self) -> None:
+        decision = self.decision("atcg-v1.complete.example.json")
+        decision["actuation_terminal_decision"]["closure_candidate"] = "ship-complete"
+        decision["actuation_terminal_decision"]["required_receipts"] = ["add_v1_delivery_decision"]
+        with self.assertRaisesRegex(MODULE.TerminalGateError, "complete.required_receipts.ship_result"):
+            MODULE.validate_decision(decision)
+
+    def test_check_rejects_ship_complete_without_add_v1_receipt(self) -> None:
+        decision = self.decision("atcg-v1.complete.example.json")
+        decision["actuation_terminal_decision"]["closure_candidate"] = "ship-complete"
+        decision["actuation_terminal_decision"]["required_receipts"] = ["ship_result"]
+        with self.assertRaisesRegex(MODULE.TerminalGateError, "complete.required_receipts.add_v1_delivery_decision"):
+            MODULE.validate_decision(decision)
+
+    def test_check_rejects_invalid_terminal_enums(self) -> None:
+        decision = self.decision("atcg-v1.complete.example.json")
+        decision["actuation_terminal_decision"]["source"] = "unknown-source"
+        decision["actuation_terminal_decision"]["closure_candidate"] = "unknown-closure"
+        with self.assertRaisesRegex(MODULE.TerminalGateError, "closure_candidate:invalid"):
+            MODULE.validate_decision(decision)
+
+    def test_check_rejects_complete_for_nonterminal_closure_candidate(self) -> None:
+        decision = self.decision("atcg-v1.complete.example.json")
+        decision["actuation_terminal_decision"]["closure_candidate"] = "ship-handoff"
+        with self.assertRaisesRegex(MODULE.TerminalGateError, "complete.closure_candidate:not-terminal"):
+            MODULE.validate_decision(decision)
+
+    def test_check_rejects_complete_with_blockers(self) -> None:
+        decision = self.decision("atcg-v1.complete.example.json")
+        decision["actuation_terminal_decision"]["blocked_reasons"] = ["cas.clean_runs:0-of-3"]
+        with self.assertRaisesRegex(MODULE.TerminalGateError, "complete:reasons-present"):
+            MODULE.validate_decision(decision)
+
+    def test_check_rejects_continue_without_next_owner(self) -> None:
+        decision = self.decision("atcg-v1.complete.example.json")
+        body = decision["actuation_terminal_decision"]
+        body["verdict"] = "continue"
+        body["can_mark_goal_complete"] = "no"
+        body["next_owner"] = "none"
+        body["continue_reasons"] = ["proof_patch:missing"]
+        with self.assertRaisesRegex(MODULE.TerminalGateError, "continue:next_owner-none"):
+            MODULE.validate_decision(decision)
+
+    def test_check_rejects_blocked_without_next_owner(self) -> None:
+        decision = self.decision("atcg-v1.complete.example.json")
+        body = decision["actuation_terminal_decision"]
+        body["verdict"] = "blocked"
+        body["can_mark_goal_complete"] = "no"
+        body["next_owner"] = "none"
+        body["blocked_reasons"] = ["artifact_scope.head_sha:missing"]
+        with self.assertRaisesRegex(MODULE.TerminalGateError, "blocked:next_owner-none"):
+            MODULE.validate_decision(decision)
+
+    def test_cli_decide_writes_terminal_decision(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            out = Path(td) / "terminal.json"
+            code = MODULE.main([
+                "decide",
+                "--context",
+                str(ASSETS / "terminal-context.proof-only.example.json"),
+                "--out",
+                str(out),
+            ])
+            self.assertEqual(code, 0)
+            body = json.loads(out.read_text())["actuation_terminal_decision"]
+            self.assertEqual(body["verdict"], "complete")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/codex/skills/actuating/tools/actuation_terminal_gate.py
+++ b/codex/skills/actuating/tools/actuation_terminal_gate.py
@@ -1,0 +1,522 @@
+#!/usr/bin/env -S uv run python
+"""Actuating terminal closure gate.
+
+ATCG-v1 prevents an actuation run from treating local verifier success as the
+terminal state when proof-patch, CAS review, delivery, or ship evidence is still
+required. It is a pure receiver-side reducer: it does not run CAS, create
+proof-patch output, publish PRs, or mutate any workspace state.
+"""
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import json
+from pathlib import Path
+import sys
+from typing import Any
+
+YES = {"yes", "true", "1", True}
+NO = {"no", "false", "0", False}
+SOURCES = {"accepted_spec", "direct_goal", "review", "st_handoff"}
+CLOSURE_CANDIDATES = {"proof-patch", "ship-handoff", "ship-complete", "blocked"}
+LOCAL_VERDICTS = {"done", "continue", "regress", "blocked", "invalid-proof", "ask-human", "refactor-kernel"}
+ADD_VERDICTS = {"handoff_to_ship", "shipping_not_requested", "blocked", "missing"}
+TERMINAL_VERDICTS = {"complete", "continue", "blocked"}
+NEXT_OWNERS = {"none", "$cas", "$proof-patch", "$ship", "$goal-grind", "human"}
+
+
+class TerminalGateError(ValueError):
+    pass
+
+
+def load_json(path: str) -> dict[str, Any]:
+    text = sys.stdin.read() if path == "-" else Path(path).read_text(encoding="utf-8")
+    value = json.loads(text)
+    if not isinstance(value, dict):
+        raise TerminalGateError("input: expected JSON object")
+    return value
+
+
+def unwrap(value: dict[str, Any], key: str) -> dict[str, Any]:
+    body = value.get(key, value)
+    if not isinstance(body, dict):
+        raise TerminalGateError(f"{key}: expected object")
+    return body
+
+
+def context_from(value: dict[str, Any]) -> dict[str, Any]:
+    return unwrap(value, "actuation_terminal_context")
+
+
+def now_utc() -> str:
+    return _dt.datetime.now(_dt.timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def as_yes(value: Any) -> bool:
+    return value in YES or (isinstance(value, str) and value.lower() in YES)
+
+
+def yes_no_string(value: Any, *, default: str = "no") -> str:
+    if as_yes(value):
+        return "yes"
+    if value in NO or (isinstance(value, str) and value.lower() in NO):
+        return "no"
+    return default
+
+
+def is_plain_int(value: Any) -> bool:
+    return isinstance(value, int) and not isinstance(value, bool)
+
+
+def count_from(value: Any) -> int | None:
+    if is_plain_int(value):
+        return value
+    if isinstance(value, str) and value.isdecimal():
+        return int(value)
+    return None
+
+
+def require_str(obj: dict[str, Any], key: str, errors: list[str]) -> str:
+    value = obj.get(key)
+    if not isinstance(value, str) or not value:
+        errors.append(f"{key}:missing")
+        return ""
+    return value
+
+
+def optional_object(obj: dict[str, Any], key: str, errors: list[str]) -> dict[str, Any]:
+    value = obj.get(key)
+    if value is None:
+        return {}
+    if not isinstance(value, dict):
+        errors.append(f"{key}:must-be-object")
+        return {}
+    return value
+
+
+def make_decision(context: dict[str, Any]) -> dict[str, Any]:
+    errors: list[str] = []
+    run_id = require_str(context, "run_id", errors)
+    source = context.get("source", "direct_goal")
+    if source not in SOURCES:
+        errors.append("source:invalid")
+        source = "direct_goal"
+    closure_candidate = context.get("closure_candidate", "blocked")
+    if closure_candidate not in CLOSURE_CANDIDATES:
+        errors.append("closure_candidate:invalid")
+        closure_candidate = "blocked"
+
+    artifact = optional_object(context, "artifact_scope", errors)
+    local_proof = optional_object(context, "local_proof", errors)
+    proof_patch = optional_object(context, "proof_patch", errors)
+    cas = optional_object(context, "cas_review", errors)
+    delivery = optional_object(context, "delivery", errors)
+    final_report = optional_object(context, "final_report_fields", errors)
+
+    unresolved: list[str] = []
+    blocked: list[str] = []
+    if errors:
+        blocked.extend(errors)
+
+    artifact_reasons = artifact_reasons_for(artifact, proof_patch)
+    blocked.extend(artifact_reasons)
+
+    local_reasons = local_proof_reasons_for(local_proof)
+    if any(reason == "local_proof.evidence_fold_verdict:blocked" for reason in local_reasons):
+        blocked.extend(local_reasons)
+    else:
+        unresolved.extend(local_reasons)
+
+    proof_reasons = proof_patch_reasons_for(proof_patch, closure_candidate)
+    unresolved.extend(proof_reasons)
+
+    cas_reasons = cas_reasons_for(cas, artifact)
+    blocked.extend(cas_reasons)
+
+    delivery_reasons, delivery_continue = delivery_reasons_for(delivery, closure_candidate, artifact)
+    blocked.extend(delivery_reasons)
+    unresolved.extend(delivery_continue)
+
+    report_reasons = final_report_reasons_for(final_report, cas, proof_patch, delivery)
+    blocked.extend(report_reasons)
+
+    if closure_candidate == "blocked":
+        blocked.append("closure_candidate:blocked")
+    elif closure_candidate == "ship-handoff":
+        unresolved.append("ship_handoff:not-terminal")
+
+    if blocked:
+        verdict = "blocked"
+        can_complete = "no"
+        next_owner = next_owner_for(blocked, [])
+    elif unresolved:
+        verdict = "continue"
+        can_complete = "no"
+        next_owner = next_owner_for([], unresolved)
+    else:
+        verdict = "complete"
+        can_complete = "yes"
+        next_owner = "none"
+
+    decision = {
+        "actuation_terminal_decision": {
+            "decision_version": "ATCG-v1",
+            "verdict": verdict,
+            "can_mark_goal_complete": can_complete,
+            "issued_at": now_utc(),
+            "run_id": run_id,
+            "source": source,
+            "closure_candidate": closure_candidate,
+            "next_owner": next_owner,
+            "blocked_reasons": blocked if verdict == "blocked" else [],
+            "continue_reasons": unresolved if verdict == "continue" else [],
+            "current_artifact_binding": {
+                "repo": artifact.get("repo", ""),
+                "branch": artifact.get("branch", ""),
+                "head_sha": artifact.get("head_sha", ""),
+                "diff_fingerprint": artifact.get("diff_fingerprint", ""),
+                "dirty_state": artifact.get("dirty_state", "unknown"),
+            },
+            "required_receipts": required_receipts_for(proof_patch, cas, delivery, closure_candidate),
+        }
+    }
+    validate_decision(decision)
+    return decision
+
+
+def artifact_reasons_for(artifact: dict[str, Any], proof_patch: dict[str, Any]) -> list[str]:
+    reasons: list[str] = []
+    for key in ("repo", "branch", "head_sha", "diff_fingerprint"):
+        if not isinstance(artifact.get(key), str) or not artifact.get(key):
+            reasons.append(f"artifact_scope.{key}:missing")
+    dirty_state = artifact.get("dirty_state", "unknown")
+    if dirty_state == "clean":
+        return reasons
+    if dirty_state == "tracked-dirty" and proof_patch_bounds_dirty_artifact(proof_patch):
+        return reasons
+    if dirty_state != "clean":
+        reasons.append(f"artifact_scope.dirty_state:{dirty_state}")
+    return reasons
+
+
+def proof_patch_bounds_dirty_artifact(proof_patch: dict[str, Any]) -> bool:
+    return (
+        as_yes(proof_patch.get("required"))
+        and as_yes(proof_patch.get("present"))
+        and as_yes(proof_patch.get("current"))
+    )
+
+
+def local_proof_reasons_for(local_proof: dict[str, Any]) -> list[str]:
+    verdict = local_proof.get("evidence_fold_verdict", "blocked")
+    if verdict not in LOCAL_VERDICTS:
+        return ["local_proof.evidence_fold_verdict:invalid"]
+    if verdict != "done":
+        return [f"local_proof.evidence_fold_verdict:{verdict}"]
+    commands = local_proof.get("commands", [])
+    if not isinstance(commands, list) or not commands:
+        return ["local_proof.commands:missing"]
+    return []
+
+
+def proof_patch_reasons_for(proof_patch: dict[str, Any], closure_candidate: str) -> list[str]:
+    required_by_candidate = closure_candidate == "proof-patch"
+    if not required_by_candidate and not as_yes(proof_patch.get("required")):
+        return []
+    reasons: list[str] = []
+    if required_by_candidate and not as_yes(proof_patch.get("required")):
+        reasons.append("proof_patch.required:missing-for-proof-patch-closure")
+    if not as_yes(proof_patch.get("present")):
+        reasons.append("proof_patch:missing")
+    if not as_yes(proof_patch.get("current")):
+        reasons.append("proof_patch:not-current")
+    return reasons
+
+
+def cas_reasons_for(cas: dict[str, Any], artifact: dict[str, Any]) -> list[str]:
+    if not as_yes(cas.get("required")):
+        return []
+    reasons: list[str] = []
+    required = cas.get("clean_runs_required", 3)
+    count = cas.get("clean_runs_count", 0)
+    if not is_plain_int(required) or required <= 0:
+        reasons.append("cas.clean_runs_required:invalid")
+        required = 3
+    if not is_plain_int(count) or count < 0:
+        reasons.append("cas.clean_runs_count:invalid")
+        count = 0
+    if count < required:
+        reasons.append(f"cas.clean_runs:{count}-of-{required}")
+    if required > 0 and not as_yes(cas.get("independent_fresh_runs")):
+        reasons.append("cas.clean_runs:not-independent")
+    if required > 0 and not as_yes(cas.get("tuple_bound")):
+        reasons.append("cas.tuple:not-bound")
+    tuple_value = cas.get("tuple") if isinstance(cas.get("tuple"), dict) else {}
+    for key in ("base_sha", "head_sha", "target_fingerprint"):
+        if required > 0 and (not isinstance(tuple_value.get(key), str) or not tuple_value.get(key)):
+            reasons.append(f"cas.tuple.{key}:missing")
+    if required > 0 and isinstance(tuple_value.get("head_sha"), str) and tuple_value.get("head_sha"):
+        if tuple_value.get("head_sha") != artifact.get("head_sha"):
+            reasons.append("cas.tuple.head_sha:artifact-mismatch")
+    if required > 0 and isinstance(tuple_value.get("target_fingerprint"), str) and tuple_value.get("target_fingerprint"):
+        if tuple_value.get("target_fingerprint") != artifact.get("diff_fingerprint"):
+            reasons.append("cas.tuple.target_fingerprint:artifact-mismatch")
+    return reasons
+
+
+def delivery_reasons_for(
+    delivery: dict[str, Any],
+    closure_candidate: str,
+    artifact: dict[str, Any],
+) -> tuple[list[str], list[str]]:
+    ship_complete = closure_candidate == "ship-complete"
+    publication_required = as_yes(delivery.get("publication_required")) or ship_complete
+    if ship_complete and not as_yes(delivery.get("pr_intent")):
+        return ["delivery.pr_intent:missing-for-ship-complete"], []
+    if publication_required and not as_yes(delivery.get("pr_intent")):
+        return ["delivery.pr_intent:missing-with-publication-required"], []
+    if not as_yes(delivery.get("pr_intent")):
+        return [], []
+    blocked: list[str] = []
+    pending: list[str] = []
+    add = add_v1_decision_from(delivery.get("add_v1_decision"))
+    add_verdict = add.get("verdict", "missing")
+    if add_verdict != "missing" and add.get("decision_version") != "ADD-v1":
+        blocked.append("delivery.add_v1_decision.decision_version:invalid")
+    if add_verdict not in ADD_VERDICTS:
+        blocked.append("delivery.add_v1_decision.verdict:invalid")
+        add_verdict = "missing"
+    if add_verdict == "blocked":
+        blocked.append("delivery.add_v1_decision:blocked")
+    elif add_verdict == "missing":
+        blocked.append("delivery.add_v1_decision:missing")
+    elif add_verdict == "shipping_not_requested":
+        blocked.append("delivery.add_v1_decision:shipping-not-requested-with-pr-intent")
+    elif add_verdict == "handoff_to_ship":
+        blocked.extend(add_v1_head_reasons_for(add, artifact))
+        ship = delivery.get("ship_result") if isinstance(delivery.get("ship_result"), dict) else {}
+        if publication_required:
+            if not as_yes(ship.get("present")):
+                pending.append("ship_result:missing")
+            if not as_yes(ship.get("current")):
+                pending.append("ship_result:not-current")
+            if not isinstance(ship.get("pr_url"), str) or not ship.get("pr_url"):
+                pending.append("ship_result.pr_url:missing")
+        else:
+            pending.append("ship_handoff:not-terminal")
+    return blocked, pending
+
+
+def add_v1_decision_from(value: Any) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        return {}
+    wrapped = value.get("actuation_delivery_decision")
+    if isinstance(wrapped, dict):
+        return wrapped
+    return value
+
+
+def add_v1_head_reasons_for(add: dict[str, Any], artifact: dict[str, Any]) -> list[str]:
+    reasons: list[str] = []
+    artifact_head = artifact.get("head_sha")
+    target_head = add.get("target_head")
+    if not isinstance(target_head, str) or not target_head:
+        reasons.append("delivery.add_v1_decision.target_head:missing")
+    elif target_head != artifact_head:
+        reasons.append("delivery.add_v1_decision.target_head:artifact-mismatch")
+
+    handoff = add.get("ship_handoff") if isinstance(add.get("ship_handoff"), dict) else {}
+    ship_input = handoff.get("ship_input") if isinstance(handoff.get("ship_input"), dict) else {}
+    ship_input_head = ship_input.get("head_sha")
+    if not isinstance(ship_input_head, str) or not ship_input_head:
+        reasons.append("delivery.add_v1_decision.ship_input.head_sha:missing")
+    elif ship_input_head != artifact_head:
+        reasons.append("delivery.add_v1_decision.ship_input.head_sha:artifact-mismatch")
+    return reasons
+
+
+def final_report_reasons_for(
+    final_report: dict[str, Any],
+    cas: dict[str, Any],
+    proof_patch: dict[str, Any],
+    delivery: dict[str, Any],
+) -> list[str]:
+    reasons: list[str] = []
+    if as_yes(cas.get("required")):
+        required = cas.get("clean_runs_required", 3)
+        if not is_plain_int(required) or required <= 0:
+            required = 3
+        value = count_from(final_report.get("normalized_cas_clean_runs"))
+        if value is None or value < required:
+            reasons.append("final_report.normalized_cas_clean_runs:not-satisfied")
+    return reasons
+
+
+def required_receipts_for(
+    proof_patch: dict[str, Any],
+    cas: dict[str, Any],
+    delivery: dict[str, Any],
+    closure_candidate: str,
+) -> list[str]:
+    receipts: list[str] = []
+    if as_yes(proof_patch.get("required")) or closure_candidate == "proof-patch":
+        receipts.append("proof_patch")
+    if as_yes(cas.get("required")):
+        receipts.append("cas_review")
+    if as_yes(delivery.get("pr_intent")) or closure_candidate == "ship-complete":
+        receipts.append("add_v1_delivery_decision")
+    if as_yes(delivery.get("publication_required")) or closure_candidate == "ship-complete":
+        receipts.append("ship_result")
+    return receipts
+
+
+def next_owner_for(blocked: list[str], pending: list[str]) -> str:
+    combined = blocked + pending
+    if any("ask-human" in reason for reason in combined):
+        return "human"
+    if any(reason.startswith("artifact_scope") for reason in combined):
+        return "$goal-grind"
+    if any(reason.startswith("cas.") or reason.startswith("final_report.normalized_cas") for reason in combined):
+        return "$cas"
+    if any(reason.startswith("proof_patch") for reason in combined):
+        return "$proof-patch"
+    if any(reason.startswith("ship") or reason.startswith("delivery") or reason.startswith("final_report.ship") for reason in combined):
+        return "$ship"
+    if any(reason.startswith("local_proof") for reason in combined):
+        return "$goal-grind"
+    return "$goal-grind"
+
+
+def validate_decision(value: dict[str, Any]) -> dict[str, Any]:
+    d = unwrap(value, "actuation_terminal_decision")
+    errors: list[str] = []
+    if d.get("decision_version") != "ATCG-v1":
+        errors.append("decision_version")
+    verdict = d.get("verdict")
+    if verdict not in TERMINAL_VERDICTS:
+        errors.append("verdict")
+    if d.get("can_mark_goal_complete") not in {"yes", "no"}:
+        errors.append("can_mark_goal_complete")
+    if d.get("next_owner") not in NEXT_OWNERS:
+        errors.append("next_owner")
+    if not isinstance(d.get("blocked_reasons"), list):
+        errors.append("blocked_reasons")
+    if not isinstance(d.get("continue_reasons"), list):
+        errors.append("continue_reasons")
+    if not isinstance(d.get("required_receipts"), list):
+        errors.append("required_receipts")
+    artifact = d.get("current_artifact_binding")
+    if not isinstance(artifact, dict):
+        errors.append("current_artifact_binding")
+        artifact = {}
+    if not isinstance(d.get("run_id"), str) or not d.get("run_id"):
+        errors.append("run_id:missing")
+    source = d.get("source")
+    if not isinstance(source, str) or not source:
+        errors.append("source:missing")
+    elif source not in SOURCES:
+        errors.append("source:invalid")
+    closure_candidate = d.get("closure_candidate")
+    if not isinstance(closure_candidate, str) or not closure_candidate:
+        errors.append("closure_candidate:missing")
+    elif closure_candidate not in CLOSURE_CANDIDATES:
+        errors.append("closure_candidate:invalid")
+    if verdict == "complete":
+        if d.get("closure_candidate") not in {"proof-patch", "ship-complete"}:
+            errors.append("complete.closure_candidate:not-terminal")
+        receipts = d.get("required_receipts") if isinstance(d.get("required_receipts"), list) else []
+        if d.get("closure_candidate") == "proof-patch" and "proof_patch" not in receipts:
+            errors.append("complete.required_receipts.proof_patch:missing")
+        if d.get("closure_candidate") == "ship-complete":
+            if "add_v1_delivery_decision" not in receipts:
+                errors.append("complete.required_receipts.add_v1_delivery_decision:missing")
+            if "ship_result" not in receipts:
+                errors.append("complete.required_receipts.ship_result:missing")
+        for key in ("repo", "branch", "head_sha", "diff_fingerprint"):
+            if not isinstance(artifact.get(key), str) or not artifact.get(key):
+                errors.append(f"complete.current_artifact_binding.{key}:missing")
+        if not complete_dirty_state_allowed(d, artifact):
+            errors.append("complete.current_artifact_binding.dirty_state:not-clean")
+
+    if verdict == "complete":
+        if d.get("can_mark_goal_complete") != "yes":
+            errors.append("complete:can_mark_goal_complete-not-yes")
+        if d.get("next_owner") != "none":
+            errors.append("complete:next_owner-not-none")
+        if d.get("blocked_reasons") or d.get("continue_reasons"):
+            errors.append("complete:reasons-present")
+    elif verdict == "blocked":
+        if d.get("can_mark_goal_complete") != "no":
+            errors.append("blocked:can_mark_goal_complete-not-no")
+        if d.get("next_owner") == "none":
+            errors.append("blocked:next_owner-none")
+        if not d.get("blocked_reasons"):
+            errors.append("blocked:reasons-required")
+    elif verdict == "continue":
+        if d.get("can_mark_goal_complete") != "no":
+            errors.append("continue:can_mark_goal_complete-not-no")
+        if d.get("next_owner") == "none":
+            errors.append("continue:next_owner-none")
+        if not d.get("continue_reasons"):
+            errors.append("continue:reasons-required")
+
+    result = {
+        "actuation_terminal_gate": {
+            "verdict": "pass" if not errors else "fail",
+            "decision_verdict": verdict,
+            "can_mark_goal_complete": d.get("can_mark_goal_complete"),
+            "run_id": d.get("run_id"),
+            "errors": errors,
+        }
+    }
+    if errors:
+        raise TerminalGateError(json.dumps(result, sort_keys=True))
+    return result
+
+
+def complete_dirty_state_allowed(decision: dict[str, Any], artifact: dict[str, Any]) -> bool:
+    dirty_state = artifact.get("dirty_state")
+    if dirty_state == "clean":
+        return True
+    receipts = decision.get("required_receipts")
+    if dirty_state == "tracked-dirty" and isinstance(receipts, list):
+        return "proof_patch" in receipts
+    return False
+
+
+def emit(obj: dict[str, Any], out: str | None = None) -> None:
+    text = json.dumps(obj, indent=2, sort_keys=True) + "\n"
+    if out:
+        Path(out).parent.mkdir(parents=True, exist_ok=True)
+        Path(out).write_text(text, encoding="utf-8")
+    else:
+        sys.stdout.write(text)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Decide or validate ATCG-v1 terminal actuation closure.")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+    p_decide = sub.add_parser("decide")
+    p_decide.add_argument("--context", required=True)
+    p_decide.add_argument("--out")
+    p_check = sub.add_parser("check")
+    p_check.add_argument("--decision", required=True)
+
+    args = parser.parse_args(argv)
+    try:
+        if args.cmd == "decide":
+            context = context_from(load_json(args.context))
+            decision = make_decision(context)
+            emit(decision, args.out)
+        elif args.cmd == "check":
+            decision = load_json(args.decision)
+            result = validate_decision(decision)
+            emit(result)
+        return 0
+    except Exception as exc:
+        print(json.dumps({"actuation_terminal_gate": {"verdict": "fail", "error": str(exc)}}, indent=2, sort_keys=True))
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/codex/skills/actuating/tools/quick_validate.py
+++ b/codex/skills/actuating/tools/quick_validate.py
@@ -30,11 +30,14 @@ def main() -> int:
         "agents/openai.yaml",
         "references/pre-mutation-interlock.md",
         "references/delivery-handoff.md",
+        "references/terminal-closure-gate.md",
         "references/decision-contract.yaml",
         "tools/actuation_authority_gate.py",
         "tools/actuation_delivery_gate.py",
+        "tools/actuation_terminal_gate.py",
         "tests/test_actuation_authority_gate.py",
         "tests/test_actuation_delivery_gate.py",
+        "tests/test_actuation_terminal_gate.py",
         "assets/gcr-v2.allowed.example.json",
         "assets/gcr-v2.self-invalidating.example.json",
         "assets/apma-v1.example.json",
@@ -44,6 +47,10 @@ def main() -> int:
         "assets/add-v1.handoff.example.json",
         "assets/add-v1.shipping-not-requested.example.json",
         "assets/add-v1.blocked.example.json",
+        "assets/atcg-v1.complete.example.json",
+        "assets/terminal-context.proof-only.example.json",
+        "assets/terminal-context.regression.example.json",
+        "assets/terminal-context.ship-continue.example.json",
     ]
     missing = [path for path in required if not (ROOT / path).is_file()]
     if missing:
@@ -52,6 +59,7 @@ def main() -> int:
     tests = [
         run_test(ROOT / "tests/test_actuation_authority_gate.py"),
         run_test(ROOT / "tests/test_actuation_delivery_gate.py"),
+        run_test(ROOT / "tests/test_actuation_terminal_gate.py"),
     ]
     ok = all(row["returncode"] == 0 for row in tests)
     print(json.dumps({

--- a/codex/skills/agent-loop-schemes/SKILL.md
+++ b/codex/skills/agent-loop-schemes/SKILL.md
@@ -194,6 +194,14 @@ patch + evidence + residual risk -> proof summary
 
 A proof summary must bind to current branch/head/diff or explicitly say artifact binding is unavailable.
 
+For `$actuating` or `$goal-actuating`, proof closure has one final reducer:
+
+```text
+evidence-fold + proof-patch/CAS/ADD-v1/ship evidence -> ATCG-v1 -> complete|continue|blocked
+```
+
+Do not claim completion unless ATCG-v1 returns `can_mark_goal_complete=yes`.
+
 ### 10. st-governed
 
 Use when durable coordination owns the work.
@@ -284,6 +292,7 @@ review needs CAS but CAS is unavailable
 three clean CAS runs are required but unavailable
 mutation authority is missing
 public side effects would occur without explicit intent
+ATCG-v1 does not permit goal completion
 the next action would repeat a known invalid strategy
 ```
 
@@ -298,6 +307,7 @@ the next action would repeat a known invalid strategy
 - `$failure-memory` when repeated classes or oscillation appear.
 - `$proof-patch` for local closure proof.
 - `$ship` for PR creation, update, promotion, or publication.
+- `ATCG-v1` as the terminal closure reducer before `$actuating` completion.
 - `$st` when durable coordination, claims, fencing, or worktrees are required.
 
 ## Guardrails

--- a/codex/skills/goal-actuating/SKILL.md
+++ b/codex/skills/goal-actuating/SKILL.md
@@ -77,6 +77,7 @@ goal_actuating_mode:
 13. Use `$failure-memory` when failures or review classes repeat.
 14. For `review-fix` and exhaustive review, require three consecutive clean normalized `$cas` review runs on the same artifact scope before completion.
 15. Close with `$proof-patch`, or hand off to `$ship` only when publication is requested and ready.
+16. Run ATCG-v1 terminal closure gate before reporting goal completion.
 
 ## Scheme Plan consumption
 
@@ -336,6 +337,7 @@ public tracker side effect would be needed without explicit intent
 review is required but $cas review is unavailable or not run
 three clean normalized $cas review runs are required but cannot be completed
 parallel fanout would cross shared invariants or conflicting resources
+ATCG-v1 does not return can_mark_goal_complete=yes
 ```
 
 ## Output
@@ -363,5 +365,6 @@ Goal Actuation:
 - review resolution, if any:
 - evidence-fold verdict:
 - proof-patch / ship handoff:
+- ATCG-v1 verdict / next owner:
 - learnings or memory-source handoff, if justified:
 ```


### PR DESCRIPTION
## Summary

- add ATCG-v1, a terminal closure gate for $actuating / $goal-actuating
- block false completion when local proof passes but CAS, proof-patch, delivery, or ship evidence is missing
- document ATCG-v1 placement in agent-loop-schemes and add regression fixtures/tests

## Root cause

Local verifier success could be mistaken for actuation completion because final closeout fields were prose-governed rather than reduced by a fail-closed terminal gate.

## Validation

- uv run python codex/skills/actuating/tests/test_actuation_terminal_gate.py
- uv run python codex/skills/actuating/tests/test_actuation_delivery_gate.py
- uv run python codex/skills/actuating/tests/test_actuating_tools.py
- uv run python codex/skills/actuating/tests/test_actuation_authority_gate.py
