### PR TITLE
Require actuation review profile coverage

### DIFF
--- a/codex/skills/actuating/references/decision-contract.yaml
+++ b/codex/skills/actuating/references/decision-contract.yaml
@@ -139,16 +139,21 @@ skill_decision_contract:
       prohibited_routes: []
       required_artifacts:
         - review profile with standard plus selected auxiliary lanes
+        - explicit not-required reason for every unselected auxiliary lane
         - folded auxiliary lane outcomes for footgun-finder, invariant-ace, or complexity-mitigator when selected
         - standard-only clean-run counter
-        - ATCG context fields for standard_clean_runs_count and selected auxiliary lane blocker/current-artifact state
+        - ATCG context fields for standard_clean_runs_count and workflow-owned review_profile blocker/current-artifact state
       success_signals:
         - footgun-finder, invariant-ace, and complexity-mitigator are available as auxiliary CAS review lanes
+        - auxiliary lane selection and non-selection are recorded by $actuating/$goal-actuating, not inferred from $cas transport state
         - auxiliary lanes may block closeout but do not increment or interrupt the standard clean streak
         - artifact-changing fixes from any lane reset the standard clean streak
+        - terminal closure rejects missing or partial review_profile coverage when workflow review is required
         - terminal closure rejects missing, blocked, rerun-required, or not-folded selected auxiliary lanes
         - terminal closure rejects selected auxiliary lane receipts that are stale against current head or diff
       failure_signals:
+        - auxiliary lane policy is stored only in cas_review transport fields
+        - terminal closure treats absent review_profile coverage as clean or not-required
         - auxiliary lane output bypasses review-fold
         - auxiliary lane is treated as mutation authority
         - standard clean streak includes non-standard attempts

--- a/codex/skills/actuating/references/terminal-closure-gate.md
+++ b/codex/skills/actuating/references/terminal-closure-gate.md
@@ -85,7 +85,7 @@ loop governance: ALSR-v1, HYL-v1, HSR-v1, or explicit fused/$st exemption
 evidence-fold verdict and proof commands
 proof-patch presence/currentness
 CAS requirement, tuple, freshness, and standard clean-run count
-auxiliary CAS review-lane folded/blocker state when selected
+workflow-owned review_profile auxiliary coverage and folded/blocker state
 ADD-v1 delivery decision
 ship result receipt when publication is required
 side-effect boundary evidence
@@ -119,17 +119,19 @@ The preferred reducer fields are:
 cas_review.standard_clean_runs_required
 cas_review.standard_clean_runs_count
 final_report_fields.standard_clean_cas_runs
-cas_review.required_auxiliary_lanes
-cas_review.auxiliary_lanes.<lane>.folded
-cas_review.auxiliary_lanes.<lane>.unresolved_blockers
-cas_review.auxiliary_lanes.<lane>.rerun_required
-cas_review.auxiliary_lanes.<lane>.head_sha
-cas_review.auxiliary_lanes.<lane>.target_fingerprint
+review_profile.standard
+review_profile.auxiliary_review_lanes.<lane>.state
+review_profile.auxiliary_review_lanes.<lane>.reason
+review_profile.auxiliary_review_lanes.<lane>.evidence_ref
+review_profile.auxiliary_review_lanes.<lane>.head_sha
+review_profile.auxiliary_review_lanes.<lane>.target_fingerprint
 ```
 
 Compatibility fields may still be named `clean_runs_required`,
 `clean_runs_count`, or `normalized_cas_clean_runs`, but their meaning is
 standard-only unless a context provides explicit `standard_clean_*` fields.
+Legacy auxiliary fields under `cas_review` remain accepted as compatibility
+evidence, but `$cas` does not own auxiliary lane selection policy.
 
 ## Common outcomes
 

--- a/codex/skills/actuating/tests/test_actuation_terminal_gate.py
+++ b/codex/skills/actuating/tests/test_actuation_terminal_gate.py
@@ -29,6 +29,42 @@ class ActuationTerminalGateTests(unittest.TestCase):
     def fixture(self, name: str):
         return json.loads((ASSETS / name).read_text())
 
+    def review_profile(self, **lane_overrides):
+        lanes = {
+            "footgun-finder": {
+                "state": "not-required",
+                "reason": "Diff does not touch misuse-prone public surfaces.",
+            },
+            "invariant-ace": {
+                "state": "not-required",
+                "reason": "Diff does not touch invariant-bearing state.",
+            },
+            "complexity-mitigator": {
+                "state": "not-required",
+                "reason": "Reviewability is not blocked by complexity.",
+            },
+        }
+        for lane, override in lane_overrides.items():
+            lanes[lane] = override
+        return {
+            "standard": "required",
+            "auxiliary_review_lanes": lanes,
+        }
+
+    def satisfied_standard_cas(self):
+        return {
+            "required": "yes",
+            "standard_clean_runs_required": 3,
+            "standard_clean_runs_count": 3,
+            "independent_fresh_runs": "yes",
+            "tuple_bound": "yes",
+            "tuple": {
+                "base_sha": "base123",
+                "head_sha": "abc123",
+                "target_fingerprint": "diff:clean",
+            },
+        }
+
     def assert_blocks_with(self, context, reason: str, next_owner: str) -> None:
         decision = MODULE.make_decision(context)
         body = decision["actuation_terminal_decision"]
@@ -479,18 +515,8 @@ class ActuationTerminalGateTests(unittest.TestCase):
 
     def test_cas_required_accepts_matching_final_report_clean_runs(self) -> None:
         context = deepcopy(self.context("terminal-context.proof-only.example.json"))
-        context["cas_review"] = {
-            "required": "yes",
-            "clean_runs_required": 3,
-            "clean_runs_count": 3,
-            "independent_fresh_runs": "yes",
-            "tuple_bound": "yes",
-            "tuple": {
-                "base_sha": "base123",
-                "head_sha": "abc123",
-                "target_fingerprint": "diff:clean",
-            },
-        }
+        context["cas_review"] = self.satisfied_standard_cas()
+        context["review_profile"] = self.review_profile()
         context["final_report_fields"]["normalized_cas_clean_runs"] = "3"
         decision = MODULE.make_decision(context)
         body = decision["actuation_terminal_decision"]
@@ -498,22 +524,106 @@ class ActuationTerminalGateTests(unittest.TestCase):
 
     def test_standard_clean_run_aliases_are_first_class(self) -> None:
         context = deepcopy(self.context("terminal-context.proof-only.example.json"))
-        context["cas_review"] = {
-            "required": "yes",
-            "standard_clean_runs_required": 3,
-            "standard_clean_runs_count": 3,
-            "independent_fresh_runs": "yes",
-            "tuple_bound": "yes",
-            "tuple": {
-                "base_sha": "base123",
-                "head_sha": "abc123",
-                "target_fingerprint": "diff:clean",
-            },
-        }
+        context["cas_review"] = self.satisfied_standard_cas()
+        context["review_profile"] = self.review_profile()
         context["final_report_fields"]["standard_clean_cas_runs"] = 3
         decision = MODULE.make_decision(context)
         body = decision["actuation_terminal_decision"]
         self.assertEqual(body["verdict"], "complete")
+
+    def test_workflow_review_requires_review_profile(self) -> None:
+        context = deepcopy(self.context("terminal-context.proof-only.example.json"))
+        context["cas_review"] = self.satisfied_standard_cas()
+        context["final_report_fields"]["standard_clean_cas_runs"] = 3
+        self.assert_blocks_with(context, "review_profile:missing", "$goal-actuating")
+
+    def test_review_profile_requires_all_auxiliary_lane_decisions(self) -> None:
+        context = deepcopy(self.context("terminal-context.proof-only.example.json"))
+        context["cas_review"] = self.satisfied_standard_cas()
+        context["review_profile"] = self.review_profile()
+        del context["review_profile"]["auxiliary_review_lanes"]["invariant-ace"]
+        context["final_report_fields"]["standard_clean_cas_runs"] = 3
+        self.assert_blocks_with(
+            context,
+            "review_profile.auxiliary_review_lanes.invariant-ace:missing",
+            "$goal-actuating",
+        )
+
+    def test_review_profile_not_required_requires_reason(self) -> None:
+        context = deepcopy(self.context("terminal-context.proof-only.example.json"))
+        context["cas_review"] = self.satisfied_standard_cas()
+        context["review_profile"] = self.review_profile(
+            **{"footgun-finder": {"state": "not-required", "reason": ""}}
+        )
+        context["final_report_fields"]["standard_clean_cas_runs"] = 3
+        self.assert_blocks_with(
+            context,
+            "review_profile.auxiliary_review_lanes.footgun-finder.reason:missing",
+            "$goal-actuating",
+        )
+
+    def test_review_profile_clean_lane_must_be_current(self) -> None:
+        context = deepcopy(self.context("terminal-context.proof-only.example.json"))
+        context["cas_review"] = self.satisfied_standard_cas()
+        context["review_profile"] = self.review_profile(
+            **{
+                "invariant-ace": {
+                    "state": "clean",
+                    "evidence_ref": "cas:invariant-ace:clean",
+                    "head_sha": "stale-head",
+                    "target_fingerprint": "stale-diff",
+                }
+            }
+        )
+        context["final_report_fields"]["standard_clean_cas_runs"] = 3
+        decision = MODULE.make_decision(context)
+        body = decision["actuation_terminal_decision"]
+        self.assertEqual(body["verdict"], "blocked")
+        self.assertIn(
+            "review_profile.auxiliary_review_lanes.invariant-ace.head_sha:artifact-mismatch",
+            body["blocked_reasons"],
+        )
+        self.assertIn(
+            "review_profile.auxiliary_review_lanes.invariant-ace.target_fingerprint:artifact-mismatch",
+            body["blocked_reasons"],
+        )
+
+    def test_review_profile_clean_lane_allows_completion(self) -> None:
+        context = deepcopy(self.context("terminal-context.proof-only.example.json"))
+        context["cas_review"] = self.satisfied_standard_cas()
+        context["review_profile"] = self.review_profile(
+            **{
+                "complexity-mitigator": {
+                    "state": "clean",
+                    "evidence_ref": "cas:complexity-mitigator:clean",
+                    "head_sha": "abc123",
+                    "target_fingerprint": "diff:clean",
+                }
+            }
+        )
+        context["final_report_fields"]["standard_clean_cas_runs"] = 3
+        decision = MODULE.make_decision(context)
+        body = decision["actuation_terminal_decision"]
+        self.assertEqual(body["verdict"], "complete")
+
+    def test_review_profile_blocker_or_rerun_blocks_completion(self) -> None:
+        context = deepcopy(self.context("terminal-context.proof-only.example.json"))
+        context["cas_review"] = self.satisfied_standard_cas()
+        context["review_profile"] = self.review_profile(
+            **{
+                "footgun-finder": {"state": "blocked", "reason": "Misuse hazard unresolved."},
+                "complexity-mitigator": {"state": "rerun-required", "reason": "Artifact changed."},
+            }
+        )
+        context["final_report_fields"]["standard_clean_cas_runs"] = 3
+        decision = MODULE.make_decision(context)
+        body = decision["actuation_terminal_decision"]
+        self.assertEqual(body["verdict"], "blocked")
+        self.assertIn("review_profile.auxiliary_review_lanes.footgun-finder:blocked", body["blocked_reasons"])
+        self.assertIn(
+            "review_profile.auxiliary_review_lanes.complexity-mitigator:rerun-required",
+            body["blocked_reasons"],
+        )
 
     def test_standard_clean_run_aliases_block_when_insufficient(self) -> None:
         context = deepcopy(self.context("terminal-context.proof-only.example.json"))
@@ -683,6 +793,16 @@ class ActuationTerminalGateTests(unittest.TestCase):
                 "target_fingerprint": "diff:clean",
             },
         }
+        context["review_profile"] = self.review_profile(
+            **{
+                "complexity-mitigator": {
+                    "state": "clean",
+                    "evidence_ref": "cas:complexity-mitigator:clean",
+                    "head_sha": "abc123",
+                    "target_fingerprint": "diff:clean",
+                }
+            }
+        )
         context["final_report_fields"]["standard_clean_cas_runs"] = 3
         decision = MODULE.make_decision(context)
         body = decision["actuation_terminal_decision"]

--- a/codex/skills/actuating/tools/actuation_terminal_gate.py
+++ b/codex/skills/actuating/tools/actuation_terminal_gate.py
@@ -363,9 +363,55 @@ def required_auxiliary_lanes_for(cas: dict[str, Any], records: dict[str, dict[st
     return required
 
 
-def standard_cas_required_for(cas: dict[str, Any]) -> bool:
+def review_profile_for(context: dict[str, Any]) -> dict[str, Any]:
+    profile = object_from(context.get("review_profile"))
+    if profile:
+        return profile
+    return object_from(object_from(context.get("loop_governance")).get("review_profile"))
+
+
+def review_profile_lane_records_for(profile: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    lanes = profile.get("auxiliary_review_lanes", profile.get("auxiliary_lanes", []))
+    records: dict[str, dict[str, Any]] = {}
+    if isinstance(lanes, dict):
+        for lane, value in lanes.items():
+            if lane not in AUXILIARY_CAS_LANES:
+                continue
+            if isinstance(value, dict):
+                record = dict(value)
+            else:
+                record = {"state": value}
+            record.setdefault("lane", lane)
+            records[lane] = record
+        return records
+    if isinstance(lanes, list):
+        for value in lanes:
+            record = {"lane": value, "state": "clean"} if isinstance(value, str) else object_from(value)
+            lane = record.get("lane")
+            if lane in AUXILIARY_CAS_LANES:
+                records[lane] = record
+    return records
+
+
+def review_profile_selects_auxiliary_lane(profile: dict[str, Any]) -> bool:
+    for record in review_profile_lane_records_for(profile).values():
+        state = str(record.get("state", record.get("status", ""))).lower()
+        if state and state != "not-required":
+            return True
+        if as_yes(record.get("selected")) or as_yes(record.get("required")):
+            return True
+    return False
+
+
+def standard_cas_required_for(cas: dict[str, Any], profile: dict[str, Any] | None = None) -> bool:
     records = auxiliary_lane_records_for(cas)
-    return as_yes(cas.get("required")) or bool(required_auxiliary_lanes_for(cas, records))
+    workflow_profile = profile or {}
+    return (
+        as_yes(cas.get("required"))
+        or bool(required_auxiliary_lanes_for(cas, records))
+        or str(workflow_profile.get("standard", "")).lower() == "required"
+        or review_profile_selects_auxiliary_lane(workflow_profile)
+    )
 
 
 def lane_binding_value(record: dict[str, Any], key: str) -> Any:
@@ -405,13 +451,68 @@ def auxiliary_lane_reasons_for(cas: dict[str, Any], artifact: dict[str, Any]) ->
     return reasons
 
 
+def review_profile_reasons_for(profile: dict[str, Any], artifact: dict[str, Any], standard_required: bool) -> list[str]:
+    if not standard_required and not profile:
+        return []
+    reasons: list[str] = []
+    if standard_required and not profile:
+        return ["review_profile:missing"]
+
+    standard_state = str(profile.get("standard", "")).lower()
+    if standard_required and standard_state != "required":
+        reasons.append("review_profile.standard:missing-required")
+
+    records = review_profile_lane_records_for(profile)
+    for lane in sorted(AUXILIARY_CAS_LANES):
+        record = records.get(lane)
+        prefix = f"review_profile.auxiliary_review_lanes.{lane}"
+        if not record:
+            reasons.append(f"{prefix}:missing")
+            continue
+        state = str(record.get("state", record.get("status", ""))).lower()
+        if not state:
+            reasons.append(f"{prefix}.state:missing")
+            continue
+        if state not in {"not-required", "clean", "findings-folded", "blocked", "rerun-required"}:
+            reasons.append(f"{prefix}.state:invalid")
+            continue
+        if state == "not-required":
+            reason = record.get("reason")
+            if not isinstance(reason, str) or not reason.strip():
+                reasons.append(f"{prefix}.reason:missing")
+            continue
+        if state == "blocked":
+            reasons.append(f"{prefix}:blocked")
+            continue
+        if state == "rerun-required":
+            reasons.append(f"{prefix}:rerun-required")
+            continue
+
+        evidence_ref = first_present(record, ("evidence_ref", "verdict_ref", "review_fold_ref", "receipt_ref"))
+        if not isinstance(evidence_ref, str) or not evidence_ref:
+            reasons.append(f"{prefix}.evidence_ref:missing")
+        head_sha = lane_binding_value(record, "head_sha")
+        if not isinstance(head_sha, str) or not head_sha:
+            reasons.append(f"{prefix}.head_sha:missing")
+        elif head_sha != artifact.get("head_sha"):
+            reasons.append(f"{prefix}.head_sha:artifact-mismatch")
+        target_fingerprint = lane_binding_value(record, "target_fingerprint")
+        if not isinstance(target_fingerprint, str) or not target_fingerprint:
+            reasons.append(f"{prefix}.target_fingerprint:missing")
+        elif target_fingerprint != artifact.get("diff_fingerprint"):
+            reasons.append(f"{prefix}.target_fingerprint:artifact-mismatch")
+    return reasons
+
+
 def cas_advisory_blocked(context: dict[str, Any], loop: dict[str, Any]) -> bool:
     cas = object_from(context.get("cas_review"))
+    profile = review_profile_for(context)
     artifact = object_from(context.get("artifact_scope"))
     final_report = object_from(context.get("final_report_fields"))
-    if cas_reasons_for(cas, artifact) or final_report_reasons_for(
+    if cas_reasons_for(cas, profile, artifact) or final_report_reasons_for(
         final_report,
         cas,
+        profile,
         object_from(context.get("proof_patch")),
         object_from(context.get("delivery")),
     ):
@@ -483,6 +584,9 @@ def make_decision(context: dict[str, Any]) -> dict[str, Any]:
     local_proof = optional_object(context, "local_proof", errors)
     proof_patch = optional_object(context, "proof_patch", errors)
     cas = optional_object(context, "cas_review", errors)
+    profile = optional_object(context, "review_profile", errors) or object_from(
+        object_from(context.get("loop_governance")).get("review_profile")
+    )
     delivery = optional_object(context, "delivery", errors)
     final_report = optional_object(context, "final_report_fields", errors)
 
@@ -505,14 +609,14 @@ def make_decision(context: dict[str, Any]) -> dict[str, Any]:
     proof_reasons = proof_patch_reasons_for(proof_patch, closure_candidate)
     unresolved.extend(proof_reasons)
 
-    cas_reasons = cas_reasons_for(cas, artifact)
+    cas_reasons = cas_reasons_for(cas, profile, artifact)
     blocked.extend(cas_reasons)
 
     delivery_reasons, delivery_continue = delivery_reasons_for(delivery, closure_candidate, artifact)
     blocked.extend(delivery_reasons)
     unresolved.extend(delivery_continue)
 
-    report_reasons = final_report_reasons_for(final_report, cas, proof_patch, delivery)
+    report_reasons = final_report_reasons_for(final_report, cas, profile, proof_patch, delivery)
     blocked.extend(report_reasons)
 
     if closure_candidate == "blocked":
@@ -552,7 +656,7 @@ def make_decision(context: dict[str, Any]) -> dict[str, Any]:
                 "diff_fingerprint": artifact.get("diff_fingerprint", ""),
                 "dirty_state": artifact.get("dirty_state", "unknown"),
             },
-            "required_receipts": required_receipts_for(proof_patch, cas, delivery, closure_candidate),
+            "required_receipts": required_receipts_for(proof_patch, cas, profile, delivery, closure_candidate),
         }
     }
     validate_decision(decision)
@@ -608,11 +712,11 @@ def proof_patch_reasons_for(proof_patch: dict[str, Any], closure_candidate: str)
     return reasons
 
 
-def cas_reasons_for(cas: dict[str, Any], artifact: dict[str, Any]) -> list[str]:
+def cas_reasons_for(cas: dict[str, Any], profile: dict[str, Any], artifact: dict[str, Any]) -> list[str]:
     reasons: list[str] = []
-    standard_required = standard_cas_required_for(cas)
+    standard_required = standard_cas_required_for(cas, profile)
     if not standard_required:
-        return auxiliary_lane_reasons_for(cas, artifact)
+        return auxiliary_lane_reasons_for(cas, artifact) + review_profile_reasons_for(profile, artifact, standard_required)
     required = standard_clean_runs_required_for(cas)
     count = standard_clean_runs_count_for(cas)
     standard_fields_used = (
@@ -652,6 +756,7 @@ def cas_reasons_for(cas: dict[str, Any], artifact: dict[str, Any]) -> list[str]:
         if tuple_value.get("target_fingerprint") != artifact.get("diff_fingerprint"):
             reasons.append("cas.tuple.target_fingerprint:artifact-mismatch")
     reasons.extend(auxiliary_lane_reasons_for(cas, artifact))
+    reasons.extend(review_profile_reasons_for(profile, artifact, standard_required))
     return reasons
 
 
@@ -768,11 +873,12 @@ def add_v1_head_reasons_for(add: dict[str, Any], artifact: dict[str, Any]) -> li
 def final_report_reasons_for(
     final_report: dict[str, Any],
     cas: dict[str, Any],
+    profile: dict[str, Any],
     proof_patch: dict[str, Any],
     delivery: dict[str, Any],
 ) -> list[str]:
     reasons: list[str] = []
-    if standard_cas_required_for(cas):
+    if standard_cas_required_for(cas, profile):
         required = standard_clean_runs_required_for(cas)
         if not is_plain_int(required) or required <= 0:
             required = 3
@@ -792,13 +898,14 @@ def final_report_reasons_for(
 def required_receipts_for(
     proof_patch: dict[str, Any],
     cas: dict[str, Any],
+    profile: dict[str, Any],
     delivery: dict[str, Any],
     closure_candidate: str,
 ) -> list[str]:
     receipts: list[str] = []
     if as_yes(proof_patch.get("required")) or closure_candidate == "proof-patch":
         receipts.append("proof_patch")
-    if standard_cas_required_for(cas):
+    if standard_cas_required_for(cas, profile):
         receipts.append("cas_review")
     if as_yes(delivery.get("pr_intent")) or closure_candidate == "ship-complete":
         receipts.append("add_v1_delivery_decision")
@@ -815,15 +922,20 @@ def next_owner_for(blocked: list[str], pending: list[str]) -> str:
         return "$st"
     if any(reason.startswith("artifact_scope") for reason in combined):
         return "$goal-grind"
-    if any(
-        reason == "cas-review-blocked"
-        or reason.startswith("cas.")
+    profile_blocked = any(reason.startswith("review_profile") for reason in combined)
+    cas_detail_blocked = any(
+        reason.startswith("cas.")
         or reason.startswith("final_report.normalized_cas")
         or reason.startswith("final_report.normalized_standard_cas")
         or reason.startswith("final_report.standard_clean_cas")
         for reason in combined
-    ):
+    )
+    if profile_blocked and not cas_detail_blocked:
+        return "$goal-actuating"
+    if "cas-review-blocked" in combined or cas_detail_blocked:
         return "$cas"
+    if profile_blocked:
+        return "$goal-actuating"
     if any(reason == "side-effect-boundary-violated" for reason in combined):
         return "$ship"
     if any(reason.startswith("blocked-loop-contract") or reason.startswith("blocked-hylo") for reason in combined):

--- a/codex/skills/goal-actuating/SKILL.md
+++ b/codex/skills/goal-actuating/SKILL.md
@@ -109,11 +109,12 @@ complexity-mitigator
 Rules:
 
 - `standard` is required whenever workflow review is required or any auxiliary lane is selected.
-- Auxiliary lanes are selected before review from the diff surface, accepted proof bar, user request, or prior review class.
+- Auxiliary lanes are selected before review from the diff surface, accepted proof bar, user request, or prior review class, and the decision lives in the workflow-owned `review_profile`.
 - Auxiliary lanes are real CAS review evidence, but they do not increment or interrupt the standard clean-review streak.
 - Auxiliary findings must be folded through `$review-fold` and may block closeout or become accepted liabilities.
 - Do not require unsupported `$cas` commands to produce semantic footgun/invariant/complexity lane labels. CAS transports and tuple-binds review evidence; the workflow owns auxiliary lens selection, folding, and blocker state.
 - A selected auxiliary lane must carry current `head_sha` and `target_fingerprint` evidence before ATCG may complete.
+- When workflow review is required, `review_profile` must explicitly account for `footgun-finder`, `invariant-ace`, and `complexity-mitigator` as selected/folded evidence or `not-required` with a reason; absence is unknown coverage, not clean review.
 - A code change from any lane resets the standard clean-review streak to zero.
 - Read-only or classification-only auxiliary lane results do not reset the standard streak unless they change artifact scope or proof bar.
 - Do not rerun auxiliary lanes on every standard clean attempt unless their surface was touched, their prior result was blocked/validate-first, the proof bar changed, or a standard review exposes a new class owned by that lens.
@@ -220,7 +221,7 @@ Explicit review mode names carry the mutation rule:
 - `review-closeout`: classify findings, implement only accepted code-change liabilities, prove closure, and stop at ATCG or `$ship` handoff.
 
 ```text
-CAS review profile selection
+workflow review_profile selection
 -> $cas standard review
 -> optional auxiliary review lenses: footgun-finder | invariant-ace | complexity-mitigator
 -> $review-fold
@@ -270,6 +271,7 @@ verification regresses
 proof is stale or not bound to the current artifact
 public tracker side effect would be needed without explicit intent
 review is required but $cas standard review is unavailable or not run
+workflow review is required but review_profile is missing, partial, or lacks explicit not-required reasons
 required auxiliary CAS review lane is unavailable, blocked, or not folded
 three clean normalized standard $cas review attempts are required but cannot be completed
 ALSR/HYL is required but missing or stale
@@ -289,7 +291,7 @@ Goal Actuation:
 - mode / persistence:
 - review profile:
   - standard CAS review: required|not-required, current verdict:
-  - auxiliary lanes: footgun-finder|invariant-ace|complexity-mitigator|none
+  - auxiliary lanes: footgun-finder|invariant-ace|complexity-mitigator each not-required|clean|findings-folded|blocked|rerun-required
   - auxiliary blockers:
 - parallelism:
   - mode:

--- a/codex/skills/review-fold/SKILL.md
+++ b/codex/skills/review-fold/SKILL.md
@@ -36,7 +36,7 @@ resolution fold = resolution plan compiler
 $goal-grind = implementation engine for accepted liabilities
 ```
 
-For `review-closeout` and exhaustive review, final completion requires three consecutive clean normalized **standard** `$cas` review attempts after implementation. `$review-fold` decides whether each review lane is normalized clean, blocking, or reset-worthy. Auxiliary CAS lanes do not increment or interrupt the standard clean streak.
+For `review-closeout` and exhaustive review, final completion requires three consecutive clean normalized **standard** `$cas` review attempts after implementation. `$review-fold` decides whether each review lane is normalized clean, blocking, or reset-worthy. `$actuating` / `$goal-actuating` own the `review_profile` that records which auxiliary lenses were selected or explicitly not required. Auxiliary CAS lanes do not increment or interrupt the standard clean streak.
 
 ## Review source rule
 
@@ -57,7 +57,7 @@ invariant-ace        auxiliary lens for illegal states, owner/source-of-truth, t
 complexity-mitigator auxiliary lens for comprehension stalls, boolean soup, mixed responsibilities, hidden state, dominated branches, incidental complexity, and one-patch-per-comment pressure
 ```
 
-Only `standard` may set `contributes_to_standard_streak: yes`. Auxiliary lanes are review evidence; they may create blockers or accepted liabilities, but they do not count as standard clean reviews and do not interrupt standard-review consecutiveness.
+Only `standard` may set `contributes_to_standard_streak: yes`. Auxiliary lanes are review evidence; they may create blockers or accepted liabilities, but they do not count as standard clean reviews and do not interrupt standard-review consecutiveness. `$cas` transports tuple-bound evidence; it does not own the auxiliary lane selection policy.
 
 ## Minimal review law
 
@@ -287,7 +287,7 @@ Auxiliary CAS review lanes may still block closeout. They do not increment the s
 
 1. Bind reviews to the original goal and current diff.
 2. If fresh/exhaustive workflow code review is required and no CAS standard review result is present, stop and request `$cas` standard review.
-3. If the review profile selected auxiliary lanes, require their CAS-backed results before final review folding unless they are explicitly marked not-required.
+3. If the workflow `review_profile` selected auxiliary lanes, require their CAS-backed results before final review folding unless they are explicitly marked not-required with a reason.
 4. Classify each finding before any implementation.
 5. Separate the claim, observed fact, and suggested repair when the review text includes all three.
 6. Reject, block, ask, or follow up before code whenever validity, liability, or scope is not established.
@@ -338,6 +338,7 @@ no changes
 - Do not miss the refactor when many comments share one owner boundary.
 - Do not replace a requested or required CAS review with non-CAS critique.
 - Do not count auxiliary CAS lanes as standard clean reviews.
+- Do not store auxiliary lane selection policy only in `$cas` transport fields.
 - Do not claim review closure before three clean normalized standard CAS attempts when `review-closeout` or exhaustive review requires them.
 - Do not resolve or reply to PR threads without explicit public-side-effect intent.
 - `$review-fold` owns active review adjudication; do not route findings through retired skill paths.


### PR DESCRIPTION
## Summary
- Add workflow-owned review_profile validation to ATCG for auxiliary review coverage.
- Keep CAS as tuple-bound review evidence transport, not the owner of auxiliary lane policy.
- Update goal-actuating/review-fold/ATCG docs and tests around missing, partial, stale, blocked, and not-required auxiliary profile states.

## Proof
- `uv run python -m unittest codex/skills/actuating/tests/test_actuation_terminal_gate.py`: pass
- `uv run python codex/skills/actuating/tools/quick_validate.py`: pass
- `uv run python codex/skills/review-fold/tests/test_contract.py`: pass
- `uv run --with pyyaml -- python3 /Users/tk/.dotfiles/codex/skills/.system/skill-creator/scripts/quick_validate.py /tmp/dotfiles-aux-review-profile.cnbRFX/codex/skills/actuating`: pass
- `uv run --with pyyaml -- python3 /Users/tk/.dotfiles/codex/skills/.system/skill-creator/scripts/quick_validate.py /tmp/dotfiles-aux-review-profile.cnbRFX/codex/skills/goal-actuating`: pass
- `uv run --with pyyaml -- python3 /Users/tk/.dotfiles/codex/skills/.system/skill-creator/scripts/quick_validate.py /tmp/dotfiles-aux-review-profile.cnbRFX/codex/skills/review-fold`: pass
- `git diff --check`: pass

## Scope
- branch: feature/aux-review-profile-coverage
- head: 719f07b5
- base: main

## Readiness
- PR mode: ready
- Reason: scoped implementation and validation complete.
- Caveats: none