### PR TITLE
Tune tune publish gate policy

### DIFF
--- a/codex/skills/tune/SKILL.md
+++ b/codex/skills/tune/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tune
-description: "Tune an existing Codex skill by comparing its intended decision contract with observed decision episodes and outcomes. Prefer `seq skill-decision-audit --mode tune-packet`; use for `$tune`, intended-vs-observed behavior, missed/false/ceremonial activations, ignored clauses, wrong routes, outcome regressions, repeated workarounds, STE-v1 packets, skill-delta candidates, explicit `$refine` handoff, or commit/push authorization questions. Stop at audit/proposal unless apply is explicit. Commit/push only with explicit publish intent after validation. `$seq` CLI changes require a separate special spec."
+description: "Tune an existing Codex skill by comparing its intended decision contract with observed decision episodes and outcomes. Prefer `seq skill-decision-audit --mode tune-packet`; use for `$tune`, intended-vs-observed behavior, missed/false/ceremonial activations, ignored clauses, wrong routes, outcome regressions, repeated workarounds, STE-v1 packets, skill-delta candidates, explicit `$refine` handoff, or commit/push authorization for skill-refinement changes. Stop at audit/proposal unless apply or skill-refinement publication is explicit. Commit/push only with explicit publish intent after validation. `$seq` CLI changes require a separate special spec."
 ---
 
 # Tune
@@ -51,7 +51,7 @@ seq skill-decision-audit \
 
 Canonical packet: `skill_tuning_evidence / STE-v1`.
 
-If the installed CLI lacks `skill-decision-audit`, use the existing narrow `$seq` surfaces, keep activation/decision/outcome evidence separate, mark decision causality `unknown` unless explicit, and emit `SEQ-SPEC-HANDOFF-v2` when the missing surface materially blocks diagnosis. Do not normalize broad raw transcript mining as the replacement workflow.
+If the installed CLI lacks `skill-decision-audit`, use the existing narrow `$seq` surfaces, keep activation/decision/outcome evidence separate, mark decision causality `unknown` unless explicit, and emit `SEQ-SPEC-HANDOFF-v1` when the missing surface materially blocks diagnosis. Do not normalize broad raw transcript mining as the replacement workflow.
 
 ## Modes
 
@@ -67,7 +67,7 @@ apply-with-refine
 
 `proposal-only`: default for "improve," "optimize," or "what should change?"; produce one bounded decision delta, terminal repeat state, or no-action decision; no edits.
 
-`apply-with-refine`: use only when the user explicitly asks to edit, apply, patch, or update now. Produce the diagnosis first, then hand a bounded brief to `$refine`. Apply means local file changes plus validation; it does not authorize commit or push.
+`apply-with-refine`: use only when the user explicitly asks to edit, apply, patch, update, or publish an already-applied validated skill refinement now. Produce the diagnosis first, then hand a bounded brief to `$refine` or report the publication-only state. Apply means local file changes plus validation; it does not authorize commit or push.
 
 ## Target skill type
 
@@ -208,8 +208,9 @@ retired
 
 Apply-with-refine may edit files only when all hold:
 
-- explicit user request to edit, apply, patch, or update now;
-- target, evidence source, intended contract, and protected-skill restrictions are identified;
+- explicit user request to edit, apply, patch, update, or publish an already-applied validated skill refinement now;
+- target, evidence source, and intended contract are identified;
+- protected-skill restrictions are satisfied;
 - decision/outcome gap is sufficiently evidenced and smallest change is known;
 - stable clause IDs are preserved unless intentionally replaced;
 - validation query exists.
@@ -228,7 +229,7 @@ If any required gate fails, stop at audit/proposal or report blocked publication
 
 `$refine` handoff: use `REFINE-SKILL-v3`. The brief must bind source packet, target kind, gap/clause refs, expected delta, optimization boundary, intervention budget, forbidden changes, smallest-change hint, static/contract/script/behavioral validation, and publish authorization when relevant. Do not hand `$refine` raw transcripts when STE-v1 is available.
 
-`$seq` special-spec handoff: when a missing evidence surface blocks diagnosis, emit `SEQ-SPEC-HANDOFF-v2` with need, observed gap, desired command/packet fields, acceptance criteria, validation examples, and source evidence. Do not edit `$seq` inside ordinary skill refinement.
+`$seq` special-spec handoff: when a missing evidence surface blocks diagnosis, emit `SEQ-SPEC-HANDOFF-v1` with need, observed gap, desired command/packet fields, acceptance criteria, validation examples, and source evidence. Do not edit `$seq` inside ordinary skill refinement.
 
 ## Subagent policy
 

--- a/codex/skills/tune/SKILL.md
+++ b/codex/skills/tune/SKILL.md
@@ -219,6 +219,8 @@ Publishing is separate:
 - commit only after validation passes and explicit commit, publish, ship, or save-to-git intent exists;
 - push only after commit succeeds and explicit push or remote-publish intent exists;
 - otherwise report commit/push as `blocked:not-requested`.
+- when publishing was requested but validation, pre-commit, or worktree checks fail,
+  report the specific blocked state instead of collapsing it to `blocked:not-requested`.
 
 If any required gate fails, stop at audit/proposal or report blocked publication.
 

--- a/codex/skills/tune/SKILL.md
+++ b/codex/skills/tune/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tune
-description: "Tune an existing Codex skill by comparing its intended decision contract with observed decision episodes and outcomes. Prefer `seq skill-decision-audit --mode tune-packet`; use for `$tune`, intended-vs-observed behavior, missed/false/ceremonial activations, ignored clauses, wrong routes, outcome regressions, repeated workarounds, STE-v1 packets, skill-delta candidates, or explicit `$refine` handoff. Stop at audit/proposal unless apply is explicit. `$seq` CLI changes require a separate special spec."
+description: "Tune an existing Codex skill by comparing its intended decision contract with observed decision episodes and outcomes. Prefer `seq skill-decision-audit --mode tune-packet`; use for `$tune`, intended-vs-observed behavior, missed/false/ceremonial activations, ignored clauses, wrong routes, outcome regressions, repeated workarounds, STE-v1 packets, skill-delta candidates, explicit `$refine` handoff, or commit/push authorization questions. Stop at audit/proposal unless apply is explicit. Commit/push only with explicit publish intent after validation. `$seq` CLI changes require a separate special spec."
 ---
 
 # Tune
@@ -15,11 +15,13 @@ decision evidence asks: what changed because of it?
 outcome evidence asks: was that change useful?
 ```
 
-`$tune` owns diagnosis and the refinement decision.
+Ownership:
 
-`$seq` owns historical/session/tool evidence.
-
-`$refine` owns in-place edits after the apply gate passes.
+```text
+$seq    gathers historical/session/tool evidence
+$tune   diagnoses the gap and decides the refinement route
+$refine owns in-place skill-package edits after the apply gate passes
+```
 
 ## Canonical evidence
 
@@ -36,12 +38,6 @@ seq skill-decision-audit \
   --format json
 ```
 
-Canonical packet:
-
-```text
-skill_tuning_evidence / STE-v1
-```
-
 For one watched session, prefer:
 
 ```bash
@@ -53,13 +49,9 @@ seq skill-decision-audit \
   --format json
 ```
 
-If the installed CLI lacks `skill-decision-audit`:
+Canonical packet: `skill_tuning_evidence / STE-v1`.
 
-1. use the existing narrow `$seq` surfaces needed for the question;
-2. keep activation, decision, and outcome evidence separate;
-3. mark decision causality as `unknown` unless explicit;
-4. emit a `seq_special_spec_handoff` when the missing surface materially limits diagnosis;
-5. do not replace the missing CLI with broad ad hoc transcript mining as the normal workflow.
+If the installed CLI lacks `skill-decision-audit`, use the existing narrow `$seq` surfaces, keep activation/decision/outcome evidence separate, mark decision causality `unknown` unless explicit, and emit `SEQ-SPEC-HANDOFF-v2` when the missing surface materially blocks diagnosis. Do not normalize broad raw transcript mining as the replacement workflow.
 
 ## Modes
 
@@ -71,98 +63,27 @@ proposal-only
 apply-with-refine
 ```
 
-### audit-only
+`audit-only`: explain what evidence supports and does not support; no edits.
 
-Explain what evidence supports and what it does not support.
+`proposal-only`: default for "improve," "optimize," or "what should change?"; produce one bounded decision delta, terminal repeat state, or no-action decision; no edits.
 
-No edits.
-
-### proposal-only
-
-Default for “improve,” “optimize,” or “what should change?”
-
-Produce a bounded decision delta, terminal repeat state, or no-action decision.
-
-No edits.
-
-### apply-with-refine
-
-Use only when the user explicitly asks to edit or apply changes now.
-
-Produce the diagnosis first, then hand a bounded brief to `$refine`.
+`apply-with-refine`: use only when the user explicitly asks to edit, apply, patch, or update now. Produce the diagnosis first, then hand a bounded brief to `$refine`. Apply means local file changes plus validation; it does not authorize commit or push.
 
 ## Target skill type
 
 Classify the target before judging it:
 
 ```text
-decision
-execution
-evidence
-orchestration
-mixed
+decision       route selection/rejection/narrowing/blocking/escalation
+execution      handoff fidelity, surface budget, validation, rework
+evidence       coverage, precision, provenance, false positives/negatives
+orchestration  phase correctness, handoff completeness, terminal states, loops
+mixed          name the relevant dimensions; do not force route-change metrics
 ```
-
-### decision
-
-Value lies in selecting, rejecting, narrowing, blocking, or escalating a route.
-
-Primary evidence:
-
-```text
-decision effect
-clause compliance
-downstream outcome
-```
-
-### execution
-
-Value lies in performing a task correctly and efficiently.
-
-Primary evidence:
-
-```text
-handoff fidelity
-surface budget
-validation
-rework
-```
-
-### evidence
-
-Value lies in retrieving, classifying, or preserving trustworthy evidence.
-
-Primary evidence:
-
-```text
-coverage
-precision
-provenance
-false-positive/negative behavior
-```
-
-### orchestration
-
-Value lies in lifecycle, state transition, concurrency, or handoff control.
-
-Primary evidence:
-
-```text
-phase correctness
-handoff completeness
-blocked/terminal states
-loop efficiency
-```
-
-### mixed
-
-Name which evidence dimensions apply.
-
-Do not force a route-change metric onto a skill whose job is evidence retrieval or execution.
 
 ## Intended-use contract
 
-Read the target skill before judging usage:
+Read the target package before judging usage:
 
 ```text
 SKILL.md
@@ -173,19 +94,7 @@ references/
 assets/
 ```
 
-Prefer an explicit:
-
-```text
-skill_decision_contract / SKDC-v1
-```
-
-If absent, reconstruct only the minimum provisional contract needed for diagnosis and label it:
-
-```text
-contract_authority: inferred
-```
-
-Do not pretend inferred clauses are stable historical identifiers.
+Prefer `skill_decision_contract / SKDC-v1`. If absent, reconstruct only the minimum provisional contract needed for diagnosis and label it `contract_authority: inferred`. Do not pretend inferred clauses are stable historical identifiers.
 
 ## Evidence hierarchy
 
@@ -199,69 +108,30 @@ Use the strongest available evidence and preserve weaker classes separately:
 5. co-occurrence or raw mention
 ```
 
-Only levels 1–2 establish a strong skill-caused decision delta.
+Only levels 1-2 establish a strong skill-caused decision delta. Levels 3-4 support alignment or association, not causal proof. Level 5 is weak evidence.
 
-Levels 3–4 support alignment or association, not causal proof.
-
-Level 5 is weak evidence.
-
-## Decision-effect classes
+Decision-effect classes:
 
 ```text
-explicit_route_change
-prevented_action
-narrowed_scope
-added_or_changed_proof
-escalated_or_blocked
-reinforced_existing_choice
-no_visible_delta
-contrary_to_contract
-trigger_missed
-false_activation
-ceremonial_activation
-unknown
+explicit_route_change | prevented_action | narrowed_scope
+added_or_changed_proof | escalated_or_blocked | reinforced_existing_choice
+no_visible_delta | contrary_to_contract | trigger_missed
+false_activation | ceremonial_activation | unknown
 ```
 
-### Ceremonial activation
-
-Use when the skill was loaded or declared but:
-
-- no clause was exercised;
-- no route, scope, proof, or lifecycle state changed;
-- the resulting work is indistinguishable from a no-skill path.
-
-Ceremony is not automatically harmful. It becomes a tuning gap when recurrent or costly.
+Ceremonial activation means the skill was loaded or declared but no clause was exercised, no route/scope/proof/lifecycle state changed, and the work is indistinguishable from a no-skill path. Ceremony is not automatically harmful; it becomes a tuning gap when recurrent or costly.
 
 ## Gap classes
 
 Classify the smallest useful gap:
 
 ```text
-activation
-interpretation
-workflow
-tooling
-resource
-validation
-metadata
-boundary
-source-scope
-decision-contract
-observability
-outcome
-ceremony
-overconstraint
+activation | interpretation | workflow | tooling | resource | validation
+metadata | boundary | source-scope | decision-contract | observability
+outcome | ceremony | overconstraint
 ```
 
-Examples:
-
-- trigger present, no activation -> `activation`
-- clause loaded but wrong route selected -> `interpretation`
-- repeated manual workaround -> `tooling` or `workflow`
-- no stable clause IDs -> `decision-contract`
-- skill appears useful but decision effect cannot be recovered -> `observability`
-- compliant route repeatedly reopens -> `outcome`
-- repeated use with no visible delta -> `ceremony`
+Examples: trigger present with no activation -> `activation`; clause loaded but wrong route selected -> `interpretation`; repeated manual workaround -> `tooling` or `workflow`; no stable clause IDs -> `decision-contract`; useful-looking skill with unrecoverable decision effect -> `observability`; compliant route repeatedly reopens -> `outcome`; repeated no-delta use -> `ceremony`.
 
 ## Decision episode analysis
 
@@ -285,36 +155,15 @@ decision_episode:
   counterevidence: []
 ```
 
-Do not infer alternatives that were never observed.
+Do not infer alternatives that were never observed. Do not count a later successful session as proof that a skill caused the success.
 
-Do not count a later successful session as proof that a skill caused the success.
+Before proposing a change, ask whether the observed action plausibly would have happened without the skill, whether the skill changed the route or merely described it, whether compliance improved the outcome, whether missed activation caused failure, and whether a companion skill owns the effect.
 
-## Counterfactual skepticism
-
-Before proposing a change, ask:
-
-```text
-Would the observed action plausibly have happened without the skill?
-Did the skill change the route, or merely describe it?
-Did compliance improve the outcome?
-Did a missed activation actually cause a failure?
-Could another companion skill own the effect?
-```
-
-For high-impact or ambiguous tuning, use:
-
-```text
-skill_decision_provenance_auditor
-skill_outcome_skeptic
-```
+For high-impact or ambiguous tuning, use `skill_decision_provenance_auditor` and/or `skill_outcome_skeptic`.
 
 ## Canonical tune packet
 
-Consume or emit `skill_tuning_evidence / STE-v1`.
-
-It must preserve target kind, contract authority, window, denominator, trigger quality, decision influence, clause compliance, outcomes, workarounds, exemplars, recurrent gaps, and limitations.
-
-See [ste-v1.md](references/ste-v1.md).
+Consume or emit `skill_tuning_evidence / STE-v1`. It must preserve target kind, contract authority, window, denominator, trigger quality, decision influence, clause compliance, outcomes, workarounds, exemplars, recurrent gaps, and limitations.
 
 Validate:
 
@@ -339,15 +188,14 @@ smallest change
 protected contracts
 validation query and plan
 proposed action
+publish authorization and commit/push state, when apply-mode is requested
 ```
 
 If there is no expected decision delta, do not produce a long redesign.
 
 ## Repeat proposal ledger
 
-Track proposal signature, first/last seen, repeat count, evidence delta, state, and next action.
-
-If the same proposal appears three times without new decision/outcome evidence, emit one terminal state:
+Track proposal signature, first/last seen, repeat count, evidence delta, state, and next action. If the same proposal appears three times without new decision/outcome evidence, emit one terminal state:
 
 ```text
 apply-blocked
@@ -356,65 +204,41 @@ transferred-to-seq
 retired
 ```
 
-## Apply gate
+## Apply / publish gates
 
-All must hold:
+Apply-with-refine may edit files only when all hold:
 
-- explicit user request to edit now;
-- target skill identified;
-- evidence source declared;
-- intended contract reconstructed;
-- decision or outcome gap is sufficiently evidenced;
-- smallest sufficient change is known;
-- stable clause IDs are preserved unless the change intentionally replaces them;
-- validation query exists;
-- protected-skill restrictions are satisfied.
+- explicit user request to edit, apply, patch, or update now;
+- target, evidence source, intended contract, and protected-skill restrictions are identified;
+- decision/outcome gap is sufficiently evidenced and smallest change is known;
+- stable clause IDs are preserved unless intentionally replaced;
+- validation query exists.
 
-If any fail, stop at audit/proposal.
+Publishing is separate:
 
-## `$refine` handoff
+- commit only after validation passes and explicit commit, publish, ship, or save-to-git intent exists;
+- push only after commit succeeds and explicit push or remote-publish intent exists;
+- otherwise report commit/push as `blocked:not-requested`.
 
-Use `REFINE-SKILL-v3`.
+If any required gate fails, stop at audit/proposal or report blocked publication.
 
-The brief must bind the source packet, target kind, gap and clause refs, expected delta, optimization boundary, intervention budget, forbidden changes, smallest-change hint, and static/contract/script/behavioral validation.
+## Handoffs
 
-Do not hand `$refine` raw transcripts when STE-v1 is available.
+`$refine` handoff: use `REFINE-SKILL-v3`. The brief must bind source packet, target kind, gap/clause refs, expected delta, optimization boundary, intervention budget, forbidden changes, smallest-change hint, static/contract/script/behavioral validation, and publish authorization when relevant. Do not hand `$refine` raw transcripts when STE-v1 is available.
 
-## `$seq` special-spec handoff
-
-When a missing evidence surface blocks diagnosis, emit `SEQ-SPEC-HANDOFF-v2` with the need, observed gap, desired command/packet fields, acceptance criteria, validation examples, and source evidence.
-
-Do not edit `$seq` inside ordinary skill refinement.
+`$seq` special-spec handoff: when a missing evidence surface blocks diagnosis, emit `SEQ-SPEC-HANDOFF-v2` with need, observed gap, desired command/packet fields, acceptance criteria, validation examples, and source evidence. Do not edit `$seq` inside ordinary skill refinement.
 
 ## Subagent policy
 
 Default root-only for small, explicit gaps.
 
-Use:
+Use `skill_contract_modeler` when the target is decision-oriented and lacks SKDC-v1.
 
-```text
-skill_contract_modeler
-```
+Use `skill_decision_provenance_auditor` when episodes are numerous or attribution is ambiguous.
 
-when the target is decision-oriented and lacks SKDC-v1.
+Use `skill_outcome_skeptic` when compliance/outcome correlation could be mistaken for causation.
 
-Use:
-
-```text
-skill_decision_provenance_auditor
-```
-
-when episodes are numerous or attribution is ambiguous.
-
-Use:
-
-```text
-skill_outcome_skeptic
-```
-
-when compliance/outcome correlation could be mistaken for causation.
-
-`$refine` owns all authorized skill-package optimization after `$tune` produces a bounded packet or brief. Do not delegate this to a system-managed optimizer.
+`$refine` owns authorized package optimization after `$tune` produces a bounded packet or brief. Do not delegate this to a system-managed optimizer.
 
 ## Validation
 
@@ -433,11 +257,7 @@ python3 codex/skills/tune/tools/decision_contract_lint.py \
   codex/skills/<skill>/references/decision-contract.yaml
 ```
 
-Behavioral:
-
-```text
-rerun the exact skill-decision-audit query named by validation_query
-```
+Behavioral: rerun the exact `skill-decision-audit` query named by `validation_query`.
 
 A text edit is not validated merely because frontmatter parses.
 
@@ -471,6 +291,7 @@ Skill delta:
 
 Handoff / action:
 - <no action | refine brief | seq spec | applied edit>
+- Publication: <authorization | commit | push>
 
 Validation:
 - Static:
@@ -492,4 +313,6 @@ Remaining uncertainty:
 - Prefer no edit over a weakly supported edit.
 - No decision delta, no full cycle.
 - No repeated proposal without terminal state.
+- Apply/edit authority is not commit/push authority.
+- No commit or push without explicit publish intent and passed validation.
 - No `$seq` CLI edit without a separate spec.

--- a/codex/skills/tune/agents/openai.yaml
+++ b/codex/skills/tune/agents/openai.yaml
@@ -3,4 +3,4 @@ policy:
 interface:
   display_name: "Tune"
   short_description: "Tune skills from decision provenance"
-  default_prompt: "Use $tune to compare a target skill's decision contract with STE-v1 decision episodes and outcomes, then produce one bounded skill delta or terminal state."
+  default_prompt: "Use $tune to compare a target skill's decision contract with STE-v1 decision episodes and outcomes, then produce one bounded skill delta or terminal state. Treat commit and push as publishing steps that require explicit user intent and passed validation."

--- a/codex/skills/tune/references/decision-contract.yaml
+++ b/codex/skills/tune/references/decision-contract.yaml
@@ -17,15 +17,19 @@ skill_decision_contract:
       exclusions:
         - style preference only
     - trigger_id: TUNE-APPLY-REQUEST
-      description: The user explicitly requests skill-file changes now.
+      description: The user explicitly requests skill-file changes or publication now; commit and push require separate publish intent.
       cue_literals:
         - apply
         - edit
         - patch
         - update the skill
+        - commit
+        - push
+        - publish
       cue_regexes: []
       exclusions:
         - what should change
+        - commit message suggestion only
   routes:
     - route_id: TUNE-NO-ACTION
       description: Evidence is too weak or no decision delta exists.
@@ -83,11 +87,16 @@ skill_decision_contract:
         - complete refine brief
         - static validation
         - behavioral validation query
+        - scoped file boundary
+        - publish authorization, when commit or push is requested
       success_signals:
         - minimal authorized edit
+        - commit/push state reported as authorized, completed, or blocked
       failure_signals:
         - edit without explicit request
-      rationale: Apply only after the evidence and edit boundaries are complete.
+        - commit or push without explicit publish request
+        - push before validation and commit succeed
+      rationale: Apply only after the evidence and edit boundaries are complete; publish only after explicit publish intent and validation.
   instrumentation:
     decision_receipt: optional
     rationale: Emit for material route decisions or repeated proposal terminal states.

--- a/codex/skills/tune/references/decision-contract.yaml
+++ b/codex/skills/tune/references/decision-contract.yaml
@@ -17,7 +17,7 @@ skill_decision_contract:
       exclusions:
         - style preference only
     - trigger_id: TUNE-APPLY-REQUEST
-      description: The user explicitly requests skill-file changes or publication now; commit and push require separate publish intent.
+      description: The user explicitly requests skill-file changes or skill-refinement publication now; commit and push require separate publish intent.
       cue_literals:
         - apply
         - edit
@@ -26,6 +26,10 @@ skill_decision_contract:
         - commit
         - push
         - publish
+        - ship
+        - save to git
+        - save-to-git
+        - save changes to git
       cue_regexes: []
       exclusions:
         - what should change
@@ -44,7 +48,7 @@ skill_decision_contract:
         - final-brief
       terminal: "yes"
     - route_id: TUNE-REFINE
-      description: Hand a complete bounded edit brief to refine.
+      description: Hand a complete bounded edit brief to refine, or report the publication state for an already-applied validated skill refinement.
       aliases:
         - handoff-refine
         - apply-with-refine
@@ -90,7 +94,7 @@ skill_decision_contract:
         - scoped file boundary
         - publish authorization, when commit or push is requested
       success_signals:
-        - minimal authorized edit
+        - minimal authorized edit or publication-only state
         - commit/push state reported as authorized, completed, or blocked
       failure_signals:
         - edit without explicit request

--- a/codex/skills/tune/references/mode-routing-probes.md
+++ b/codex/skills/tune/references/mode-routing-probes.md
@@ -88,9 +88,9 @@ Use $tune on the slides skill and apply the smallest validated fix.
 
 Expected mode: `apply-with-refine`
 
-Expected source: `mixed`: usage evidence plus `worktree` for validation/publishing.
+Expected source: `mixed`: usage evidence plus `worktree` for validation and publication status.
 
-Reason: The user explicitly asks to apply a fix and requires validation. After validation passes, `$tune` should commit and push the atomic change.
+Reason: The user explicitly asks to apply a fix and requires validation. Apply authority permits local edits and validation only; commit and push should be reported as `blocked:not-requested`.
 
 Prompt:
 
@@ -102,7 +102,7 @@ Expected mode: `apply-with-refine`
 
 Expected source: `history` + `worktree`
 
-Reason: The user explicitly asks to patch files and validate. After validation passes, `$tune` should commit and push the atomic change.
+Reason: The user explicitly asks to patch files and validate. Patch authority permits local edits and validation only; commit and push should be reported as `blocked:not-requested`.
 
 Prompt:
 
@@ -180,4 +180,4 @@ Open a PR for these skill changes.
 
 Expected owner: `$ship`
 
-Reason: PR creation is not `$tune`'s responsibility. `$tune` may commit and push validated apply-mode changes, but `$ship` owns PR creation.
+Reason: PR creation is not `$tune`'s responsibility. `$tune` may commit and push only when explicit publish intent exists and validation passes; `$ship` owns PR creation.

--- a/codex/skills/tune/references/refinement-brief-template.md
+++ b/codex/skills/tune/references/refinement-brief-template.md
@@ -22,7 +22,10 @@ Apply gate:
 - pass | blocked: <reason>
 
 Commit/push policy:
-- For apply-with-refine, commit and push each validated atomic change unless the user explicitly disables publishing.
+- Apply, edit, patch, or update authorizes local file changes and validation only.
+- Commit only when the user explicitly asks to commit, publish, ship, or save changes to git.
+- Push only when the user explicitly asks to push or publish remotely, and only after the commit succeeds.
+- If publishing is not authorized, report commit/push as blocked: not requested.
 
 Tuning goal:
 - <one-line goal>
@@ -90,12 +93,12 @@ Validation:
 - If quick_validate.py is unavailable, report validation as blocked and do not claim a pass.
 
 Publishing, apply-with-refine only:
+- Authorization: <none | commit-only | commit-and-push>, with exact user intent source.
 - Atomic change boundary: <what this commit contains and why it is one coherent change>
 - Scoped files to stage: <files justified by the brief>
 - Unrelated worktree changes: <none | present and left unstaged | blocked because inseparable>
-- Commit command: git commit -m "Tune <skill>: <short gap/fix summary>"
-- Commit SHA: <sha | blocked/not run and why>
-- Push command/result: <git push result | blocked/not run and why>
+- Commit command/result: <blocked:not-requested | git commit -m "Tune <skill>: <short gap/fix summary>" -> sha>
+- Push command/result: <blocked:not-requested | blocked:commit-failed | git push result>
 - Do not create PRs, merge branches, or clean up branches unless the user separately invokes that workflow.
 
 Privacy / sanitization:

--- a/codex/skills/tune/references/refinement-brief-template.md
+++ b/codex/skills/tune/references/refinement-brief-template.md
@@ -25,7 +25,8 @@ Commit/push policy:
 - Apply, edit, patch, or update authorizes local file changes and validation only.
 - Commit only when the user explicitly asks to commit, publish, ship, or save changes to git.
 - Push only when the user explicitly asks to push or publish remotely, and only after the commit succeeds.
-- If publishing is not authorized, report commit/push as blocked: not requested.
+- If publishing is not authorized, report commit/push as `blocked:not-requested`.
+- If publishing is authorized but validation, pre-commit, or worktree checks fail, report the specific blocked state.
 
 Tuning goal:
 - <one-line goal>
@@ -97,8 +98,8 @@ Publishing, apply-with-refine only:
 - Atomic change boundary: <what this commit contains and why it is one coherent change>
 - Scoped files to stage: <files justified by the brief>
 - Unrelated worktree changes: <none | present and left unstaged | blocked because inseparable>
-- Commit command/result: <blocked:not-requested | git commit -m "Tune <skill>: <short gap/fix summary>" -> sha>
-- Push command/result: <blocked:not-requested | blocked:commit-failed | git push result>
+- Commit command/result: <blocked:not-requested | blocked:validation-failed | blocked:pre-commit-failed | blocked:worktree-inseparable | git commit -m "Tune <skill>: <short gap/fix summary>" -> sha>
+- Push command/result: <blocked:not-requested | blocked:validation-failed | blocked:pre-commit-failed | blocked:worktree-inseparable | blocked:commit-failed | git push result>
 - Do not create PRs, merge branches, or clean up branches unless the user separately invokes that workflow.
 
 Privacy / sanitization:

--- a/codex/skills/tune/scripts/tune-scaffold
+++ b/codex/skills/tune/scripts/tune-scaffold
@@ -266,6 +266,7 @@ Commit/push policy:
 - Apply/edit/patch authorizes local file changes and validation only.
 - Commit authorization: <none | explicit commit/publish/save-to-git request>
 - Push authorization: <none | explicit push/remote-publish request>
+- Failed validation, pre-commit, or worktree checks must produce a specific blocked publication state.
 
 Tuning goal:
 - $goal
@@ -312,6 +313,6 @@ Publishing, apply-with-refine only:
 - Atomic change boundary: <what this commit contains and why it is one coherent change>
 - Scoped files to stage: <files justified by the brief>
 - Unrelated worktree changes: <none | present and left unstaged | blocked because inseparable>
-- Commit command/result: <blocked:not-requested | git commit -m "Tune $skill: <short gap/fix summary>" -> sha>
-- Push command/result: <blocked:not-requested | blocked:commit-failed | git push result>
+- Commit command/result: <blocked:not-requested | blocked:validation-failed | blocked:pre-commit-failed | blocked:worktree-inseparable | git commit -m "Tune $skill: <short gap/fix summary>" -> sha>
+- Push command/result: <blocked:not-requested | blocked:validation-failed | blocked:pre-commit-failed | blocked:worktree-inseparable | blocked:commit-failed | git push result>
 TUNE_OUT

--- a/codex/skills/tune/scripts/tune-scaffold
+++ b/codex/skills/tune/scripts/tune-scaffold
@@ -28,7 +28,8 @@ Options:
   -h, --help                       Show this help.
 
 This helper scaffolds deterministic evidence collection only. $tune still owns source
-selection, diagnosis, gap classification, mode decisions, and whether $refine may apply an edit.
+selection, diagnosis, gap classification, mode decisions, whether $refine may apply
+an edit, and whether publishing is authorized.
 USAGE
 }
 
@@ -142,7 +143,7 @@ Mode: $mode
 Evidence source: $evidence_source
 History scope: $history_scope
 Apply gate: $apply_gate
-Publish gate: validate before commit/push; stage only scoped files
+Publish gate: commit requires explicit git/publish intent; push requires explicit remote-publish intent after validation and commit
 Protected/self-target gate: $is_protected
 User goal: $goal
 
@@ -261,6 +262,11 @@ Evidence sources:
 Apply gate:
 - <pass | blocked: reason>
 
+Commit/push policy:
+- Apply/edit/patch authorizes local file changes and validation only.
+- Commit authorization: <none | explicit commit/publish/save-to-git request>
+- Push authorization: <none | explicit push/remote-publish request>
+
 Tuning goal:
 - $goal
 
@@ -302,10 +308,10 @@ Validation:
 - codex/skills/tune/scripts/validate-changed-skills -- codex/skills/$skill, if shared assumptions or multiple skills changed
 
 Publishing, apply-with-refine only:
+- Authorization: <none | commit-only | commit-and-push>, with exact user intent source.
 - Atomic change boundary: <what this commit contains and why it is one coherent change>
 - Scoped files to stage: <files justified by the brief>
 - Unrelated worktree changes: <none | present and left unstaged | blocked because inseparable>
-- Commit command: git commit -m "Tune $skill: <short gap/fix summary>"
-- Commit SHA: <sha | blocked/not run and why>
-- Push result: <git push result | blocked/not run and why>
+- Commit command/result: <blocked:not-requested | git commit -m "Tune $skill: <short gap/fix summary>" -> sha>
+- Push command/result: <blocked:not-requested | blocked:commit-failed | git push result>
 TUNE_OUT


### PR DESCRIPTION
## Summary
- Make `$tune` distinguish local apply/edit/patch authority from commit and push publishing authority.
- Require explicit commit/publish intent before committing and explicit push/remote-publish intent before pushing.
- Reflect the policy in `codex/skills/tune/SKILL.md`, the SKDC-v1 decision contract, refinement brief template, mode-routing probes, tune scaffold output, and agent default prompt.

## Validation
- Reviewed live PR metadata and diff: 6 scoped `$tune` files changed.
- Ran `codex/skills/tune/scripts/validate-changed-skills --base origin/main`: `validated_skills=1 decision_contracts=1 skipped=0 failures=0`.
- Ran `uv run --with pyyaml -- python3 codex/skills/.system/skill-creator/scripts/quick_validate.py codex/skills/tune`: `Skill is valid!`.
- Ran `uv run --with pyyaml -- python3 codex/skills/tune/tools/decision_contract_lint.py codex/skills/tune/references/decision-contract.yaml`: `verdict: pass`, `errors: []`, `warnings: []`.
- Ran `codex/skills/tune/scripts/tune-scaffold --skill tune --mode apply-with-refine --goal 'verify publish gate blocked states'`: completed successfully and emitted the updated publish-gate scaffold text.
- Searched for stale publish-gate phrases (`commit and push the atomic`, `blocked/not run`, `SEQ-SPEC-HANDOFF-v2`, and related mismatches): no matches.

## Notes
- This PR updates only `$tune` skill-package surfaces. It does not change `$seq` CLI behavior or create/publish any new workflow outside the tune package.
