### PR TITLE
Surface loop receipts in proof-patch

### DIFF
--- a/codex/skills/proof-patch/SKILL.md
+++ b/codex/skills/proof-patch/SKILL.md
@@ -30,9 +30,45 @@ This is not a release process. `$ship` still owns stronger publication/release g
 ## Changed
 ...
 
+## Loop governance
+- ALSR-v1:
+- HYL-v1:
+- latest HSR-v1:
+- selected loop:
+- fused/unfused:
+- verifier:
+- stop rule:
+- terminal fold:
+- ATCG-v1:
+- residual loop risk:
+
+If ALSR/HYL exists, summarize the current receipts and cite their artifact
+binding. If no ALSR/HYL exists because the run is direct-action fused, state
+`direct-action fused exemption` and still name the objective, artifact scope,
+verifier, stop rule, terminal fold, and side-effect boundary. Do not claim
+completion unless ATCG-v1 permits it.
+
+## Review closure
+- CAS review source:
+- review-fold disposition:
+- resolve pass:
+- accepted liabilities:
+- no-code dispositions:
+- clean normalized CAS runs:
+- cached CAS receipts counted as fresh: no
+
 ## Review disposition
 | Class | Disposition | Why |
 |---|---|---|
+
+## Parallelism
+- mode:
+- safe frontier:
+- subagents used:
+- fan-in reducer:
+- accepted/rejected results:
+- integration order:
+- CAS clean-run reset:
 
 ## Evidence
 | Check | Result | Notes |
@@ -56,15 +92,25 @@ This is not a release process. `$ship` still owns stronger publication/release g
 
 1. Bind to current branch/head/diff or state that artifact binding is unavailable.
 2. Summarize only the changes relevant to the goal.
-3. Include evidence commands and results.
-4. Include review-fold disposition when review pressure was present.
-5. Include anti-gaming checks.
-6. Name residual risks and focused human review targets.
-7. Hand off to `$ship` only when PR/release/publication gates are required.
+3. Surface loop governance from ALSR-v1/HYL-v1/HSR-v1/ATCG-v1 receipts when
+   they exist; otherwise state the direct-action fused exemption.
+4. Include evidence commands and results.
+5. Include review closure and review-fold disposition when review pressure was
+   present.
+6. Include parallelism state, even when the mode is `none`.
+7. Include anti-gaming checks.
+8. Name residual risks and focused human review targets.
+9. Hand off to `$ship` only when PR/release/publication gates are required.
 
 ## Guardrails
 
 - Do not turn proof into marketing.
 - Do not hide failed or unavailable verification.
 - Do not claim review closure without review disposition.
+- Do not count cached CAS receipts as fresh clean CAS runs.
+- Do not claim completion unless ATCG-v1 permits it.
+- Do not claim completion unless ATCG-v1 returns a completion verdict that
+  permits completion.
 - Do not replace `$ship` for release or public-side-effect authority.
+- Do not publish, update PR state, resolve GitHub threads, or perform delivery
+  side effects; `$ship` owns that boundary.

--- a/codex/skills/proof-patch/agents/openai.yaml
+++ b/codex/skills/proof-patch/agents/openai.yaml
@@ -5,6 +5,9 @@ interface:
   short_description: "Create current-artifact proof summaries for goal completion and PR handoff"
   default_prompt: >-
     Use $proof-patch before final /goal completion or PR handoff. Bind to current
-    artifact state, summarize changed paths, validation, review dispositions,
-    anti-gaming checks, residual risk, and human review focus. Escalate to $ship
-    only for stronger publication or release gates.
+    artifact state, summarize changed paths, loop governance receipts, review
+    closure, parallelism, validation, review dispositions, anti-gaming checks,
+    residual risk, and human review focus. State direct-action fused exemption
+    when ALSR/HYL is absent, never count cached CAS receipts as fresh clean runs,
+    and do not claim completion unless ATCG-v1 permits it. Escalate to $ship only
+    for publication, PR updates, thread resolution, or stronger release gates.

--- a/codex/skills/proof-patch/tests/test_contract.py
+++ b/codex/skills/proof-patch/tests/test_contract.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env -S uv run python
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SKILL = (ROOT / "SKILL.md").read_text(encoding="utf-8")
+AGENT = (ROOT / "agents" / "openai.yaml").read_text(encoding="utf-8")
+NORMALIZED_AGENT = " ".join(AGENT.split())
+
+
+class ProofPatchContractTests(unittest.TestCase):
+    def test_loop_governance_fields_are_required(self) -> None:
+        fields = [
+            "## Loop governance",
+            "- ALSR-v1:",
+            "- HYL-v1:",
+            "- latest HSR-v1:",
+            "- selected loop:",
+            "- fused/unfused:",
+            "- verifier:",
+            "- stop rule:",
+            "- terminal fold:",
+            "- ATCG-v1:",
+            "- residual loop risk:",
+        ]
+        for field in fields:
+            with self.subTest(field=field):
+                self.assertIn(field, SKILL)
+
+    def test_review_closure_fields_are_required(self) -> None:
+        fields = [
+            "## Review closure",
+            "- CAS review source:",
+            "- review-fold disposition:",
+            "- resolve pass:",
+            "- accepted liabilities:",
+            "- no-code dispositions:",
+            "- clean normalized CAS runs:",
+            "- cached CAS receipts counted as fresh: no",
+        ]
+        for field in fields:
+            with self.subTest(field=field):
+                self.assertIn(field, SKILL)
+
+    def test_parallelism_fields_are_required(self) -> None:
+        fields = [
+            "## Parallelism",
+            "- mode:",
+            "- safe frontier:",
+            "- subagents used:",
+            "- fan-in reducer:",
+            "- accepted/rejected results:",
+            "- integration order:",
+            "- CAS clean-run reset:",
+        ]
+        for field in fields:
+            with self.subTest(field=field):
+                self.assertIn(field, SKILL)
+
+    def test_completion_and_publication_boundaries_are_explicit(self) -> None:
+        required_phrases = [
+            "direct-action fused exemption",
+            "Do not claim completion unless ATCG-v1 permits it.",
+            "Do not count cached CAS receipts as fresh clean CAS runs.",
+            "Do not publish, update PR state, resolve GitHub threads",
+            "$ship` owns that boundary",
+        ]
+        for phrase in required_phrases:
+            with self.subTest(phrase=phrase):
+                self.assertIn(phrase, SKILL)
+
+    def test_agent_prompt_mentions_new_receipt_surfaces(self) -> None:
+        required_phrases = [
+            "loop governance receipts",
+            "review closure",
+            "parallelism",
+            "direct-action fused exemption",
+            "never count cached CAS receipts as fresh clean runs",
+            "do not claim completion unless ATCG-v1 permits it",
+            "Escalate to $ship only",
+        ]
+        for phrase in required_phrases:
+            with self.subTest(phrase=phrase):
+                self.assertIn(phrase, NORMALIZED_AGENT)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add loop governance, review closure, and parallelism sections to proof-patch output.
- Require direct-action fused exemption, ATCG completion guard, cached-CAS freshness guard, and ship/publication boundary language.
- Add regression tests for the proof-patch contract fields and boundaries.

## Proof
- `uv run python -m unittest discover -s codex/skills/proof-patch/tests -p 'test_*.py'`: pass
- `uv run --with pyyaml -- python3 /Users/tk/.dotfiles/codex/skills/.system/skill-creator/scripts/quick_validate.py /tmp/dotfiles-proof-patch-land.xcJsGN/codex/skills/proof-patch`: pass
- `git -C /tmp/dotfiles-proof-patch-land.xcJsGN diff --check origin/main..HEAD`: pass

## Scope
- branch: codex/proof-patch-loop-receipts
- head: 5ce16c53
- base: main

## Readiness
- PR mode: ready
- Reason: scoped skill contract change with focused regression coverage.
- Caveats: the shared skill quick validator is local-only and not present on origin/main, so it was run from the main worktree against the isolated branch.