### PR TITLE
Add ATCG advisory validation

### DIFF
--- a/codex/skills/actuating/assets/terminal-context.advisory-fused.example.json
+++ b/codex/skills/actuating/assets/terminal-context.advisory-fused.example.json
@@ -1,0 +1,70 @@
+{
+  "actuation_terminal_context": {
+    "run_id": "ACT-terminal-advisory-fused",
+    "source": "direct_goal",
+    "closure_candidate": "proof-patch",
+    "artifact_scope": {
+      "repo": "tkersey/example",
+      "branch": "feature/example",
+      "head_sha": "abc123",
+      "diff_fingerprint": "diff:clean",
+      "dirty_state": "clean"
+    },
+    "local_proof": {
+      "evidence_fold_verdict": "done",
+      "commands": [
+        "uv run python codex/skills/actuating/tests/test_actuation_terminal_gate.py"
+      ]
+    },
+    "proof_patch": {
+      "required": "yes",
+      "present": "yes",
+      "current": "yes",
+      "ref": "proof-patch:abc123"
+    },
+    "cas_review": {
+      "required": "no",
+      "clean_runs_required": 0,
+      "clean_runs_count": 0,
+      "independent_fresh_runs": "no",
+      "tuple_bound": "no",
+      "tuple": {}
+    },
+    "delivery": {
+      "pr_intent": "no",
+      "publication_required": "no",
+      "add_v1_decision": {
+        "verdict": "shipping_not_requested",
+        "ref": "add-v1:none"
+      },
+      "ship_result": {
+        "present": "no",
+        "current": "unknown",
+        "pr_url": "",
+        "ref": ""
+      }
+    },
+    "final_report_fields": {
+      "normalized_cas_clean_runs": "not-required",
+      "proof_patch_or_ship_handoff": "proof-patch",
+      "blockers_residual_risk": "none"
+    },
+    "loop_governance": {
+      "mode": "direct_action_fused",
+      "direct_action_fused": "yes",
+      "side_effect_boundary": {
+        "respected": "yes"
+      },
+      "proof": {
+        "required": "yes",
+        "matches_verifier": "yes"
+      }
+    }
+  },
+  "advisory_expectation": {
+    "would_block": false,
+    "would_block_reasons": [],
+    "can_mark_goal_complete": true,
+    "next_owner": "none"
+  }
+}

--- a/codex/skills/actuating/assets/terminal-context.advisory-st-governed.example.json
+++ b/codex/skills/actuating/assets/terminal-context.advisory-st-governed.example.json
@@ -1,0 +1,72 @@
+{
+  "actuation_terminal_context": {
+    "run_id": "ACT-terminal-advisory-st-governed",
+    "source": "st_handoff",
+    "closure_candidate": "proof-patch",
+    "artifact_scope": {
+      "repo": "tkersey/example",
+      "branch": "feature/example",
+      "head_sha": "abc123",
+      "diff_fingerprint": "diff:clean",
+      "dirty_state": "clean"
+    },
+    "local_proof": {
+      "evidence_fold_verdict": "done",
+      "commands": [
+        "uv run python codex/skills/actuating/tests/test_actuation_terminal_gate.py"
+      ]
+    },
+    "proof_patch": {
+      "required": "yes",
+      "present": "yes",
+      "current": "yes",
+      "ref": "proof-patch:abc123"
+    },
+    "cas_review": {
+      "required": "no",
+      "clean_runs_required": 0,
+      "clean_runs_count": 0,
+      "independent_fresh_runs": "no",
+      "tuple_bound": "no",
+      "tuple": {}
+    },
+    "delivery": {
+      "pr_intent": "no",
+      "publication_required": "no",
+      "add_v1_decision": {
+        "verdict": "shipping_not_requested",
+        "ref": "add-v1:none"
+      },
+      "ship_result": {
+        "present": "no",
+        "current": "unknown",
+        "pr_url": "",
+        "ref": ""
+      }
+    },
+    "final_report_fields": {
+      "normalized_cas_clean_runs": "not-required",
+      "proof_patch_or_ship_handoff": "proof-patch",
+      "blockers_residual_risk": "none"
+    },
+    "loop_governance": {
+      "mode": "st_governed",
+      "st_control": {
+        "current": "yes"
+      },
+      "side_effect_boundary": {
+        "respected": "yes"
+      },
+      "proof": {
+        "required": "yes",
+        "matches_verifier": "yes"
+      }
+    }
+  },
+  "advisory_expectation": {
+    "would_block": false,
+    "would_block_reasons": [],
+    "can_mark_goal_complete": true,
+    "next_owner": "none"
+  }
+}

--- a/codex/skills/actuating/assets/terminal-context.advisory-would-block.example.json
+++ b/codex/skills/actuating/assets/terminal-context.advisory-would-block.example.json
@@ -1,0 +1,118 @@
+{
+  "actuation_terminal_context": {
+    "run_id": "ACT-terminal-advisory-would-block",
+    "source": "accepted_spec",
+    "closure_candidate": "proof-patch",
+    "artifact_scope": {
+      "repo": "tkersey/example",
+      "branch": "feature/example",
+      "head_sha": "abc123",
+      "diff_fingerprint": "diff:clean",
+      "dirty_state": "clean"
+    },
+    "local_proof": {
+      "evidence_fold_verdict": "done",
+      "commands": [
+        "uv run python codex/skills/actuating/tests/test_actuation_terminal_gate.py"
+      ]
+    },
+    "proof_patch": {
+      "required": "yes",
+      "present": "yes",
+      "current": "yes",
+      "ref": "proof-patch:abc123"
+    },
+    "cas_review": {
+      "required": "no",
+      "clean_runs_required": 0,
+      "clean_runs_count": 0,
+      "independent_fresh_runs": "no",
+      "tuple_bound": "no",
+      "tuple": {}
+    },
+    "delivery": {
+      "pr_intent": "no",
+      "publication_required": "no",
+      "add_v1_decision": {
+        "verdict": "shipping_not_requested",
+        "ref": "add-v1:none"
+      },
+      "ship_result": {
+        "present": "no",
+        "current": "unknown",
+        "pr_url": "",
+        "ref": ""
+      }
+    },
+    "final_report_fields": {
+      "normalized_cas_clean_runs": "not-required",
+      "proof_patch_or_ship_handoff": "proof-patch",
+      "blockers_residual_risk": "none"
+    },
+    "loop_governance": {
+      "mode": "ALSR-HYL",
+      "material": "yes",
+      "alsr": {
+        "required": "yes",
+        "present": "no",
+        "current": "no"
+      },
+      "hyl": {
+        "required": "yes",
+        "present": "no",
+        "current": "no"
+      },
+      "hsr": {
+        "terminal_present": "no",
+        "latest_fold_current_artifact_bound": "no",
+        "material_mutations": [
+          {
+            "has_unfold": "yes",
+            "has_action": "yes",
+            "has_fold": "no"
+          }
+        ]
+      },
+      "selected_loop": {
+        "matches_task_shape": "no"
+      },
+      "review_fix": {
+        "required": "yes",
+        "cas_reviewed": "no",
+        "review_folded": "no",
+        "resolve_passed": "no"
+      },
+      "cas_clean_runs": {
+        "required": "yes",
+        "required_count": 3,
+        "count": 1,
+        "independent_fresh_runs": "yes",
+        "tuple_bound": "yes"
+      },
+      "side_effect_boundary": {
+        "respected": "no"
+      },
+      "proof": {
+        "required": "yes",
+        "matches_verifier": "no"
+      }
+    }
+  },
+  "advisory_expectation": {
+    "would_block": true,
+    "would_block_reasons": [
+      "blocked-alsr-missing",
+      "blocked-hyl-missing",
+      "blocked-hylo-terminal-missing",
+      "blocked-material-mutation-without-hsr",
+      "blocked-latest-fold-not-current-artifact-bound",
+      "blocked-selected-loop-task-shape-mismatch",
+      "blocked-review-fix-protocol",
+      "blocked-cas-clean-runs-incomplete",
+      "blocked-side-effect-boundary",
+      "blocked-proof-verifier-mismatch"
+    ],
+    "can_mark_goal_complete": false,
+    "next_owner": "$cas"
+  }
+}

--- a/codex/skills/actuating/references/terminal-closure-gate.md
+++ b/codex/skills/actuating/references/terminal-closure-gate.md
@@ -92,6 +92,46 @@ tracked-dirty artifact + current proof-patch receipt -> may complete
 tracked-dirty artifact without proof-patch receipt -> blocked
 ```
 
+## Advisory validation
+
+Advisory mode reports ATCG-v1 completion blockers without enforcing them. A
+would-block advisory result is evidence for the caller, not a terminal stop
+condition by itself.
+
+```json
+{
+  "verdict": "advisory",
+  "would_block": true,
+  "would_block_reasons": [
+    "blocked-hylo-terminal-missing"
+  ],
+  "can_mark_goal_complete": false,
+  "next_owner": "$goal-actuating"
+}
+```
+
+Advisory mode checks loop governance and terminal proof state in the same
+required-check order used by `$actuating`:
+
+```text
+ALSR exists when required
+ALSR current against branch/head/diff
+HYL exists when recursive/material
+terminal HSR exists
+every material mutation has HSR unfold/action/fold
+latest fold is current-artifact-bound
+selected loop matches task shape
+review-fix obeyed CAS/review-fold/resolve
+three clean normalized CAS runs complete when required
+side-effect boundary respected
+proof matches verifier
+```
+
+Direct-action fused and `$st`-governed runs may exempt ALSR/HYL/HSR receipt
+checks only when the advisory context explicitly carries the exemption.
+Advisory would-block results exit successfully; malformed input or unsupported
+mode/format remains a CLI failure.
+
 ## Validator
 
 ```bash
@@ -103,6 +143,12 @@ uv run python codex/skills/actuating/tools/actuation_terminal_gate.py \
 uv run python codex/skills/actuating/tools/actuation_terminal_gate.py \
   check \
   --decision .ledger/actuating/<run-id>/terminal-decision.json
+
+uv run python codex/skills/actuating/tools/actuation_terminal_gate.py \
+  validate \
+  --context .ledger/actuating/<run-id>/terminal-context.json \
+  --mode advisory \
+  --format json
 ```
 
 ## Falsifier

--- a/codex/skills/actuating/tests/test_actuation_terminal_gate.py
+++ b/codex/skills/actuating/tests/test_actuation_terminal_gate.py
@@ -5,6 +5,8 @@ from copy import deepcopy
 import importlib.util
 import json
 from pathlib import Path
+import subprocess
+import sys
 import tempfile
 import unittest
 
@@ -22,6 +24,9 @@ class ActuationTerminalGateTests(unittest.TestCase):
         return json.loads((ASSETS / name).read_text())["actuation_terminal_context"]
 
     def decision(self, name: str):
+        return json.loads((ASSETS / name).read_text())
+
+    def fixture(self, name: str):
         return json.loads((ASSETS / name).read_text())
 
     def test_proof_only_context_can_complete(self) -> None:
@@ -47,6 +52,66 @@ class ActuationTerminalGateTests(unittest.TestCase):
         self.assertEqual(body["next_owner"], "$cas")
         self.assertIn("cas.clean_runs:0-of-3", body["blocked_reasons"])
         self.assertIn("final_report.normalized_cas_clean_runs:not-satisfied", body["blocked_reasons"])
+
+    def test_advisory_would_block_matches_fixture_expectation(self) -> None:
+        fixture = self.fixture("terminal-context.advisory-would-block.example.json")
+        advisory = MODULE.make_advisory(fixture["actuation_terminal_context"])
+        self.assertEqual(advisory["verdict"], "advisory")
+        self.assertEqual(advisory["would_block"], fixture["advisory_expectation"]["would_block"])
+        self.assertEqual(
+            advisory["would_block_reasons"],
+            fixture["advisory_expectation"]["would_block_reasons"],
+        )
+        self.assertEqual(
+            advisory["can_mark_goal_complete"],
+            fixture["advisory_expectation"]["can_mark_goal_complete"],
+        )
+        self.assertEqual(advisory["next_owner"], fixture["advisory_expectation"]["next_owner"])
+
+    def test_advisory_cli_would_block_is_non_blocking(self) -> None:
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT),
+                "validate",
+                "--context",
+                str(ASSETS / "terminal-context.advisory-would-block.example.json"),
+                "--mode",
+                "advisory",
+                "--format",
+                "json",
+            ],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        body = json.loads(result.stdout)
+        self.assertEqual(body["verdict"], "advisory")
+        self.assertTrue(body["would_block"])
+        self.assertFalse(body["can_mark_goal_complete"])
+
+    def test_advisory_direct_action_fused_exempts_loop_receipts(self) -> None:
+        fixture = self.fixture("terminal-context.advisory-fused.example.json")
+        advisory = MODULE.make_advisory(fixture["actuation_terminal_context"])
+        self.assertEqual(advisory, {
+            "verdict": "advisory",
+            "would_block": False,
+            "would_block_reasons": [],
+            "can_mark_goal_complete": True,
+            "next_owner": "none",
+        })
+
+    def test_advisory_st_governed_exempts_loop_receipts(self) -> None:
+        fixture = self.fixture("terminal-context.advisory-st-governed.example.json")
+        advisory = MODULE.make_advisory(fixture["actuation_terminal_context"])
+        self.assertEqual(advisory, {
+            "verdict": "advisory",
+            "would_block": False,
+            "would_block_reasons": [],
+            "can_mark_goal_complete": True,
+            "next_owner": "none",
+        })
 
     def test_proof_patch_closure_requires_proof_patch_receipt(self) -> None:
         context = deepcopy(self.context())

--- a/codex/skills/actuating/tools/actuation_terminal_gate.py
+++ b/codex/skills/actuating/tools/actuation_terminal_gate.py
@@ -23,6 +23,21 @@ LOCAL_VERDICTS = {"done", "continue", "regress", "blocked", "invalid-proof", "as
 ADD_VERDICTS = {"handoff_to_ship", "shipping_not_requested", "blocked", "missing"}
 TERMINAL_VERDICTS = {"complete", "continue", "blocked"}
 NEXT_OWNERS = {"none", "$cas", "$proof-patch", "$ship", "$goal-grind", "human"}
+ADVISORY_REASON_ORDER = [
+    "blocked-alsr-missing",
+    "blocked-alsr-stale",
+    "blocked-hyl-missing",
+    "blocked-hyl-stale",
+    "blocked-hylo-terminal-missing",
+    "blocked-material-mutation-without-hsr",
+    "blocked-latest-fold-not-current-artifact-bound",
+    "blocked-selected-loop-task-shape-mismatch",
+    "blocked-review-fix-protocol",
+    "blocked-cas-clean-runs-incomplete",
+    "blocked-side-effect-boundary",
+    "blocked-proof-verifier-mismatch",
+    "blocked-st-control-missing",
+]
 
 
 class TerminalGateError(ValueError):
@@ -92,6 +107,218 @@ def optional_object(obj: dict[str, Any], key: str, errors: list[str]) -> dict[st
         errors.append(f"{key}:must-be-object")
         return {}
     return value
+
+
+def object_from(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def list_from(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def explicit_no(value: Any) -> bool:
+    return value in NO or (isinstance(value, str) and value.lower() in NO)
+
+
+def make_advisory(context: dict[str, Any]) -> dict[str, Any]:
+    reasons = advisory_reasons_for(context)
+    would_block = bool(reasons)
+    return {
+        "verdict": "advisory",
+        "would_block": would_block,
+        "would_block_reasons": reasons,
+        "can_mark_goal_complete": not would_block,
+        "next_owner": advisory_next_owner_for(reasons),
+    }
+
+
+def advisory_reasons_for(context: dict[str, Any]) -> list[str]:
+    loop = object_from(context.get("loop_governance"))
+    hsr = object_from(loop.get("hsr"))
+    reasons: list[str] = []
+
+    direct_action_fused = as_yes(loop.get("direct_action_fused")) or loop.get("mode") in {
+        "direct_action_fused",
+        "direct-action-fused",
+        "fused",
+    }
+    st_governed = as_yes(loop.get("st_governed")) or loop.get("mode") in {
+        "st_governed",
+        "st-governed",
+        "st_owned",
+        "st-owned",
+    }
+    st_current = st_governed and (
+        as_yes(loop.get("st_control_current"))
+        or as_yes(object_from(loop.get("st_control")).get("current"))
+        or context.get("source") == "st_handoff"
+    )
+    loop_receipts_exempt = direct_action_fused or st_current
+    loop_required = loop_receipts_required(loop, hsr)
+
+    alsr = object_from(loop.get("alsr"))
+    alsr_required = (
+        not loop_receipts_exempt
+        and (as_yes(loop.get("alsr_required")) or as_yes(alsr.get("required")) or loop_required)
+    )
+    if alsr_required:
+        if not as_yes(alsr.get("present")):
+            append_reason(reasons, "blocked-alsr-missing")
+        elif not as_yes(alsr.get("current")):
+            append_reason(reasons, "blocked-alsr-stale")
+
+    hyl = object_from(loop.get("hyl"))
+    hyl_required = not loop_receipts_exempt and (
+        as_yes(loop.get("hyl_required"))
+        or as_yes(loop.get("recursive"))
+        or as_yes(loop.get("material"))
+        or as_yes(hyl.get("required"))
+        or loop_required
+    )
+    if hyl_required:
+        if not as_yes(hyl.get("present")):
+            append_reason(reasons, "blocked-hyl-missing")
+        elif not as_yes(hyl.get("current")):
+            append_reason(reasons, "blocked-hyl-stale")
+
+    if st_governed and not st_current:
+        append_reason(reasons, "blocked-st-control-missing")
+
+    if loop_required and not loop_receipts_exempt:
+        if not as_yes(hsr.get("terminal_present")):
+            append_reason(reasons, "blocked-hylo-terminal-missing")
+        if not material_mutations_have_hsr(loop, hsr):
+            append_reason(reasons, "blocked-material-mutation-without-hsr")
+        if not as_yes(hsr.get("latest_fold_current_artifact_bound")):
+            append_reason(reasons, "blocked-latest-fold-not-current-artifact-bound")
+
+    selected_loop = object_from(loop.get("selected_loop"))
+    if selected_loop and not as_yes(selected_loop.get("matches_task_shape")):
+        append_reason(reasons, "blocked-selected-loop-task-shape-mismatch")
+
+    review_fix = object_from(loop.get("review_fix"))
+    if as_yes(review_fix.get("required")) and not review_fix_obeyed(review_fix):
+        append_reason(reasons, "blocked-review-fix-protocol")
+
+    if cas_advisory_blocked(context, loop):
+        append_reason(reasons, "blocked-cas-clean-runs-incomplete")
+
+    if side_effect_boundary_violated(context, loop):
+        append_reason(reasons, "blocked-side-effect-boundary")
+
+    if proof_verifier_mismatch(context, loop):
+        append_reason(reasons, "blocked-proof-verifier-mismatch")
+
+    return sort_advisory_reasons(reasons)
+
+
+def append_reason(reasons: list[str], reason: str) -> None:
+    if reason not in reasons:
+        reasons.append(reason)
+
+
+def sort_advisory_reasons(reasons: list[str]) -> list[str]:
+    order = {reason: index for index, reason in enumerate(ADVISORY_REASON_ORDER)}
+    return sorted(reasons, key=lambda reason: order.get(reason, len(order)))
+
+
+def loop_receipts_required(loop: dict[str, Any], hsr: dict[str, Any]) -> bool:
+    return any(
+        as_yes(value)
+        for value in (
+            loop.get("loop_contract_required"),
+            loop.get("material"),
+            loop.get("recursive"),
+            object_from(loop.get("alsr")).get("required"),
+            object_from(loop.get("hyl")).get("required"),
+            hsr.get("required"),
+            hsr.get("terminal_required"),
+        )
+    )
+
+
+def material_mutations_have_hsr(loop: dict[str, Any], hsr: dict[str, Any]) -> bool:
+    mutations = list_from(loop.get("material_mutations")) or list_from(hsr.get("material_mutations"))
+    if not mutations:
+        return not as_yes(loop.get("material"))
+    for mutation in mutations:
+        item = object_from(mutation)
+        if as_yes(item.get("has_hsr")):
+            continue
+        if not (
+            as_yes(item.get("has_unfold"))
+            and as_yes(item.get("has_action"))
+            and as_yes(item.get("has_fold"))
+        ):
+            return False
+    return True
+
+
+def review_fix_obeyed(review_fix: dict[str, Any]) -> bool:
+    return (
+        as_yes(review_fix.get("cas_reviewed"))
+        and as_yes(review_fix.get("review_folded"))
+        and as_yes(review_fix.get("resolve_passed"))
+    )
+
+
+def cas_advisory_blocked(context: dict[str, Any], loop: dict[str, Any]) -> bool:
+    cas = object_from(context.get("cas_review"))
+    artifact = object_from(context.get("artifact_scope"))
+    final_report = object_from(context.get("final_report_fields"))
+    if cas_reasons_for(cas, artifact) or final_report_reasons_for(
+        final_report,
+        cas,
+        object_from(context.get("proof_patch")),
+        object_from(context.get("delivery")),
+    ):
+        return True
+
+    clean_runs = object_from(loop.get("cas_clean_runs"))
+    if not as_yes(clean_runs.get("required")):
+        return False
+    required = clean_runs.get("required_count", clean_runs.get("clean_runs_required", 3))
+    count = clean_runs.get("count", clean_runs.get("clean_runs_count", 0))
+    if not is_plain_int(required) or required <= 0:
+        return True
+    if not is_plain_int(count) or count < required:
+        return True
+    if not as_yes(clean_runs.get("independent_fresh_runs")):
+        return True
+    if not as_yes(clean_runs.get("tuple_bound")):
+        return True
+    return False
+
+
+def side_effect_boundary_violated(context: dict[str, Any], loop: dict[str, Any]) -> bool:
+    side = object_from(loop.get("side_effect_boundary")) or object_from(context.get("side_effect_boundary"))
+    if not side:
+        return False
+    if explicit_no(side.get("respected")):
+        return True
+    performed = side.get("public_side_effects") == "performed" or as_yes(side.get("performed"))
+    allowed = as_yes(side.get("public_side_effects_allowed")) or as_yes(side.get("publish_allowed"))
+    return performed and not allowed
+
+
+def proof_verifier_mismatch(context: dict[str, Any], loop: dict[str, Any]) -> bool:
+    proof = object_from(loop.get("proof")) or object_from(context.get("proof"))
+    if explicit_no(proof.get("matches_verifier")):
+        return True
+    if as_yes(proof.get("required")) and "matches_verifier" not in proof:
+        return True
+    return False
+
+
+def advisory_next_owner_for(reasons: list[str]) -> str:
+    if not reasons:
+        return "none"
+    if "blocked-cas-clean-runs-incomplete" in reasons:
+        return "$cas"
+    if "blocked-side-effect-boundary" in reasons:
+        return "$ship"
+    return "$goal-actuating"
 
 
 def make_decision(context: dict[str, Any]) -> dict[str, Any]:
@@ -540,6 +767,10 @@ def main(argv: list[str] | None = None) -> int:
     p_decide.add_argument("--out")
     p_check = sub.add_parser("check")
     p_check.add_argument("--decision", required=True)
+    p_validate = sub.add_parser("validate")
+    p_validate.add_argument("--context", required=True)
+    p_validate.add_argument("--mode", choices=("advisory",), required=True)
+    p_validate.add_argument("--format", choices=("json",), default="json")
 
     args = parser.parse_args(argv)
     try:
@@ -550,6 +781,10 @@ def main(argv: list[str] | None = None) -> int:
         elif args.cmd == "check":
             decision = load_json(args.decision)
             result = validate_decision(decision)
+            emit(result)
+        elif args.cmd == "validate":
+            context = context_from(load_json(args.context))
+            result = make_advisory(context)
             emit(result)
         return 0
     except Exception as exc:

--- a/codex/skills/actuating/tools/quick_validate.py
+++ b/codex/skills/actuating/tools/quick_validate.py
@@ -51,6 +51,9 @@ def main() -> int:
         "assets/terminal-context.proof-only.example.json",
         "assets/terminal-context.regression.example.json",
         "assets/terminal-context.ship-continue.example.json",
+        "assets/terminal-context.advisory-would-block.example.json",
+        "assets/terminal-context.advisory-fused.example.json",
+        "assets/terminal-context.advisory-st-governed.example.json",
     ]
     missing = [path for path in required if not (ROOT / path).is_file()]
     if missing:


### PR DESCRIPTION
## Summary
- add non-blocking ATCG advisory validation with deterministic would-block reasons
- cover direct-action fused and st-governed exemptions with fixtures
- document the advisory command and include the fixtures in actuating quick validation

## Proof
- `uv run python codex/skills/actuating/tests/test_actuation_terminal_gate.py`: pass, 39 tests
- `uv run python codex/skills/actuating/tests/test_actuating_tools.py`: pass
- `uv run python codex/skills/actuating/tools/quick_validate.py`: pass

## Scope
- branch: feature/atcg-advisory-validation
- head: ef4b02c0bd235596c47d2fecdd18d7718cff850b
- base: main

## Readiness
- PR mode: ready
- Reason: scoped implementation is complete and focused validation passes
- Caveats: no repository GitHub workflow files are present; local proof is the available validation surface
