### PR TITLE
Surface proof-patch resolution fold

### DIFF
--- a/codex/skills/proof-patch/SKILL.md
+++ b/codex/skills/proof-patch/SKILL.md
@@ -51,7 +51,7 @@ completion unless ATCG-v1 permits it.
 ## Review closure
 - CAS review source:
 - review-fold disposition:
-- resolve pass:
+- resolution fold:
 - accepted liabilities:
 - no-code dispositions:
 - clean normalized CAS runs:
@@ -95,8 +95,8 @@ completion unless ATCG-v1 permits it.
 3. Surface loop governance from ALSR-v1/HYL-v1/HSR-v1/ATCG-v1 receipts when
    they exist; otherwise state the direct-action fused exemption.
 4. Include evidence commands and results.
-5. Include review closure and review-fold disposition when review pressure was
-   present.
+5. Include review closure, review-fold disposition, and resolution fold state
+   when review pressure was present.
 6. Include parallelism state, even when the mode is `none`.
 7. Include anti-gaming checks.
 8. Name residual risks and focused human review targets.

--- a/codex/skills/proof-patch/agents/openai.yaml
+++ b/codex/skills/proof-patch/agents/openai.yaml
@@ -6,8 +6,9 @@ interface:
   default_prompt: >-
     Use $proof-patch before final /goal completion or PR handoff. Bind to current
     artifact state, summarize changed paths, loop governance receipts, review
-    closure, parallelism, validation, review dispositions, anti-gaming checks,
-    residual risk, and human review focus. State direct-action fused exemption
-    when ALSR/HYL is absent, never count cached CAS receipts as fresh clean runs,
-    and do not claim completion unless ATCG-v1 permits it. Escalate to $ship only
-    for publication, PR updates, thread resolution, or stronger release gates.
+    closure including resolution fold state, parallelism, validation, review
+    dispositions, anti-gaming checks, residual risk, and human review focus.
+    State direct-action fused exemption when ALSR/HYL is absent, never count
+    cached CAS receipts as fresh clean runs, and do not claim completion unless
+    ATCG-v1 permits it. Escalate to $ship only for publication, PR updates,
+    thread resolution, or stronger release gates.

--- a/codex/skills/proof-patch/tests/test_contract.py
+++ b/codex/skills/proof-patch/tests/test_contract.py
@@ -35,7 +35,7 @@ class ProofPatchContractTests(unittest.TestCase):
             "## Review closure",
             "- CAS review source:",
             "- review-fold disposition:",
-            "- resolve pass:",
+            "- resolution fold:",
             "- accepted liabilities:",
             "- no-code dispositions:",
             "- clean normalized CAS runs:",
@@ -76,6 +76,7 @@ class ProofPatchContractTests(unittest.TestCase):
         required_phrases = [
             "loop governance receipts",
             "review closure",
+            "resolution fold",
             "parallelism",
             "direct-action fused exemption",
             "never count cached CAS receipts as fresh clean runs",


### PR DESCRIPTION
## Summary
- Require proof-patch review closure to surface the resolution fold field.
- Align the proof-patch agent prompt and contract tests with the requested receipt surface.

## Proof
- `uv run python -m unittest codex/skills/proof-patch/tests/test_contract.py`: pass
- `rg -n "Loop governance|resolution fold:|cached CAS receipts counted as fresh: no|ATCG-v1 permits|Do not publish, update PR state" codex/skills/proof-patch`: pass
- `rg -n "resolve pass:" codex/skills/proof-patch || true`: no matches
- `uv run python -m unittest codex/skills/actuating/tests/test_actuation_terminal_gate.py`: pass

## Scope
- branch: proof-patch-loop-receipt-surfacing
- head: 2d8946a3
- base: main

## Readiness
- PR mode: ready
- Reason: scoped contract/prompt/test change with local validation passing.
- Caveats: none