### PR TITLE
[codex] Harden ATCG ADD-v1 receipt validation

### DIFF
--- a/codex/skills/actuating/assets/terminal-context.ship-continue.example.json
+++ b/codex/skills/actuating/assets/terminal-context.ship-continue.example.json
@@ -37,10 +37,39 @@
         "decision_version": "ADD-v1",
         "verdict": "handoff_to_ship",
         "ref": "add-v1:handoff",
+        "run_id": "run-ship-001",
+        "plan_id": "plan-example",
+        "target_branch": "feature/example",
         "target_head": "abc123",
+        "branch_epoch": 4,
+        "integrated_change_set_receipts": [
+          ".ledger/st/integration/receipts/igr-001.json"
+        ],
+        "proof_complete_receipt": {
+          "present": "yes",
+          "current": "yes",
+          "ref": ".ledger/st/proof/plan-example/proof-complete.json"
+        },
+        "integration": {
+          "queue_quiescent": "yes",
+          "receipts": [
+            ".ledger/st/integration/receipts/igr-001.json"
+          ]
+        },
+        "cross_plan_dependency_status": "clear",
+        "pr_intent": {
+          "present": "yes",
+          "source": "actuation_run",
+          "requested_mode": "ready"
+        },
         "ship_handoff": {
+          "next_owner": "$ship",
           "ship_input": {
-            "head_sha": "abc123"
+            "branch": "feature/example",
+            "head_sha": "abc123",
+            "actuation": {
+              "plan_id": "plan-example"
+            }
           }
         }
       },

--- a/codex/skills/actuating/references/terminal-closure-gate.md
+++ b/codex/skills/actuating/references/terminal-closure-gate.md
@@ -81,6 +81,7 @@ ship-complete closure + missing delivery evidence -> blocked, next_owner=$ship
 ship-complete closure + missing ADD-v1 or ship receipt -> invalid decision
 wrapped ADD-v1 delivery decision -> accepted as delivery evidence
 ADD-shaped handoff without decision_version=ADD-v1 -> blocked
+partial ADD-v1 handoff without proof/integration receipts -> blocked
 ADD-v1 target_head or ship_input.head_sha mismatches current artifact -> blocked
 complete + closure_candidate=ship-handoff|blocked -> invalid decision
 artifact binding missing/stale -> blocked, next_owner=$goal-grind

--- a/codex/skills/actuating/tests/test_actuation_terminal_gate.py
+++ b/codex/skills/actuating/tests/test_actuation_terminal_gate.py
@@ -137,6 +137,38 @@ class ActuationTerminalGateTests(unittest.TestCase):
         self.assertEqual(body["verdict"], "blocked")
         self.assertIn("delivery.add_v1_decision.decision_version:invalid", body["blocked_reasons"])
 
+    def test_ship_complete_rejects_partial_add_v1_handoff_with_version(self) -> None:
+        context = deepcopy(self.context())
+        context["closure_candidate"] = "ship-complete"
+        context["delivery"] = {
+            "pr_intent": "yes",
+            "publication_required": "yes",
+            "add_v1_decision": {
+                "decision_version": "ADD-v1",
+                "verdict": "handoff_to_ship",
+                "target_branch": "feature/example",
+                "target_head": "abc123",
+                "ship_handoff": {
+                    "next_owner": "$ship",
+                    "ship_input": {
+                        "branch": "feature/example",
+                        "head_sha": "abc123",
+                    }
+                },
+            },
+            "ship_result": {
+                "present": "yes",
+                "current": "yes",
+                "pr_url": "https://github.com/tkersey/example/pull/1",
+                "ref": "ship:example",
+            },
+        }
+        decision = MODULE.make_decision(context)
+        body = decision["actuation_terminal_decision"]
+        self.assertEqual(body["verdict"], "blocked")
+        self.assertIn("delivery.add_v1_decision.run_id:missing", body["blocked_reasons"])
+        self.assertIn("delivery.add_v1_decision.integrated_change_set_receipts:empty", body["blocked_reasons"])
+
     def test_cached_cas_receipt_does_not_count_as_fresh_clean_run(self) -> None:
         context = self.context("terminal-context.proof-only.example.json")
         context["cas_review"] = {

--- a/codex/skills/actuating/tools/actuation_terminal_gate.py
+++ b/codex/skills/actuating/tools/actuation_terminal_gate.py
@@ -281,8 +281,8 @@ def delivery_reasons_for(
     pending: list[str] = []
     add = add_v1_decision_from(delivery.get("add_v1_decision"))
     add_verdict = add.get("verdict", "missing")
-    if add_verdict != "missing" and add.get("decision_version") != "ADD-v1":
-        blocked.append("delivery.add_v1_decision.decision_version:invalid")
+    if add_verdict != "missing":
+        blocked.extend(add_v1_receipt_reasons_for(add, artifact))
     if add_verdict not in ADD_VERDICTS:
         blocked.append("delivery.add_v1_decision.verdict:invalid")
         add_verdict = "missing"
@@ -293,7 +293,6 @@ def delivery_reasons_for(
     elif add_verdict == "shipping_not_requested":
         blocked.append("delivery.add_v1_decision:shipping-not-requested-with-pr-intent")
     elif add_verdict == "handoff_to_ship":
-        blocked.extend(add_v1_head_reasons_for(add, artifact))
         ship = delivery.get("ship_result") if isinstance(delivery.get("ship_result"), dict) else {}
         if publication_required:
             if not as_yes(ship.get("present")):
@@ -314,6 +313,46 @@ def add_v1_decision_from(value: Any) -> dict[str, Any]:
     if isinstance(wrapped, dict):
         return wrapped
     return value
+
+
+def add_v1_receipt_reasons_for(add: dict[str, Any], artifact: dict[str, Any]) -> list[str]:
+    reasons: list[str] = []
+    if add.get("decision_version") != "ADD-v1":
+        reasons.append("delivery.add_v1_decision.decision_version:invalid")
+    for key in ("run_id", "plan_id", "target_branch", "target_head"):
+        if not isinstance(add.get(key), str) or not add.get(key):
+            reasons.append(f"delivery.add_v1_decision.{key}:missing")
+    if add.get("target_branch") != artifact.get("branch"):
+        reasons.append("delivery.add_v1_decision.target_branch:artifact-mismatch")
+    if not is_plain_int(add.get("branch_epoch")) or add.get("branch_epoch", -1) < 0:
+        reasons.append("delivery.add_v1_decision.branch_epoch:invalid")
+    receipts = add.get("integrated_change_set_receipts")
+    if not isinstance(receipts, list) or not receipts:
+        reasons.append("delivery.add_v1_decision.integrated_change_set_receipts:empty")
+    proof = add.get("proof_complete_receipt") if isinstance(add.get("proof_complete_receipt"), dict) else {}
+    if proof.get("present") != "yes" or proof.get("current") != "yes":
+        reasons.append("delivery.add_v1_decision.proof_complete_receipt:not-current")
+    integration = add.get("integration") if isinstance(add.get("integration"), dict) else {}
+    if integration.get("queue_quiescent") != "yes":
+        reasons.append("delivery.add_v1_decision.integration.queue_quiescent:not-yes")
+    if add.get("cross_plan_dependency_status") != "clear":
+        reasons.append("delivery.add_v1_decision.cross_plan_dependency_status:not-clear")
+    pr_intent = add.get("pr_intent") if isinstance(add.get("pr_intent"), dict) else {}
+    if pr_intent.get("present") != "yes":
+        reasons.append("delivery.add_v1_decision.pr_intent:not-present")
+
+    if add.get("verdict") == "handoff_to_ship":
+        reasons.extend(add_v1_head_reasons_for(add, artifact))
+        handoff = add.get("ship_handoff") if isinstance(add.get("ship_handoff"), dict) else {}
+        if handoff.get("next_owner") != "$ship":
+            reasons.append("delivery.add_v1_decision.ship_handoff.next_owner:invalid")
+        ship_input = handoff.get("ship_input") if isinstance(handoff.get("ship_input"), dict) else {}
+        if ship_input.get("branch") != add.get("target_branch"):
+            reasons.append("delivery.add_v1_decision.ship_input.branch:mismatch")
+        actuation = ship_input.get("actuation") if isinstance(ship_input.get("actuation"), dict) else {}
+        if actuation.get("plan_id") != add.get("plan_id"):
+            reasons.append("delivery.add_v1_decision.ship_input.actuation.plan_id:mismatch")
+    return reasons
 
 
 def add_v1_head_reasons_for(add: dict[str, Any], artifact: dict[str, Any]) -> list[str]:


### PR DESCRIPTION
Follow-up to #62. PR #62 merged before the final CAS liability was applied: ATCG accepted ADD-shaped stubs for ship-complete delivery evidence.\n\nThis patch requires ADD-v1 handoff evidence to carry the same receipt fields enforced by ADD-v1: decision version, run/plan/branch/head binding, proof/current integration receipts, clear dependency status, PR intent, and ship handoff consistency. It also expands the ship-continue fixture and terminal-gate regressions.\n\nLocal proof:\n- uv run python codex/skills/actuating/tools/quick_validate.py\n- uv run python codex/skills/actuating/tests/test_actuating_tools.py\n- uv run python codex/skills/plan/tests/test_policy_tools.py