### PR TITLE
[codex] Document CAS-RER workflow evidence boundary

### DIFF
--- a/codex/skills/actuating/SKILL.md
+++ b/codex/skills/actuating/SKILL.md
@@ -123,7 +123,7 @@ When the user asks for review, review closure, code review, CAS review, review r
 4. Implement only accepted code-change liabilities.
 5. Preserve no-code dispositions: `reject`, `proof-only`, `follow-up`, and `ask-human`.
 6. Prefer `refactor-kernel` when several findings share one owner boundary.
-7. Run three consecutive clean normalized `$cas` review passes on the same artifact scope.
+7. Run three consecutive clean CAS-RER review records on the same artifact scope.
 8. Close with `$evidence-fold` and `$proof-patch`.
 
 Do not treat `resolve-and-fix` as one patch per comment.
@@ -186,7 +186,7 @@ $cas review
 -> $goal-grind accepted liabilities only
 -> optional patch-fanout over disjoint accepted liabilities only
 -> $evidence-fold
--> 3 clean normalized $cas review runs
+-> 3 clean CAS-RER review records
 -> $proof-patch
 -> $ship only when PR update/publication is requested
 ```
@@ -194,15 +194,15 @@ $cas review
 Only accepted code-change liabilities may reach implementation.
 Raw review prose never reaches implementation directly.
 
-#### Three clean normalized CAS review runs
+#### Three clean CAS-RER review records
 
-For `resolve-and-fix` and exhaustive review, completion requires three consecutive clean normalized `$cas` review runs against the same current artifact scope unless the user explicitly lowers the review bar.
+For `resolve-and-fix` and exhaustive review, completion requires three consecutive clean CAS-RER review records against the same current artifact scope unless the user explicitly lowers the review bar.
 
-A clean normalized CAS run means `$cas` produces no new in-scope accepted liability after `$review-fold` and the resolve pass. The run is not made dirty by findings that are duplicate, rejected, out-of-scope, already-proven proof-only, deferred follow-up, or already-resolved by the current refactor kernel.
+A clean CAS-RER review record means `$cas` recorded current-tuple evidence with `verdict.status=clean`, strong usable principal for the caller's proof bar, and no new in-scope accepted liability after `$review-fold` and the resolve pass. The record is not made dirty by findings that are duplicate, rejected, out-of-scope, already-proven proof-only, deferred follow-up, or already-resolved by the current refactor kernel.
 
 Do not increment the clean-run counter from repeated normalization of one cached
-CAS receipt. After terminal evidence exists for the tuple, request each
-additional independent run with `--fresh-attempt REASON`, then track the streak in the caller workflow from independent CAS review verdicts.
+CAS receipt or record. After terminal evidence exists for the tuple, request each
+additional independent run with `--fresh-attempt REASON`, then track the streak in the caller workflow from independent CAS-RER records.
 
 Reset the clean-run counter to zero when:
 
@@ -211,7 +211,7 @@ code changes
 review scope changes
 base/head/diff changes
 accepted proof bar changes
-CAS lane/session changes in a way that invalidates continuity
+the workflow cannot prove CAS-RER records are current, strong, and distinct
 accepted parallel patch result is integrated
 branch-race winner is integrated
 serial integration changes the artifact
@@ -292,7 +292,7 @@ actuating_status:
 accepted spec -> optional $recursion-scheme-planner -> goal contract
 goal contract -> work list only if decomposition changes execution
 review requirement -> $cas review source mode
-CAS/existing review output -> $review-fold disposition before code
+CAS-RER/existing review output -> $review-fold disposition before code
 review classes -> optional review-class fanout
 competing strategies -> optional branch-race
 accepted disjoint liabilities -> optional patch-fanout
@@ -364,7 +364,7 @@ ATCG-v1 can_mark_goal_complete = yes
 
 If ATCG-v1 returns `continue`, continue with `next_owner`. If it returns
 `blocked`, report the blocked actuation verdict and reasons. Do not substitute
-local proof, proof-complete graph state, cached CAS receipts, or ADD-v1
+local proof, proof-complete graph state, cached CAS receipts/records, or ADD-v1
 `handoff_to_ship` for terminal completion.
 
 ## Stop rules
@@ -377,7 +377,7 @@ scope, non-goals, compatibility, or proof bar are unresolved
 review findings expand product/API scope
 raw review text has not been reduced to dispositions
 review is required but $cas review is unavailable or not run
-three clean normalized $cas review runs are required but cannot be completed
+three clean CAS-RER review records are required but cannot be completed
 $st authority is required but absent
 parallel fanout would cross shared invariants or conflicting resources
 verification regresses and the next action is not isolate/revert/prove
@@ -403,8 +403,8 @@ Actuating:
   - integration order:
   - conflicts:
   - CAS clean-run counter reset: yes|no
-- review source / CAS verdict, if required:
-- normalized CAS clean runs: 0|1|2|3|not-required
+- review source / CAS-RER record, if required:
+- clean CAS-RER review records: 0|1|2|3|not-required
 - goal contract / work list:
 - review-fold disposition:
 - execution owner: goal-grind | st-bounded-slice | none

--- a/codex/skills/actuating/SKILL.md
+++ b/codex/skills/actuating/SKILL.md
@@ -123,7 +123,7 @@ When the user asks for review, review closure, code review, CAS review, review r
 4. Implement only accepted code-change liabilities.
 5. Preserve no-code dispositions: `reject`, `proof-only`, `follow-up`, and `ask-human`.
 6. Prefer `refactor-kernel` when several findings share one owner boundary.
-7. Run three consecutive clean CAS-RER review records on the same artifact scope.
+7. Run three consecutive clean CAS review evidence units on the same artifact scope.
 8. Close with `$evidence-fold` and `$proof-patch`.
 
 Do not treat `resolve-and-fix` as one patch per comment.
@@ -186,7 +186,7 @@ $cas review
 -> $goal-grind accepted liabilities only
 -> optional patch-fanout over disjoint accepted liabilities only
 -> $evidence-fold
--> 3 clean CAS-RER review records
+-> 3 clean CAS review evidence units
 -> $proof-patch
 -> $ship only when PR update/publication is requested
 ```
@@ -194,15 +194,15 @@ $cas review
 Only accepted code-change liabilities may reach implementation.
 Raw review prose never reaches implementation directly.
 
-#### Three clean CAS-RER review records
+#### Three clean CAS review evidence units
 
-For `resolve-and-fix` and exhaustive review, completion requires three consecutive clean CAS-RER review records against the same current artifact scope unless the user explicitly lowers the review bar.
+For `resolve-and-fix` and exhaustive review, completion requires three consecutive clean CAS review evidence units against the same current artifact scope unless the user explicitly lowers the review bar.
 
-A clean CAS-RER review record means `$cas` recorded current-tuple evidence with `verdict.status=clean`, strong usable principal for the caller's proof bar, and no new in-scope accepted liability after `$review-fold` and the resolve pass. The record is not made dirty by findings that are duplicate, rejected, out-of-scope, already-proven proof-only, deferred follow-up, or already-resolved by the current refactor kernel.
+A clean CAS review evidence unit is either a `CAS-RER-v1` record or, on dispatchers without the ledger surface, a normalized tuple-bound `reviewVerdict` compatibility projection. It must carry current-tuple clean evidence with strong usable principal for the caller's proof bar and no new in-scope accepted liability after `$review-fold` and the resolve pass. The unit is not made dirty by findings that are duplicate, rejected, out-of-scope, already-proven proof-only, deferred follow-up, or already-resolved by the current refactor kernel.
 
 Do not increment the clean-run counter from repeated normalization of one cached
 CAS receipt or record. After terminal evidence exists for the tuple, request each
-additional independent run with `--fresh-attempt REASON`, then track the streak in the caller workflow from independent CAS-RER records.
+additional independent run with `--fresh-attempt REASON`, then track the streak in the caller workflow from independent CAS review evidence units.
 
 Reset the clean-run counter to zero when:
 
@@ -211,7 +211,7 @@ code changes
 review scope changes
 base/head/diff changes
 accepted proof bar changes
-the workflow cannot prove CAS-RER records are current, strong, and distinct
+the workflow cannot prove CAS review evidence units are current, strong, and distinct
 accepted parallel patch result is integrated
 branch-race winner is integrated
 serial integration changes the artifact
@@ -292,7 +292,7 @@ actuating_status:
 accepted spec -> optional $recursion-scheme-planner -> goal contract
 goal contract -> work list only if decomposition changes execution
 review requirement -> $cas review source mode
-CAS-RER/existing review output -> $review-fold disposition before code
+CAS review evidence/existing review output -> $review-fold disposition before code
 review classes -> optional review-class fanout
 competing strategies -> optional branch-race
 accepted disjoint liabilities -> optional patch-fanout
@@ -377,7 +377,7 @@ scope, non-goals, compatibility, or proof bar are unresolved
 review findings expand product/API scope
 raw review text has not been reduced to dispositions
 review is required but $cas review is unavailable or not run
-three clean CAS-RER review records are required but cannot be completed
+three clean CAS review evidence units are required but cannot be completed
 $st authority is required but absent
 parallel fanout would cross shared invariants or conflicting resources
 verification regresses and the next action is not isolate/revert/prove
@@ -403,8 +403,8 @@ Actuating:
   - integration order:
   - conflicts:
   - CAS clean-run counter reset: yes|no
-- review source / CAS-RER record, if required:
-- clean CAS-RER review records: 0|1|2|3|not-required
+- review source / CAS evidence unit, if required:
+- clean CAS review evidence units: 0|1|2|3|not-required
 - goal contract / work list:
 - review-fold disposition:
 - execution owner: goal-grind | st-bounded-slice | none

--- a/codex/skills/actuating/references/decision-contract.yaml
+++ b/codex/skills/actuating/references/decision-contract.yaml
@@ -65,7 +65,7 @@ skill_decision_contract:
       expected_routes: [ACT-CAS-REVIEW, ACT-GOAL, ACT-BLOCK]
       prohibited_routes: []
       required_artifacts:
-        - CAS-RER review record when workflow code review is required
+        - CAS review evidence unit when workflow code review is required
         - review-fold disposition
       success_signals:
         - fresh or exhaustive workflow review comes from $cas

--- a/codex/skills/actuating/references/decision-contract.yaml
+++ b/codex/skills/actuating/references/decision-contract.yaml
@@ -65,7 +65,7 @@ skill_decision_contract:
       expected_routes: [ACT-CAS-REVIEW, ACT-GOAL, ACT-BLOCK]
       prohibited_routes: []
       required_artifacts:
-        - CAS review verdict when workflow code review is required
+        - CAS-RER review record when workflow code review is required
         - review-fold disposition
       success_signals:
         - fresh or exhaustive workflow review comes from $cas

--- a/codex/skills/agent-loop-schemes/SKILL.md
+++ b/codex/skills/agent-loop-schemes/SKILL.md
@@ -120,7 +120,7 @@ $cas review
 -> closure-agenda pass
 -> $goal-grind accepted liabilities only
 -> $evidence-fold
--> 3 clean normalized $cas review runs
+-> 3 clean CAS-RER review records
 -> $proof-patch
 -> $ship only if PR publication/update is requested
 ```
@@ -232,13 +232,13 @@ plan only
 no changes
 ```
 
-For `review-fix` and exhaustive review, completion requires three consecutive clean normalized `$cas` review runs against the same artifact scope unless the user explicitly lowers the review bar.
+For `review-fix` and exhaustive review, completion requires three consecutive clean CAS-RER review records against the same artifact scope unless the user explicitly lowers the review bar.
 
-A clean normalized run means no new in-scope accepted liability, unresolved proof gap, unresolved refactor-kernel candidate, or human-owned blocker remains after `$review-fold` and the closure-agenda pass.
+A clean CAS-RER review record means current-tuple `verdict.status=clean` evidence with strong usable principal and no new in-scope accepted liability, unresolved proof gap, unresolved refactor-kernel candidate, or human-owned blocker after `$review-fold` and the closure-agenda pass.
 
 Do not reset the clean-run counter for duplicate, rejected, out-of-scope, already-proven proof-only, follow-up, or already-addressed findings.
 
-Reset the counter when code changes, review scope changes, base/head/diff changes, the proof bar changes, or CAS lane/session continuity is lost.
+Reset the counter when code changes, review scope changes, base/head/diff changes, the proof bar changes, or the workflow cannot prove CAS-RER records are current, strong, and distinct.
 
 ## Minimality law
 

--- a/codex/skills/agent-loop-schemes/SKILL.md
+++ b/codex/skills/agent-loop-schemes/SKILL.md
@@ -120,7 +120,7 @@ $cas review
 -> closure-agenda pass
 -> $goal-grind accepted liabilities only
 -> $evidence-fold
--> 3 clean CAS-RER review records
+-> 3 clean CAS review evidence units
 -> $proof-patch
 -> $ship only if PR publication/update is requested
 ```
@@ -232,13 +232,13 @@ plan only
 no changes
 ```
 
-For `review-fix` and exhaustive review, completion requires three consecutive clean CAS-RER review records against the same artifact scope unless the user explicitly lowers the review bar.
+For `review-fix` and exhaustive review, completion requires three consecutive clean CAS review evidence units against the same artifact scope unless the user explicitly lowers the review bar.
 
-A clean CAS-RER review record means current-tuple `verdict.status=clean` evidence with strong usable principal and no new in-scope accepted liability, unresolved proof gap, unresolved refactor-kernel candidate, or human-owned blocker after `$review-fold` and the closure-agenda pass.
+A clean CAS review evidence unit is either a `CAS-RER-v1` record or, on dispatchers without the ledger surface, a normalized tuple-bound `reviewVerdict` compatibility projection. It must carry current-tuple clean evidence with strong usable principal and must show no new in-scope accepted liability, unresolved proof gap, unresolved refactor-kernel candidate, or human-owned blocker after `$review-fold` and the closure-agenda pass.
 
 Do not reset the clean-run counter for duplicate, rejected, out-of-scope, already-proven proof-only, follow-up, or already-addressed findings.
 
-Reset the counter when code changes, review scope changes, base/head/diff changes, the proof bar changes, or the workflow cannot prove CAS-RER records are current, strong, and distinct.
+Reset the counter when code changes, review scope changes, base/head/diff changes, the proof bar changes, or the workflow cannot prove CAS review evidence units are current, strong, and distinct.
 
 ## Minimality law
 

--- a/codex/skills/agent-loop-schemes/references/examples.md
+++ b/codex/skills/agent-loop-schemes/references/examples.md
@@ -9,7 +9,7 @@
 Means:
 
 ```text
-CAS review, classify, build a closure agenda, fix accepted liabilities only, verify, require caller-owned repeated clean CAS review runs, then proof-patch.
+CAS review, classify, build a closure agenda, fix accepted liabilities only, verify, require caller-owned repeated clean CAS review evidence units, then proof-patch.
 ```
 
 ## Existing PR, no implementation

--- a/codex/skills/agent-loop-schemes/references/review-loop.md
+++ b/codex/skills/agent-loop-schemes/references/review-loop.md
@@ -8,7 +8,7 @@ $cas review
 -> closure-agenda pass
 -> $goal-grind accepted liabilities only
 -> $evidence-fold
--> 3 clean normalized $cas review runs
+-> 3 clean CAS-RER review records
 -> $proof-patch
 -> $ship only when PR update/publication is requested
 ```
@@ -21,10 +21,10 @@ $cas review
 | agenda-only | Produce the closure agenda. | No |
 | review-fix | Default review remediation. Classify, fix accepted liabilities, prove closure. | Yes |
 
-## Clean normalized CAS run
+## Clean CAS-RER review record
 
-A clean normalized CAS run means no new in-scope accepted liability, unresolved proof gap, unresolved refactor-kernel candidate, or human-owned blocker remains after review-fold and the closure-agenda pass.
+A clean CAS-RER review record means current-tuple `verdict.status=clean` evidence with strong usable principal and no new in-scope accepted liability, unresolved proof gap, unresolved refactor-kernel candidate, or human-owned blocker remains after review-fold and the closure-agenda pass.
 
 The run is still clean when findings are duplicate, rejected, out-of-scope, already-proven proof-only, follow-up, or already addressed by the current implementation.
 
-Reset the clean-run counter when code changes, review scope changes, base/head/diff changes, proof bar changes, or CAS lane/session continuity is lost.
+Reset the clean-run counter when code changes, review scope changes, base/head/diff changes, proof bar changes, or the workflow cannot prove CAS-RER records are current, strong, and distinct.

--- a/codex/skills/agent-loop-schemes/references/review-loop.md
+++ b/codex/skills/agent-loop-schemes/references/review-loop.md
@@ -8,7 +8,7 @@ $cas review
 -> closure-agenda pass
 -> $goal-grind accepted liabilities only
 -> $evidence-fold
--> 3 clean CAS-RER review records
+-> 3 clean CAS review evidence units
 -> $proof-patch
 -> $ship only when PR update/publication is requested
 ```
@@ -21,10 +21,10 @@ $cas review
 | agenda-only | Produce the closure agenda. | No |
 | review-fix | Default review remediation. Classify, fix accepted liabilities, prove closure. | Yes |
 
-## Clean CAS-RER review record
+## Clean CAS review evidence unit
 
-A clean CAS-RER review record means current-tuple `verdict.status=clean` evidence with strong usable principal and no new in-scope accepted liability, unresolved proof gap, unresolved refactor-kernel candidate, or human-owned blocker remains after review-fold and the closure-agenda pass.
+A clean CAS review evidence unit is either a `CAS-RER-v1` record or, on dispatchers without the ledger surface, a normalized tuple-bound `reviewVerdict` compatibility projection. It must carry current-tuple clean evidence with strong usable principal and must show no new in-scope accepted liability, unresolved proof gap, unresolved refactor-kernel candidate, or human-owned blocker after review-fold and the closure-agenda pass.
 
 The run is still clean when findings are duplicate, rejected, out-of-scope, already-proven proof-only, follow-up, or already addressed by the current implementation.
 
-Reset the clean-run counter when code changes, review scope changes, base/head/diff changes, proof bar changes, or the workflow cannot prove CAS-RER records are current, strong, and distinct.
+Reset the clean-run counter when code changes, review scope changes, base/head/diff changes, proof bar changes, or the workflow cannot prove CAS review evidence units are current, strong, and distinct.

--- a/codex/skills/cas/SKILL.md
+++ b/codex/skills/cas/SKILL.md
@@ -1,13 +1,22 @@
 ---
 name: cas
-description: "Run Zig CAS helpers (`cas`, `cas_account`, `cas_goal`, `cas_smoke_check`, `cas_instance_runner`, `cas_review_session`, `cas_session_inquiry`, `cas_conformance_suite`) for v2 app-server account status, smoke checks, goal lifecycle control, direct thread/turn execution, detached review control, session inquiry replay, multi-instance fanout, and `$st` swarm conformance/retry-policy checks. For review sessions, distinguish pre-review lane transport, real review attempts, normalized tuple-bound review verdicts, account/resource exhaustion, and tuple concurrency guards."
+description: "Run Zig CAS helpers (`cas`, `cas_account`, `cas_goal`, `cas_smoke_check`, `cas_instance_runner`, `cas_review_session`, `cas_session_inquiry`, `cas_conformance_suite`) for v2 app-server account status, smoke checks, goal lifecycle control, direct thread/turn execution, detached review control, review evidence ledger import/validation, session inquiry replay, multi-instance fanout, and `$st` swarm conformance/retry-policy checks. For review evidence, distinguish CAS-RER records, pre-review lane transport, real review attempts, normalized tuple-bound review verdicts, account/resource exhaustion, and tuple concurrency guards."
 ---
 
 # cas (Zig App-Server Control)
 
 ## Mission
 
-`$cas` is the Zig-backed app-server control skill. It owns protocol preflight, account/status probes, goal lifecycle control, direct method execution, detached review lifecycle, persistent review lanes, receipt normalization, safe session-inquiry replay, and `$st` conformance probes.
+`$cas` is the Zig-backed app-server control skill. It owns protocol preflight, account/status probes, goal lifecycle control, direct method execution, detached review lifecycle, review evidence normalization into CAS-RER records, safe session-inquiry replay, and `$st` conformance probes.
+
+For review evidence, the doctrine is:
+
+```text
+CAS records evidence.
+Workflows certify meaning.
+```
+
+CAS does not own closeout policy, clean streaks, architecture hardening mode, PR closure, or semantic reviewer adjudication. Those are workflow-owned projections over CAS review evidence.
 
 For review work, the governing invariant is:
 
@@ -31,6 +40,7 @@ cas account status
 cas goal <resolve|get|set|clear|status|wait>
 cas smoke_check
 cas instance_runner
+cas review <run|current|list|import|inspect|validate-record>
 cas review_session
 cas session_inquiry <preflight|run|start|status|wait|interrupt|receipt|cleanup>
 cas conformance
@@ -42,20 +52,38 @@ cas conformance
 
 `cas session_inquiry` owns safe historical replay lifecycle for `$retrace`; see `references/retrace-session-inquiry.md`.
 
-## Review session boundary
+## Review evidence boundary
 
-Use `cas review_session` when detached review lifecycle control matters: persisted `reviewThreadId`, wait/status/interrupt, compatibility diagnostics, approval/runtime overrides, or repeatable review receipts.
+Public review consumers should read CAS review evidence as `CAS-RER-v1` records. Legacy receipts, raw event logs, lane records, and parent-session rows are import inputs or attachments, not peer truth objects.
+
+Current public ledger helpers:
+
+```bash
+cas review run --cwd <repo> --base <base> --json --fallback none
+cas review current --cwd <repo> --base <base> --json
+cas review list --cwd <repo> --base <base> --json
+cas review import --path <receipt.json> --json
+cas review inspect --record <rer.json> --json
+cas review validate-record --record <rer.json> --json
+```
+
+`cas review run` emits `CAS-RUN-v1` with a `CAS-RER-v1` record and broker decision for normal waited review evidence. `cas review current` and `cas review list` read the ledger records for the requested current tuple. `cas review import` normalizes legacy receipt/session artifacts into `CAS-RER-v1` and writes the record under:
+
+```text
+~/.codex/cas/review_ledger/records/<record_id>.json
+```
+
+Use `cas review inspect` and `cas review validate-record` for diagnostics and schema/invariant validation only. They have no workflow closeout authority.
+
+Use `cas review_session` when low-level detached review lifecycle control matters: persisted `reviewThreadId`, wait/status/interrupt, compatibility diagnostics, approval/runtime overrides, or migration/debug receipts.
 
 For ordinary one-review closure, prefer the broker:
 
 ```bash
-cas review_session run --cwd <repo> --base <base> --json --fallback none
+cas review run --cwd <repo> --base <base> --json --fallback none
 ```
 
-`run` waits, returns one caller-facing `reviewVerdict`, and includes
-`reviewBrokerDecision` so callers can see whether CAS created a new attempt,
-normalized terminal evidence, auto-replaced a proven-dead transport, or blocked
-because an active attempt might still be live.
+The public broker output is `CAS-RUN-v1`: one `CAS-RER-v1` record plus a broker decision. If a low-level `review_session` command returns the legacy `reviewBrokerDecision + reviewVerdict` surface, immediately import or normalize the persisted artifact before a workflow consumes it as evidence.
 
 For local detached review inspection, prefer:
 
@@ -71,7 +99,7 @@ fields. Use `--review-thread-id <id>` when checking a non-latest session or
 when a workflow already owns the handle. Do not use latest-session selection
 for destructive control; `interrupt` requires an explicit `reviewThreadId`.
 
-Use `cas review_session lane` only when persistent review-lane capability is current for the active `cas`/`codex`/repo tuple. The lane owns transport reuse only. Callers still own review adjudication, clean-streak accounting, proof gates, commits, PR comments, and closure decisions.
+Use `cas review_session lane` only for debugging, migration, or broker backend diagnostics. A persistent lane owns transport reuse only. It is not canonical proof and not a workflow policy backend.
 
 If a caller only needs low-level start/wait control, use:
 
@@ -84,6 +112,8 @@ when the waited review reaches terminal state with a trusted review result and
 complete tuple identity. Use `receipt normalize` for saved outputs, fixture
 summaries, or an explicit requested-tuple recheck, not as the normal review
 happy path.
+
+Do not branch production workflow logic on `receipt gate`, `lane status`, raw `start/wait` output, diagnostic proof/inspect output, or raw receipts. Import them into CAS-RER first, then let the owning workflow apply its policy.
 
 ## CLI spec order
 
@@ -298,8 +328,8 @@ stale => require explicit takeover
 Default repeated review commands consume cached terminal evidence; they are not
 new independent review runs. For workflows that require multiple independent CAS
 reviews on the same tuple, callers must request each additional post-terminal
-attempt with `--fresh-attempt REASON` and evaluate the resulting review verdicts
-outside CAS. CAS does not own clean streaks, final eligibility, or verdict
+attempt with `--fresh-attempt REASON` and evaluate the resulting CAS-RER records
+outside CAS. CAS does not own clean streaks, final eligibility, or closeout
 strength.
 
 ## Hooks, approvals, and fallback
@@ -308,20 +338,26 @@ strength.
 
 `--fallback native-review` is explicit degraded verdict preservation. It is not detached CAS review transport and must be reported as `backendClass="cas-native-fallback"` with `fallbackUsed=true`.
 
-Do not infer success from app-server process liveness, `reviewThreadId` creation alone, `start --wait` returning, archived threads, or a terminal turn status. Structured `reviewVerdict` decides caller control flow.
+Do not infer success from app-server process liveness, `reviewThreadId` creation alone, `start --wait` returning, archived threads, or a terminal turn status. A `CAS-RER-v1` record, or an explicitly imported/validated projection into one, is the workflow-consumable evidence surface.
 
 ## Tools and examples
 
 Reference validators and classifiers:
 
 ```bash
+cas review import --path <receipt.json> --cwd <repo> --base <base> --json
+cas review current --cwd <repo> --base <base> --json
+cas review list --cwd <repo> --base <base> --json
+cas review inspect --record <rer.json> --json
+cas review validate-record --record <rer.json> --json
 cas review_session status --latest --json
 cas review_session wait --latest --json
 cas review_session run --cwd <repo> --base <base> --json
-cas review_session receipt gate --path <receipt.json> --format json
 cas review_session lock gate --path <lock.json> --format json
 cas review_session receipt classify --path <receipts.jsonl> --format jsonl
 ```
+
+`cas review_session receipt gate` is compatibility-only. Do not use it as a production gate; import to CAS-RER and validate the record instead.
 
 Example receipts live under `assets/`.
 
@@ -331,6 +367,7 @@ When reporting CAS review work, include:
 
 ```text
 CAS Review:
+- recordId / schema:
 - backend:
 - reviewAttemptPhase:
 - reviewAttemptExists:
@@ -348,14 +385,14 @@ CAS Review:
 
 - A lane is not a review.
 - A review starts at `reviewThreadId`.
-- CAS reports tuple-bound `reviewVerdict`; caller workflows decide what that means.
-- Use `cas review_session run` as the normal one-review path.
+- CAS records tuple-bound CAS-RER evidence; caller workflows decide what that means.
+- Use `cas review run` as the normal one-review path, and import/validate legacy artifacts before workflow consumption.
 - Do not treat `pre_review_lane_transport_lost` as a failed review.
 - Do not duplicate a review when an active tuple lock points to an existing `reviewThreadId`.
 - Do not manually list and `jq` review-session records when latest-session status is enough; use `cas review_session status --latest --json`, then verify tuple fields before acting.
 - Do not treat completed findings as transport failure.
 - Do not treat `usageLimitExceeded` as reviewer output or transport failure.
 - Do not rely on persistent lane continuity for repeated-review policy until first-review creation smoke is current.
-- `start --wait` evidence is strict review input only when its `reviewVerdict` is tuple-bound; otherwise normalize or recover first.
+- `start --wait` evidence is workflow input only after it is represented as tuple-bound CAS-RER evidence; otherwise import, normalize, or recover first.
 - `cas smoke_check` is protocol validation, not review output.
 - Native fallback is degraded verdict preservation, not detached CAS review transport.

--- a/codex/skills/cas/SKILL.md
+++ b/codex/skills/cas/SKILL.md
@@ -40,7 +40,6 @@ cas account status
 cas goal <resolve|get|set|clear|status|wait>
 cas smoke_check
 cas instance_runner
-cas review <run|current|list|import|inspect|validate-record>
 cas review_session
 cas session_inquiry <preflight|run|start|status|wait|interrupt|receipt|cleanup>
 cas conformance
@@ -54,9 +53,25 @@ cas conformance
 
 ## Review evidence boundary
 
-Public review consumers should read CAS review evidence as `CAS-RER-v1` records. Legacy receipts, raw event logs, lane records, and parent-session rows are import inputs or attachments, not peer truth objects.
+Public review consumers should prefer `CAS-RER-v1` records when the installed
+dispatcher emits them. On current dispatchers that expose only
+`cas review_session`, consume the normalized tuple-bound `reviewVerdict` from
+`cas review_session run` as the compatibility projection, and do not pretend a
+cached receipt is an independent CAS-RER record. Legacy receipts, raw event
+logs, lane records, and parent-session rows are import inputs or attachments,
+not peer truth objects.
 
-Current public ledger helpers:
+Current production helpers:
+
+```bash
+cas review_session run --cwd <repo> --base <base> --json --fallback none
+cas review_session status --latest --json
+cas review_session wait --latest --json
+cas review_session receipt normalize --path <receipt.json> --format json --summary
+cas review_session receipt classify --path <receipts.jsonl> --format jsonl
+```
+
+When available, newer ledger helpers have this shape:
 
 ```bash
 cas review run --cwd <repo> --base <base> --json --fallback none
@@ -77,13 +92,13 @@ Use `cas review inspect` and `cas review validate-record` for diagnostics and sc
 
 Use `cas review_session` when low-level detached review lifecycle control matters: persisted `reviewThreadId`, wait/status/interrupt, compatibility diagnostics, approval/runtime overrides, or migration/debug receipts.
 
-For ordinary one-review closure, prefer the broker:
+For ordinary one-review closure on the current dispatcher, prefer the shipped broker:
 
 ```bash
-cas review run --cwd <repo> --base <base> --json --fallback none
+cas review_session run --cwd <repo> --base <base> --json --fallback none
 ```
 
-The public broker output is `CAS-RUN-v1`: one `CAS-RER-v1` record plus a broker decision. If a low-level `review_session` command returns the legacy `reviewBrokerDecision + reviewVerdict` surface, immediately import or normalize the persisted artifact before a workflow consumes it as evidence.
+The current broker output is the legacy `reviewBrokerDecision + reviewVerdict` surface. Consume it as workflow evidence only when `reviewVerdict.tupleVerdictExists=true` and the base/head/fingerprint match the requested tuple. If the newer `cas review` ledger surface is available, prefer its `CAS-RUN-v1` output: one `CAS-RER-v1` record plus a broker decision.
 
 For local detached review inspection, prefer:
 
@@ -113,7 +128,7 @@ complete tuple identity. Use `receipt normalize` for saved outputs, fixture
 summaries, or an explicit requested-tuple recheck, not as the normal review
 happy path.
 
-Do not branch production workflow logic on `receipt gate`, `lane status`, raw `start/wait` output, diagnostic proof/inspect output, or raw receipts. Import them into CAS-RER first, then let the owning workflow apply its policy.
+Do not branch production workflow logic on `receipt gate`, `lane status`, raw `start/wait` output, diagnostic proof/inspect output, or raw receipts. Normalize them to tuple-bound `reviewVerdict`, or import them into CAS-RER when the ledger surface exists, then let the owning workflow apply its policy.
 
 ## CLI spec order
 
@@ -329,8 +344,8 @@ Default repeated review commands consume cached terminal evidence; they are not
 new independent review runs. For workflows that require multiple independent CAS
 reviews on the same tuple, callers must request each additional post-terminal
 attempt with `--fresh-attempt REASON` and evaluate the resulting CAS-RER records
-outside CAS. CAS does not own clean streaks, final eligibility, or closeout
-strength.
+or tuple-bound compatibility projections outside CAS. CAS does not own clean
+streaks, final eligibility, or closeout strength.
 
 ## Hooks, approvals, and fallback
 
@@ -338,26 +353,26 @@ strength.
 
 `--fallback native-review` is explicit degraded verdict preservation. It is not detached CAS review transport and must be reported as `backendClass="cas-native-fallback"` with `fallbackUsed=true`.
 
-Do not infer success from app-server process liveness, `reviewThreadId` creation alone, `start --wait` returning, archived threads, or a terminal turn status. A `CAS-RER-v1` record, or an explicitly imported/validated projection into one, is the workflow-consumable evidence surface.
+Do not infer success from app-server process liveness, `reviewThreadId` creation alone, `start --wait` returning, archived threads, or a terminal turn status. A `CAS-RER-v1` record, or a normalized tuple-bound `reviewVerdict` compatibility projection, is the workflow-consumable evidence surface.
 
 ## Tools and examples
 
 Reference validators and classifiers:
 
 ```bash
-cas review import --path <receipt.json> --cwd <repo> --base <base> --json
-cas review current --cwd <repo> --base <base> --json
-cas review list --cwd <repo> --base <base> --json
-cas review inspect --record <rer.json> --json
-cas review validate-record --record <rer.json> --json
 cas review_session status --latest --json
 cas review_session wait --latest --json
 cas review_session run --cwd <repo> --base <base> --json
 cas review_session lock gate --path <lock.json> --format json
+cas review_session receipt normalize --path <receipt.json> --format json --summary
 cas review_session receipt classify --path <receipts.jsonl> --format jsonl
 ```
 
-`cas review_session receipt gate` is compatibility-only. Do not use it as a production gate; import to CAS-RER and validate the record instead.
+Use `cas review <run|current|list|import|inspect|validate-record>` only after
+`cas --help` or `cas capabilities` confirms that subcommand exists in the
+installed dispatcher.
+
+`cas review_session receipt gate` is compatibility-only. Do not use it as a production gate; normalize or import to tuple-bound evidence instead.
 
 Example receipts live under `assets/`.
 
@@ -367,7 +382,7 @@ When reporting CAS review work, include:
 
 ```text
 CAS Review:
-- recordId / schema:
+- recordId / schema, if emitted:
 - backend:
 - reviewAttemptPhase:
 - reviewAttemptExists:
@@ -385,8 +400,8 @@ CAS Review:
 
 - A lane is not a review.
 - A review starts at `reviewThreadId`.
-- CAS records tuple-bound CAS-RER evidence; caller workflows decide what that means.
-- Use `cas review run` as the normal one-review path, and import/validate legacy artifacts before workflow consumption.
+- CAS records tuple-bound review evidence; caller workflows decide what that means.
+- Use `cas review_session run` as the current normal one-review path unless the installed dispatcher exposes `cas review run`.
 - Do not treat `pre_review_lane_transport_lost` as a failed review.
 - Do not duplicate a review when an active tuple lock points to an existing `reviewThreadId`.
 - Do not manually list and `jq` review-session records when latest-session status is enough; use `cas review_session status --latest --json`, then verify tuple fields before acting.

--- a/codex/skills/cas/SKILL.md
+++ b/codex/skills/cas/SKILL.md
@@ -408,6 +408,6 @@ CAS Review:
 - Do not treat completed findings as transport failure.
 - Do not treat `usageLimitExceeded` as reviewer output or transport failure.
 - Do not rely on persistent lane continuity for repeated-review policy until first-review creation smoke is current.
-- `start --wait` evidence is workflow input only after it is represented as tuple-bound CAS-RER evidence; otherwise import, normalize, or recover first.
+- `start --wait` evidence is workflow input only after it is represented as tuple-bound review evidence; otherwise import, normalize, or recover first.
 - `cas smoke_check` is protocol validation, not review output.
 - Native fallback is degraded verdict preservation, not detached CAS review transport.

--- a/codex/skills/goal-actuating/SKILL.md
+++ b/codex/skills/goal-actuating/SKILL.md
@@ -75,7 +75,7 @@ goal_actuating_mode:
 11. Execute one useful action at a time with `$goal-grind`, unless `$st` owns execution.
 12. Fold verification, review, and subagent results with `$evidence-fold`, `$review-fold`, or the closure-agenda pass as appropriate.
 13. Use `$failure-memory` when failures or review classes repeat.
-14. For `review-fix` and exhaustive review, require three consecutive clean normalized `$cas` review runs on the same artifact scope before completion.
+14. For `review-fix` and exhaustive review, require three consecutive clean CAS-RER review records on the same artifact scope before completion.
 15. Close with `$proof-patch`, or hand off to `$ship` only when publication is requested and ready.
 16. Run ATCG-v1 terminal closure gate before reporting goal completion.
 
@@ -205,7 +205,7 @@ $cas review
 -> $goal-grind accepted liabilities only
 -> optional patch-fanout over disjoint accepted liabilities only
 -> $evidence-fold
--> 3 clean normalized $cas review runs
+-> 3 clean CAS-RER review records
 -> $proof-patch
 ```
 
@@ -227,17 +227,17 @@ Prefer `refactor-kernel` when several findings share one missing abstraction, in
 
 Exhaustive review is not optional once requested or required. `$review-fold` controls which findings become code changes; it must not remove the CAS review gate.
 
-## Three clean normalized CAS review runs
+## Three clean CAS-RER review records
 
-For `review-fix` and exhaustive review, completion requires three consecutive clean normalized `$cas` review runs against the same artifact scope unless the user explicitly lowers the review bar.
+For `review-fix` and exhaustive review, completion requires three consecutive clean CAS-RER review records against the same artifact scope unless the user explicitly lowers the review bar.
 
-A clean normalized CAS run means `$cas` produces no new in-scope accepted liability, unresolved proof gap, unresolved refactor-kernel candidate, or human-owned blocker after `$review-fold` and the closure-agenda pass.
+A clean CAS-RER review record means `$cas` recorded current-tuple evidence with `verdict.status=clean`, strong usable principal for the caller's proof bar, and no new in-scope accepted liability, unresolved proof gap, unresolved refactor-kernel candidate, or human-owned blocker after `$review-fold` and the closure-agenda pass.
 
 Do not reset the clean-run counter for findings that are duplicate, rejected, out-of-scope, already-proven proof-only, follow-up, or already addressed by the current implementation.
 
 Do not increment the clean-run counter from repeated normalization of one cached
-CAS receipt. After terminal evidence exists for the tuple, request each
-additional independent run with `--fresh-attempt REASON`, then track the streak in the caller workflow from independent CAS review verdicts. CAS does not own the streak.
+CAS receipt or record. After terminal evidence exists for the tuple, request each
+additional independent run with `--fresh-attempt REASON`, then track the streak in the caller workflow from independent CAS-RER records. CAS does not own the streak.
 
 Reset the clean-run counter to zero when:
 
@@ -246,7 +246,7 @@ code changes
 review scope changes
 base/head/diff changes
 accepted proof bar changes
-CAS lane/session continuity is lost
+the workflow cannot prove CAS-RER records are current, strong, and distinct
 accepted parallel patch result is integrated
 branch-race winner is integrated
 serial integration changes the artifact
@@ -335,7 +335,7 @@ verification regresses
 proof is stale or not bound to the current artifact
 public tracker side effect would be needed without explicit intent
 review is required but $cas review is unavailable or not run
-three clean normalized $cas review runs are required but cannot be completed
+three clean CAS-RER review records are required but cannot be completed
 parallel fanout would cross shared invariants or conflicting resources
 ATCG-v1 does not return can_mark_goal_complete=yes
 ```
@@ -357,8 +357,8 @@ Goal Actuation:
   - integration order:
   - conflicts:
   - CAS clean-run counter reset: yes|no
-- review source / CAS verdict, if required:
-- clean normalized CAS review runs: 0|1|2|3|not-required
+- review source / CAS-RER record, if required:
+- clean CAS-RER review records: 0|1|2|3|not-required
 - goal contract summary:
 - work list / next action:
 - review-fold disposition, if any:

--- a/codex/skills/goal-actuating/SKILL.md
+++ b/codex/skills/goal-actuating/SKILL.md
@@ -56,7 +56,7 @@ goal_actuating_mode:
 - `direct-goal`: execute a goal that already has outcome, constraints, and proof checks.
 - `review-only`: classify review findings and stop without mutation.
 - `agenda-only`: classify findings and produce a closure agenda without mutation.
-- `review-fix`: default review mode; classify findings, implement accepted liabilities only, and require caller-owned repeated clean CAS review runs before completion.
+- `review-fix`: default review mode; classify findings, implement accepted liabilities only, and require caller-owned repeated clean CAS review evidence units before completion.
 - `dry-plan`: show the goal contract and work list only; do not mutate.
 - `st-governed`: hand off to `$st` with bounded execution slices when durable coordination owns the work.
 
@@ -75,7 +75,7 @@ goal_actuating_mode:
 11. Execute one useful action at a time with `$goal-grind`, unless `$st` owns execution.
 12. Fold verification, review, and subagent results with `$evidence-fold`, `$review-fold`, or the closure-agenda pass as appropriate.
 13. Use `$failure-memory` when failures or review classes repeat.
-14. For `review-fix` and exhaustive review, require three consecutive clean CAS-RER review records on the same artifact scope before completion.
+14. For `review-fix` and exhaustive review, require three consecutive clean CAS review evidence units on the same artifact scope before completion.
 15. Close with `$proof-patch`, or hand off to `$ship` only when publication is requested and ready.
 16. Run ATCG-v1 terminal closure gate before reporting goal completion.
 
@@ -205,7 +205,7 @@ $cas review
 -> $goal-grind accepted liabilities only
 -> optional patch-fanout over disjoint accepted liabilities only
 -> $evidence-fold
--> 3 clean CAS-RER review records
+-> 3 clean CAS review evidence units
 -> $proof-patch
 ```
 
@@ -227,17 +227,17 @@ Prefer `refactor-kernel` when several findings share one missing abstraction, in
 
 Exhaustive review is not optional once requested or required. `$review-fold` controls which findings become code changes; it must not remove the CAS review gate.
 
-## Three clean CAS-RER review records
+## Three clean CAS review evidence units
 
-For `review-fix` and exhaustive review, completion requires three consecutive clean CAS-RER review records against the same artifact scope unless the user explicitly lowers the review bar.
+For `review-fix` and exhaustive review, completion requires three consecutive clean CAS review evidence units against the same artifact scope unless the user explicitly lowers the review bar.
 
-A clean CAS-RER review record means `$cas` recorded current-tuple evidence with `verdict.status=clean`, strong usable principal for the caller's proof bar, and no new in-scope accepted liability, unresolved proof gap, unresolved refactor-kernel candidate, or human-owned blocker after `$review-fold` and the closure-agenda pass.
+A clean CAS review evidence unit is either a `CAS-RER-v1` record or, on dispatchers without the ledger surface, a normalized tuple-bound `reviewVerdict` compatibility projection. It must carry current-tuple clean evidence with strong usable principal for the caller's proof bar and must show no new in-scope accepted liability, unresolved proof gap, unresolved refactor-kernel candidate, or human-owned blocker after `$review-fold` and the closure-agenda pass.
 
 Do not reset the clean-run counter for findings that are duplicate, rejected, out-of-scope, already-proven proof-only, follow-up, or already addressed by the current implementation.
 
 Do not increment the clean-run counter from repeated normalization of one cached
 CAS receipt or record. After terminal evidence exists for the tuple, request each
-additional independent run with `--fresh-attempt REASON`, then track the streak in the caller workflow from independent CAS-RER records. CAS does not own the streak.
+additional independent run with `--fresh-attempt REASON`, then track the streak in the caller workflow from independent CAS review evidence units. CAS does not own the streak.
 
 Reset the clean-run counter to zero when:
 
@@ -246,7 +246,7 @@ code changes
 review scope changes
 base/head/diff changes
 accepted proof bar changes
-the workflow cannot prove CAS-RER records are current, strong, and distinct
+the workflow cannot prove CAS review evidence units are current, strong, and distinct
 accepted parallel patch result is integrated
 branch-race winner is integrated
 serial integration changes the artifact
@@ -335,7 +335,7 @@ verification regresses
 proof is stale or not bound to the current artifact
 public tracker side effect would be needed without explicit intent
 review is required but $cas review is unavailable or not run
-three clean CAS-RER review records are required but cannot be completed
+three clean CAS review evidence units are required but cannot be completed
 parallel fanout would cross shared invariants or conflicting resources
 ATCG-v1 does not return can_mark_goal_complete=yes
 ```
@@ -357,8 +357,8 @@ Goal Actuation:
   - integration order:
   - conflicts:
   - CAS clean-run counter reset: yes|no
-- review source / CAS-RER record, if required:
-- clean CAS-RER review records: 0|1|2|3|not-required
+- review source / CAS evidence unit, if required:
+- clean CAS review evidence units: 0|1|2|3|not-required
 - goal contract summary:
 - work list / next action:
 - review-fold disposition, if any:

--- a/codex/skills/recursion-scheme-planner/SKILL.md
+++ b/codex/skills/recursion-scheme-planner/SKILL.md
@@ -299,7 +299,7 @@ proof fanout
 disjoint patch fanout
 ```
 
-Route: subagents can work on leaves, but the lead owns fan-in, integration, proof, CAS-RER clean-record counting, and `$ship`.
+Route: subagents can work on leaves, but the lead owns fan-in, integration, proof, CAS review evidence clean-counting, and `$ship`.
 
 ## Review loop rule
 
@@ -314,7 +314,7 @@ $cas review
 -> $goal-grind accepted liabilities only
 -> optional patch-fanout over disjoint accepted liabilities only
 -> $evidence-fold
--> 3 clean CAS-RER review records
+-> 3 clean CAS review evidence units
 -> $proof-patch
 -> $ship only when PR update/publication is requested
 ```

--- a/codex/skills/recursion-scheme-planner/SKILL.md
+++ b/codex/skills/recursion-scheme-planner/SKILL.md
@@ -299,7 +299,7 @@ proof fanout
 disjoint patch fanout
 ```
 
-Route: subagents can work on leaves, but the lead owns fan-in, integration, proof, CAS clean-run counting, and `$ship`.
+Route: subagents can work on leaves, but the lead owns fan-in, integration, proof, CAS-RER clean-record counting, and `$ship`.
 
 ## Review loop rule
 
@@ -314,7 +314,7 @@ $cas review
 -> $goal-grind accepted liabilities only
 -> optional patch-fanout over disjoint accepted liabilities only
 -> $evidence-fold
--> 3 clean normalized $cas review runs
+-> 3 clean CAS-RER review records
 -> $proof-patch
 -> $ship only when PR update/publication is requested
 ```

--- a/codex/skills/recursion-scheme-planner/references/scheme-catalog.md
+++ b/codex/skills/recursion-scheme-planner/references/scheme-catalog.md
@@ -36,7 +36,7 @@ parallel PR review = ana(review classes) + parallel traversal + cata(closure fan
 For `review-fix` and exhaustive review:
 
 ```text
-3 consecutive clean normalized CAS review runs
+3 consecutive clean CAS-RER review records
 ```
 
-A clean normalized run is a fold result, not raw absence of comments. Duplicate, rejected, out-of-scope, already-proven proof-only, follow-up, or already-addressed findings do not dirty the run.
+A clean CAS-RER review record is a fold result over current-tuple `verdict.status=clean` evidence, not raw absence of comments. Duplicate, rejected, out-of-scope, already-proven proof-only, follow-up, or already-addressed findings do not dirty the record.

--- a/codex/skills/recursion-scheme-planner/references/scheme-catalog.md
+++ b/codex/skills/recursion-scheme-planner/references/scheme-catalog.md
@@ -36,7 +36,7 @@ parallel PR review = ana(review classes) + parallel traversal + cata(closure fan
 For `review-fix` and exhaustive review:
 
 ```text
-3 consecutive clean CAS-RER review records
+3 consecutive clean CAS review evidence units
 ```
 
-A clean CAS-RER review record is a fold result over current-tuple `verdict.status=clean` evidence, not raw absence of comments. Duplicate, rejected, out-of-scope, already-proven proof-only, follow-up, or already-addressed findings do not dirty the record.
+A clean CAS review evidence unit is a fold result over current-tuple clean evidence, not raw absence of comments. It can be a `CAS-RER-v1` record or, on dispatchers without the ledger surface, a normalized tuple-bound `reviewVerdict` compatibility projection. Duplicate, rejected, out-of-scope, already-proven proof-only, follow-up, or already-addressed findings do not dirty the unit.

--- a/codex/skills/review-fold/SKILL.md
+++ b/codex/skills/review-fold/SKILL.md
@@ -36,7 +36,7 @@ resolve pass = closure agenda compiler
 $goal-grind = implementation engine for accepted liabilities
 ```
 
-For `resolve-and-fix` and exhaustive review, final completion requires three consecutive clean CAS-RER review records after implementation. `$review-fold` decides whether each CAS-RER record is clean for the caller-owned policy, but clean-run counting must be backed by distinct current-tuple CAS attempts rather than repeated normalization of one cached receipt.
+For `resolve-and-fix` and exhaustive review, final completion requires three consecutive clean CAS review evidence units after implementation. `$review-fold` decides whether each evidence unit is clean for the caller-owned policy, but clean-run counting must be backed by distinct current-tuple CAS attempts rather than repeated normalization of one cached receipt.
 
 ## Review source rule
 
@@ -44,7 +44,7 @@ For `resolve-and-fix` and exhaustive review, final completion requires three con
 workflow-initiated code review -> $cas review -> $review-fold -> implementation only for accepted liabilities
 ```
 
-Existing PR comments, human reviewer comments, or prior CAS-RER records may be folded directly as review pressure. But if the workflow itself is asked to do code review, close review, run adversarial review, or satisfy a review proof bar, it must obtain that review through `$cas` first.
+Existing PR comments, human reviewer comments, or prior CAS review evidence may be folded directly as review pressure. But if the workflow itself is asked to do code review, close review, run adversarial review, or satisfy a review proof bar, it must obtain that review through `$cas` first.
 
 ## Review fold schema
 
@@ -123,7 +123,7 @@ review_fold:
 
 - `review-only`: classify findings and stop without a remediation agenda.
 - `resolve-only`: classify findings and produce a closure agenda without implementation.
-- `resolve-and-fix`: default `$actuating` review mode; implement only accepted code-change liabilities after the resolve pass, then require caller-owned repeated clean CAS review runs before completion.
+- `resolve-and-fix`: default `$actuating` review mode; implement only accepted code-change liabilities after the resolve pass, then require caller-owned repeated clean CAS review evidence units before completion.
 
 ### `adjudicate-only`
 
@@ -154,21 +154,21 @@ Hand off to `$st` when review remediation requires durable resource claims, exte
 When the source is `cas-exhaustive`, do not treat review as optional or merely advisory. Continue review/fix/fold cycles until one of these holds:
 
 ```text
-three consecutive clean CAS-RER review records are complete
+three consecutive clean CAS review evidence units are complete
 CAS review is blocked and the blocker is reported
 user explicitly lowers the review proof bar
 ```
 
-A clean CAS-RER review record means the record is current-tuple evidence with `verdict.status=clean`, strong usable principal for the caller's proof bar, and no new in-scope accepted liability, unresolved proof gap, unresolved refactor-kernel candidate, or human-owned blocker after `$review-fold` and the resolve pass. Duplicate, rejected, out-of-scope, already-proven proof-only, follow-up, or already-resolved findings do not make the record dirty.
+A clean CAS review evidence unit is either a `CAS-RER-v1` record or, on dispatchers without the ledger surface, a normalized tuple-bound `reviewVerdict` compatibility projection. It must carry current-tuple clean evidence with strong usable principal for the caller's proof bar and must show no new in-scope accepted liability, unresolved proof gap, unresolved refactor-kernel candidate, or human-owned blocker after `$review-fold` and the resolve pass. Duplicate, rejected, out-of-scope, already-proven proof-only, follow-up, or already-resolved findings do not make the unit dirty.
 
-Each clean record must be a distinct tuple-bound CAS review attempt. When a terminal
+Each clean unit must be a distinct tuple-bound CAS review attempt. When a terminal
 or normalized tuple record already exists, callers must request the next
 independent run with `--fresh-attempt REASON`; cached normalization of the same
 `reviewThreadId` does not increment the counter. Track the clean-run count in
-the caller workflow from CAS-RER record facts; `$cas` does not own that
+the caller workflow from CAS review evidence facts; `$cas` does not own that
 policy.
 
-Reset the clean-run counter to zero when code changes, review scope changes, base/head/diff changes, the proof bar changes, or the workflow cannot prove records are current, strong, and distinct.
+Reset the clean-run counter to zero when code changes, review scope changes, base/head/diff changes, the proof bar changes, or the workflow cannot prove CAS review evidence units are current, strong, and distinct.
 
 `$review-fold` may reject or mark findings proof-only, but it must not convert an exhaustive review gate into a no-review closure.
 
@@ -191,7 +191,7 @@ Reset the clean-run counter to zero when code changes, review scope changes, bas
 When called by `$actuating`:
 
 - default to `resolve-and-fix` for review requests;
-- require three consecutive clean CAS-RER records before completing `resolve-and-fix` or exhaustive review;
+- require three consecutive clean CAS review evidence units before completing `resolve-and-fix` or exhaustive review;
 - use `review-only` only when the user explicitly asks for no implementation or classification only;
 - use `resolve-only` only when the user explicitly asks for a plan/agenda without implementation;
 - preserve no-code dispositions for rejected, proof-only, follow-up, or human-owned findings;
@@ -216,6 +216,6 @@ no changes
 - Do not accept scope expansion without user authority.
 - Do not miss the refactor when many comments share one owner boundary.
 - Do not replace a requested or required CAS review with non-CAS critique.
-- Do not claim review closure before caller-owned repeated clean CAS-RER policy passes when `resolve-and-fix` or exhaustive review requires them.
-- Do not close from diagnostic inspect/proof output, `receipt gate`, lane status, raw receipts, or raw start/wait output; import/validate CAS-RER first.
+- Do not claim review closure before caller-owned repeated clean CAS review evidence policy passes when `resolve-and-fix` or exhaustive review requires it.
+- Do not close from diagnostic inspect/proof output, `receipt gate`, lane status, raw receipts, or raw start/wait output; normalize or import to tuple-bound CAS review evidence first.
 - Do not resolve or reply to PR threads without explicit public-side-effect intent.

--- a/codex/skills/review-fold/SKILL.md
+++ b/codex/skills/review-fold/SKILL.md
@@ -36,7 +36,7 @@ resolve pass = closure agenda compiler
 $goal-grind = implementation engine for accepted liabilities
 ```
 
-For `resolve-and-fix` and exhaustive review, final completion requires three consecutive clean normalized `$cas` review runs after implementation. `$review-fold` decides whether each CAS run is normalized clean, but clean-run counting must be backed by distinct tuple-bound CAS attempts rather than repeated normalization of one cached receipt.
+For `resolve-and-fix` and exhaustive review, final completion requires three consecutive clean CAS-RER review records after implementation. `$review-fold` decides whether each CAS-RER record is clean for the caller-owned policy, but clean-run counting must be backed by distinct current-tuple CAS attempts rather than repeated normalization of one cached receipt.
 
 ## Review source rule
 
@@ -44,7 +44,7 @@ For `resolve-and-fix` and exhaustive review, final completion requires three con
 workflow-initiated code review -> $cas review -> $review-fold -> implementation only for accepted liabilities
 ```
 
-Existing PR comments, human reviewer comments, or prior CAS verdicts may be folded directly as review pressure. But if the workflow itself is asked to do code review, close review, run adversarial review, or satisfy a review proof bar, it must obtain that review through `$cas` first.
+Existing PR comments, human reviewer comments, or prior CAS-RER records may be folded directly as review pressure. But if the workflow itself is asked to do code review, close review, run adversarial review, or satisfy a review proof bar, it must obtain that review through `$cas` first.
 
 ## Review fold schema
 
@@ -154,21 +154,21 @@ Hand off to `$st` when review remediation requires durable resource claims, exte
 When the source is `cas-exhaustive`, do not treat review as optional or merely advisory. Continue review/fix/fold cycles until one of these holds:
 
 ```text
-three consecutive clean normalized CAS review runs are complete
+three consecutive clean CAS-RER review records are complete
 CAS review is blocked and the blocker is reported
 user explicitly lowers the review proof bar
 ```
 
-A clean normalized CAS run means no new in-scope accepted liability, unresolved proof gap, unresolved refactor-kernel candidate, or human-owned blocker remains after `$review-fold` and the resolve pass. Duplicate, rejected, out-of-scope, already-proven proof-only, follow-up, or already-resolved findings do not make the run dirty.
+A clean CAS-RER review record means the record is current-tuple evidence with `verdict.status=clean`, strong usable principal for the caller's proof bar, and no new in-scope accepted liability, unresolved proof gap, unresolved refactor-kernel candidate, or human-owned blocker after `$review-fold` and the resolve pass. Duplicate, rejected, out-of-scope, already-proven proof-only, follow-up, or already-resolved findings do not make the record dirty.
 
-Each clean run must be a distinct tuple-bound CAS review attempt. When a terminal
-or normalized tuple receipt already exists, callers must request the next
+Each clean record must be a distinct tuple-bound CAS review attempt. When a terminal
+or normalized tuple record already exists, callers must request the next
 independent run with `--fresh-attempt REASON`; cached normalization of the same
 `reviewThreadId` does not increment the counter. Track the clean-run count in
-the caller workflow from fresh CAS review verdicts; `$cas` does not own that
+the caller workflow from CAS-RER record facts; `$cas` does not own that
 policy.
 
-Reset the clean-run counter to zero when code changes, review scope changes, base/head/diff changes, the proof bar changes, or CAS lane continuity is lost.
+Reset the clean-run counter to zero when code changes, review scope changes, base/head/diff changes, the proof bar changes, or the workflow cannot prove records are current, strong, and distinct.
 
 `$review-fold` may reject or mark findings proof-only, but it must not convert an exhaustive review gate into a no-review closure.
 
@@ -191,7 +191,7 @@ Reset the clean-run counter to zero when code changes, review scope changes, bas
 When called by `$actuating`:
 
 - default to `resolve-and-fix` for review requests;
-- require three consecutive clean normalized `$cas` review runs before completing `resolve-and-fix` or exhaustive review;
+- require three consecutive clean CAS-RER records before completing `resolve-and-fix` or exhaustive review;
 - use `review-only` only when the user explicitly asks for no implementation or classification only;
 - use `resolve-only` only when the user explicitly asks for a plan/agenda without implementation;
 - preserve no-code dispositions for rejected, proof-only, follow-up, or human-owned findings;
@@ -216,5 +216,6 @@ no changes
 - Do not accept scope expansion without user authority.
 - Do not miss the refactor when many comments share one owner boundary.
 - Do not replace a requested or required CAS review with non-CAS critique.
-- Do not claim review closure before caller-owned repeated clean CAS runs when `resolve-and-fix` or exhaustive review requires them.
+- Do not claim review closure before caller-owned repeated clean CAS-RER policy passes when `resolve-and-fix` or exhaustive review requires them.
+- Do not close from diagnostic inspect/proof output, `receipt gate`, lane status, raw receipts, or raw start/wait output; import/validate CAS-RER first.
 - Do not resolve or reply to PR threads without explicit public-side-effect intent.

--- a/codex/skills/review-fold/agents/openai.yaml
+++ b/codex/skills/review-fold/agents/openai.yaml
@@ -10,4 +10,4 @@ interface:
     review-only, resolve-only, resolve-and-fix, proof-only, minimal-fix,
     refactor-kernel, branch-race, or st-governed before code changes. If fresh or
     exhaustive workflow review is required and no CAS result is present, route to
-    $cas review first. Mark normalized CAS clean runs when closing review.
+    $cas review first. Mark clean CAS-RER records when closing review.

--- a/codex/skills/review-fold/agents/openai.yaml
+++ b/codex/skills/review-fold/agents/openai.yaml
@@ -10,4 +10,4 @@ interface:
     review-only, resolve-only, resolve-and-fix, proof-only, minimal-fix,
     refactor-kernel, branch-race, or st-governed before code changes. If fresh or
     exhaustive workflow review is required and no CAS result is present, route to
-    $cas review first. Mark clean CAS-RER records when closing review.
+    $cas review first. Mark clean CAS review evidence units when closing review.


### PR DESCRIPTION
## Summary

- Updates `$cas` documentation around CAS-RER review evidence and public `cas review` surfaces.
- Updates goal/actuating/review-fold workflow text so workflows consume CAS-RER records and own closeout policy.
- Demotes receipt gate, diagnostic inspect/proof output, lane status, raw receipts, and raw start/wait output as closeout proof.

## Validation

- `git diff --check`
- Skill text grep confirmed CAS-RER and diagnostic/receipt-gate boundaries are represented in affected workflow docs.
