### PR TITLE
Add evaluation contracts to Codebase Doctrine handoffs

### DIFF
--- a/codex/skills/codebase-doctrine/agents/openai.yaml
+++ b/codex/skills/codebase-doctrine/agents/openai.yaml
@@ -13,5 +13,6 @@ interface:
     questions directly or continue doctrine work. Compile DIG-v2 to CDI-v2, pin artifact state, close every evidence
     graph edge, distinguish current from target doctrine, route durable knowledge
     before skills, permit zero skills, and emit the mode-specific validated
-    artifact. Do not implement, persist, or create skills without explicit
-    authorization.
+    artifact. Any skill handoff must include the evaluation/update criteria used
+    to grade future skill use. Do not implement, persist, or create skills without
+    explicit authorization.

--- a/codex/skills/codebase-doctrine/assets/codebase-skill-handoff.example.yaml
+++ b/codex/skills/codebase-doctrine/assets/codebase-skill-handoff.example.yaml
@@ -44,6 +44,64 @@ codebase_skill_handoff:
   validation:
   - quick_validate
   - decision-contract lint
+  evaluation_contract:
+    evaluation_cadence: First after 10 material decision episodes or 30 days, then
+      after any doctrine refresh.
+    evaluator: $seq skill-decision-audit -> $tune -> $refine, with changed laws returned
+      to $codebase-doctrine refresh.
+    decision_record: Record route decisions, pass/fail signals, evidence refs, and whether
+      the skill changed the selected authority or proof path.
+    update_policy: Update the skill only from evidence-bearing decision episodes, changed
+      doctrine, or repeated failure signals; never from raw mention counts.
+    evaluation_evidence:
+    - seq skill-decision-audit episodes
+    - accepted or refuted route decisions
+    - refreshed CBD/CBDD proof and authority changes
+    quality_criteria:
+    - criterion_id: EVAL-OWNER-ROUTING
+      question: Did the skill route publication changes to Store.commit rather than
+        reader-side tolerance or shadow owners?
+      pass_signals:
+      - selected Store.commit or rejected shadow owner route under matching applicability
+      fail_signals:
+      - accepted reader-side tolerance despite NEG-READER-TOLERANCE applicability
+      evidence_refs:
+      - E-CODE
+      - E-HISTORY
+    - criterion_id: EVAL-PROOF-BAR
+      question: Did the skill require a current law-level proof receipt before recommending
+        change closure?
+      pass_signals:
+      - current visibility proof receipt requested or verified
+      fail_signals:
+      - closure allowed from static reasoning without current proof
+      evidence_refs:
+      - E-TEST
+      - E-CI
+    update_triggers:
+    - trigger_id: UPDATE-AUTHORITY-DRIFT
+      condition: New doctrine or empirical episodes show a different publication authority
+        or repeated owner-routing mistakes.
+      required_update: Run $codebase-doctrine refresh, then tune/refine the generated
+        skill against the accepted delta.
+      evidence_refs:
+      - E-CODE
+      - E-HISTORY
+    - trigger_id: UPDATE-PROOF-GAP
+      condition: Skill use repeatedly misses required proof surfaces or accepts stale
+        receipts.
+      required_update: Add proof-surface checks to the skill contract and validate with
+        current receipts.
+      evidence_refs:
+      - E-TEST
+      - E-CI
+    retirement_criteria:
+    - criterion_id: RETIRE-TO-ENFORCEMENT
+      condition: The contextual decision becomes fully enforced by code, test, static
+        tooling, or CI and no longer needs skill judgment.
+      evidence_refs:
+      - E-CODE
+      - E-CI
   future_evaluation:
   - seq skill-decision-audit after 30 days
   - tune matched decision episodes

--- a/codex/skills/codebase-doctrine/references/skill-evaluation-contract.md
+++ b/codex/skills/codebase-doctrine/references/skill-evaluation-contract.md
@@ -1,0 +1,43 @@
+# Generated skill evaluation contract
+
+A Codebase Doctrine skill handoff must include the criteria by which the generated
+skill will be graded after real use. The contract is part of CBSH-v2 because `$ms`
+needs the update policy when it creates the package; it is not enough to say that
+`$seq`, `$tune`, or `$refine` will evaluate the skill later.
+
+## Required fields
+
+```yaml
+evaluation_contract:
+  evaluation_cadence:
+  evaluator:
+  decision_record:
+  update_policy:
+  evaluation_evidence: []
+  quality_criteria:
+    - criterion_id:
+      question:
+      pass_signals: []
+      fail_signals: []
+      evidence_refs: []
+  update_triggers:
+    - trigger_id:
+      condition:
+      required_update:
+      evidence_refs: []
+  retirement_criteria:
+    - criterion_id:
+      condition:
+      evidence_refs: []
+```
+
+## Rules
+
+- Grade the generated skill on decision quality, not raw activation or mention counts.
+- Each quality criterion asks a concrete question about an empirical decision episode.
+- Pass and fail signals must be observable from skill-decision audit evidence.
+- Update triggers identify when `$tune`/`$refine` should change the package.
+- Doctrine-changing triggers must return to `$codebase-doctrine refresh` before tuning.
+- Retirement criteria state when the knowledge is better enforced by code, tests,
+  tooling, CI, repository guidance, ADRs, or the negative ledger than by a skill.
+- Evidence refs must resolve in the source CBD-v2 evidence index.

--- a/codex/skills/codebase-doctrine/schemas/cbsh-v2.schema.json
+++ b/codex/skills/codebase-doctrine/schemas/cbsh-v2.schema.json
@@ -30,6 +30,7 @@
         "allowed_package",
         "explicit_user_authorization",
         "validation",
+        "evaluation_contract",
         "future_evaluation"
       ],
       "type": "object"

--- a/codex/skills/codebase-doctrine/tests/test_packet_tools.py
+++ b/codex/skills/codebase-doctrine/tests/test_packet_tools.py
@@ -80,6 +80,28 @@ class PacketAndHandoffTests(unittest.TestCase):
         )
         self.assertTrue(any("authorized:not-yes" in item for item in errors))
 
+    def test_handoff_rejects_missing_evaluation_contract(self) -> None:
+        handoff = self.load("codebase-skill-handoff.example.yaml")
+        del handoff["codebase_skill_handoff"]["evaluation_contract"]
+        errors, _warnings = handoff_gate.validate_handoff(
+            handoff,
+            self.load("codebase-doctrine.example.yaml"),
+        )
+        self.assertTrue(any("evaluation_contract:must-be-object" in item for item in errors))
+
+    def test_handoff_rejects_unknown_evaluation_evidence(self) -> None:
+        handoff = self.load("codebase-skill-handoff.example.yaml")
+        handoff["codebase_skill_handoff"]["evaluation_contract"]["quality_criteria"][0][
+            "evidence_refs"
+        ] = ["E-MISSING"]
+        errors, _warnings = handoff_gate.validate_handoff(
+            handoff,
+            self.load("codebase-doctrine.example.yaml"),
+        )
+        self.assertTrue(
+            any("evaluation_contract.quality_criteria[0].evidence_refs:unknown:E-MISSING" in item for item in errors)
+        )
+
     def test_worker_suite(self) -> None:
         errors, warnings, counts = worker_suite_check.validate_suite(CODEX_ROOT / "agents")
         self.assertEqual(errors, [])

--- a/codex/skills/codebase-doctrine/tools/handoff_gate.py
+++ b/codex/skills/codebase-doctrine/tools/handoff_gate.py
@@ -8,6 +8,7 @@ from pathlib import PurePosixPath
 from typing import Any
 
 from common import (
+    check_refs,
     dump_data,
     is_yes,
     load_data,
@@ -28,6 +29,108 @@ def find_candidate(doctrine: dict[str, Any], candidate_id: str) -> dict[str, Any
         if isinstance(candidate, dict) and candidate.get("candidate_id") == candidate_id:
             return candidate
     return None
+
+
+def doctrine_evidence_ids(doctrine: dict[str, Any]) -> set[str]:
+    return {
+        str(row["evidence_id"])
+        for row in doctrine.get("evidence_index", [])
+        if isinstance(row, dict) and row.get("evidence_id")
+    }
+
+
+def validate_text_list(value: Any, label: str, errors: list[str], *, nonempty: bool = False) -> None:
+    rows = require_list(value, label, errors, nonempty=nonempty)
+    for index, raw in enumerate(rows):
+        require_text(raw, f"{label}[{index}]", errors)
+
+
+def validate_evaluation_contract(
+    handoff: dict[str, Any],
+    doctrine: dict[str, Any],
+    errors: list[str],
+) -> None:
+    """Validate the generated-skill grading and update rubric.
+
+    CBSH-v2 is the authority package handed to `$ms`. A creatable skill must carry
+    not just trigger guidance, but the empirical criteria by which future use is
+    graded, updated, or retired.
+    """
+    prefix = "evaluation_contract"
+    contract = require_object(handoff.get("evaluation_contract"), prefix, errors, nonempty=True)
+    if not contract:
+        return
+
+    for field in ("evaluation_cadence", "evaluator", "decision_record", "update_policy"):
+        require_text(contract.get(field), f"{prefix}.{field}", errors)
+    validate_text_list(
+        contract.get("evaluation_evidence"),
+        f"{prefix}.evaluation_evidence",
+        errors,
+        nonempty=True,
+    )
+
+    evidence_ids = doctrine_evidence_ids(doctrine)
+
+    quality = require_list(
+        contract.get("quality_criteria"),
+        f"{prefix}.quality_criteria",
+        errors,
+        nonempty=True,
+    )
+    for index, raw in enumerate(quality):
+        row_prefix = f"{prefix}.quality_criteria[{index}]"
+        row = require_object(raw, row_prefix, errors)
+        require_text(row.get("criterion_id"), f"{row_prefix}.criterion_id", errors)
+        require_text(row.get("question"), f"{row_prefix}.question", errors)
+        validate_text_list(row.get("pass_signals"), f"{row_prefix}.pass_signals", errors, nonempty=True)
+        validate_text_list(row.get("fail_signals"), f"{row_prefix}.fail_signals", errors, nonempty=True)
+        check_refs(
+            row.get("evidence_refs"),
+            evidence_ids,
+            f"{row_prefix}.evidence_refs",
+            errors,
+            nonempty=True,
+        )
+
+    updates = require_list(
+        contract.get("update_triggers"),
+        f"{prefix}.update_triggers",
+        errors,
+        nonempty=True,
+    )
+    for index, raw in enumerate(updates):
+        row_prefix = f"{prefix}.update_triggers[{index}]"
+        row = require_object(raw, row_prefix, errors)
+        require_text(row.get("trigger_id"), f"{row_prefix}.trigger_id", errors)
+        require_text(row.get("condition"), f"{row_prefix}.condition", errors)
+        require_text(row.get("required_update"), f"{row_prefix}.required_update", errors)
+        check_refs(
+            row.get("evidence_refs"),
+            evidence_ids,
+            f"{row_prefix}.evidence_refs",
+            errors,
+            nonempty=True,
+        )
+
+    retirement = require_list(
+        contract.get("retirement_criteria"),
+        f"{prefix}.retirement_criteria",
+        errors,
+        nonempty=True,
+    )
+    for index, raw in enumerate(retirement):
+        row_prefix = f"{prefix}.retirement_criteria[{index}]"
+        row = require_object(raw, row_prefix, errors)
+        require_text(row.get("criterion_id"), f"{row_prefix}.criterion_id", errors)
+        require_text(row.get("condition"), f"{row_prefix}.condition", errors)
+        check_refs(
+            row.get("evidence_refs"),
+            evidence_ids,
+            f"{row_prefix}.evidence_refs",
+            errors,
+            nonempty=True,
+        )
 
 
 def validate_handoff(
@@ -99,6 +202,8 @@ def validate_handoff(
             actual = require_list(handoff.get(field), field, errors)
             if actual != expected:
                 errors.append(f"{field}:candidate-mismatch")
+
+    validate_evaluation_contract(handoff, doctrine, errors)
 
     authorization = require_object(
         handoff.get("explicit_user_authorization"),

--- a/codex/skills/ms/references/codebase-doctrine-handoff.md
+++ b/codex/skills/ms/references/codebase-doctrine-handoff.md
@@ -18,6 +18,7 @@ protected doctrine IDs
 allowed package
 explicit user authorization
 validation
+evaluation contract
 future empirical evaluation
 ```
 
@@ -39,5 +40,11 @@ A `recommended_for_trial` candidate may be created only under explicit user
 authorization and must retain its trial status until empirical decision episodes
 justify acceptance.
 
-Preserve governing law IDs in the package decision contract without requiring
-the full CBD artifact at runtime.
+The `evaluation_contract` tells `$ms` how the generated skill will be graded,
+updated, or retired after real use. It must include quality criteria, pass/fail
+signals, update triggers, retirement criteria, evaluation evidence, cadence,
+evaluator, decision-record expectations, and a policy that prevents tuning from
+raw mention counts.
+
+Preserve governing law IDs and the evaluation contract in the package decision
+contract without requiring the full CBD artifact at runtime.


### PR DESCRIPTION
## Summary
- require CBSH-v2 handoffs to carry an explicit `evaluation_contract`
- validate generated-skill quality criteria, update triggers, retirement criteria, cadence, evaluator, decision record, and source-doctrine evidence references in `handoff_gate.py`
- update the handoff example, schema, OpenAI prompt, `$ms` handoff reference, and add a reference doc for generated-skill evaluation contracts
- add regression coverage for missing evaluation contracts and unknown evaluation evidence refs

## Testing
- Not run locally; this environment does not have network access to clone the repository. The changes are limited to handoff validation/docs/examples and should be covered by `uv run --with pyyaml python codex/skills/codebase-doctrine/tools/quick_validate.py` on checkout.
