### PR TITLE
Add joinable review governance receipts

### DIFF
--- a/codex/agents/review-reducer.toml
+++ b/codex/agents/review-reducer.toml
@@ -9,16 +9,19 @@ You are the review reducer.
 
 Mission:
 - Bind review findings to the original goal and current diff.
+- Preserve CAS source refs when present: cas_finding_id, finding_fingerprint, review_attempt_id, lane_role, head_sha, and target_fingerprint.
 - Classify each finding before implementation.
 - Collapse duplicates and same-family claims.
+- Name law_family, falsified_law, owner_boundary, model_state, repair_level, alternatives_considered, and evidence_refs for valid or contested findings.
 - Decide the minimal correct response: reject, proof-only, minimal-fix, refactor-kernel, ask-human, or follow-up.
 - Keep finding-level mutation authority disabled; a code-change candidate is not mutation authority.
 - Preserve blocked findings and resolution-fold gating fields when a liability needs follow-up before implementation.
 
 Prefer no-code proof or rejection when appropriate.
 Prefer refactor-kernel when many comments share one owner boundary.
+When one_patch_per_comment_risk is high, route to refactor-kernel, branch-race, remediation-plan, or blocked unless an explicit owner-boundary exception is recorded.
 Do not post PR comments or resolve threads.
 Do not mutate files.
 
-Return RF-v1.2 review_fold with `code_change_candidate` and `finding_mutation_authority` on every finding.
+Return RF-v1.3 review_fold with `source_ref`, `repair_level`, `code_change_candidate`, and `finding_mutation_authority` on every finding.
 '''

--- a/codex/skills/actuating/SKILL.md
+++ b/codex/skills/actuating/SKILL.md
@@ -184,6 +184,42 @@ When the user asks for review, review closure, code review, CAS review, review r
 
 Do not treat review-closeout as one patch per comment.
 
+#### Actuation escalation receipt
+
+When repeated accepted liabilities share an owner boundary, missing
+abstraction, state transition, validation rule, invariant, proof surface, or
+misuse trap, `$actuating` records the repair-mode escalation decision before
+more mutation.
+
+```yaml
+actuation_escalation_receipt:
+  version: AER-v1
+  run_id:
+  owner_boundary:
+  repeated_finding_class:
+  accepted_liabilities:
+    - cas_finding_id:
+      finding_fingerprint:
+      review_fold_ref:
+      liability:
+  prior_resolution_mode: minimal-fix|proof-only|refactor-kernel|branch-race|none
+  next_resolution_mode: minimal-fix|refactor-kernel|branch-race|remediation-plan|blocked
+  escalation_trigger:
+  alternatives_considered: []
+  selected_route:
+  verifier: []
+  current_artifact_scope:
+    branch:
+    head_sha:
+    target_fingerprint:
+```
+
+AER-v1 is not review adjudication and not mutation authority. It records why
+the actuation loop continued with a local fix, pivoted to a refactor kernel,
+started a branch race, stopped for a remediation plan, or blocked. `$seq` may
+later audit whether this receipt existed and whether behavior contradicted it;
+`$actuating` owns the active escalation decision.
+
 #### Triage
 
 Use when the user wants review findings classified without implementation:
@@ -445,6 +481,7 @@ Switch to `refactor-kernel` when repeated findings share an owner boundary.
 Switch to `branch-race` when local fix and refactor-kernel are both plausible and can be compared under the same verifier.
 Switch to `st-governed` only when durable claims, fencing, worktrees, or serialized integration are required.
 Switch to `ship-handoff` only when PR/publication intent is explicit or inherited from the accepted spec.
+Emit AER-v1 before continuing mutation when repeated accepted liabilities require or reject escalation from minimal-fix to refactor-kernel, branch-race, remediation-plan, or blocked.
 
 ## Terminal closure gate
 
@@ -521,6 +558,7 @@ Actuating:
 - normalized CAS clean runs: 0|1|2|3|not-required
 - goal contract / work list:
 - review-fold disposition:
+- actuation escalation receipt:
 - execution owner: goal-grind | st-bounded-slice | none
 - evidence-fold verdict:
 - proof-patch / ship handoff:

--- a/codex/skills/actuating/agents/openai.yaml
+++ b/codex/skills/actuating/agents/openai.yaml
@@ -14,4 +14,10 @@ interface:
     remediation-plan, or another no-implementation mode. Fresh or exhaustive
     workflow review must use $cas review, findings must pass through
     $review-fold, and only accepted code-change liabilities may reach
-    implementation. Completion requires terminal ATCG-v1.
+    implementation. When repeated accepted liabilities share an owner boundary,
+    missing abstraction, invariant, proof surface, or misuse trap, emit an
+    AER-v1 actuation_escalation_receipt with owner_boundary,
+    repeated_finding_class, accepted_liabilities, prior_resolution_mode,
+    next_resolution_mode, escalation_trigger, alternatives_considered,
+    selected_route, verifier, and current_artifact_scope before further
+    mutation. Completion requires terminal ATCG-v1.

--- a/codex/skills/actuating/assets/aer-v1.example.json
+++ b/codex/skills/actuating/assets/aer-v1.example.json
@@ -1,0 +1,32 @@
+{
+  "actuation_escalation_receipt": {
+    "version": "AER-v1",
+    "run_id": "ACT-example-001",
+    "owner_boundary": "codex/skills/review-fold",
+    "repeated_finding_class": "same owner boundary and proof surface",
+    "accepted_liabilities": [
+      {
+        "cas_finding_id": "cas-finding:attempt-001:0001",
+        "finding_fingerprint": "sha256:cross-attempt-example",
+        "review_fold_ref": "RF-v1.3:example:finding-1",
+        "liability": "invariant-gap"
+      }
+    ],
+    "prior_resolution_mode": "minimal-fix",
+    "next_resolution_mode": "refactor-kernel",
+    "escalation_trigger": "Repeated accepted findings share one owner boundary.",
+    "alternatives_considered": [
+      "minimal-fix",
+      "branch-race"
+    ],
+    "selected_route": "refactor-kernel",
+    "verifier": [
+      "uv run python -m unittest discover codex/skills/review-fold/tests"
+    ],
+    "current_artifact_scope": {
+      "branch": "main",
+      "head_sha": "head456",
+      "target_fingerprint": "diff:example"
+    }
+  }
+}

--- a/codex/skills/actuating/references/decision-contract.yaml
+++ b/codex/skills/actuating/references/decision-contract.yaml
@@ -3,7 +3,7 @@ skill_decision_contract:
   skill:
     name: actuating
     kind: workflow
-    source_fingerprint: actuating-v7-review-lane-standard-streak
+    source_fingerprint: actuating-v7-review-lane-standard-streak-aer-v1
   triggers:
     - trigger_id: ACT-SPEC-GOAL
       description: The user wants an accepted implementation spec executed through the goal workflow.
@@ -28,6 +28,11 @@ skill_decision_contract:
     - trigger_id: ACT-ST-GOVERNED
       description: Execution requires durable coordination or existing $st state.
       cue_literals: [st-governed, resource claim, fencing token, external worktree, serialized integration]
+      cue_regexes: []
+      exclusions: []
+    - trigger_id: ACT-ESCALATION
+      description: Repeated accepted review liabilities may require escalation from local fixes to a refactor kernel or branch race.
+      cue_literals: [AER-v1, actuation_escalation_receipt, refactor-kernel, repeated accepted liabilities, one-patch-per-comment risk]
       cue_regexes: []
       exclusions: []
   routes:
@@ -62,6 +67,10 @@ skill_decision_contract:
     - route_id: ACT-ATCG
       description: Run terminal closure gate before completion.
       aliases: [ATCG-v1]
+      terminal: "no"
+    - route_id: ACT-ESCALATION-RECEIPT
+      description: Record the repair-mode escalation decision before continuing mutation under repeated review pressure.
+      aliases: [AER-v1, actuation-escalation-receipt]
       terminal: "no"
     - route_id: ACT-PROOF
       description: Close with current-artifact proof or an explicit $ship handoff.
@@ -157,6 +166,22 @@ skill_decision_contract:
       failure_signals:
         - direct implementation claims fenced authority without $st participation
       rationale: The old transaction-controller behavior is preserved only under st-governed mode.
+    - clause_id: ACT-ESCALATION-001
+      trigger_refs: [ACT-ESCALATION]
+      expected_routes: [ACT-ESCALATION-RECEIPT, ACT-GOAL, ACT-ATCG, ACT-BLOCK]
+      prohibited_routes: []
+      required_artifacts:
+        - AER-v1 actuation_escalation_receipt when repeated accepted liabilities share one owner boundary or missing abstraction
+      success_signals:
+        - owner boundary is named before further mutation
+        - prior and next resolution modes are explicit
+        - alternatives considered are recorded
+        - selected route is tied to verifier and current artifact scope
+      failure_signals:
+        - repeated accepted liabilities continue as silent one-patch-per-comment local fixes
+        - refactor-kernel escalation happens without a cited owner boundary
+        - AER-v1 is treated as review finding acceptance or mutation authority
+      rationale: Escalation belongs to active workflow governance while preserving auditable evidence for later forensic tools.
   instrumentation:
     decision_receipt: required
-    rationale: Material decisions include accepted-spec routing, scheme planning, loop contract, review backend and lanes, persistence mode, HYL/HSR execution legality, ATCG terminal closure, and proof/ship closure.
+    rationale: Material decisions include accepted-spec routing, scheme planning, loop contract, review backend and lanes, repair-mode escalation, persistence mode, HYL/HSR execution legality, ATCG terminal closure, and proof/ship closure.

--- a/codex/skills/actuating/tests/test_aer_contract.py
+++ b/codex/skills/actuating/tests/test_aer_contract.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env -S uv run python
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SKILL = (ROOT / "SKILL.md").read_text(encoding="utf-8")
+AGENT = (ROOT / "agents" / "openai.yaml").read_text(encoding="utf-8")
+DECISION = (ROOT / "references" / "decision-contract.yaml").read_text(encoding="utf-8")
+FIXTURE = json.loads((ROOT / "assets" / "aer-v1.example.json").read_text(encoding="utf-8"))
+NORMALIZED = " ".join((SKILL + "\n" + AGENT + "\n" + DECISION).split())
+
+
+class ActuationEscalationReceiptContractTests(unittest.TestCase):
+    def test_aer_v1_fields_are_documented(self) -> None:
+        required = [
+            "actuation_escalation_receipt:",
+            "version: AER-v1",
+            "owner_boundary:",
+            "repeated_finding_class:",
+            "accepted_liabilities:",
+            "prior_resolution_mode:",
+            "next_resolution_mode:",
+            "escalation_trigger:",
+            "alternatives_considered:",
+            "selected_route:",
+            "verifier:",
+            "current_artifact_scope:",
+        ]
+        for token in required:
+            with self.subTest(token=token):
+                self.assertIn(token, SKILL)
+
+    def test_aer_v1_boundary_is_explicit(self) -> None:
+        required = [
+            "AER-v1 is not review adjudication and not mutation authority",
+            "`$seq` may later audit whether this receipt existed",
+            "$actuating` owns the active escalation decision",
+            "AER-v1 is treated as review finding acceptance or mutation authority",
+        ]
+        for token in required:
+            with self.subTest(token=token):
+                self.assertIn(token, NORMALIZED)
+
+    def test_aer_v1_fixture_carries_joinable_liability(self) -> None:
+        receipt = FIXTURE["actuation_escalation_receipt"]
+        self.assertEqual(receipt["version"], "AER-v1")
+        self.assertEqual(receipt["next_resolution_mode"], "refactor-kernel")
+        liability = receipt["accepted_liabilities"][0]
+        for key in ["cas_finding_id", "finding_fingerprint", "review_fold_ref", "liability"]:
+            with self.subTest(key=key):
+                self.assertIn(key, liability)
+        for key in ["branch", "head_sha", "target_fingerprint"]:
+            with self.subTest(key=key):
+                self.assertIn(key, receipt["current_artifact_scope"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/codex/skills/actuating/tools/quick_validate.py
+++ b/codex/skills/actuating/tools/quick_validate.py
@@ -47,6 +47,7 @@ def main() -> int:
         "assets/add-v1.handoff.example.json",
         "assets/add-v1.shipping-not-requested.example.json",
         "assets/add-v1.blocked.example.json",
+        "assets/aer-v1.example.json",
         "assets/atcg-v1.complete.example.json",
         "assets/terminal-context.proof-only.example.json",
         "assets/terminal-context.regression.example.json",
@@ -63,6 +64,7 @@ def main() -> int:
         run_test(ROOT / "tests/test_actuation_authority_gate.py"),
         run_test(ROOT / "tests/test_actuation_delivery_gate.py"),
         run_test(ROOT / "tests/test_actuation_terminal_gate.py"),
+        run_test(ROOT / "tests/test_aer_contract.py"),
     ]
     ok = all(row["returncode"] == 0 for row in tests)
     print(json.dumps({

--- a/codex/skills/cas/SKILL.md
+++ b/codex/skills/cas/SKILL.md
@@ -275,6 +275,64 @@ All review backends should produce one caller-facing surface:
 }
 ```
 
+## Per-finding identity projection
+
+When a completed review emits findings, CAS should expose a stable
+per-finding evidence projection so workflow receipts can join later decisions,
+patch epochs, proof epochs, and clean-review attempts back to the exact review
+row.
+
+CAS owns the identity fields as evidence. It does not decide whether a finding
+is accepted, rejected, proof-only, minimal-fix, refactor-kernel, or mutation
+authority.
+
+Each normalized finding row should carry:
+
+```json
+{
+  "findingId": "cas-finding:<reviewAttemptId>:<ordinal-or-source-id>",
+  "findingFingerprint": "best-effort-cross-attempt-hash",
+  "reviewAttemptId": "cas-review-attempt-id",
+  "lane": "standard|footgun-finder|invariant-ace|complexity-mitigator|other",
+  "laneRole": "standard|auxiliary|unknown",
+  "contributesToStandardStreak": false,
+  "reviewThreadId": "thread-id",
+  "reviewTurnId": "turn-id",
+  "baseSha": "base",
+  "headSha": "head",
+  "targetFingerprint": "diff-fingerprint",
+  "titleHash": "sha256:title",
+  "bodyHash": "sha256:body",
+  "normalizedLocation": {
+    "path": "src/file.ext",
+    "line": 1,
+    "side": "RIGHT|LEFT|unknown"
+  },
+  "severity": "info|low|medium|high|unknown",
+  "verdictStatus": "findings"
+}
+```
+
+Identity semantics:
+
+```text
+findingId = exact emitted finding row in one CAS review attempt
+findingFingerprint = best-effort same issue across attempts
+reviewAttemptId = stable attempt row or compatibility projection ID
+laneRole = standard only when the attempt is the ordinary standard lane
+contributesToStandardStreak = true only for normalized clean standard attempts, not finding rows
+```
+
+If native CAS output cannot provide a source finding ID, compatibility
+normalization may synthesize `findingId` from review attempt identity, tuple,
+lane, normalized location, title/body hashes, and ordinal. It must still mark
+cross-attempt matching as best-effort through `findingFingerprint`.
+
+Downstream aliases may convert these fields to snake_case (`finding_id`,
+`finding_fingerprint`, `review_attempt_id`, and so on), but CAS should preserve
+the tuple and thread fields needed by `$review-fold`, `$actuating`, and `$seq`
+to cite evidence without re-parsing review prose.
+
 `run` and `start --wait` output is tuple-bound review evidence only when its emitted
 `reviewVerdict` has `tupleVerdictExists=true`, a terminal tuple status
 (`clean`, `findings`, or `account_resource_exhausted`), and matching
@@ -406,6 +464,7 @@ CAS Review:
 - Do not duplicate a review when an active tuple lock points to an existing `reviewThreadId`.
 - Do not manually list and `jq` review-session records when latest-session status is enough; use `cas review_session status --latest --json`, then verify tuple fields before acting.
 - Do not treat completed findings as transport failure.
+- Do not treat per-finding identity as acceptance, rejection, repair mode, clean-streak authority, or mutation authority.
 - Do not treat `usageLimitExceeded` as reviewer output or transport failure.
 - Do not rely on persistent lane continuity for repeated-review policy until first-review creation smoke is current.
 - `start --wait` evidence is workflow input only after it is represented as tuple-bound review evidence; otherwise import, normalize, or recover first.

--- a/codex/skills/cas/agents/openai.yaml
+++ b/codex/skills/cas/agents/openai.yaml
@@ -3,4 +3,12 @@ policy:
 interface:
   display_name: "cas"
   short_description: "Zig CAS CLI for app-server checks, detached review control, fanout, and swarm conformance"
-  default_prompt: "Use $cas for Zig-only v2 app-server smoke checks, detached review-session control, direct thread and turn requests, multi-instance CAS fanout, and swarm conformance checks around $st claims and retry policy."
+  default_prompt: >-
+    Use $cas for Zig-only v2 app-server smoke checks, detached review-session
+    control, direct thread and turn requests, multi-instance CAS fanout, and
+    swarm conformance checks around $st claims and retry policy. For review
+    evidence, preserve tuple-bound reviewVerdict fields and per-finding
+    identity fields such as findingId, findingFingerprint, reviewAttemptId,
+    laneRole, reviewThreadId, reviewTurnId, headSha, and targetFingerprint.
+    CAS records evidence; caller workflows certify meaning, clean streaks,
+    review-fold disposition, repair mode, and mutation authority.

--- a/codex/skills/cas/assets/finding-identity.example.json
+++ b/codex/skills/cas/assets/finding-identity.example.json
@@ -1,0 +1,41 @@
+{
+  "reviewVerdict": {
+    "status": "findings",
+    "reviewAttemptPhase": "normalized_verdict",
+    "reviewAttemptExists": true,
+    "tupleVerdictExists": true,
+    "backendClass": "cas-review-session",
+    "clean": false,
+    "findingCount": 1,
+    "failureCode": null,
+    "baseSha": "base123",
+    "headSha": "head456",
+    "targetFingerprint": "diff:example",
+    "reviewThreadId": "thread-abc",
+    "reviewTurnId": "turn-def",
+    "findings": [
+      {
+        "findingId": "cas-finding:attempt-001:0001",
+        "findingFingerprint": "sha256:cross-attempt-example",
+        "reviewAttemptId": "attempt-001",
+        "lane": "standard",
+        "laneRole": "standard",
+        "contributesToStandardStreak": false,
+        "reviewThreadId": "thread-abc",
+        "reviewTurnId": "turn-def",
+        "baseSha": "base123",
+        "headSha": "head456",
+        "targetFingerprint": "diff:example",
+        "titleHash": "sha256:title",
+        "bodyHash": "sha256:body",
+        "normalizedLocation": {
+          "path": "codex/skills/example/SKILL.md",
+          "line": 42,
+          "side": "RIGHT"
+        },
+        "severity": "medium",
+        "verdictStatus": "findings"
+      }
+    ]
+  }
+}

--- a/codex/skills/cas/references/review-proof-boundary.md
+++ b/codex/skills/cas/references/review-proof-boundary.md
@@ -4,4 +4,8 @@
 
 Callers that need repeated clean reviews own that policy outside CAS. They may request additional independent attempts with `--fresh-attempt REASON`, then count and evaluate the resulting review verdicts themselves.
 
-CAS receipt normalization may expose transport facts such as `reviewAttemptPhase`, `reviewAttemptExists`, `reviewThreadId`, `reviewTurnId`, `baseSha`, `headSha`, `targetFingerprint`, `reviewVerdict.status`, `findingCount`, and failure fields. These fields are observational and are not guarantees.
+CAS receipt normalization may expose transport facts such as `reviewAttemptPhase`, `reviewAttemptExists`, `reviewThreadId`, `reviewTurnId`, `baseSha`, `headSha`, `targetFingerprint`, `reviewVerdict.status`, `findingCount`, and failure fields. It may also expose per-finding identity fields such as `findingId`, `findingFingerprint`, `reviewAttemptId`, `laneRole`, `titleHash`, `bodyHash`, and `normalizedLocation` so downstream receipts can cite the exact review row.
+
+These fields are observational and are not guarantees. Per-finding identity is
+not acceptance, rejection, repair-mode selection, clean-streak authority, or
+mutation authority.

--- a/codex/skills/cas/tests/test_contract.py
+++ b/codex/skills/cas/tests/test_contract.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env -S uv run python
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SKILL = (ROOT / "SKILL.md").read_text(encoding="utf-8")
+BOUNDARY = (ROOT / "references" / "review-proof-boundary.md").read_text(encoding="utf-8")
+AGENT = (ROOT / "agents" / "openai.yaml").read_text(encoding="utf-8")
+NORMALIZED_CONTRACT = " ".join((SKILL + "\n" + BOUNDARY).split())
+NORMALIZED_AGENT = " ".join(AGENT.split())
+FINDING_IDENTITY = json.loads(
+    (ROOT / "assets" / "finding-identity.example.json").read_text(encoding="utf-8")
+)
+
+
+class CasContractTests(unittest.TestCase):
+    def test_per_finding_identity_fields_are_documented(self) -> None:
+        required = [
+            "## Per-finding identity projection",
+            "findingId",
+            "findingFingerprint",
+            "reviewAttemptId",
+            "laneRole",
+            "contributesToStandardStreak",
+            "reviewThreadId",
+            "reviewTurnId",
+            "baseSha",
+            "headSha",
+            "targetFingerprint",
+            "titleHash",
+            "bodyHash",
+            "normalizedLocation",
+            "verdictStatus",
+        ]
+        for token in required:
+            with self.subTest(token=token):
+                self.assertIn(token, SKILL)
+
+    def test_cas_does_not_claim_workflow_authority(self) -> None:
+        required = [
+            "CAS records evidence.",
+            "Workflows certify meaning.",
+            "It does not decide whether a finding is accepted",
+            "Do not treat per-finding identity as acceptance",
+            "Per-finding identity is not acceptance",
+        ]
+        for token in required:
+            with self.subTest(token=token):
+                self.assertIn(token, NORMALIZED_CONTRACT)
+
+    def test_agent_prompt_mentions_finding_identity_boundary(self) -> None:
+        required = [
+            "per-finding identity fields",
+            "findingId",
+            "findingFingerprint",
+            "reviewAttemptId",
+            "laneRole",
+            "caller workflows certify meaning",
+            "mutation authority",
+        ]
+        for token in required:
+            with self.subTest(token=token):
+                self.assertIn(token, NORMALIZED_AGENT)
+
+    def test_finding_identity_fixture_carries_join_keys(self) -> None:
+        verdict = FINDING_IDENTITY["reviewVerdict"]
+        finding = verdict["findings"][0]
+        self.assertEqual(verdict["status"], "findings")
+        self.assertEqual(finding["laneRole"], "standard")
+        self.assertFalse(finding["contributesToStandardStreak"])
+        for key in [
+            "findingId",
+            "findingFingerprint",
+            "reviewAttemptId",
+            "reviewThreadId",
+            "reviewTurnId",
+            "baseSha",
+            "headSha",
+            "targetFingerprint",
+            "titleHash",
+            "bodyHash",
+            "normalizedLocation",
+            "verdictStatus",
+        ]:
+            with self.subTest(key=key):
+                self.assertIn(key, finding)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/codex/skills/proof-patch/SKILL.md
+++ b/codex/skills/proof-patch/SKILL.md
@@ -50,10 +50,13 @@ completion unless ATCG-v1 permits it.
 
 ## Review closure
 - CAS review source:
+- CAS finding IDs:
 - review-fold disposition:
+- review-fold receipt version:
 - resolution fold:
 - accepted liabilities:
 - no-code dispositions:
+- actuation escalation receipt:
 - clean normalized CAS runs:
 - cached CAS receipts counted as fresh: no
 
@@ -97,6 +100,8 @@ completion unless ATCG-v1 permits it.
 4. Include evidence commands and results.
 5. Include review closure, review-fold disposition, and resolution fold state
    when review pressure was present.
+   Preserve joinable CAS finding IDs, RF-v1.3 receipt version, and AER-v1
+   escalation receipt state when they exist.
 6. Include parallelism state, even when the mode is `none`.
 7. Include anti-gaming checks.
 8. Name residual risks and focused human review targets.

--- a/codex/skills/proof-patch/agents/openai.yaml
+++ b/codex/skills/proof-patch/agents/openai.yaml
@@ -6,8 +6,10 @@ interface:
   default_prompt: >-
     Use $proof-patch before final /goal completion or PR handoff. Bind to current
     artifact state, summarize changed paths, loop governance receipts, review
-    closure including resolution fold state, parallelism, validation, review
-    dispositions, anti-gaming checks, residual risk, and human review focus.
+    closure including CAS finding IDs, RF-v1.3 review-fold receipt version,
+    AER-v1 actuation escalation receipt state, and resolution fold state,
+    parallelism, validation, review dispositions, anti-gaming checks, residual
+    risk, and human review focus.
     State direct-action fused exemption when ALSR/HYL is absent, never count
     cached CAS receipts as fresh clean runs, and do not claim completion unless
     ATCG-v1 permits it. Escalate to $ship only for publication, PR updates,

--- a/codex/skills/proof-patch/tests/test_contract.py
+++ b/codex/skills/proof-patch/tests/test_contract.py
@@ -34,10 +34,13 @@ class ProofPatchContractTests(unittest.TestCase):
         fields = [
             "## Review closure",
             "- CAS review source:",
+            "- CAS finding IDs:",
             "- review-fold disposition:",
+            "- review-fold receipt version:",
             "- resolution fold:",
             "- accepted liabilities:",
             "- no-code dispositions:",
+            "- actuation escalation receipt:",
             "- clean normalized CAS runs:",
             "- cached CAS receipts counted as fresh: no",
         ]
@@ -76,6 +79,9 @@ class ProofPatchContractTests(unittest.TestCase):
         required_phrases = [
             "loop governance receipts",
             "review closure",
+            "CAS finding IDs",
+            "RF-v1.3",
+            "AER-v1",
             "resolution fold",
             "parallelism",
             "direct-action fused exemption",

--- a/codex/skills/review-fold/SKILL.md
+++ b/codex/skills/review-fold/SKILL.md
@@ -2,7 +2,7 @@
 name: review-fold
 description: "Compress review pressure into intent-anchored review work: classify findings, reject non-liabilities, choose proof-only vs minimal-fix vs refactor-kernel, and prevent one-patch-per-comment churn. Use after $cas review, PR review comments, CAS findings, reviewer suggestions, and review-like claims. Owns active review finding classification for goal workflows."
 metadata:
-  version: "1.2.0"
+  version: "1.3.0"
   activation_cost: medium
   default_depth: high
 ---
@@ -85,7 +85,7 @@ This is a routing guard, not a counterexample compiler. Do not introduce CEX/AC/
 
 ```yaml
 review_fold:
-  version: RF-v1.2
+  version: RF-v1.3
   goal_id:
   source:
     pr:
@@ -118,17 +118,33 @@ review_fold:
     changed_paths: []
   findings:
     - id:
+      source_ref:
+        cas_finding_id:
+        finding_fingerprint:
+        review_attempt_id:
+        review_thread_id:
+        review_turn_id:
+        lane_role: standard|auxiliary|unknown
+        head_sha:
+        target_fingerprint:
       lane: standard|footgun-finder|invariant-ace|complexity-mitigator|human|prior-artifact|unknown
       claim:
       observed_fact:
       suggested_repair:
+      law_family:
+      falsified_law:
+      owner_boundary:
+      model_state: intact|local-gap|boundary-gap|unknown
       validity: valid|invalid|unproven|needs-owner
       liability: blocks-goal|regression-risk|style|new-requirement|out-of-scope|proof-gap|misuse-hazard|invariant-gap|complexity-stall
       intent_relation: core|adjacent|unrelated|expands-scope
       novelty: duplicate|same-class|new-class
       disposition: reject|proof-only|minimal-fix|refactor-kernel|ask-human|follow-up|blocked
+      repair_level: none|proof-only|minimal-fix|refactor-kernel|branch-race|ask-human|follow-up|blocked
       minimal_response:
       proof_needed:
+      alternatives_considered: []
+      evidence_refs: []
       code_change_candidate: yes|no
       finding_mutation_authority:
         allowed: no
@@ -136,8 +152,13 @@ review_fold:
   compression:
     equivalence_classes: []
     repeated_kernel:
+    kernel_pressure: none|low|medium|high
+    refactor_trigger:
+      present: yes|no
+      reason:
     reabstraction_candidate: yes|no
     one_patch_per_comment_risk: low|medium|high
+    minimal_fix_regret_risk: low|medium|high
     lane_overlap:
       footgun_to_invariant: []
       footgun_to_complexity: []
@@ -168,6 +189,12 @@ review_fold:
     reviewer_response_draft: []
 ```
 
+RF-v1.3 folds the useful RFDEC-v1 receipt ideas into one review-fold schema
+rather than creating a second active finding-decision format. CAS finding IDs
+and fingerprints are evidence references only; `$review-fold` still classifies
+validity, liability, owner boundary, and repair level, and the resolution fold
+still owns mutation-authorizing work nodes.
+
 ## Disposition law
 
 - `reject`: claim is false, stale, duplicate with no new proof value, unrelated, already handled, incompatible with the goal, or merely preference/style without accepted liability.
@@ -191,6 +218,20 @@ duplicate/same-class -> compress; do not create a new implementation distinction
 ```
 
 A finding row never grants mutation authority. It only marks whether the resolution fold may consider code-changing work.
+
+When `one_patch_per_comment_risk: high`, do not silently recommend more
+minimal fixes. Route to one of:
+
+```text
+refactor-kernel
+branch-race
+remediation-plan
+blocked
+```
+
+Use an explicit exception only when `alternatives_considered` shows why a local
+minimal fix is still owner-correct and does not preserve the repeated failure
+class. Record that exception in `evidence_refs`.
 
 ## Modes
 
@@ -250,16 +291,19 @@ Auxiliary CAS review lanes may still block closeout. They do not increment the s
 4. Classify each finding before any implementation.
 5. Separate the claim, observed fact, and suggested repair when the review text includes all three.
 6. Reject, block, ask, or follow up before code whenever validity, liability, or scope is not established.
-7. Collapse duplicates and same-family comments across lanes.
-8. Mark whether the current standard attempt is normalized clean and whether the standard clean-run counter resets.
-9. Mark auxiliary lane state as `clean`, `findings-folded`, `blocked`, or `rerun-required`; never count it as a standard clean run.
-10. Recommend `triage`, `remediation-plan`, or `review-closeout` from the user's requested mode and the accepted liabilities.
-11. Decide whether each finding's proper response is no code, proof, local fix, refactor, branch race, ask, or follow-up.
-12. Mark review-class fanout safe only for classification/investigation classes; raw findings must not fan out directly to patch workers.
-13. Produce a small work graph only for accepted liabilities and only after the resolution fold accepts code-changing work.
-14. Hand off to `$goal-grind` for implementation and `$evidence-fold` for proof only after a resolution fold accepts code-change liabilities.
-15. For post-implementation CAS runs, mark whether the normalized standard result is clean and whether the standard clean-run counter resets.
-16. Preserve reviewer response drafts as drafts; do not post public comments unless explicitly asked.
+7. Preserve CAS source refs when present: `cas_finding_id`, `finding_fingerprint`, `review_attempt_id`, tuple, and lane role.
+8. Name the falsified law, owner boundary, model state, and repair level when a finding is valid or unresolved.
+9. Collapse duplicates and same-family comments across lanes.
+10. Mark whether the current standard attempt is normalized clean and whether the standard clean-run counter resets.
+11. Mark auxiliary lane state as `clean`, `findings-folded`, `blocked`, or `rerun-required`; never count it as a standard clean run.
+12. Recommend `triage`, `remediation-plan`, or `review-closeout` from the user's requested mode and the accepted liabilities.
+13. Decide whether each finding's proper response is no code, proof, local fix, refactor, branch race, ask, or follow-up.
+14. Escalate high one-patch-per-comment risk to `refactor-kernel`, `branch-race`, `remediation-plan`, or `blocked` unless an explicit owner-boundary exception is recorded.
+15. Mark review-class fanout safe only for classification/investigation classes; raw findings must not fan out directly to patch workers.
+16. Produce a small work graph only for accepted liabilities and only after the resolution fold accepts code-changing work.
+17. Hand off to `$goal-grind` for implementation and `$evidence-fold` for proof only after a resolution fold accepts code-change liabilities.
+18. For post-implementation CAS runs, mark whether the normalized standard result is clean and whether the standard clean-run counter resets.
+19. Preserve reviewer response drafts as drafts; do not post public comments unless explicitly asked.
 
 ## Default behavior in `$actuating`
 

--- a/codex/skills/review-fold/agents/openai.yaml
+++ b/codex/skills/review-fold/agents/openai.yaml
@@ -12,4 +12,11 @@ interface:
     finding is never mutation authority; the resolution fold must accept any
     code-change candidate before implementation. If fresh or exhaustive workflow
     review is required and no CAS result is present, route to $cas review first.
-    Mark normalized CAS clean runs when closing review.
+    Return RF-v1.3 when possible, preserving CAS source refs such as
+    cas_finding_id, finding_fingerprint, review_attempt_id, lane_role,
+    head_sha, and target_fingerprint. For valid or contested findings, name the
+    law_family, falsified_law, owner_boundary, model_state, repair_level,
+    alternatives_considered, and evidence_refs. Mark normalized CAS clean runs
+    when closing review. If one_patch_per_comment_risk is high, route to
+    refactor-kernel, branch-race, remediation-plan, or blocked unless an
+    explicit owner-boundary exception is recorded.

--- a/codex/skills/review-fold/tests/test_contract.py
+++ b/codex/skills/review-fold/tests/test_contract.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env -S uv run python
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CODEX_ROOT = ROOT.parents[1]
+SKILL = (ROOT / "SKILL.md").read_text(encoding="utf-8")
+AGENT = (ROOT / "agents" / "openai.yaml").read_text(encoding="utf-8")
+REDUCER = (CODEX_ROOT / "agents" / "review-reducer.toml").read_text(encoding="utf-8")
+NORMALIZED = " ".join((AGENT + "\n" + REDUCER).split())
+
+
+class ReviewFoldContractTests(unittest.TestCase):
+    def test_rf_v13_schema_has_joinable_source_refs(self) -> None:
+        required = [
+            "version: RF-v1.3",
+            "source_ref:",
+            "cas_finding_id",
+            "finding_fingerprint",
+            "review_attempt_id",
+            "review_thread_id",
+            "review_turn_id",
+            "lane_role: standard|auxiliary|unknown",
+            "head_sha",
+            "target_fingerprint",
+        ]
+        for token in required:
+            with self.subTest(token=token):
+                self.assertIn(token, SKILL)
+
+    def test_rf_v13_schema_names_law_model_and_repair_fields(self) -> None:
+        required = [
+            "law_family",
+            "falsified_law",
+            "owner_boundary",
+            "model_state: intact|local-gap|boundary-gap|unknown",
+            "repair_level:",
+            "alternatives_considered: []",
+            "evidence_refs: []",
+            "kernel_pressure:",
+            "refactor_trigger:",
+            "minimal_fix_regret_risk:",
+        ]
+        for token in required:
+            with self.subTest(token=token):
+                self.assertIn(token, SKILL)
+
+    def test_high_one_patch_risk_requires_explicit_route(self) -> None:
+        required = [
+            "When `one_patch_per_comment_risk: high`",
+            "refactor-kernel",
+            "branch-race",
+            "remediation-plan",
+            "blocked",
+            "explicit owner-boundary exception",
+        ]
+        for token in required:
+            with self.subTest(token=token):
+                self.assertIn(token, SKILL)
+
+    def test_prompts_request_rf_v13_receipts(self) -> None:
+        required = [
+            "RF-v1.3",
+            "cas_finding_id",
+            "finding_fingerprint",
+            "review_attempt_id",
+            "law_family",
+            "falsified_law",
+            "owner_boundary",
+            "repair_level",
+            "one_patch_per_comment_risk is high",
+        ]
+        for token in required:
+            with self.subTest(token=token):
+                self.assertIn(token, NORMALIZED)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add CAS per-finding identity evidence for review findings.
- Upgrade review-fold to RF-v1.3 with CAS source refs, law/model fields, and refactor-kernel pressure routing.
- Add AER-v1 actuation escalation receipts and proof-patch reporting fields.
- Add contract fixtures/tests for CAS, review-fold, actuating, and proof-patch.

## Proof
- `uv run python -m unittest discover codex/skills/cas/tests`: pass
- `uv run python -m unittest discover codex/skills/review-fold/tests`: pass
- `uv run python -m unittest discover codex/skills/actuating/tests`: pass
- `uv run python -m unittest discover codex/skills/proof-patch/tests`: pass
- `uv run python codex/skills/actuating/tools/quick_validate.py`: pass
- `uv run --with pyyaml -- python3 codex/skills/.system/skill-creator/scripts/quick_validate.py codex/skills/cas`: pass
- `uv run --with pyyaml -- python3 codex/skills/.system/skill-creator/scripts/quick_validate.py codex/skills/review-fold`: pass
- `uv run --with pyyaml -- python3 codex/skills/.system/skill-creator/scripts/quick_validate.py codex/skills/actuating`: pass
- `uv run --with pyyaml -- python3 codex/skills/.system/skill-creator/scripts/quick_validate.py codex/skills/proof-patch`: pass
- `git diff --check`: pass

## Scope
- branch: codex/review-governance-joinable-receipts
- head: 87fbe98904887cb9eef324bafc8317f0e7e7344a
- base: main

## Readiness
- PR mode: ready
- Reason: focused skill-contract update with targeted tests and skill validation passing.
- Caveats: no runtime CAS implementation change; this is documentation, fixtures, prompts, and contract-test coverage.
