### PR TITLE
Enforce auxiliary lens evidence contracts

### DIFF
--- a/codex/skills/actuating/references/terminal-closure-gate.md
+++ b/codex/skills/actuating/references/terminal-closure-gate.md
@@ -110,8 +110,10 @@ evidence, but they do not count toward the three standard clean reviews and do
 not interrupt standard-review consecutiveness.
 
 Auxiliary lanes may still block completion. ATCG rejects completion when a
-required auxiliary lane is missing, blocked, rerun-required, or not folded
-through `$review-fold` / the resolution fold.
+required auxiliary lane is missing, blocked, rerun-required, not folded through
+`$review-fold` / the resolution fold, or missing current lens-shaped evidence.
+CAS lane labels are transport evidence; they do not prove that the corresponding
+skill lens executed.
 
 The preferred reducer fields are:
 
@@ -122,10 +124,32 @@ final_report_fields.standard_clean_cas_runs
 review_profile.standard
 review_profile.auxiliary_review_lanes.<lane>.state
 review_profile.auxiliary_review_lanes.<lane>.reason
+review_profile.auxiliary_review_lanes.<lane>.lens_contract
+review_profile.auxiliary_review_lanes.<lane>.lens_evidence_state
+review_profile.auxiliary_review_lanes.<lane>.lens_evidence_ref
 review_profile.auxiliary_review_lanes.<lane>.evidence_ref
 review_profile.auxiliary_review_lanes.<lane>.head_sha
 review_profile.auxiliary_review_lanes.<lane>.target_fingerprint
+review_profile.complexity_pressure
 ```
+
+Selected auxiliary lanes with `clean` or `findings-folded` state must carry the
+lane contract expected by ATCG:
+
+```text
+footgun-finder       -> footgun-lens-v1
+invariant-ace        -> invariant-gate-v1
+complexity-mitigator -> complexity-preflight-v1
+```
+
+`lens_evidence_state` must be `valid` for terminal completion. `missing`,
+`invalid`, `stale`, `blocked`, and `rerun-required` are blocking states.
+`not-required` is valid only for lanes explicitly not selected and still needs a
+reason.
+
+`complexity_pressure` records review churn, one-patch-per-comment pressure, or
+comprehension blockage. When it is present, `complexity-mitigator` cannot remain
+`not-required` unless the pressure is explicitly marked not applicable.
 
 Compatibility fields may still be named `clean_runs_required`,
 `clean_runs_count`, or `normalized_cas_clean_runs`, but their meaning is
@@ -145,7 +169,7 @@ $st-governed completion without current $st control receipt -> st-authority-bloc
 CAS required + standard clean runs < required -> blocked, next_owner=$cas
 CAS required + standard_clean_runs_required <= 0 -> blocked, next_owner=$cas
 CAS required + final report standard clean runs < required -> blocked, next_owner=$cas
-required auxiliary CAS review lane missing|not-folded|blocked|rerun-required -> cas-review-blocked, next_owner=$cas
+required auxiliary CAS review lane missing|not-folded|blocked|rerun-required|lens-evidence-invalid -> cas-review-blocked, next_owner=$cas
 required auxiliary CAS review lane stale against head/diff -> cas-review-blocked, next_owner=$cas
 review-closeout protocol incomplete -> cas-review-blocked, next_owner=$cas
 proof-patch required + missing/stale -> continue, next_owner=$proof-patch

--- a/codex/skills/actuating/tests/test_actuation_terminal_gate.py
+++ b/codex/skills/actuating/tests/test_actuation_terminal_gate.py
@@ -29,6 +29,22 @@ class ActuationTerminalGateTests(unittest.TestCase):
     def fixture(self, name: str):
         return json.loads((ASSETS / name).read_text())
 
+    def lens_evidence(self, lane: str, **overrides):
+        contracts = {
+            "footgun-finder": "footgun-lens-v1",
+            "invariant-ace": "invariant-gate-v1",
+            "complexity-mitigator": "complexity-preflight-v1",
+        }
+        record = {
+            "lens_contract": contracts[lane],
+            "lens_evidence_state": "valid",
+            "lens_evidence_ref": f"cas:{lane}:lens",
+            "head_sha": "abc123",
+            "target_fingerprint": "diff:clean",
+        }
+        record.update(overrides)
+        return record
+
     def review_profile(self, **lane_overrides):
         lanes = {
             "footgun-finder": {
@@ -569,9 +585,12 @@ class ActuationTerminalGateTests(unittest.TestCase):
             **{
                 "invariant-ace": {
                     "state": "clean",
-                    "evidence_ref": "cas:invariant-ace:clean",
-                    "head_sha": "stale-head",
-                    "target_fingerprint": "stale-diff",
+                    **self.lens_evidence(
+                        "invariant-ace",
+                        evidence_ref="cas:invariant-ace:clean",
+                        head_sha="stale-head",
+                        target_fingerprint="stale-diff",
+                    ),
                 }
             }
         )
@@ -588,14 +607,14 @@ class ActuationTerminalGateTests(unittest.TestCase):
             body["blocked_reasons"],
         )
 
-    def test_review_profile_clean_lane_allows_completion(self) -> None:
+    def test_review_profile_clean_lane_requires_lens_contract(self) -> None:
         context = deepcopy(self.context("terminal-context.proof-only.example.json"))
         context["cas_review"] = self.satisfied_standard_cas()
         context["review_profile"] = self.review_profile(
             **{
-                "complexity-mitigator": {
+                "footgun-finder": {
                     "state": "clean",
-                    "evidence_ref": "cas:complexity-mitigator:clean",
+                    "evidence_ref": "cas:footgun-finder:clean",
                     "head_sha": "abc123",
                     "target_fingerprint": "diff:clean",
                 }
@@ -604,7 +623,91 @@ class ActuationTerminalGateTests(unittest.TestCase):
         context["final_report_fields"]["standard_clean_cas_runs"] = 3
         decision = MODULE.make_decision(context)
         body = decision["actuation_terminal_decision"]
+        self.assertEqual(body["verdict"], "blocked")
+        self.assertIn(
+            "review_profile.auxiliary_review_lanes.footgun-finder.lens_contract:missing",
+            body["blocked_reasons"],
+        )
+        self.assertIn(
+            "review_profile.auxiliary_review_lanes.footgun-finder.lens_evidence_state:missing",
+            body["blocked_reasons"],
+        )
+
+    def test_review_profile_rejects_wrong_lens_contract(self) -> None:
+        context = deepcopy(self.context("terminal-context.proof-only.example.json"))
+        context["cas_review"] = self.satisfied_standard_cas()
+        context["review_profile"] = self.review_profile(
+            **{
+                "invariant-ace": {
+                    "state": "findings-folded",
+                    **self.lens_evidence("invariant-ace", lens_contract="footgun-lens-v1"),
+                }
+            }
+        )
+        context["final_report_fields"]["standard_clean_cas_runs"] = 3
+        decision = MODULE.make_decision(context)
+        body = decision["actuation_terminal_decision"]
+        self.assertEqual(body["verdict"], "blocked")
+        self.assertIn(
+            "review_profile.auxiliary_review_lanes.invariant-ace.lens_contract:invalid",
+            body["blocked_reasons"],
+        )
+
+    def test_review_profile_rejects_non_valid_lens_evidence_state(self) -> None:
+        context = deepcopy(self.context("terminal-context.proof-only.example.json"))
+        context["cas_review"] = self.satisfied_standard_cas()
+        context["review_profile"] = self.review_profile(
+            **{
+                "complexity-mitigator": {
+                    "state": "clean",
+                    **self.lens_evidence("complexity-mitigator", lens_evidence_state="stale"),
+                }
+            }
+        )
+        context["final_report_fields"]["standard_clean_cas_runs"] = 3
+        decision = MODULE.make_decision(context)
+        body = decision["actuation_terminal_decision"]
+        self.assertEqual(body["verdict"], "blocked")
+        self.assertIn(
+            "review_profile.auxiliary_review_lanes.complexity-mitigator.lens_evidence_state:stale",
+            body["blocked_reasons"],
+        )
+
+    def test_review_profile_clean_lane_allows_completion(self) -> None:
+        context = deepcopy(self.context("terminal-context.proof-only.example.json"))
+        context["cas_review"] = self.satisfied_standard_cas()
+        context["review_profile"] = self.review_profile(
+            **{
+                "complexity-mitigator": {
+                    "state": "clean",
+                    **self.lens_evidence(
+                        "complexity-mitigator",
+                        evidence_ref="cas:complexity-mitigator:clean",
+                    ),
+                }
+            }
+        )
+        context["final_report_fields"]["standard_clean_cas_runs"] = 3
+        decision = MODULE.make_decision(context)
+        body = decision["actuation_terminal_decision"]
         self.assertEqual(body["verdict"], "complete")
+
+    def test_complexity_pressure_requires_complexity_lens(self) -> None:
+        context = deepcopy(self.context("terminal-context.proof-only.example.json"))
+        context["cas_review"] = self.satisfied_standard_cas()
+        context["review_profile"] = self.review_profile()
+        context["review_profile"]["complexity_pressure"] = {
+            "review_churn": "yes",
+            "one_patch_per_comment_pressure": "yes",
+        }
+        context["final_report_fields"]["standard_clean_cas_runs"] = 3
+        decision = MODULE.make_decision(context)
+        body = decision["actuation_terminal_decision"]
+        self.assertEqual(body["verdict"], "blocked")
+        self.assertIn(
+            "review_profile.auxiliary_review_lanes.complexity-mitigator:complexity-pressure-required",
+            body["blocked_reasons"],
+        )
 
     def test_review_profile_blocker_or_rerun_blocks_completion(self) -> None:
         context = deepcopy(self.context("terminal-context.proof-only.example.json"))
@@ -671,6 +774,42 @@ class ActuationTerminalGateTests(unittest.TestCase):
         self.assertEqual(body["next_owner"], "$cas")
         self.assertIn("cas-review-blocked", body["blocked_reasons"])
         self.assertIn("cas.auxiliary_lanes.footgun-finder:missing", body["blocked_reasons"])
+
+    def test_required_auxiliary_lane_clean_requires_lens_contract(self) -> None:
+        context = deepcopy(self.context("terminal-context.proof-only.example.json"))
+        context["cas_review"] = {
+            "required": "yes",
+            "standard_clean_runs_required": 3,
+            "standard_clean_runs_count": 3,
+            "required_auxiliary_lanes": ["footgun-finder"],
+            "auxiliary_lanes": {
+                "footgun-finder": {
+                    "status": "clean",
+                    "folded": "yes",
+                    "head_sha": "abc123",
+                    "target_fingerprint": "diff:clean",
+                },
+            },
+            "independent_fresh_runs": "yes",
+            "tuple_bound": "yes",
+            "tuple": {
+                "base_sha": "base123",
+                "head_sha": "abc123",
+                "target_fingerprint": "diff:clean",
+            },
+        }
+        context["final_report_fields"]["standard_clean_cas_runs"] = 3
+        decision = MODULE.make_decision(context)
+        body = decision["actuation_terminal_decision"]
+        self.assertEqual(body["verdict"], "blocked")
+        self.assertIn(
+            "cas.auxiliary_lanes.footgun-finder.lens_contract:missing",
+            body["blocked_reasons"],
+        )
+        self.assertIn(
+            "cas.auxiliary_lanes.footgun-finder.lens_evidence_state:missing",
+            body["blocked_reasons"],
+        )
 
     def test_required_auxiliary_lane_blocker_or_rerun_blocks_completion(self) -> None:
         context = deepcopy(self.context("terminal-context.proof-only.example.json"))
@@ -745,8 +884,11 @@ class ActuationTerminalGateTests(unittest.TestCase):
                 "invariant-ace": {
                     "status": "clean",
                     "folded": "yes",
-                    "head_sha": "stale-head",
-                    "target_fingerprint": "stale-diff",
+                    **self.lens_evidence(
+                        "invariant-ace",
+                        head_sha="stale-head",
+                        target_fingerprint="stale-diff",
+                    ),
                 },
             },
             "independent_fresh_runs": "yes",
@@ -781,8 +923,7 @@ class ActuationTerminalGateTests(unittest.TestCase):
                 "complexity-mitigator": {
                     "status": "clean",
                     "folded": "yes",
-                    "head_sha": "abc123",
-                    "target_fingerprint": "diff:clean",
+                    **self.lens_evidence("complexity-mitigator"),
                 },
             },
             "independent_fresh_runs": "yes",
@@ -797,9 +938,10 @@ class ActuationTerminalGateTests(unittest.TestCase):
             **{
                 "complexity-mitigator": {
                     "state": "clean",
-                    "evidence_ref": "cas:complexity-mitigator:clean",
-                    "head_sha": "abc123",
-                    "target_fingerprint": "diff:clean",
+                    **self.lens_evidence(
+                        "complexity-mitigator",
+                        evidence_ref="cas:complexity-mitigator:clean",
+                    ),
                 }
             }
         )

--- a/codex/skills/actuating/tools/actuation_terminal_gate.py
+++ b/codex/skills/actuating/tools/actuation_terminal_gate.py
@@ -24,6 +24,12 @@ ADD_VERDICTS = {"handoff_to_ship", "shipping_not_requested", "blocked", "missing
 TERMINAL_VERDICTS = {"complete", "continue", "blocked"}
 NEXT_OWNERS = {"none", "$cas", "$proof-patch", "$ship", "$goal-grind", "$goal-actuating", "$st", "human"}
 AUXILIARY_CAS_LANES = {"footgun-finder", "invariant-ace", "complexity-mitigator"}
+AUXILIARY_LENS_CONTRACTS = {
+    "footgun-finder": "footgun-lens-v1",
+    "invariant-ace": "invariant-gate-v1",
+    "complexity-mitigator": "complexity-preflight-v1",
+}
+VALID_LENS_EVIDENCE_STATES = {"valid", "missing", "invalid", "stale", "blocked", "rerun-required", "not-required"}
 HARD_REASON_ORDER = [
     "blocked-loop-contract-missing",
     "blocked-loop-contract-stale",
@@ -419,6 +425,64 @@ def lane_binding_value(record: dict[str, Any], key: str) -> Any:
     return first_present(record, (key,), tuple_value.get(key))
 
 
+def lens_evidence_ref_for(record: dict[str, Any]) -> Any:
+    return first_present(
+        record,
+        (
+            "lens_evidence_ref",
+            "evidence_ref",
+            "verdict_ref",
+            "review_fold_ref",
+            "receipt_ref",
+        ),
+    )
+
+
+def lens_contract_reasons_for(record: dict[str, Any], lane: str, prefix: str) -> list[str]:
+    reasons: list[str] = []
+    expected = AUXILIARY_LENS_CONTRACTS[lane]
+    contract = record.get("lens_contract")
+    if not isinstance(contract, str) or not contract:
+        reasons.append(f"{prefix}.lens_contract:missing")
+    elif contract != expected:
+        reasons.append(f"{prefix}.lens_contract:invalid")
+
+    state = str(record.get("lens_evidence_state", "")).lower()
+    if not state:
+        reasons.append(f"{prefix}.lens_evidence_state:missing")
+    elif state not in VALID_LENS_EVIDENCE_STATES:
+        reasons.append(f"{prefix}.lens_evidence_state:invalid")
+    elif state != "valid":
+        reasons.append(f"{prefix}.lens_evidence_state:{state}")
+
+    evidence_ref = lens_evidence_ref_for(record)
+    if not isinstance(evidence_ref, str) or not evidence_ref:
+        reasons.append(f"{prefix}.lens_evidence_ref:missing")
+    return reasons
+
+
+def complexity_pressure_requires_lens(profile: dict[str, Any]) -> bool:
+    pressure = profile.get("complexity_pressure")
+    if pressure is None or pressure == "":
+        return False
+    if isinstance(pressure, dict):
+        if any(explicit_no(pressure.get(key)) for key in ("required", "applies", "present")):
+            return False
+        return any(
+            as_yes(pressure.get(key))
+            for key in (
+                "required",
+                "present",
+                "review_churn",
+                "one_patch_per_comment_pressure",
+                "comprehension_blocked",
+                "mixed_responsibilities",
+                "boolean_soup",
+            )
+        ) or str(pressure.get("level", "")).lower() in {"medium", "high", "required"}
+    return as_yes(pressure) or str(pressure).lower() in {"present", "required", "medium", "high"}
+
+
 def auxiliary_lane_reasons_for(cas: dict[str, Any], artifact: dict[str, Any]) -> list[str]:
     records = auxiliary_lane_records_for(cas)
     required = required_auxiliary_lanes_for(cas, records)
@@ -438,6 +502,8 @@ def auxiliary_lane_reasons_for(cas: dict[str, Any], artifact: dict[str, Any]) ->
             reasons.append(f"cas.auxiliary_lanes.{lane}:blocked")
         if as_yes(record.get("rerun_required")) or state == "rerun-required":
             reasons.append(f"cas.auxiliary_lanes.{lane}:rerun-required")
+        if folded and state not in {"blocked", "rerun-required"}:
+            reasons.extend(lens_contract_reasons_for(record, lane, f"cas.auxiliary_lanes.{lane}"))
         head_sha = lane_binding_value(record, "head_sha")
         if not isinstance(head_sha, str) or not head_sha:
             reasons.append(f"cas.auxiliary_lanes.{lane}.head_sha:missing")
@@ -480,6 +546,8 @@ def review_profile_reasons_for(profile: dict[str, Any], artifact: dict[str, Any]
             reason = record.get("reason")
             if not isinstance(reason, str) or not reason.strip():
                 reasons.append(f"{prefix}.reason:missing")
+            if lane == "complexity-mitigator" and complexity_pressure_requires_lens(profile):
+                reasons.append(f"{prefix}:complexity-pressure-required")
             continue
         if state == "blocked":
             reasons.append(f"{prefix}:blocked")
@@ -488,7 +556,8 @@ def review_profile_reasons_for(profile: dict[str, Any], artifact: dict[str, Any]
             reasons.append(f"{prefix}:rerun-required")
             continue
 
-        evidence_ref = first_present(record, ("evidence_ref", "verdict_ref", "review_fold_ref", "receipt_ref"))
+        reasons.extend(lens_contract_reasons_for(record, lane, prefix))
+        evidence_ref = lens_evidence_ref_for(record)
         if not isinstance(evidence_ref, str) or not evidence_ref:
             reasons.append(f"{prefix}.evidence_ref:missing")
         head_sha = lane_binding_value(record, "head_sha")

--- a/codex/skills/goal-actuating/SKILL.md
+++ b/codex/skills/goal-actuating/SKILL.md
@@ -113,8 +113,10 @@ Rules:
 - Auxiliary lanes are real CAS review evidence, but they do not increment or interrupt the standard clean-review streak.
 - Auxiliary findings must be folded through `$review-fold` and may block closeout or become accepted liabilities.
 - Do not require unsupported `$cas` commands to produce semantic footgun/invariant/complexity lane labels. CAS transports and tuple-binds review evidence; the workflow owns auxiliary lens selection, folding, and blocker state.
-- A selected auxiliary lane must carry current `head_sha` and `target_fingerprint` evidence before ATCG may complete.
+- A selected auxiliary lane must carry current `head_sha`, `target_fingerprint`, `lens_contract`, `lens_evidence_state`, and `lens_evidence_ref` before ATCG may complete. `clean` and `findings-folded` are not enough without the lane contract.
+- ATCG lane contracts are `footgun-lens-v1`, `invariant-gate-v1`, and `complexity-preflight-v1`. `lens_evidence_state` must be `valid` for completion.
 - When workflow review is required, `review_profile` must explicitly account for `footgun-finder`, `invariant-ace`, and `complexity-mitigator` as selected/folded evidence or `not-required` with a reason; absence is unknown coverage, not clean review.
+- Record `complexity_pressure` when standard or auxiliary reviews show repeated same-class findings, one-patch-per-comment pressure, review churn, or comprehension blockage. That pressure selects `complexity-mitigator` unless it is explicitly marked not applicable.
 - A code change from any lane resets the standard clean-review streak to zero.
 - Read-only or classification-only auxiliary lane results do not reset the standard streak unless they change artifact scope or proof bar.
 - Do not rerun auxiliary lanes on every standard clean attempt unless their surface was touched, their prior result was blocked/validate-first, the proof bar changed, or a standard review exposes a new class owned by that lens.
@@ -241,6 +243,7 @@ Auxiliary lane selection:
 - Use `footgun-finder` when the diff touches APIs, CLIs, config, examples, docs, defaults, flags, fallbacks, auth/permissions, persistence, lifecycle/state-machine surfaces, degraded success, or partial-success ambiguity.
 - Use `invariant-ace` when the diff or proof bar touches illegal states, owner/source-of-truth ambiguity, transition preservation, policy exceptions, witness parity, fixture preconditions, races, retries, duplicates, stale handles, or loop invariants.
 - Use `complexity-mitigator` when reviewability is blocked by hard-to-follow existing code, deep nesting, boolean soup, hidden state, mixed responsibilities, cross-file hops, duplicated/dominated factors, or likely one-patch-per-comment churn.
+  Record this as `complexity_pressure` in `review_profile`; do not leave the lane implicit.
 
 No-code modifiers include:
 
@@ -291,7 +294,7 @@ Goal Actuation:
 - mode / persistence:
 - review profile:
   - standard CAS review: required|not-required, current verdict:
-  - auxiliary lanes: footgun-finder|invariant-ace|complexity-mitigator each not-required|clean|findings-folded|blocked|rerun-required
+  - auxiliary lanes: footgun-finder|invariant-ace|complexity-mitigator each not-required|clean|findings-folded|blocked|rerun-required, with `lens_contract` / `lens_evidence_state` / `lens_evidence_ref` when selected
   - auxiliary blockers:
 - parallelism:
   - mode:

--- a/codex/skills/review-fold/SKILL.md
+++ b/codex/skills/review-fold/SKILL.md
@@ -104,6 +104,9 @@ review_fold:
         reason:
       auxiliary_lanes:
         - lane: footgun-finder|invariant-ace|complexity-mitigator
+          lens_contract: footgun-lens-v1|invariant-gate-v1|complexity-preflight-v1
+          lens_evidence_state: valid|missing|invalid|stale|blocked|rerun-required|not-required
+          lens_evidence_ref:
           verdict_ref:
           head_sha:
           target_fingerprint:
@@ -387,7 +390,7 @@ Auxiliary CAS review lanes may still block closeout. They do not increment the s
 
 1. Bind reviews to the original goal and current diff.
 2. If fresh/exhaustive workflow code review is required and no CAS standard review result is present, stop and request `$cas` standard review.
-3. If the workflow `review_profile` selected auxiliary lanes, require their CAS-backed results before final review folding unless they are explicitly marked not-required with a reason.
+3. If the workflow `review_profile` selected auxiliary lanes, require their CAS-backed lens evidence before final review folding unless they are explicitly marked not-required with a reason.
 4. Classify each finding before any implementation.
 5. Separate the claim, observed fact, and suggested repair when the review text includes all three.
 6. Reject, block, ask, or follow up before code whenever validity, liability, or scope is not established.
@@ -403,7 +406,7 @@ Auxiliary CAS review lanes may still block closeout. They do not increment the s
 16. Treat each new CAS attempt result, follow-up finding batch, reopened thread batch, or dirty clean-streak attempt as a new receipt scope; do not reuse an earlier RF receipt for later findings.
 17. Collapse duplicates and same-family comments across lanes.
 18. Mark whether the current standard attempt is normalized clean and whether the standard clean-run counter resets.
-19. Mark auxiliary lane state as `clean`, `findings-folded`, `blocked`, or `rerun-required`; never count it as a standard clean run.
+19. Mark auxiliary lane state as `clean`, `findings-folded`, `blocked`, or `rerun-required`; include the lane's `lens_contract`, `lens_evidence_state`, and `lens_evidence_ref`; never count it as a standard clean run.
 20. Recommend `triage`, `remediation-plan`, or `review-closeout` from the user's requested mode and the accepted liabilities.
 21. Decide whether each finding's proper response is no code, proof, local fix, refactor, branch race, ask, or follow-up.
 22. Escalate high one-patch-per-comment risk to `refactor-kernel`, `branch-race`, `remediation-plan`, or `blocked` unless an explicit owner-boundary exception is recorded.

--- a/codex/skills/spec-pipeline/tools/auto_plan_handoff_gate.py
+++ b/codex/skills/spec-pipeline/tools/auto_plan_handoff_gate.py
@@ -14,7 +14,13 @@ def load(path: str) -> Any:
         return json.loads(text)
     if yaml is None:
         return json.loads(text)
-    return yaml.safe_load(text)
+    parsed = yaml.safe_load(text)
+    if isinstance(parsed, dict):
+        return parsed
+    marker = "spec_governance_receipt:"
+    if marker in text:
+        return yaml.safe_load(text[text.index(marker):])
+    return parsed
 
 def unwrap(obj: Any) -> dict[str, Any]:
     if isinstance(obj, dict) and "spec_governance_receipt" in obj:
@@ -37,6 +43,9 @@ def eq(actual: Any, expected: Any) -> bool:
     if expected == "no":
         return actual is False or str(actual).lower() == "no"
     return actual == expected
+
+def yes_no_string(value: Any) -> str:
+    return "yes" if eq(value, "yes") else "no"
 
 def empty_list(v: Any) -> bool:
     return v is None or v == []
@@ -77,18 +86,28 @@ def main(argv: list[str]) -> int:
         actual = get(sgr, *parts)
         if expected == "full|repair":
             if actual not in ("full", "repair"):
-                errors.append(f"{dotted}: expected full|repair, got {actual!r}")
+                errors.append(f"{dotted}:expected:full-or-repair")
         else:
             if not eq(actual, expected):
-                errors.append(f"{dotted}: expected {expected!r}, got {actual!r}")
+                errors.append(f"{dotted}:expected:{expected}")
     if not empty_list(get(sgr, "execution_handoff", "do_not_execute_before")):
-        errors.append("execution_handoff.do_not_execute_before must be empty")
+        errors.append("execution_handoff.do_not_execute_before:must-be-empty")
     if errors:
-        print("auto-plan-handoff: blocked", file=sys.stderr)
-        for err in errors:
-            print(f"- {err}", file=sys.stderr)
-        return 1
-    print("auto-plan-handoff: eligible")
+        if eq(get(sgr, "auto_plan_handoff", "eligible"), "yes"):
+            errors.append("eligible=yes-but-predicates-failed")
+        print(json.dumps({"auto_plan_handoff_gate": {
+            "verdict": "blocked",
+            "eligible": yes_no_string(get(sgr, "auto_plan_handoff", "eligible")),
+            "next_owner": get(sgr, "execution_handoff", "next_owner", default=""),
+            "errors": errors,
+        }}, sort_keys=True))
+        return 2
+    print(json.dumps({"auto_plan_handoff_gate": {
+        "verdict": "pass",
+        "eligible": "yes",
+        "next_owner": get(sgr, "execution_handoff", "next_owner", default=""),
+        "errors": [],
+    }}, sort_keys=True))
     return 0
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Enforce lane-specific auxiliary review evidence contracts in ATCG.
- Document the contract in goal-actuating, review-fold, and terminal closure doctrine.
- Repair auto-plan handoff gate output so spec-pipeline validation is machine-readable again.

## Proof
- `uv run python codex/skills/actuating/tests/test_actuation_terminal_gate.py`: pass (78 tests)
- `uv run python codex/skills/actuating/tools/quick_validate.py`: pass
- `uv run python codex/skills/spec-pipeline/tools/quick_validate.py`: pass
- `git diff --check`: pass

## Scope
- branch: auxiliary-lens-execution-accountability
- head: 2e54ac4f6cce570c9d18e577a3ec73f8a44c348d
- base: main

## Readiness
- PR mode: ready
- Reason: implementation and validation are complete.
- Caveats: none known.
