### PR TITLE
Enforce ATCG hard completion blockers

### DIFF
--- a/codex/skills/actuating/SKILL.md
+++ b/codex/skills/actuating/SKILL.md
@@ -463,6 +463,25 @@ ATCG-v1 can_mark_goal_complete = yes
 
 If ATCG-v1 returns `continue`, continue with `next_owner`. If it returns `blocked`, report the blocked actuation verdict and reasons. Do not substitute local proof, proof-complete graph state, cached CAS receipts, or ADD-v1 `handoff_to_ship` for terminal completion.
 
+Hard ATCG-v1 completion blockers:
+
+```text
+blocked-loop-contract-missing
+blocked-loop-contract-stale
+blocked-hylo-frontier-missing
+blocked-hylo-fold-missing
+blocked-hylo-terminal-missing
+cas-review-blocked
+st-authority-blocked
+proof-stale
+side-effect-boundary-violated
+```
+
+Direct-action fused and `$st`-governed runs may exempt ALSR/HYL/HSR checks only
+when the terminal context explicitly carries the exemption. `$st`-governed
+completion also requires current `$st` control evidence; a `st_handoff` source
+without a current receipt is not enough.
+
 ## Stop rules
 
 Stop rather than implement when:

--- a/codex/skills/actuating/assets/terminal-context.advisory-would-block.example.json
+++ b/codex/skills/actuating/assets/terminal-context.advisory-would-block.example.json
@@ -101,16 +101,13 @@
   "advisory_expectation": {
     "would_block": true,
     "would_block_reasons": [
-      "blocked-alsr-missing",
-      "blocked-hyl-missing",
+      "blocked-loop-contract-missing",
+      "blocked-hylo-frontier-missing",
+      "blocked-hylo-fold-missing",
       "blocked-hylo-terminal-missing",
-      "blocked-material-mutation-without-hsr",
-      "blocked-latest-fold-not-current-artifact-bound",
-      "blocked-selected-loop-task-shape-mismatch",
-      "blocked-review-fix-protocol",
-      "blocked-cas-clean-runs-incomplete",
-      "blocked-side-effect-boundary",
-      "blocked-proof-verifier-mismatch"
+      "cas-review-blocked",
+      "proof-stale",
+      "side-effect-boundary-violated"
     ],
     "can_mark_goal_complete": false,
     "next_owner": "$cas"

--- a/codex/skills/actuating/references/terminal-closure-gate.md
+++ b/codex/skills/actuating/references/terminal-closure-gate.md
@@ -25,7 +25,7 @@ actuation_terminal_decision:
   run_id:
   source: accepted_spec | direct_goal | review | st_handoff
   closure_candidate: proof-patch | ship-handoff | ship-complete | blocked
-  next_owner: none | $cas | $proof-patch | $ship | $goal-grind | human
+  next_owner: none | $cas | $proof-patch | $ship | $goal-grind | $goal-actuating | $st | human
   blocked_reasons: []
   continue_reasons: []
   current_artifact_binding:
@@ -57,11 +57,13 @@ ATCG-v1 consumes current receiver-owned evidence:
 
 ```text
 current branch/head/diff binding
+loop governance: ALSR-v1, HYL-v1, HSR-v1, or explicit fused/$st exemption
 evidence-fold verdict and proof commands
 proof-patch presence/currentness
 CAS requirement, tuple, freshness, and clean-run count
 ADD-v1 delivery decision
 ship result receipt when publication is required
+side-effect boundary evidence
 final report field values
 ```
 
@@ -71,13 +73,22 @@ mutate workspace state.
 ## Common outcomes
 
 ```text
+ALSR/HYL required + missing -> blocked-loop-contract-missing, next_owner=$goal-actuating
+ALSR/HYL required + stale -> blocked-loop-contract-stale, next_owner=$goal-actuating
+material mutation without unfold/action evidence -> blocked-hylo-frontier-missing, next_owner=$goal-actuating
+previous material action without fold evidence -> blocked-hylo-fold-missing, next_owner=$goal-actuating
+completion without terminal HSR -> blocked-hylo-terminal-missing, next_owner=$goal-actuating
+$st-governed completion without current $st control receipt -> st-authority-blocked, next_owner=$st
 CAS required + clean runs < required -> blocked, next_owner=$cas
 CAS required + clean_runs_required <= 0 -> blocked, next_owner=$cas
 CAS required + final report clean runs < required -> blocked, next_owner=$cas
+review-fix protocol incomplete -> cas-review-blocked, next_owner=$cas
 proof-patch required + missing/stale -> continue, next_owner=$proof-patch
 proof-patch closure + missing proof-patch receipt -> continue, next_owner=$proof-patch
 ADD-v1 handoff + ship result missing -> continue, next_owner=$ship
 ship-complete closure + missing delivery evidence -> blocked, next_owner=$ship
+public side effect outside $ship boundary -> side-effect-boundary-violated, next_owner=$ship
+proof verifier mismatch or stale current-artifact binding -> proof-stale, next_owner=$goal-grind
 ship-complete closure + missing ADD-v1 or ship receipt -> invalid decision
 wrapped ADD-v1 delivery decision -> accepted as delivery evidence
 ADD-shaped handoff without decision_version=ADD-v1 -> blocked
@@ -92,11 +103,30 @@ tracked-dirty artifact + current proof-patch receipt -> may complete
 tracked-dirty artifact without proof-patch receipt -> blocked
 ```
 
+## Hard blocker names
+
+ATCG-v1 hard decisions use these canonical blocker names:
+
+```text
+blocked-loop-contract-missing
+blocked-loop-contract-stale
+blocked-hylo-frontier-missing
+blocked-hylo-fold-missing
+blocked-hylo-terminal-missing
+cas-review-blocked
+st-authority-blocked
+proof-stale
+side-effect-boundary-violated
+```
+
+Detailed legacy reasons may accompany canonical blockers for compatibility, but
+canonical blockers are the terminal governance signal.
+
 ## Advisory validation
 
-Advisory mode reports ATCG-v1 completion blockers without enforcing them. A
-would-block advisory result is evidence for the caller, not a terminal stop
-condition by itself.
+Advisory mode reports the same ATCG-v1 completion blockers without enforcing
+them. A would-block advisory result is evidence for the caller, not a terminal
+stop condition by itself.
 
 ```json
 {
@@ -128,9 +158,10 @@ proof matches verifier
 ```
 
 Direct-action fused and `$st`-governed runs may exempt ALSR/HYL/HSR receipt
-checks only when the advisory context explicitly carries the exemption.
-Advisory would-block results exit successfully; malformed input or unsupported
-mode/format remains a CLI failure.
+checks only when the context explicitly carries the exemption. `$st`-governed
+completion additionally requires current `$st` control evidence; `source:
+st_handoff` alone is not sufficient. Advisory would-block results exit
+successfully; malformed input or unsupported mode/format remains a CLI failure.
 
 ## Validator
 

--- a/codex/skills/actuating/tests/test_actuation_terminal_gate.py
+++ b/codex/skills/actuating/tests/test_actuation_terminal_gate.py
@@ -29,6 +29,14 @@ class ActuationTerminalGateTests(unittest.TestCase):
     def fixture(self, name: str):
         return json.loads((ASSETS / name).read_text())
 
+    def assert_blocks_with(self, context, reason: str, next_owner: str) -> None:
+        decision = MODULE.make_decision(context)
+        body = decision["actuation_terminal_decision"]
+        self.assertEqual(body["verdict"], "blocked")
+        self.assertEqual(body["can_mark_goal_complete"], "no")
+        self.assertEqual(body["next_owner"], next_owner)
+        self.assertIn(reason, body["blocked_reasons"])
+
     def test_proof_only_context_can_complete(self) -> None:
         decision = MODULE.make_decision(self.context())
         body = decision["actuation_terminal_decision"]
@@ -50,6 +58,7 @@ class ActuationTerminalGateTests(unittest.TestCase):
         self.assertEqual(body["verdict"], "blocked")
         self.assertEqual(body["can_mark_goal_complete"], "no")
         self.assertEqual(body["next_owner"], "$cas")
+        self.assertIn("cas-review-blocked", body["blocked_reasons"])
         self.assertIn("cas.clean_runs:0-of-3", body["blocked_reasons"])
         self.assertIn("final_report.normalized_cas_clean_runs:not-satisfied", body["blocked_reasons"])
 
@@ -91,6 +100,16 @@ class ActuationTerminalGateTests(unittest.TestCase):
         self.assertTrue(body["would_block"])
         self.assertFalse(body["can_mark_goal_complete"])
 
+    def test_hard_decision_blocks_advisory_fixture(self) -> None:
+        fixture = self.fixture("terminal-context.advisory-would-block.example.json")
+        decision = MODULE.make_decision(fixture["actuation_terminal_context"])
+        body = decision["actuation_terminal_decision"]
+        self.assertEqual(body["verdict"], "blocked")
+        self.assertEqual(body["can_mark_goal_complete"], "no")
+        self.assertEqual(body["next_owner"], fixture["advisory_expectation"]["next_owner"])
+        for reason in fixture["advisory_expectation"]["would_block_reasons"]:
+            self.assertIn(reason, body["blocked_reasons"])
+
     def test_advisory_direct_action_fused_exempts_loop_receipts(self) -> None:
         fixture = self.fixture("terminal-context.advisory-fused.example.json")
         advisory = MODULE.make_advisory(fixture["actuation_terminal_context"])
@@ -102,6 +121,14 @@ class ActuationTerminalGateTests(unittest.TestCase):
             "next_owner": "none",
         })
 
+    def test_hard_direct_action_fused_can_complete(self) -> None:
+        fixture = self.fixture("terminal-context.advisory-fused.example.json")
+        decision = MODULE.make_decision(fixture["actuation_terminal_context"])
+        body = decision["actuation_terminal_decision"]
+        self.assertEqual(body["verdict"], "complete")
+        self.assertEqual(body["can_mark_goal_complete"], "yes")
+        self.assertEqual(body["next_owner"], "none")
+
     def test_advisory_st_governed_exempts_loop_receipts(self) -> None:
         fixture = self.fixture("terminal-context.advisory-st-governed.example.json")
         advisory = MODULE.make_advisory(fixture["actuation_terminal_context"])
@@ -112,6 +139,85 @@ class ActuationTerminalGateTests(unittest.TestCase):
             "can_mark_goal_complete": True,
             "next_owner": "none",
         })
+
+    def test_hard_st_governed_current_receipt_can_complete(self) -> None:
+        fixture = self.fixture("terminal-context.advisory-st-governed.example.json")
+        decision = MODULE.make_decision(fixture["actuation_terminal_context"])
+        body = decision["actuation_terminal_decision"]
+        self.assertEqual(body["verdict"], "complete")
+        self.assertEqual(body["can_mark_goal_complete"], "yes")
+        self.assertEqual(body["next_owner"], "none")
+
+    def test_hard_st_governed_requires_current_receipt(self) -> None:
+        context = deepcopy(self.context("terminal-context.advisory-st-governed.example.json"))
+        context["loop_governance"]["st_control"]["current"] = "no"
+        self.assert_blocks_with(context, "st-authority-blocked", "$st")
+
+    def test_hard_stale_loop_contract_blocks_completion(self) -> None:
+        context = deepcopy(self.context())
+        context["loop_governance"] = {
+            "material": "yes",
+            "alsr": {"required": "yes", "present": "yes", "current": "no"},
+            "hyl": {"required": "yes", "present": "yes", "current": "yes"},
+            "hsr": {
+                "terminal_present": "yes",
+                "latest_fold_current_artifact_bound": "yes",
+                "material_mutations": [{"has_hsr": "yes"}],
+            },
+        }
+        self.assert_blocks_with(context, "blocked-loop-contract-stale", "$goal-actuating")
+
+    def test_hard_missing_frontier_blocks_completion(self) -> None:
+        context = deepcopy(self.context())
+        context["loop_governance"] = {
+            "material": "yes",
+            "alsr": {"required": "yes", "present": "yes", "current": "yes"},
+            "hyl": {"required": "yes", "present": "yes", "current": "yes"},
+            "hsr": {
+                "terminal_present": "yes",
+                "latest_fold_current_artifact_bound": "yes",
+                "material_mutations": [{"has_unfold": "no", "has_action": "yes", "has_fold": "yes"}],
+            },
+        }
+        self.assert_blocks_with(context, "blocked-hylo-frontier-missing", "$goal-actuating")
+
+    def test_hard_missing_fold_blocks_completion(self) -> None:
+        context = deepcopy(self.context())
+        context["loop_governance"] = {
+            "material": "yes",
+            "alsr": {"required": "yes", "present": "yes", "current": "yes"},
+            "hyl": {"required": "yes", "present": "yes", "current": "yes"},
+            "hsr": {
+                "terminal_present": "yes",
+                "latest_fold_current_artifact_bound": "yes",
+                "material_mutations": [{"has_unfold": "yes", "has_action": "yes", "has_fold": "no"}],
+            },
+        }
+        self.assert_blocks_with(context, "blocked-hylo-fold-missing", "$goal-actuating")
+
+    def test_hard_missing_terminal_hsr_blocks_completion(self) -> None:
+        context = deepcopy(self.context())
+        context["loop_governance"] = {
+            "material": "yes",
+            "alsr": {"required": "yes", "present": "yes", "current": "yes"},
+            "hyl": {"required": "yes", "present": "yes", "current": "yes"},
+            "hsr": {
+                "terminal_present": "no",
+                "latest_fold_current_artifact_bound": "yes",
+                "material_mutations": [{"has_hsr": "yes"}],
+            },
+        }
+        self.assert_blocks_with(context, "blocked-hylo-terminal-missing", "$goal-actuating")
+
+    def test_hard_proof_stale_blocks_completion(self) -> None:
+        context = deepcopy(self.context())
+        context["proof"] = {"required": "yes", "matches_verifier": "no"}
+        self.assert_blocks_with(context, "proof-stale", "$goal-grind")
+
+    def test_hard_side_effect_boundary_blocks_completion(self) -> None:
+        context = deepcopy(self.context())
+        context["side_effect_boundary"] = {"respected": "no"}
+        self.assert_blocks_with(context, "side-effect-boundary-violated", "$ship")
 
     def test_proof_patch_closure_requires_proof_patch_receipt(self) -> None:
         context = deepcopy(self.context())

--- a/codex/skills/actuating/tools/actuation_terminal_gate.py
+++ b/codex/skills/actuating/tools/actuation_terminal_gate.py
@@ -22,21 +22,17 @@ CLOSURE_CANDIDATES = {"proof-patch", "ship-handoff", "ship-complete", "blocked"}
 LOCAL_VERDICTS = {"done", "continue", "regress", "blocked", "invalid-proof", "ask-human", "refactor-kernel"}
 ADD_VERDICTS = {"handoff_to_ship", "shipping_not_requested", "blocked", "missing"}
 TERMINAL_VERDICTS = {"complete", "continue", "blocked"}
-NEXT_OWNERS = {"none", "$cas", "$proof-patch", "$ship", "$goal-grind", "human"}
-ADVISORY_REASON_ORDER = [
-    "blocked-alsr-missing",
-    "blocked-alsr-stale",
-    "blocked-hyl-missing",
-    "blocked-hyl-stale",
+NEXT_OWNERS = {"none", "$cas", "$proof-patch", "$ship", "$goal-grind", "$goal-actuating", "$st", "human"}
+HARD_REASON_ORDER = [
+    "blocked-loop-contract-missing",
+    "blocked-loop-contract-stale",
+    "blocked-hylo-frontier-missing",
+    "blocked-hylo-fold-missing",
     "blocked-hylo-terminal-missing",
-    "blocked-material-mutation-without-hsr",
-    "blocked-latest-fold-not-current-artifact-bound",
-    "blocked-selected-loop-task-shape-mismatch",
-    "blocked-review-fix-protocol",
-    "blocked-cas-clean-runs-incomplete",
-    "blocked-side-effect-boundary",
-    "blocked-proof-verifier-mismatch",
-    "blocked-st-control-missing",
+    "cas-review-blocked",
+    "st-authority-blocked",
+    "proof-stale",
+    "side-effect-boundary-violated",
 ]
 
 
@@ -122,7 +118,7 @@ def explicit_no(value: Any) -> bool:
 
 
 def make_advisory(context: dict[str, Any]) -> dict[str, Any]:
-    reasons = advisory_reasons_for(context)
+    reasons = hard_completion_reasons_for(context)
     would_block = bool(reasons)
     return {
         "verdict": "advisory",
@@ -134,6 +130,10 @@ def make_advisory(context: dict[str, Any]) -> dict[str, Any]:
 
 
 def advisory_reasons_for(context: dict[str, Any]) -> list[str]:
+    return hard_completion_reasons_for(context)
+
+
+def hard_completion_reasons_for(context: dict[str, Any]) -> list[str]:
     loop = object_from(context.get("loop_governance"))
     hsr = object_from(loop.get("hsr"))
     reasons: list[str] = []
@@ -152,7 +152,6 @@ def advisory_reasons_for(context: dict[str, Any]) -> list[str]:
     st_current = st_governed and (
         as_yes(loop.get("st_control_current"))
         or as_yes(object_from(loop.get("st_control")).get("current"))
-        or context.get("source") == "st_handoff"
     )
     loop_receipts_exempt = direct_action_fused or st_current
     loop_required = loop_receipts_required(loop, hsr)
@@ -164,9 +163,9 @@ def advisory_reasons_for(context: dict[str, Any]) -> list[str]:
     )
     if alsr_required:
         if not as_yes(alsr.get("present")):
-            append_reason(reasons, "blocked-alsr-missing")
+            append_reason(reasons, "blocked-loop-contract-missing")
         elif not as_yes(alsr.get("current")):
-            append_reason(reasons, "blocked-alsr-stale")
+            append_reason(reasons, "blocked-loop-contract-stale")
 
     hyl = object_from(loop.get("hyl"))
     hyl_required = not loop_receipts_exempt and (
@@ -178,39 +177,40 @@ def advisory_reasons_for(context: dict[str, Any]) -> list[str]:
     )
     if hyl_required:
         if not as_yes(hyl.get("present")):
-            append_reason(reasons, "blocked-hyl-missing")
+            append_reason(reasons, "blocked-loop-contract-missing")
         elif not as_yes(hyl.get("current")):
-            append_reason(reasons, "blocked-hyl-stale")
+            append_reason(reasons, "blocked-loop-contract-stale")
 
     if st_governed and not st_current:
-        append_reason(reasons, "blocked-st-control-missing")
+        append_reason(reasons, "st-authority-blocked")
 
     if loop_required and not loop_receipts_exempt:
         if not as_yes(hsr.get("terminal_present")):
             append_reason(reasons, "blocked-hylo-terminal-missing")
-        if not material_mutations_have_hsr(loop, hsr):
-            append_reason(reasons, "blocked-material-mutation-without-hsr")
+        reasons.extend(material_mutation_hsr_reasons(loop, hsr))
+        if explicit_no(hsr.get("latest_fold_present")):
+            append_reason(reasons, "blocked-hylo-fold-missing")
         if not as_yes(hsr.get("latest_fold_current_artifact_bound")):
-            append_reason(reasons, "blocked-latest-fold-not-current-artifact-bound")
+            append_reason(reasons, "proof-stale")
 
     selected_loop = object_from(loop.get("selected_loop"))
     if selected_loop and not as_yes(selected_loop.get("matches_task_shape")):
-        append_reason(reasons, "blocked-selected-loop-task-shape-mismatch")
+        append_reason(reasons, "blocked-hylo-frontier-missing")
 
     review_fix = object_from(loop.get("review_fix"))
     if as_yes(review_fix.get("required")) and not review_fix_obeyed(review_fix):
-        append_reason(reasons, "blocked-review-fix-protocol")
+        append_reason(reasons, "cas-review-blocked")
 
     if cas_advisory_blocked(context, loop):
-        append_reason(reasons, "blocked-cas-clean-runs-incomplete")
+        append_reason(reasons, "cas-review-blocked")
 
     if side_effect_boundary_violated(context, loop):
-        append_reason(reasons, "blocked-side-effect-boundary")
+        append_reason(reasons, "side-effect-boundary-violated")
 
     if proof_verifier_mismatch(context, loop):
-        append_reason(reasons, "blocked-proof-verifier-mismatch")
+        append_reason(reasons, "proof-stale")
 
-    return sort_advisory_reasons(reasons)
+    return sort_hard_reasons(reasons)
 
 
 def append_reason(reasons: list[str], reason: str) -> None:
@@ -218,8 +218,8 @@ def append_reason(reasons: list[str], reason: str) -> None:
         reasons.append(reason)
 
 
-def sort_advisory_reasons(reasons: list[str]) -> list[str]:
-    order = {reason: index for index, reason in enumerate(ADVISORY_REASON_ORDER)}
+def sort_hard_reasons(reasons: list[str]) -> list[str]:
+    order = {reason: index for index, reason in enumerate(HARD_REASON_ORDER)}
     return sorted(reasons, key=lambda reason: order.get(reason, len(order)))
 
 
@@ -239,20 +239,23 @@ def loop_receipts_required(loop: dict[str, Any], hsr: dict[str, Any]) -> bool:
 
 
 def material_mutations_have_hsr(loop: dict[str, Any], hsr: dict[str, Any]) -> bool:
+    return not material_mutation_hsr_reasons(loop, hsr)
+
+
+def material_mutation_hsr_reasons(loop: dict[str, Any], hsr: dict[str, Any]) -> list[str]:
     mutations = list_from(loop.get("material_mutations")) or list_from(hsr.get("material_mutations"))
     if not mutations:
-        return not as_yes(loop.get("material"))
+        return ["blocked-hylo-frontier-missing"] if as_yes(loop.get("material")) else []
+    reasons: list[str] = []
     for mutation in mutations:
         item = object_from(mutation)
         if as_yes(item.get("has_hsr")):
             continue
-        if not (
-            as_yes(item.get("has_unfold"))
-            and as_yes(item.get("has_action"))
-            and as_yes(item.get("has_fold"))
-        ):
-            return False
-    return True
+        if not as_yes(item.get("has_unfold")) or not as_yes(item.get("has_action")):
+            append_reason(reasons, "blocked-hylo-frontier-missing")
+        if not as_yes(item.get("has_fold")):
+            append_reason(reasons, "blocked-hylo-fold-missing")
+    return reasons
 
 
 def review_fix_obeyed(review_fix: dict[str, Any]) -> bool:
@@ -314,10 +317,14 @@ def proof_verifier_mismatch(context: dict[str, Any], loop: dict[str, Any]) -> bo
 def advisory_next_owner_for(reasons: list[str]) -> str:
     if not reasons:
         return "none"
-    if "blocked-cas-clean-runs-incomplete" in reasons:
+    if "st-authority-blocked" in reasons:
+        return "$st"
+    if "cas-review-blocked" in reasons:
         return "$cas"
-    if "blocked-side-effect-boundary" in reasons:
+    if "side-effect-boundary-violated" in reasons:
         return "$ship"
+    if any(reason.startswith("blocked-loop-contract") or reason.startswith("blocked-hylo") for reason in reasons):
+        return "$goal-actuating"
     return "$goal-actuating"
 
 
@@ -344,6 +351,8 @@ def make_decision(context: dict[str, Any]) -> dict[str, Any]:
     blocked: list[str] = []
     if errors:
         blocked.extend(errors)
+
+    blocked.extend(hard_completion_reasons_for(context))
 
     artifact_reasons = artifact_reasons_for(artifact, proof_patch)
     blocked.extend(artifact_reasons)
@@ -640,10 +649,23 @@ def next_owner_for(blocked: list[str], pending: list[str]) -> str:
     combined = blocked + pending
     if any("ask-human" in reason for reason in combined):
         return "human"
+    if any(reason == "st-authority-blocked" for reason in combined):
+        return "$st"
     if any(reason.startswith("artifact_scope") for reason in combined):
         return "$goal-grind"
-    if any(reason.startswith("cas.") or reason.startswith("final_report.normalized_cas") for reason in combined):
+    if any(
+        reason == "cas-review-blocked"
+        or reason.startswith("cas.")
+        or reason.startswith("final_report.normalized_cas")
+        for reason in combined
+    ):
         return "$cas"
+    if any(reason == "side-effect-boundary-violated" for reason in combined):
+        return "$ship"
+    if any(reason.startswith("blocked-loop-contract") or reason.startswith("blocked-hylo") for reason in combined):
+        return "$goal-actuating"
+    if any(reason == "proof-stale" for reason in combined):
+        return "$goal-grind"
     if any(reason.startswith("proof_patch") for reason in combined):
         return "$proof-patch"
     if any(reason.startswith("ship") or reason.startswith("delivery") or reason.startswith("final_report.ship") for reason in combined):


### PR DESCRIPTION
## Summary
- Enforce canonical ATCG hard completion blockers for loop governance, CAS, $st, proof, and side-effect boundaries.
- Apply the same blocker reducer to advisory diagnostics and hard terminal decisions.
- Add regression coverage for invalid completion blockers and valid direct-action fused / $st-governed completion.

## Proof
- `uv run python codex/skills/actuating/tests/test_actuation_terminal_gate.py`: pass (49 tests)
- `uv run python codex/skills/actuating/tools/quick_validate.py`: pass

## Scope
- branch: codex/atcg-hard-enforcement
- head: b92b31f6136c737d15731f12fbc597aae2325112
- base: main

## Readiness
- PR mode: ready
- Reason: focused implementation complete with committed-head proof passing.
- Caveats: none.
