### PR TITLE
Gate goal completion through ATCG allowance

### DIFF
--- a/codex/skills/actuating/SKILL.md
+++ b/codex/skills/actuating/SKILL.md
@@ -461,6 +461,19 @@ ATCG-v1 verdict = complete
 ATCG-v1 can_mark_goal_complete = yes
 ```
 
+Before a workflow calls `update_goal complete`, it must run the local completion
+allowance guard over the current ATCG-v1 decision:
+
+```bash
+uv run python codex/skills/actuating/tools/actuation_terminal_gate.py \
+  allow-complete \
+  --decision .ledger/actuating/<run-id>/terminal-decision.json
+```
+
+Only `can_call_update_goal_complete = yes` permits the `update_goal complete`
+call. A valid ATCG `continue` or `blocked` decision must deny completion and
+carry the `next_owner`, `continue_reasons`, or `blocked_reasons` forward.
+
 If ATCG-v1 returns `continue`, continue with `next_owner`. If it returns `blocked`, report the blocked actuation verdict and reasons. Do not substitute local proof, proof-complete graph state, cached CAS receipts, or ADD-v1 `handoff_to_ship` for terminal completion.
 
 Hard ATCG-v1 completion blockers:

--- a/codex/skills/actuating/references/terminal-closure-gate.md
+++ b/codex/skills/actuating/references/terminal-closure-gate.md
@@ -47,6 +47,30 @@ verdict = complete
 can_mark_goal_complete = yes
 ```
 
+The local workflow must then run the completion allowance guard:
+
+```bash
+uv run python codex/skills/actuating/tools/actuation_terminal_gate.py \
+  allow-complete \
+  --decision .ledger/actuating/<run-id>/terminal-decision.json
+```
+
+The guard emits:
+
+```yaml
+actuation_completion_allowance:
+  verdict: allowed | denied
+  can_call_update_goal_complete: yes | no
+  decision_verdict: complete | continue | blocked
+  next_owner: none | $cas | $proof-patch | $ship | $goal-grind | $goal-actuating | $st | human
+  blocked_reasons: []
+  continue_reasons: []
+```
+
+Only `can_call_update_goal_complete: yes` permits `update_goal complete`.
+Denied `continue` and `blocked` decisions are valid ATCG outputs, not malformed
+gate results.
+
 Any other verdict keeps the actuation run active or reports the specific blocked
 state. A local verifier pass, proof-complete graph, or ADD-v1
 `handoff_to_ship` result is not enough by itself.
@@ -173,6 +197,10 @@ uv run python codex/skills/actuating/tools/actuation_terminal_gate.py \
 
 uv run python codex/skills/actuating/tools/actuation_terminal_gate.py \
   check \
+  --decision .ledger/actuating/<run-id>/terminal-decision.json
+
+uv run python codex/skills/actuating/tools/actuation_terminal_gate.py \
+  allow-complete \
   --decision .ledger/actuating/<run-id>/terminal-decision.json
 
 uv run python codex/skills/actuating/tools/actuation_terminal_gate.py \

--- a/codex/skills/actuating/tests/test_actuation_terminal_gate.py
+++ b/codex/skills/actuating/tests/test_actuation_terminal_gate.py
@@ -526,6 +526,65 @@ class ActuationTerminalGateTests(unittest.TestCase):
         self.assertEqual(result["actuation_terminal_gate"]["verdict"], "pass")
         self.assertEqual(result["actuation_terminal_gate"]["can_mark_goal_complete"], "yes")
 
+    def test_completion_allowance_accepts_only_complete_yes(self) -> None:
+        allowance = MODULE.make_completion_allowance(self.decision("atcg-v1.complete.example.json"))
+        body = allowance["actuation_completion_allowance"]
+        self.assertEqual(body["verdict"], "allowed")
+        self.assertEqual(body["can_call_update_goal_complete"], "yes")
+        self.assertEqual(body["decision_verdict"], "complete")
+        self.assertEqual(body["can_mark_goal_complete"], "yes")
+
+    def test_completion_allowance_denies_continue_with_next_owner(self) -> None:
+        context = deepcopy(self.context())
+        context["proof_patch"] = {}
+        allowance = MODULE.make_completion_allowance(MODULE.make_decision(context))
+        body = allowance["actuation_completion_allowance"]
+        self.assertEqual(body["verdict"], "denied")
+        self.assertEqual(body["can_call_update_goal_complete"], "no")
+        self.assertEqual(body["decision_verdict"], "continue")
+        self.assertEqual(body["next_owner"], "$proof-patch")
+        self.assertIn("proof_patch.required:missing-for-proof-patch-closure", body["continue_reasons"])
+
+    def test_completion_allowance_denies_missing_loop_contract(self) -> None:
+        context = deepcopy(self.context())
+        context["loop_governance"] = {
+            "material": "yes",
+            "alsr": {"required": "yes", "present": "no", "current": "no"},
+            "hyl": {"required": "yes", "present": "no", "current": "no"},
+            "hsr": {
+                "terminal_present": "yes",
+                "latest_fold_current_artifact_bound": "yes",
+                "material_mutations": [{"has_hsr": "yes"}],
+            },
+        }
+        allowance = MODULE.make_completion_allowance(MODULE.make_decision(context))
+        body = allowance["actuation_completion_allowance"]
+        self.assertEqual(body["verdict"], "denied")
+        self.assertEqual(body["can_call_update_goal_complete"], "no")
+        self.assertEqual(body["decision_verdict"], "blocked")
+        self.assertEqual(body["next_owner"], "$goal-actuating")
+        self.assertIn("blocked-loop-contract-missing", body["blocked_reasons"])
+
+    def test_completion_allowance_denies_stale_proof(self) -> None:
+        context = deepcopy(self.context())
+        context["proof"] = {"required": "yes", "matches_verifier": "no"}
+        allowance = MODULE.make_completion_allowance(MODULE.make_decision(context))
+        body = allowance["actuation_completion_allowance"]
+        self.assertEqual(body["verdict"], "denied")
+        self.assertEqual(body["can_call_update_goal_complete"], "no")
+        self.assertEqual(body["next_owner"], "$goal-grind")
+        self.assertIn("proof-stale", body["blocked_reasons"])
+
+    def test_completion_allowance_denies_side_effect_boundary_violation(self) -> None:
+        context = deepcopy(self.context())
+        context["side_effect_boundary"] = {"respected": "no"}
+        allowance = MODULE.make_completion_allowance(MODULE.make_decision(context))
+        body = allowance["actuation_completion_allowance"]
+        self.assertEqual(body["verdict"], "denied")
+        self.assertEqual(body["can_call_update_goal_complete"], "no")
+        self.assertEqual(body["next_owner"], "$ship")
+        self.assertIn("side-effect-boundary-violated", body["blocked_reasons"])
+
     def test_check_rejects_complete_without_artifact_binding(self) -> None:
         decision = self.decision("atcg-v1.complete.example.json")
         decision["actuation_terminal_decision"]["current_artifact_binding"]["head_sha"] = ""
@@ -611,6 +670,47 @@ class ActuationTerminalGateTests(unittest.TestCase):
             self.assertEqual(code, 0)
             body = json.loads(out.read_text())["actuation_terminal_decision"]
             self.assertEqual(body["verdict"], "complete")
+
+    def test_cli_allow_complete_accepts_valid_complete_decision(self) -> None:
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT),
+                "allow-complete",
+                "--decision",
+                str(ASSETS / "atcg-v1.complete.example.json"),
+            ],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        body = json.loads(result.stdout)["actuation_completion_allowance"]
+        self.assertEqual(body["can_call_update_goal_complete"], "yes")
+
+    def test_cli_allow_complete_denies_valid_noncomplete_decision(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            decision_path = Path(td) / "blocked.json"
+            decision_path.write_text(
+                json.dumps(MODULE.make_decision(self.context("terminal-context.advisory-would-block.example.json"))),
+                encoding="utf-8",
+            )
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPT),
+                    "allow-complete",
+                    "--decision",
+                    str(decision_path),
+                ],
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+        self.assertEqual(result.returncode, 1, result.stdout + result.stderr)
+        body = json.loads(result.stdout)["actuation_completion_allowance"]
+        self.assertEqual(body["can_call_update_goal_complete"], "no")
+        self.assertEqual(body["decision_verdict"], "blocked")
 
 
 if __name__ == "__main__":

--- a/codex/skills/actuating/tools/actuation_terminal_gate.py
+++ b/codex/skills/actuating/tools/actuation_terminal_gate.py
@@ -762,6 +762,26 @@ def validate_decision(value: dict[str, Any]) -> dict[str, Any]:
     return result
 
 
+def make_completion_allowance(value: dict[str, Any]) -> dict[str, Any]:
+    validate_decision(value)
+    d = unwrap(value, "actuation_terminal_decision")
+    allowed = d.get("verdict") == "complete" and d.get("can_mark_goal_complete") == "yes"
+    result = {
+        "actuation_completion_allowance": {
+            "verdict": "allowed" if allowed else "denied",
+            "can_call_update_goal_complete": "yes" if allowed else "no",
+            "decision_version": d.get("decision_version"),
+            "decision_verdict": d.get("verdict"),
+            "can_mark_goal_complete": d.get("can_mark_goal_complete"),
+            "run_id": d.get("run_id"),
+            "next_owner": d.get("next_owner"),
+            "blocked_reasons": d.get("blocked_reasons", []),
+            "continue_reasons": d.get("continue_reasons", []),
+        }
+    }
+    return result
+
+
 def complete_dirty_state_allowed(decision: dict[str, Any], artifact: dict[str, Any]) -> bool:
     dirty_state = artifact.get("dirty_state")
     if dirty_state == "clean":
@@ -789,6 +809,8 @@ def main(argv: list[str] | None = None) -> int:
     p_decide.add_argument("--out")
     p_check = sub.add_parser("check")
     p_check.add_argument("--decision", required=True)
+    p_allow = sub.add_parser("allow-complete")
+    p_allow.add_argument("--decision", required=True)
     p_validate = sub.add_parser("validate")
     p_validate.add_argument("--context", required=True)
     p_validate.add_argument("--mode", choices=("advisory",), required=True)
@@ -804,6 +826,11 @@ def main(argv: list[str] | None = None) -> int:
             decision = load_json(args.decision)
             result = validate_decision(decision)
             emit(result)
+        elif args.cmd == "allow-complete":
+            decision = load_json(args.decision)
+            result = make_completion_allowance(decision)
+            emit(result)
+            return 0 if result["actuation_completion_allowance"]["can_call_update_goal_complete"] == "yes" else 1
         elif args.cmd == "validate":
             context = context_from(load_json(args.context))
             result = make_advisory(context)

--- a/codex/skills/goal-actuating/SKILL.md
+++ b/codex/skills/goal-actuating/SKILL.md
@@ -128,6 +128,12 @@ subagent result -> accept/reject/integrate through lead reducer
 ATCG -> complete|continue|blocked
 ```
 
+Before `$goal-actuating` calls `update_goal complete`, it must run the ATCG
+completion allowance guard over the current terminal decision. The goal may be
+marked complete only when the guard returns `can_call_update_goal_complete =
+yes`; valid `continue` and `blocked` ATCG decisions must continue with
+`next_owner` or report their blockers instead.
+
 ## Parallel scheduler
 
 `$goal-actuating` owns bounded parallel scheduling for the goal workflow.


### PR DESCRIPTION
## Summary
- add an ATCG completion allowance guard before local workflows can call `update_goal complete`
- deny valid `continue`/`blocked` ATCG decisions while preserving next owner and reasons
- update `$actuating`, `$goal-actuating`, and terminal-closure docs

## Proof
- `uv run python codex/skills/actuating/tests/test_actuation_terminal_gate.py`
- `uv run python codex/skills/actuating/tools/quick_validate.py`
- `git diff --check HEAD~1..HEAD`