### PR TITLE
[codex] Cover ATCG gates and normalize resolve workflow

### DIFF
--- a/codex/skills/actuating/SKILL.md
+++ b/codex/skills/actuating/SKILL.md
@@ -27,7 +27,7 @@ Use it as:
 
 ```text
 /goal $actuating implement the accepted spec
-/goal $actuating review and fix this PR
+/goal $actuating resolve this PR
 ```
 
 `$actuating` does not directly edit code, claim resources, patch review findings, spawn subagents, or publish PRs. It routes to the owner that should act and enforces the gates that make the run valid.
@@ -157,24 +157,24 @@ If the request is still ambiguous, `$actuating` must call `$spec-pipeline` in ga
 Use when the work is review closure:
 
 ```text
-/goal $actuating review and fix this PR
+/goal $actuating resolve this PR
 /goal $actuating close the review for this branch
 ```
 
-The default review behavior is `resolve-and-fix`.
+The default review behavior is `resolve`.
 
 When the user asks for review, review closure, code review, CAS review, review remediation, or to address review findings without explicitly saying not to implement, the workflow must:
 
 1. Use `$cas` as the review backend for fresh or exhaustive workflow review.
 2. Pass findings through `$review-fold`.
-3. Run a resolve pass to produce the smallest correct closure agenda.
+3. Run a resolution fold to produce the smallest correct resolution plan.
 4. Implement only accepted code-change liabilities.
 5. Preserve no-code dispositions: `reject`, `proof-only`, `follow-up`, and `ask-human`.
 6. Prefer `refactor-kernel` when several findings share one owner boundary.
 7. Run three consecutive clean normalized `$cas` review passes on the same artifact scope.
 8. Close through `$evidence-fold`, `$proof-patch`, and ATCG-v1.
 
-Do not treat `resolve-and-fix` as one patch per comment.
+Do not treat `resolve` as one patch per comment.
 
 #### Review-only
 
@@ -195,12 +195,12 @@ $cas review
 
 Do not call `$goal-grind`. The three-clean-review closure bar does not apply unless the user explicitly asks for exhaustive review certification.
 
-#### Resolve-only
+#### Resolution-plan-only
 
-Use when the user wants a closure agenda without implementation:
+Use when the user wants a resolution plan without implementation:
 
 ```text
-/goal $actuating resolve review findings for this branch; do not implement
+/goal $actuating make a resolution plan for this branch; do not implement
 ```
 
 The workflow performs:
@@ -208,19 +208,19 @@ The workflow performs:
 ```text
 $cas review or existing review findings
 -> $review-fold
--> resolve pass
--> resolution agenda
+-> resolution fold
+-> resolution plan
 -> stop
 ```
 
 Do not call `$goal-grind`. The three-clean-review closure bar does not apply because no remediation has occurred.
 
-#### Resolve-and-fix
+#### Resolve
 
 This is the default for review work unless the user explicitly requests no implementation:
 
 ```text
-/goal $actuating review and fix this PR
+/goal $actuating resolve this PR
 ```
 
 The workflow performs:
@@ -229,7 +229,7 @@ The workflow performs:
 $cas review
 -> $review-fold
 -> optional review-class-fanout
--> resolve pass
+-> resolution fold
 -> optional branch-race
 -> $goal-grind accepted liabilities only
 -> optional patch-fanout over disjoint accepted liabilities only
@@ -245,9 +245,9 @@ Raw review prose never reaches implementation directly.
 
 #### Three clean normalized CAS review runs
 
-For `resolve-and-fix` and exhaustive review, completion requires three consecutive clean normalized `$cas` review runs against the same current artifact scope unless the user explicitly lowers the review bar.
+For `resolve` and exhaustive review, completion requires three consecutive clean normalized `$cas` review runs against the same current artifact scope unless the user explicitly lowers the review bar.
 
-A clean normalized CAS run means `$cas` produces no new in-scope accepted liability after `$review-fold` and the resolve pass. The run is not made dirty by findings that are duplicate, rejected, out-of-scope, already-proven proof-only, deferred follow-up, or already-resolved by the current refactor kernel.
+A clean normalized CAS run means `$cas` produces no new in-scope accepted liability after `$review-fold` and the resolution fold. The run is not made dirty by findings that are duplicate, rejected, out-of-scope, already-proven proof-only, deferred follow-up, or already-resolved by the current refactor kernel.
 
 Do not increment the clean-run counter from repeated normalization of one cached CAS receipt. After terminal evidence exists for the tuple, request each additional independent run with `--fresh-attempt REASON`, then track the streak in the caller workflow from independent CAS review verdicts.
 
@@ -291,7 +291,7 @@ Allowed fanout modes:
 - `scout-fanout`: parallel read-only repository investigation.
 - `review-class-fanout`: parallel investigation or classification of review finding classes after `$cas review` and `$review-fold`.
 - `branch-race`: compare isolated strategies under the same verifier.
-- `patch-fanout`: implement disjoint accepted liabilities after the resolve pass.
+- `patch-fanout`: implement disjoint accepted liabilities after the resolution fold.
 - `proof-fanout`: run independent verification checks in parallel.
 
 Forbidden fanout:
@@ -412,7 +412,7 @@ Choose the narrowest mode that can complete safely:
 
 ```yaml
 actuating_mode:
-  source: direct-goal|spec-first|review-only|resolve-only|resolve-and-fix|dry-plan|st-governed
+  source: direct-goal|spec-first|review-only|resolution-plan-only|resolve|dry-plan|st-governed
   persistence: update_plan|goal-artifacts|st
   implementation: none|proof-only|minimal-fix|refactor-kernel|branch-race
   review_source: none|existing-review|cas-probe|cas-lane|cas-exhaustive
@@ -428,9 +428,9 @@ Default:
 spec-first + update_plan + minimal-fix + proof-patch
 ```
 
-Switch to `resolve-and-fix` when reviews, CAS findings, or reviewer suggestions are present and no no-code modifier is present.
+Switch to `resolve` when reviews, CAS findings, or reviewer suggestions are present and no no-code modifier is present.
 Switch to `review-only` when the user asks for review-only, audit-only, classify-only, no changes, or do not implement behavior.
-Switch to `resolve-only` when the user asks for a plan or resolution agenda without implementation.
+Switch to `resolution-plan-only` when the user asks for a plan or resolution plan without implementation.
 Switch to `cas-exhaustive` when exhaustive review is requested or required by the proof bar.
 Switch to `refactor-kernel` when repeated findings share an owner boundary.
 Switch to `branch-race` when local fix and refactor-kernel are both plausible and can be compared under the same verifier.
@@ -461,39 +461,7 @@ ATCG-v1 verdict = complete
 ATCG-v1 can_mark_goal_complete = yes
 ```
 
-Before a workflow calls `update_goal complete`, it must run the local completion
-allowance guard over the current ATCG-v1 decision:
-
-```bash
-uv run python codex/skills/actuating/tools/actuation_terminal_gate.py \
-  allow-complete \
-  --decision .ledger/actuating/<run-id>/terminal-decision.json
-```
-
-Only `can_call_update_goal_complete = yes` permits the `update_goal complete`
-call. A valid ATCG `continue` or `blocked` decision must deny completion and
-carry the `next_owner`, `continue_reasons`, or `blocked_reasons` forward.
-
 If ATCG-v1 returns `continue`, continue with `next_owner`. If it returns `blocked`, report the blocked actuation verdict and reasons. Do not substitute local proof, proof-complete graph state, cached CAS receipts, or ADD-v1 `handoff_to_ship` for terminal completion.
-
-Hard ATCG-v1 completion blockers:
-
-```text
-blocked-loop-contract-missing
-blocked-loop-contract-stale
-blocked-hylo-frontier-missing
-blocked-hylo-fold-missing
-blocked-hylo-terminal-missing
-cas-review-blocked
-st-authority-blocked
-proof-stale
-side-effect-boundary-violated
-```
-
-Direct-action fused and `$st`-governed runs may exempt ALSR/HYL/HSR checks only
-when the terminal context explicitly carries the exemption. `$st`-governed
-completion also requires current `$st` control evidence; a `st_handoff` source
-without a current receipt is not enough.
 
 ## Stop rules
 

--- a/codex/skills/actuating/agents/openai.yaml
+++ b/codex/skills/actuating/agents/openai.yaml
@@ -10,7 +10,7 @@ interface:
     nontrivial. For material recursive work, require $agent-loop-schemes to emit
     ALSR-v1 and HYL-v1 before mutation unless the run is direct-action fused or
     $st-governed. $goal-actuating interprets HYL-v1 and emits HSR-v1 steps. For
-    review requests, default to resolve-and-fix unless the user explicitly says
+    review requests, default to resolve unless the user explicitly says
     not to implement. Fresh or exhaustive workflow review must use $cas review,
     findings must pass through $review-fold, and only accepted code-change
     liabilities may reach implementation. Completion requires terminal ATCG-v1.

--- a/codex/skills/actuating/assets/terminal-context.advisory-would-block.example.json
+++ b/codex/skills/actuating/assets/terminal-context.advisory-would-block.example.json
@@ -76,11 +76,11 @@
       "selected_loop": {
         "matches_task_shape": "no"
       },
-      "review_fix": {
+      "resolve": {
         "required": "yes",
         "cas_reviewed": "no",
         "review_folded": "no",
-        "resolve_passed": "no"
+        "resolve_obeyed": "no"
       },
       "cas_clean_runs": {
         "required": "yes",

--- a/codex/skills/actuating/references/decision-contract.yaml
+++ b/codex/skills/actuating/references/decision-contract.yaml
@@ -12,7 +12,7 @@ skill_decision_contract:
       exclusions: []
     - trigger_id: ACT-REVIEW
       description: The user wants review closure or code review as part of the workflow.
-      cue_literals: [review closure, code review, exhaustive review, close review, review and fix]
+      cue_literals: [review closure, code review, exhaustive review, close review, resolve]
       cue_regexes: []
       exclusions: []
     - trigger_id: ACT-HYLO
@@ -102,7 +102,7 @@ skill_decision_contract:
       required_artifacts:
         - CAS review verdict when workflow code review is required
         - review-fold disposition
-        - resolve pass for resolve-and-fix
+        - resolution fold for resolve
         - three clean normalized CAS review runs unless explicitly lowered
       success_signals:
         - fresh or exhaustive workflow review comes from $cas

--- a/codex/skills/actuating/references/terminal-closure-gate.md
+++ b/codex/skills/actuating/references/terminal-closure-gate.md
@@ -106,7 +106,7 @@ $st-governed completion without current $st control receipt -> st-authority-bloc
 CAS required + clean runs < required -> blocked, next_owner=$cas
 CAS required + clean_runs_required <= 0 -> blocked, next_owner=$cas
 CAS required + final report clean runs < required -> blocked, next_owner=$cas
-review-fix protocol incomplete -> cas-review-blocked, next_owner=$cas
+resolve protocol incomplete -> cas-review-blocked, next_owner=$cas
 proof-patch required + missing/stale -> continue, next_owner=$proof-patch
 proof-patch closure + missing proof-patch receipt -> continue, next_owner=$proof-patch
 ADD-v1 handoff + ship result missing -> continue, next_owner=$ship
@@ -175,7 +175,7 @@ terminal HSR exists
 every material mutation has HSR unfold/action/fold
 latest fold is current-artifact-bound
 selected loop matches task shape
-review-fix obeyed CAS/review-fold/resolve
+resolve obeyed CAS/review-fold/resolve
 three clean normalized CAS runs complete when required
 side-effect boundary respected
 proof matches verifier

--- a/codex/skills/actuating/tests/test_actuation_terminal_gate.py
+++ b/codex/skills/actuating/tests/test_actuation_terminal_gate.py
@@ -62,7 +62,7 @@ class ActuationTerminalGateTests(unittest.TestCase):
         self.assertIn("cas.clean_runs:0-of-3", body["blocked_reasons"])
         self.assertIn("final_report.normalized_cas_clean_runs:not-satisfied", body["blocked_reasons"])
 
-    def test_advisory_would_block_matches_fixture_expectation(self) -> None:
+    def test_advisory_would_block_matches_seq_fixture_expectation(self) -> None:
         fixture = self.fixture("terminal-context.advisory-would-block.example.json")
         advisory = MODULE.make_advisory(fixture["actuation_terminal_context"])
         self.assertEqual(advisory["verdict"], "advisory")
@@ -109,6 +109,45 @@ class ActuationTerminalGateTests(unittest.TestCase):
         self.assertEqual(body["next_owner"], fixture["advisory_expectation"]["next_owner"])
         for reason in fixture["advisory_expectation"]["would_block_reasons"]:
             self.assertIn(reason, body["blocked_reasons"])
+
+    def test_resolve_governance_accepts_cas_review_fold_and_resolve(self) -> None:
+        context = deepcopy(self.context())
+        context["loop_governance"] = {
+            "resolve": {
+                "required": "yes",
+                "cas_reviewed": "yes",
+                "review_folded": "yes",
+                "resolve_obeyed": "yes",
+            }
+        }
+        decision = MODULE.make_decision(context)
+        body = decision["actuation_terminal_decision"]
+        self.assertEqual(body["verdict"], "complete")
+        self.assertEqual(body["can_mark_goal_complete"], "yes")
+
+    def test_resolve_governance_blocks_without_cas_review_fold_or_resolve(self) -> None:
+        context = deepcopy(self.context())
+        context["loop_governance"] = {
+            "resolve": {
+                "required": "yes",
+                "cas_reviewed": "no",
+                "review_folded": "yes",
+                "resolve_obeyed": "yes",
+            }
+        }
+        self.assert_blocks_with(context, "cas-review-blocked", "$cas")
+
+    def test_legacy_review_fix_governance_still_blocks_without_resolve(self) -> None:
+        context = deepcopy(self.context())
+        context["loop_governance"] = {
+            "review_fix": {
+                "required": "yes",
+                "cas_reviewed": "yes",
+                "review_folded": "yes",
+                "resolve_passed": "no",
+            }
+        }
+        self.assert_blocks_with(context, "cas-review-blocked", "$cas")
 
     def test_advisory_direct_action_fused_exempts_loop_receipts(self) -> None:
         fixture = self.fixture("terminal-context.advisory-fused.example.json")

--- a/codex/skills/actuating/tools/actuation_terminal_gate.py
+++ b/codex/skills/actuating/tools/actuation_terminal_gate.py
@@ -197,8 +197,8 @@ def hard_completion_reasons_for(context: dict[str, Any]) -> list[str]:
     if selected_loop and not as_yes(selected_loop.get("matches_task_shape")):
         append_reason(reasons, "blocked-hylo-frontier-missing")
 
-    review_fix = object_from(loop.get("review_fix"))
-    if as_yes(review_fix.get("required")) and not review_fix_obeyed(review_fix):
+    resolve = resolve_governance_for(loop)
+    if as_yes(resolve.get("required")) and not resolve_obeyed(resolve):
         append_reason(reasons, "cas-review-blocked")
 
     if cas_advisory_blocked(context, loop):
@@ -258,11 +258,22 @@ def material_mutation_hsr_reasons(loop: dict[str, Any], hsr: dict[str, Any]) -> 
     return reasons
 
 
-def review_fix_obeyed(review_fix: dict[str, Any]) -> bool:
+def resolve_governance_for(loop: dict[str, Any]) -> dict[str, Any]:
+    resolve = object_from(loop.get("resolve"))
+    if resolve:
+        return resolve
+    return object_from(loop.get("review_fix"))
+
+
+def any_yes(obj: dict[str, Any], *keys: str) -> bool:
+    return any(as_yes(obj.get(key)) for key in keys)
+
+
+def resolve_obeyed(resolve: dict[str, Any]) -> bool:
     return (
-        as_yes(review_fix.get("cas_reviewed"))
-        and as_yes(review_fix.get("review_folded"))
-        and as_yes(review_fix.get("resolve_passed"))
+        any_yes(resolve, "cas_reviewed", "cas_obeyed", "cas_satisfied")
+        and any_yes(resolve, "review_folded", "review_fold_obeyed", "review_fold_satisfied")
+        and any_yes(resolve, "resolve_passed", "resolve_obeyed", "resolved", "resolution_folded")
     )
 
 

--- a/codex/skills/agent-loop-schemes/SKILL.md
+++ b/codex/skills/agent-loop-schemes/SKILL.md
@@ -80,7 +80,7 @@ agent_loop_scheme_receipt:
     diff_digest:
     paths: []
   task_shape: direct|goal|review|debug|migration|branch_race|proof_closure|st_governed
-  selected_loop: direct_action|goal_grind|resolve_and_fix|review_only|resolve_only|debug_history|migration_memoized|branch_race|proof_patch|st_governed
+  selected_loop: direct_action|goal_grind|resolve|review_only|resolution_plan_only|debug_history|migration_memoized|branch_race|proof_patch|st_governed
   seed:
     source:
     authority:
@@ -160,7 +160,7 @@ actuation_hylomorphism:
       - verify
       - cas_review
       - review_fold
-      - resolve_pass
+      - resolution_fold
       - subagent_spawn
       - branch_race
       - st_handoff
@@ -173,7 +173,7 @@ actuation_hylomorphism:
       - command_output
       - cas_review
       - review_fold
-      - resolve_pass
+      - resolution_fold
       - subagent_result
       - proof_patch
     emits: continue|complete|blocked|regress|replan|refactor-kernel|st-required
@@ -302,14 +302,14 @@ Use for ordinary long-running coding goals with a verifier.
 goal contract -> work list when useful -> HYL step -> evidence fold -> continue or stop
 ```
 
-### Resolve-and-fix
+### Resolve
 
 Default for review work unless the user explicitly says not to implement.
 
 ```text
 $cas review
 -> $review-fold
--> resolve pass
+-> resolution fold
 -> $goal-grind accepted liabilities only
 -> $evidence-fold
 -> 3 clean normalized $cas review runs
@@ -333,15 +333,15 @@ $cas review
 
 No `$goal-grind`.
 
-### Resolve-only
+### Resolution-plan-only
 
-Use when the user wants the minimal closure agenda but no code changes.
+Use when the user wants the minimal resolution plan but no code changes.
 
 ```text
 $cas review or existing findings
 -> $review-fold
--> resolve pass
--> review closure agenda
+-> resolution fold
+-> review resolution plan
 -> stop
 ```
 
@@ -432,7 +432,7 @@ same canonical owner
 same invalid state transition
 ```
 
-A resolve-and-fix HYL unfolds review classes and accepted liabilities, not raw findings.
+A resolve HYL unfolds review classes and accepted liabilities, not raw findings.
 
 ## Parallelism law
 
@@ -523,7 +523,7 @@ terminal_without_stop_rule
 terminal_without_atcg
 parallel_fanout_without_fanin
 stale_hylo_after_diff_change
-review_fix_without_review_fold
+resolve_without_review_fold
 raw_review_to_patch
 cached_cas_counted_as_fresh
 ```
@@ -554,7 +554,7 @@ the next action would repeat a known invalid strategy
 - `$actuating` when the user wants the high-level workflow.
 - `$cas` as the review backend for workflow code review.
 - `$review-fold` to classify findings before implementation.
-- `$resolve` only when a dedicated closure agenda is needed.
+- `$resolve` only when a dedicated resolution fold or closure decision is needed.
 - `$goal-grind` for accepted implementation liabilities.
 - `$evidence-fold` after verification or review results.
 - `$failure-memory` when repeated classes or oscillation appear.

--- a/codex/skills/agent-loop-schemes/references/examples.md
+++ b/codex/skills/agent-loop-schemes/references/examples.md
@@ -1,15 +1,15 @@
 # Examples
 
-## Existing PR, review and fix
+## Existing PR, resolve
 
 ```text
-/goal $actuating review and fix this PR
+/goal $actuating resolve this PR
 ```
 
 Means:
 
 ```text
-CAS review, classify, build a closure agenda, fix accepted liabilities only, verify, require caller-owned repeated clean CAS review evidence units, then proof-patch.
+CAS review, classify, build a resolution plan, fix accepted liabilities only, verify, require caller-owned repeated clean CAS review evidence units, then proof-patch.
 ```
 
 ## Existing PR, no implementation

--- a/codex/skills/agent-loop-schemes/references/review-loop.md
+++ b/codex/skills/agent-loop-schemes/references/review-loop.md
@@ -5,7 +5,7 @@
 ```text
 $cas review
 -> $review-fold
--> closure-agenda pass
+-> resolution fold
 -> $goal-grind accepted liabilities only
 -> $evidence-fold
 -> 3 clean CAS review evidence units
@@ -18,12 +18,12 @@ $cas review
 | Mode | Purpose | Code changes |
 |---|---|---|
 | review-only | Find and classify review findings. | No |
-| agenda-only | Produce the closure agenda. | No |
-| review-fix | Default review remediation. Classify, fix accepted liabilities, prove closure. | Yes |
+| resolution-plan-only | Produce the resolution plan. | No |
+| resolve | Default review remediation. Classify, fix accepted liabilities, prove closure. | Yes |
 
 ## Clean CAS review evidence unit
 
-A clean CAS review evidence unit is either a `CAS-RER-v1` record or, on dispatchers without the ledger surface, a normalized tuple-bound `reviewVerdict` compatibility projection. It must carry current-tuple clean evidence with strong usable principal and must show no new in-scope accepted liability, unresolved proof gap, unresolved refactor-kernel candidate, or human-owned blocker after review-fold and the closure-agenda pass.
+A clean CAS review evidence unit is either a `CAS-RER-v1` record or, on dispatchers without the ledger surface, a normalized tuple-bound `reviewVerdict` compatibility projection. It must carry current-tuple clean evidence with strong usable principal and must show no new in-scope accepted liability, unresolved proof gap, unresolved refactor-kernel candidate, or human-owned blocker after review-fold and the resolution fold.
 
 The run is still clean when findings are duplicate, rejected, out-of-scope, already-proven proof-only, follow-up, or already addressed by the current implementation.
 

--- a/codex/skills/agent-loop-schemes/references/schemas/alsr-v1.schema.yml
+++ b/codex/skills/agent-loop-schemes/references/schemas/alsr-v1.schema.yml
@@ -10,7 +10,7 @@ agent_loop_scheme_receipt:
     diff_digest:
     paths: []
   task_shape: direct|goal|review|debug|migration|branch_race|proof_closure|st_governed
-  selected_loop: direct_action|goal_grind|resolve_and_fix|review_only|resolve_only|debug_history|migration_memoized|branch_race|proof_patch|st_governed
+  selected_loop: direct_action|goal_grind|resolve|review_only|resolution_plan_only|debug_history|migration_memoized|branch_race|proof_patch|st_governed
   seed:
     source:
     authority:

--- a/codex/skills/goal-actuating/SKILL.md
+++ b/codex/skills/goal-actuating/SKILL.md
@@ -45,11 +45,11 @@ When an accepted implementation spec is present, treat it as the source of truth
 
 ```yaml
 goal_actuating_mode:
-  source: direct-goal|spec-first|review-only|resolve-only|resolve-and-fix|dry-plan|st-governed
+  source: direct-goal|spec-first|review-only|resolution-plan-only|resolve|dry-plan|st-governed
   persistence: update_plan|goal-artifacts|st
   implementation: none|proof-only|minimal-fix|refactor-kernel|branch-race
   review: none|existing-review|cas-probe|cas-lane|cas-exhaustive
-  resolution: none|review-fold-only|resolve-pass|resolve-and-fix|resolve-campaign
+  resolution: none|review-fold-only|resolution-fold|resolve|resolve-campaign
   scheme_plan: none|required|present
   loop_contract: fused|ALSR-HYL|required|st-owned
   parallelism: none|scout-fanout|review-class-fanout|patch-fanout|proof-fanout|branch-race
@@ -67,13 +67,13 @@ goal_actuating_mode:
 7. Interpret HYL-v1: unfold a legal work node/frontier, execute it, fold evidence, and emit HSR-v1.
 8. If the workflow performs fresh or exhaustive review, run `$cas` review.
 9. Classify review findings with `$review-fold`.
-10. Run a resolve pass when review work needs a closure agenda.
+10. Run a resolution fold when review work needs a resolution plan.
 11. Create a work list with `$goal-workgraph` only when decomposition changes execution.
 12. Schedule bounded subagents only for explicit safe frontier nodes.
 13. Execute one useful action at a time with `$goal-grind`, unless `$st` owns execution.
-14. Fold verification, review, and subagent results with `$evidence-fold`, `$review-fold`, or the resolve pass as appropriate.
+14. Fold verification, review, and subagent results with `$evidence-fold`, `$review-fold`, or the resolution fold as appropriate.
 15. Use `$failure-memory` when failures or review classes repeat.
-16. For `resolve-and-fix` and exhaustive review, require three consecutive clean normalized `$cas` review runs on the same artifact scope before completion.
+16. For `resolve` and exhaustive review, require three consecutive clean normalized `$cas` review runs on the same artifact scope before completion.
 17. Run ATCG-v1 before completion.
 18. Close with `$proof-patch`, or hand off to `$ship` only when publication is requested and ready.
 
@@ -104,7 +104,7 @@ if material and no ALSR/HYL -> produce agent-loop-schemes node
 if no goal contract -> produce goal-contract node
 if review requested and no CAS result -> produce CAS review node
 if CAS findings unclassified -> produce review-fold node
-if review requested and no resolve agenda -> produce resolve-pass node
+if review requested and no resolve agenda -> produce resolution-fold node
 if accepted liabilities remain -> produce patch/refactor/branch-race node
 if proof missing -> produce verifier/proof node
 if clean CAS count < 3 -> produce fresh CAS review node
@@ -121,18 +121,12 @@ The algebra folds effects into actuation state:
 code change -> reset clean CAS count and proof freshness
 CAS review -> normalize through review-fold and update clean counter
 review-fold -> update dispositions and quotient findings into classes
-resolve pass -> update accepted liabilities / no-code dispositions / blockers
+resolution fold -> update accepted liabilities / no-code dispositions / blockers
 proof check -> update verifier state
 proof patch -> update proof state
 subagent result -> accept/reject/integrate through lead reducer
 ATCG -> complete|continue|blocked
 ```
-
-Before `$goal-actuating` calls `update_goal complete`, it must run the ATCG
-completion allowance guard over the current terminal decision. The goal may be
-marked complete only when the guard returns `can_call_update_goal_complete =
-yes`; valid `continue` and `blocked` ATCG decisions must continue with
-`next_owner` or report their blockers instead.
 
 ## Parallel scheduler
 
@@ -145,7 +139,7 @@ Allowed scheduler decisions:
 - use `repo_scout` for read-only fact-finding over independent repository areas;
 - use `review_reducer` over review classes after `$cas review` and `$review-fold`;
 - use `branch_racer` when strategies can be isolated and compared by the same verifier;
-- use `patch_worker` only after the resolve pass accepts code-change liabilities and the nodes are file-disjoint or otherwise isolated;
+- use `patch_worker` only after the resolution fold accepts code-change liabilities and the nodes are file-disjoint or otherwise isolated;
 - use `evidence_critic` for proof fan-in or contested evidence.
 
 The lead must fold all subagent outputs before continuing.
@@ -156,7 +150,7 @@ No subagent may declare the goal complete, post/update public PR state, or broad
 Every subagent result must fold through exactly one owner:
 
 - `review-fold` for review classification results;
-- `resolve pass` for closure agenda decisions;
+- `resolution fold` for resolution plan decisions;
 - `evidence-fold` for tests, proof, diffs, logs, and verifier output;
 - lead integration for accepted patches;
 - `$ship` only for PR creation/update/promotion/publication.
@@ -189,13 +183,13 @@ A goal may close without code review only when the accepted proof requirements d
 
 ## Review behavior
 
-If review is requested and no no-code modifier is present, use `resolve-and-fix`.
+If review is requested and no no-code modifier is present, use `resolve`.
 
 ```text
 $cas review
 -> $review-fold
 -> optional review-class-fanout
--> resolve pass
+-> resolution fold
 -> optional branch-race
 -> $goal-grind accepted liabilities only
 -> optional patch-fanout over disjoint accepted liabilities only
@@ -212,7 +206,7 @@ do not implement
 review only
 audit only
 classify only
-resolve only
+resolution plan only
 plan only
 no changes
 ```

--- a/codex/skills/goal-workgraph/SKILL.md
+++ b/codex/skills/goal-workgraph/SKILL.md
@@ -63,7 +63,7 @@ work_graph:
     mode: none|scout-fanout|review-class-fanout|patch-fanout|proof-fanout|branch-race
     max_agents:
     allowed_roles: []
-    fan_in: evidence-fold|review-fold|resolve-pass|lead-integration
+    fan_in: evidence-fold|review-fold|resolution-fold|lead-integration
     stop_on_blocker: yes|no
     stop_on_winner: yes|no
   escalation:
@@ -88,7 +88,7 @@ work_graph:
 1. Emit `parallel_safe: yes` only when dependencies are satisfied, paths/resources do not conflict, and the proof surface is known.
 2. Use `scout-fanout` only for read-only fact finding.
 3. Use `review-class-fanout` only after CAS findings have been grouped.
-4. Use `patch-fanout` only after the resolve pass accepts code-change liabilities.
+4. Use `patch-fanout` only after the resolution fold accepts code-change liabilities.
 5. Use `branch-race` only when all strategies share the same verifier.
 6. Mark shared invariants, shared files, or shared owner-boundary fixes as `parallel_safe: no`.
 7. Prefer one `refactor-kernel` node over parallel local patches when findings share an owner boundary.

--- a/codex/skills/recursion-scheme-planner/references/examples.md
+++ b/codex/skills/recursion-scheme-planner/references/examples.md
@@ -24,7 +24,7 @@ handoff:
 Input:
 
 ```text
-/goal $actuating review and fix this PR
+/goal $actuating resolve this PR
 ```
 
 Output:
@@ -40,7 +40,7 @@ selected:
     - zygo: proof-patch
 review_policy:
   source: cas-review
-  mode: resolve-and-fix
+  mode: resolve
   clean_cas_runs_required: 3
 ```
 

--- a/codex/skills/recursion-scheme-planner/references/scheme-catalog.md
+++ b/codex/skills/recursion-scheme-planner/references/scheme-catalog.md
@@ -24,7 +24,7 @@ This catalogue is a practical planning map. It is not a theorem-prover and not a
 Most real coding tasks use combinations:
 
 ```text
-review resolve-and-fix = cata(CAS findings) + dyna(review classes) + hylo(accepted fixes) + zygo(proof) + terminal CAS fixed point
+review resolve = cata(CAS findings) + dyna(review classes) + hylo(accepted fixes) + zygo(proof) + terminal CAS fixed point
 migration = ana(package/error matrix) + dyna(class memoization) + hylo(apply/prove) + cata(repo evidence)
 hard debug = histo(attempts) + futu(strategy branches) + hylo(action/evidence)
 refactor = para(original code) + meta(old->new shape) + zygo(proof)
@@ -33,7 +33,7 @@ parallel PR review = ana(review classes) + parallel traversal + cata(resolve/fan
 
 ## Clean CAS fixed point
 
-For `resolve-and-fix` and exhaustive review:
+For `resolve` and exhaustive review:
 
 ```text
 3 consecutive clean normalized CAS review runs

--- a/codex/skills/review-fold/SKILL.md
+++ b/codex/skills/review-fold/SKILL.md
@@ -27,16 +27,16 @@ This skill is the review-specific evidence fold for the recursive goal scheme. I
 
 `$review-fold` classifies findings. It does not, by itself, decide that review work stops.
 
-For `$actuating` review workflows, default closure mode is `resolve-and-fix` unless the user explicitly requests `review-only`, `resolve-only`, audit-only, or no implementation.
+For `$actuating` review workflows, default closure mode is `resolve` unless the user explicitly requests `review-only`, `resolution-plan-only`, audit-only, or no implementation.
 
 ```text
 $cas = review source
 $review-fold = finding classifier
-resolve pass = closure agenda compiler
+resolution fold = resolution plan compiler
 $goal-grind = implementation engine for accepted liabilities
 ```
 
-For `resolve-and-fix` and exhaustive review, final completion requires three consecutive clean normalized `$cas` review runs after implementation. `$review-fold` decides whether each CAS run is normalized clean.
+For `resolve` and exhaustive review, final completion requires three consecutive clean normalized `$cas` review runs after implementation. `$review-fold` decides whether each CAS run is normalized clean.
 
 ## Review source rule
 
@@ -87,7 +87,7 @@ review_fold:
     reabstraction_candidate: yes|no
     one_patch_per_comment_risk: low|medium|high
   recommended_resolution:
-    mode: review-only|resolve-only|resolve-and-fix
+    mode: review-only|resolution-plan-only|resolve
     reason:
     no_code_modifier_detected: yes|no
     accepted_liability_count:
@@ -122,8 +122,8 @@ review_fold:
 ### Workflow resolution modes
 
 - `review-only`: classify findings and stop without a remediation agenda.
-- `resolve-only`: classify findings and produce a closure agenda without implementation.
-- `resolve-and-fix`: default `$actuating` review mode; implement only accepted code-change liabilities after the resolve pass, then require three clean normalized CAS review runs before completion.
+- `resolution-plan-only`: classify findings and produce a resolution plan without implementation.
+- `resolve`: default `$actuating` review mode; implement only accepted code-change liabilities after the resolution fold, then require three clean normalized CAS review runs before completion.
 
 ### `adjudicate-only`
 
@@ -159,7 +159,7 @@ CAS review is blocked and the blocker is reported
 user explicitly lowers the review proof bar
 ```
 
-A clean normalized CAS run means no new in-scope accepted liability, unresolved proof gap, unresolved refactor-kernel candidate, or human-owned blocker remains after `$review-fold` and the resolve pass. Duplicate, rejected, out-of-scope, already-proven proof-only, follow-up, or already-resolved findings do not make the run dirty.
+A clean normalized CAS run means no new in-scope accepted liability, unresolved proof gap, unresolved refactor-kernel candidate, or human-owned blocker remains after `$review-fold` and the resolution fold. Duplicate, rejected, out-of-scope, already-proven proof-only, follow-up, or already-resolved findings do not make the run dirty.
 
 Reset the clean-run counter to zero when code changes, review scope changes, base/head/diff changes, the proof bar changes, or CAS lane continuity is lost.
 
@@ -171,11 +171,11 @@ Reset the clean-run counter to zero when code changes, review scope changes, bas
 2. If fresh/exhaustive workflow code review is required and no CAS result is present, stop and request `$cas` review.
 3. Classify each finding before any implementation.
 4. Collapse duplicates and same-family comments.
-5. Recommend `review-only`, `resolve-only`, or `resolve-and-fix` from the user's requested mode and the accepted liabilities.
+5. Recommend `review-only`, `resolution-plan-only`, or `resolve` from the user's requested mode and the accepted liabilities.
 6. Decide whether each finding's proper response is no code, proof, local fix, refactor, branch race, ask, or follow-up.
 7. Mark review-class fanout safe only for classification/investigation classes; raw findings must not fan out directly to patch workers.
 8. Produce a small work graph only for accepted liabilities.
-9. Hand off to `$goal-grind` for implementation and `$evidence-fold` for proof only after a resolve pass accepts code-change liabilities.
+9. Hand off to `$goal-grind` for implementation and `$evidence-fold` for proof only after a resolution fold accepts code-change liabilities.
 10. For post-implementation CAS runs, mark whether the normalized result is clean and whether the clean-run counter resets.
 11. Preserve reviewer response drafts as drafts; do not post public comments unless explicitly asked.
 
@@ -183,10 +183,10 @@ Reset the clean-run counter to zero when code changes, review scope changes, bas
 
 When called by `$actuating`:
 
-- default to `resolve-and-fix` for review requests;
-- require three consecutive clean normalized `$cas` review runs before completing `resolve-and-fix` or exhaustive review;
+- default to `resolve` for review requests;
+- require three consecutive clean normalized `$cas` review runs before completing `resolve` or exhaustive review;
 - use `review-only` only when the user explicitly asks for no implementation or classification only;
-- use `resolve-only` only when the user explicitly asks for a plan/agenda without implementation;
+- use `resolution-plan-only` only when the user explicitly asks for a plan/agenda without implementation;
 - preserve no-code dispositions for rejected, proof-only, follow-up, or human-owned findings;
 - never send raw review findings directly to implementation.
 
@@ -197,7 +197,7 @@ do not implement
 review only
 audit only
 classify only
-resolve only
+resolution plan only
 plan only
 no changes
 ```
@@ -209,5 +209,5 @@ no changes
 - Do not accept scope expansion without user authority.
 - Do not miss the refactor when many comments share one owner boundary.
 - Do not replace a requested or required CAS review with non-CAS critique.
-- Do not claim review closure before three clean normalized CAS runs when `resolve-and-fix` or exhaustive review requires them.
+- Do not claim review closure before three clean normalized CAS runs when `resolve` or exhaustive review requires them.
 - Do not resolve or reply to PR threads without explicit public-side-effect intent.

--- a/codex/skills/review-fold/agents/openai.yaml
+++ b/codex/skills/review-fold/agents/openai.yaml
@@ -7,7 +7,7 @@ interface:
     Use $review-fold for CAS findings, PR comments, reviewer suggestions, or
     review-like claims. Bind findings to the original goal and current diff,
     compress duplicates, classify liability and intent relation, and choose
-    review-only, resolve-only, resolve-and-fix, proof-only, minimal-fix,
+    review-only, resolution-plan-only, resolve, proof-only, minimal-fix,
     refactor-kernel, branch-race, or st-governed before code changes. If fresh or
     exhaustive workflow review is required and no CAS result is present, route to
     $cas review first. Mark normalized CAS clean runs when closing review.

--- a/codex/skills/review-fold/references/review-modes.md
+++ b/codex/skills/review-fold/references/review-modes.md
@@ -4,7 +4,7 @@ The review loop is a reducer, not a patch queue.
 
 ## Workflow defaults
 
-`$actuating review ...` defaults to `resolve-and-fix`.
+`$actuating review ...` defaults to `resolve`.
 
 No-code modes require explicit language:
 
@@ -13,12 +13,12 @@ do not implement
 review only
 audit only
 classify only
-resolve only
+resolution plan only
 plan only
 no changes
 ```
 
-`resolve-and-fix` still preserves no-code dispositions. A review with ten findings may close as:
+`resolve` still preserves no-code dispositions. A review with ten findings may close as:
 
 ```text
 2 rejected


### PR DESCRIPTION
## Summary

- Tightens ATCG #04/#05 coverage by accepting explicit `resolve` loop governance for CAS/review-fold/resolve checks while preserving legacy `review_fix` compatibility.
- Updates the advisory would-block fixture and terminal closure docs to match the advisory/hard-enforcement spec wording.
- Normalizes review workflow terminology across actuation, loop scheme, workgraph, and review-fold docs from `resolve-and-fix` / `resolve-only` to `resolve` / `resolution-plan-only`.

## Proof

- `uv run python codex/skills/actuating/tests/test_actuation_terminal_gate.py`: pass, 59 tests OK
- `uv run python codex/skills/actuating/tools/quick_validate.py`: pass, authority 7 / delivery 8 / terminal 59
- `rg -n "resolve-and-fix|resolve_only|resolve-only|resolve_and_fix|resolve pass|resolve-pass|closure agenda|closure-agenda|review and fix|review-fix" codex/skills -g '!*__pycache__*'`: only unrelated legacy agent filename reference remains

## Scope

- branch: `codex/atcg-advisory-hard-coverage`
- head: `ae830542845e212783fe94809d05bcc476a77672`
- base: `main`

## Readiness

- PR mode: ready
- Reason: requested all dotfiles changes merged; validation passed locally.
- Caveats: hosted check rollup is empty at PR update time.
