### PR TITLE
Make review-fold emit kernel-fold receipts

### DIFF
--- a/codex/agents/review-reducer.toml
+++ b/codex/agents/review-reducer.toml
@@ -1,5 +1,5 @@
 name = "review_reducer"
-description = "Review-loop agent that classifies reviewer findings, compresses same-family claims, and chooses proof-only, minimal-fix, refactor-kernel, reject, ask-human, follow-up, or blocked without granting mutation authority."
+description = "Review-loop agent that classifies reviewer findings, compresses same-family claims, emits RF-v1.4 kernel-fold receipts, and keeps mutation authority disabled."
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 nickname_candidates = ["Review Reducer", "Review Folder", "Review Classifier"]
@@ -10,26 +10,26 @@ You are the review reducer.
 Mission:
 - Bind review findings to the original goal, accepted scope, non-goals, current diff, and current artifact state.
 - Preserve source refs when present: backend, source_batch_id, finding_id, finding_fingerprint, review_attempt_id, review_thread_id, review_turn_id, lane_role, head_sha, target_fingerprint, and backend_specific fields.
-- Keep review evidence backend neutral. CAS-specific fields are evidence refs only, not validity, liability, repair level, clean-run effect, or mutation authority.
+- Keep review evidence backend neutral. CAS-specific fields are evidence refs only, not validity, liability, kernel status, clean-run effect, or mutation authority.
 - Classify each finding before implementation.
 - Separate claim, observed_fact, and suggested_repair.
 - Collapse duplicates and same-family claims.
-- Name law_family, falsified_law, owner_boundary, model_state, repair_level, alternatives_considered, and evidence_refs for valid or contested findings.
-- Decide the minimal correct response: reject, proof-only, minimal-fix, refactor-kernel, ask-human, follow-up, or blocked.
+- Name law_family, falsified_law, owner_boundary, model_state, kernel_fold, alternatives_considered, and evidence_refs for valid or contested findings.
+- Decide the correct review disposition: reject, proof-only, accepted-liability, ask-human, follow-up, or blocked.
 - Keep finding-level mutation authority disabled; a code-change candidate is not mutation authority.
 - Preserve blocked findings and resolution-fold gating fields when a liability needs follow-up before implementation.
 
 Prefer no-code proof or rejection when appropriate.
-Prefer refactor-kernel when many comments share one owner boundary.
-When one_patch_per_comment_risk is high, route to refactor-kernel, branch-race, remediation-plan, or blocked unless an explicit owner-boundary exception is recorded.
+Prefer kernel_fold.status: structural when many comments share one owner boundary.
+When kernel pressure is high, do not emit kernel_fold.status: point unless point_safety is proven with evidence; otherwise use structural, unknown, or blocked.
 Do not post PR comments or resolve threads.
 Do not mutate files.
 Do not choose or run a fresh review backend.
 Do not claim terminal review closure.
 
-Return RF-v1.3 review_fold with source_ref, repair_level, code_change_candidate, and finding_mutation_authority on every finding. If the full schema would be too large for the current handoff, return an RF-v1.3 compact block with source_ref including backend or explicit unknown backend, lane_role when known, head_sha, target_fingerprint, validity, liability, intent_relation, disposition, repair_level, owner_boundary, law_family, evidence_refs, clean_run effect when applicable, and finding_mutation_authority.allowed: no.
+Return RF-v1.4 review_fold with source_ref, kernel_fold, code_change_candidate, and finding_mutation_authority on every finding. If the full schema would be too large for the current handoff, return an RF-v1.4 compact block with source_ref including backend or explicit unknown backend, lane_role when known, head_sha, target_fingerprint, validity, liability, intent_relation, disposition, kernel_fold, owner_boundary, law_family, evidence_refs, clean_run effect when applicable, and finding_mutation_authority.allowed: no.
 
-Shortcut prose is not a receipt. Material fold trigger classes are semantic, not literal phrase matching: acceptance shortcut, repair shortcut, proof-gap shortcut, clean-run accounting, thread disposition, grouped-liability / owner-boundary shortcut, and source-batch boundary. Emit full RF-v1.3 or RF-v1.3 compact before material decisions reach the resolution fold, mutation planning, closeout accounting, or public review-thread handling.
+Shortcut prose is not a receipt. Material fold trigger classes are semantic, not literal phrase matching: acceptance shortcut, repair shortcut, proof-gap shortcut, clean-run accounting, thread disposition, grouped-liability / owner-boundary shortcut, and source-batch boundary. Emit full RF-v1.4 or RF-v1.4 compact before material decisions reach the resolution fold, mutation planning, closeout accounting, or public review-thread handling.
 
-Earlier RF receipts do not cover later review attempts, follow-up finding batches, reopened thread batches, dirty clean-run attempts, or thread-disposition batches. Emit a fresh RF-v1.3 compact/full receipt for each new source batch.
+Earlier RF receipts do not cover later review attempts, follow-up finding batches, reopened thread batches, dirty clean-run attempts, or thread-disposition batches. Emit a fresh RF-v1.4 compact/full receipt for each new source batch.
 '''

--- a/codex/skills/cas/SKILL.md
+++ b/codex/skills/cas/SKILL.md
@@ -283,8 +283,8 @@ patch epochs, proof epochs, and clean-review attempts back to the exact review
 row.
 
 CAS owns the identity fields as evidence. It does not decide whether a finding
-is accepted, rejected, proof-only, minimal-fix, refactor-kernel, or mutation
-authority.
+is accepted, rejected, proof-only, follow-up, blocked, which kernel status it
+has, or whether it grants mutation authority.
 
 Each normalized finding row should carry:
 
@@ -464,7 +464,7 @@ CAS Review:
 - Do not duplicate a review when an active tuple lock points to an existing `reviewThreadId`.
 - Do not manually list and `jq` review-session records when latest-session status is enough; use `cas review_session status --latest --json`, then verify tuple fields before acting.
 - Do not treat completed findings as transport failure.
-- Do not treat per-finding identity as acceptance, rejection, repair mode, clean-streak authority, or mutation authority.
+- Do not treat per-finding identity as acceptance, rejection, kernel status, clean-streak authority, or mutation authority.
 - Do not treat `usageLimitExceeded` as reviewer output or transport failure.
 - Do not rely on persistent lane continuity for repeated-review policy until first-review creation smoke is current.
 - `start --wait` evidence is workflow input only after it is represented as tuple-bound review evidence; otherwise import, normalize, or recover first.

--- a/codex/skills/cas/agents/openai.yaml
+++ b/codex/skills/cas/agents/openai.yaml
@@ -11,4 +11,4 @@ interface:
     identity fields such as findingId, findingFingerprint, reviewAttemptId,
     laneRole, reviewThreadId, reviewTurnId, headSha, and targetFingerprint.
     CAS records evidence; caller workflows certify meaning, clean streaks,
-    review-fold disposition, repair mode, and mutation authority.
+    review-fold disposition, kernel status, and mutation authority.

--- a/codex/skills/goal-workgraph/SKILL.md
+++ b/codex/skills/goal-workgraph/SKILL.md
@@ -91,12 +91,12 @@ work_graph:
 4. Use `patch-fanout` only after the resolution fold accepts code-change liabilities.
 5. Use `branch-race` only when all strategies share the same verifier.
 6. Mark shared invariants, shared files, or shared owner-boundary fixes as `parallel_safe: no`.
-7. Prefer one `refactor-kernel` node over parallel local patches when findings share an owner boundary.
+7. Consume `$review-fold` `kernel_fold.status`: `structural` becomes one owner-level work node, `point` may become one bounded node, and `unknown` must inspect, ask, block, or branch-race before mutation.
 8. Do not let subagents update public tracker state, resolve threads, or declare completion.
 
 ## Reabstraction trigger
 
-When review or failure nodes share any of the following, prefer a `refactor-kernel` node over local patches:
+When review or failure nodes share any of the following, prefer a structural kernel node over local patches:
 
 ```text
 same invariant violated in multiple places

--- a/codex/skills/review-fold/SKILL.md
+++ b/codex/skills/review-fold/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: review-fold
-description: "Compress review pressure into intent-anchored review decisions: classify findings, reject non-liabilities, choose proof-only vs minimal-fix vs refactor-kernel, and prevent review prose from becoming mutation authority. Use after reviewer comments, PR threads, CAS-backed review evidence, human review, prior artifacts, local audit output, or review-like claims. Owns active review finding classification for goal workflows; does not own review backend selection, closeout policy, or implementation authority."
+description: "Compress review pressure into intent-anchored kernel-fold decisions: classify findings, reject non-liabilities, identify accepted liabilities, attach a kernel account to every material finding, and prevent review prose from becoming mutation authority. Use after reviewer comments, PR threads, CAS-backed review evidence, human review, prior artifacts, local audit output, or review-like claims. Owns active review finding classification for goal workflows; does not own review backend selection, closeout policy, resolution planning, or implementation authority."
 metadata:
-  version: "1.5.0"
+  version: "1.6.0"
   activation_cost: medium
   default_depth: high
 ---
@@ -11,24 +11,32 @@ metadata:
 
 ## Mission
 
-Turn review pressure into the right next decision, not more code by default.
+Turn review pressure into classified evidence plus a kernel account, not a
+patch queue.
 
 ```text
 review findings + goal contract + current artifact state
 -> review fold
--> reject | proof-only | minimal-fix | refactor-kernel | ask-human | follow-up | blocked
+-> reject | proof-only | accepted-liability | ask-human | follow-up | blocked
+-> kernel_fold: none | point | structural | unknown
 ```
 
-`$review-fold` is the review-specific evidence reducer for goal workflows. It classifies review-like claims, separates claims from facts and liabilities, compresses duplicates and same-family findings, and decides which findings may be considered by the resolution fold.
+`$review-fold` is the review-specific evidence reducer for goal workflows. It
+classifies review-like claims, separates claims from facts and liabilities,
+compresses duplicates and same-family findings, and gives every material
+finding a kernel account that the downstream resolution fold can consume.
 
-It is deliberately **review-backend neutral**. Review findings may come from CAS-backed review evidence, GitHub PR comments, human review, prior artifacts, local audit output, or another normalized source. `$review-fold` consumes the evidence; it does not choose the backend.
+It is deliberately **review-backend neutral**. Review findings may come from
+CAS-backed review evidence, GitHub PR comments, human review, prior artifacts,
+local audit output, or another normalized source. `$review-fold` consumes the
+evidence; it does not choose the backend.
 
 ## Ownership boundaries
 
 `$review-fold` owns:
 
 ```text
-review finding -> validity / liability / intent relation / disposition / repair level
+review finding -> validity / liability / intent relation / disposition / kernel_fold
 ```
 
 It does not own:
@@ -36,24 +44,30 @@ It does not own:
 ```text
 fresh review backend selection
 review-profile / auxiliary-lens selection
+resolution planning
 implementation authority
 PR thread mutation or public replies
 terminal closeout authority
 ```
 
-Workflow owners such as `$actuating` and `$goal-actuating` decide whether fresh review is required and which backend satisfies that requirement. In the current goal workflow, fresh or closure-grade code review may be CAS-backed; that policy lives in the caller workflow and `$cas`, not in `$review-fold`.
+Workflow owners such as `$actuating` and `$goal-actuating` decide whether fresh
+review is required and which backend satisfies that requirement. In the current
+goal workflow, fresh or closure-grade code review may be CAS-backed; that
+policy lives in the caller workflow and `$cas`, not in `$review-fold`.
 
 The normal review-closeout chain is:
 
 ```text
 review source evidence
--> $review-fold finding classification
+-> $review-fold finding classification + kernel_fold
 -> resolution fold work-node decision
--> implementation only for accepted code-change liabilities
+-> implementation only for accepted liabilities with valid mutation authority
 -> evidence fold / proof / terminal closure gate
 ```
 
-A review finding never grants mutation authority by itself. A code-change candidate becomes implementation work only after the resolution fold accepts it and the actuation loop has valid mutation authority.
+A review finding never grants mutation authority by itself. A code-change
+candidate becomes implementation work only after the resolution fold accepts it
+and the actuation loop has valid mutation authority.
 
 ## Minimal review law
 
@@ -65,6 +79,7 @@ fact != liability
 liability != scope
 scope != code change
 code-change candidate != mutation authority
+kernel fold != repair plan
 ```
 
 Operationally:
@@ -74,12 +89,15 @@ Operationally:
 - A branch-liable observation is not automatically in accepted scope.
 - An in-scope liability is not automatically a code change.
 - A code-change candidate is not mutation authority until the resolution fold accepts it.
+- A kernel account classifies shape and pressure; it does not choose the patch.
 
-This is a routing guard, not a counterexample compiler. Do not introduce CEX, AC, kernel, or review-backend ceremony merely to classify ordinary review findings.
+This is a routing guard, not a counterexample compiler. Do not introduce CEX,
+AC, or review-backend ceremony merely to classify ordinary review findings.
 
 ## Source model
 
-Preserve source identity when it exists, but do not make one backend the ontology.
+Preserve source identity when it exists, but do not make one backend the
+ontology.
 
 ```yaml
 source_ref:
@@ -99,15 +117,15 @@ source_ref:
 Rules:
 
 - `backend` is required for material receipts; use `unknown` only when the source really lacks identity.
-- CAS-specific fields are evidence references only. They do not imply validity, liability, repair level, clean-run effect, or mutation authority.
+- CAS-specific fields are evidence references only. They do not imply validity, liability, kernel status, clean-run effect, or mutation authority.
 - PR thread IDs are source references only. Do not resolve threads, post replies, or mutate public review state without explicit public-side-effect intent.
 - If fresh workflow review is required but no review source evidence is present, `$review-fold` reports a source blocker and hands control to the caller or review-source owner.
 
-## RF-v1.3 schema
+## RF-v1.4 schema
 
 ```yaml
 review_fold:
-  version: RF-v1.3
+  version: RF-v1.4
   goal_id:
   source:
     backend: cas|github-comments|human-review|prior-artifact|local-audit|other|unknown
@@ -145,13 +163,21 @@ review_fold:
       law_family:
       falsified_law:
       owner_boundary:
-      model_state: intact|local-gap|boundary-gap|unknown
+      model_state: intact|point-gap|structural-gap|unknown
       validity: valid|invalid|unproven|needs-owner
       liability: blocks-goal|regression-risk|style|new-requirement|out-of-scope|proof-gap|misuse-hazard|invariant-gap|complexity-stall
       intent_relation: core|adjacent|unrelated|expands-scope
       novelty: duplicate|same-class|new-class
-      disposition: reject|proof-only|minimal-fix|refactor-kernel|ask-human|follow-up|blocked
-      repair_level: none|proof-only|minimal-fix|refactor-kernel|branch-race|ask-human|follow-up|blocked
+      disposition: reject|proof-only|accepted-liability|ask-human|follow-up|blocked
+      kernel_fold:
+        status: none|point|structural|unknown
+        pressure: none|low|medium|high
+        equivalence_class:
+        owner_boundary:
+        law_family:
+        falsifier:
+        point_safety: proven|not-proven|not-applicable
+        evidence_refs: []
       minimal_response:
       proof_needed:
       alternatives_considered: []
@@ -164,18 +190,15 @@ review_fold:
     equivalence_classes: []
     repeated_kernel:
     kernel_pressure: none|low|medium|high
-    refactor_trigger:
-      present: yes|no
-      reason:
     reabstraction_candidate: yes|no
-    one_patch_per_comment_risk: low|medium|high
-    minimal_fix_regret_risk: low|medium|high
+    patch_per_comment_risk: low|medium|high
+    local_response_regret_risk: low|medium|high
   recommended_resolution:
     review_mode: triage|remediation-plan|review-closeout
     reason:
     no_code_modifier_detected: yes|no
     accepted_liability_count:
-    refactor_kernel_candidate_count:
+    structural_kernel_candidate_count:
     clean_run_accounting:
       applies: yes|no
       normalized_clean_this_source: yes|no|not-applicable
@@ -188,25 +211,26 @@ review_fold:
     review_class_fanout_safe: yes|no
     patch_fanout_safe_after_resolve: yes|no
     unsafe_parallel_reasons: []
-  action_plan:
-    mode: adjudicate-only|proof-only|minimal-fix|refactor-kernel|branch-race|blocked
-    work_nodes: []
-    do_not_fix: []
-    reviewer_response_draft: []
 ```
 
-RF-v1.3 is a finding-classification receipt. It is not a resolution plan, graph-control receipt, proof receipt, PR publication receipt, or terminal completion proof.
+RF-v1.4 is a finding-classification and kernel-account receipt. It is not a
+resolution plan, graph-control receipt, proof receipt, PR publication receipt,
+or terminal completion proof.
 
 ## Compact receipt floor
 
-Full RF-v1.3 is preferred for artifacts, handoffs, and review bundles. For progress updates or tight review-closeout loops, do not collapse a material fold to bare prose such as `valid minimal-fix` or `threads are clean`.
+Full RF-v1.4 is preferred for artifacts, handoffs, and review bundles. For
+progress updates or tight review-closeout loops, do not collapse a material
+fold to bare prose such as `valid liability` or `threads are clean`.
 
-Emit at least one joinable block headed `RF-v1.3 compact:` whenever a fold affects mutation, clean-run accounting, thread disposition, blocker state, or closure state.
+Emit at least one joinable block headed `RF-v1.4 compact:` whenever a fold
+affects mutation, clean-run accounting, thread disposition, blocker state, or
+closure state.
 
 Minimum compact fields:
 
 ```yaml
-RF-v1.3 compact:
+RF-v1.4 compact:
   source_ref:
     backend: cas|github-comments|human-review|prior-artifact|local-audit|other|unknown
     source_batch_id:
@@ -220,8 +244,16 @@ RF-v1.3 compact:
   validity: valid|invalid|unproven|needs-owner
   liability: blocks-goal|regression-risk|style|new-requirement|out-of-scope|proof-gap|misuse-hazard|invariant-gap|complexity-stall
   intent_relation: core|adjacent|unrelated|expands-scope
-  disposition: reject|proof-only|minimal-fix|refactor-kernel|ask-human|follow-up|blocked
-  repair_level: none|proof-only|minimal-fix|refactor-kernel|branch-race|ask-human|follow-up|blocked
+  disposition: reject|proof-only|accepted-liability|ask-human|follow-up|blocked
+  kernel_fold:
+    status: none|point|structural|unknown
+    pressure: none|low|medium|high
+    equivalence_class:
+    owner_boundary:
+    law_family:
+    falsifier:
+    point_safety: proven|not-proven|not-applicable
+    evidence_refs: []
   owner_boundary:
   law_family:
   evidence_refs: []
@@ -234,13 +266,15 @@ RF-v1.3 compact:
     reason:
 ```
 
-If a source lacks a field, write `unknown` and name the backend rather than omitting the field.
+If a source lacks a field, write `unknown` and name the backend rather than
+omitting the field.
 
 ## Material fold trigger classes
 
 Shortcut prose does not relax the receipt floor. Treat the semantic class, not the literal wording, as the trigger.
 
-See `references/material-fold-triggers.yaml` for the canonical trigger taxonomy.
+See `references/material-fold-triggers.yaml` for the canonical trigger
+taxonomy.
 
 Material fold classes:
 
@@ -256,25 +290,26 @@ source-batch boundary
 
 Examples:
 
-- “valid finding,” “accepted liability,” “both are liabilities,” or a severity label used as acceptance is an acceptance shortcut.
-- “owner fix,” “clean fix,” or “next patch” is a repair shortcut when it points to mutation.
+- “valid finding,” “accepted liability,” “both findings are liabilities,” or a severity label used as acceptance is an acceptance shortcut.
+- “owner fix,” “clean fix,” or “next patch” is a repair shortcut when it points to mutation; the fold must record kernel status and disabled mutation authority before resolution.
 - “proof gaps remain” or “proof gaps resolved” is a proof-gap shortcut.
 - “review attempt is clean,” “clean streak advances,” or “counter resets” is clean-run accounting.
 - “threads are resolved,” “no unresolved threads,” or “thread sweep is clean” is thread disposition.
 - “same owner boundary,” “same class,” or “larger repeated class” is grouped-liability pressure.
 - A later review attempt, follow-up finding batch, reopened thread batch, or dirty clean-run attempt is a new source-batch boundary.
 
-Emit a full or compact RF-v1.3 receipt before any such decision reaches the resolution fold, mutation planning, closeout accounting, or public review-thread handling.
+Emit a full or compact RF-v1.4 receipt before any such decision reaches the
+resolution fold, mutation planning, closeout accounting, or public review-thread
+handling.
 
 ## Disposition law
 
 - `reject`: claim is false, stale, duplicate with no new proof value, unrelated, already handled, incompatible with the goal, or merely preference/style without accepted liability.
 - `proof-only`: current code likely satisfies the goal and the right response is proof, inspection, or reviewer explanation before editing.
-- `minimal-fix`: one valid, in-scope, owner-correct liability has a small local response and does not share a broader missing boundary with other findings.
-- `refactor-kernel`: multiple findings share one missing abstraction, owner boundary, state transition, validation rule, invariant, proof surface, or misuse trap.
+- `accepted-liability`: one or more valid, in-scope liabilities may be considered by the resolution fold; the kernel account still decides whether the evidence is point, structural, or unknown.
 - `ask-human`: review introduces a product, compatibility, API, UX, performance, security, or scope decision.
 - `follow-up`: valid but not part of the intended change.
-- `blocked`: validity, liability, current artifact state, review source, or accepted scope is unclear enough that implementation would be guesswork.
+- `blocked`: validity, liability, current artifact state, review source, accepted scope, or kernel status is unclear enough that implementation would be guesswork.
 
 Deterministic downroutes:
 
@@ -284,49 +319,56 @@ reviewer preference only -> reject unless the accepted goal made it material
 valid but outside accepted scope -> follow-up or ask-human
 scope expansion -> ask-human
 missing proof -> proof-only before code
-unknown validity/liability/scope/source/current-artifact -> blocked or ask-human
+unknown validity/liability/scope/source/current-artifact/kernel -> blocked or ask-human
 duplicate/same-class -> compress; do not create a new implementation distinction
 ```
 
-A finding row never grants mutation authority. It only marks whether the resolution fold may consider code-changing work.
+A finding row never grants mutation authority. It only marks whether the
+resolution fold may consider code-changing work.
 
-When `one_patch_per_comment_risk: high`, do not silently recommend more minimal fixes. Route to one of:
+## Kernel fold law
 
-```text
-refactor-kernel
-branch-race
-remediation-plan
-blocked
-```
+Every finding receives a `kernel_fold`.
 
-Use an explicit exception only when `alternatives_considered` shows why a local minimal fix is still owner-correct and does not preserve the repeated failure class. Record that exception in `evidence_refs`.
+- `none`: no in-scope code liability remains after rejection, proof, follow-up, or human-owned scope handling.
+- `point`: the liability is owner-correct, bounded to one kernel boundary, has no live same-family pressure, and records `point_safety: proven`.
+- `structural`: multiple findings, repeated classes, shared owner boundaries, shared invariants, or repeated proof obligations require one normal-form owner correction.
+- `unknown`: the fold cannot prove whether the liability is point or structural; the next owner must block, inspect, ask, or branch-race before mutation.
+
+When `kernel_fold.pressure: high`, do not silently emit `status: point`. A point
+kernel under high pressure is valid only with `point_safety: proven` and
+evidence that same-family pressure is absent or already owned by the selected
+boundary. Otherwise emit `structural`, `unknown`, or `blocked`.
+
+Downstream implementation may realize `status: point` as a small owner-boundary
+change. That realization is not a review-fold output; it belongs to the
+resolution fold and the actuation loop.
 
 ## Modes
 
 ### Workflow review modes
 
 - `triage`: classify findings and stop without a remediation agenda or implementation.
-- `remediation-plan`: classify findings and produce a resolution plan without implementation.
-- `review-closeout`: classify findings, preserve no-code dispositions, hand accepted liabilities to the resolution fold, and let the caller workflow prove closure.
-
-### Action modes
-
-- `adjudicate-only`: classify findings and stop. No mutation.
-- `proof-only`: run checks, inspect current artifacts, or draft a response. No code unless proof fails and the resolution fold creates an accepted liability.
-- `minimal-fix`: smallest owner-correct change for accepted liabilities.
-- `refactor-kernel`: replace many local fixes with one normal-form correction.
-- `branch-race`: compare two or more plausible fix/refactor strategies under the same verifier.
-- `blocked`: stop when review remediation requires durable resource claims, external worktrees, or serialized integration that no supported controller owns.
+- `remediation-plan`: classify findings and produce resolution inputs without implementation.
+- `review-closeout`: classify findings, preserve no-code dispositions, hand accepted liabilities and kernel accounts to the resolution fold, and let the caller workflow prove closure.
 
 ## Clean-run and exhaustive-review behavior
 
-When the caller has a review-closeout or exhaustive-review proof bar, `$review-fold` may decide whether a review source is normalized clean, dirty, blocking, or reset-worthy. The caller owns the clean-run counter, proof bar, backend, and terminal completion gate.
+When the caller has a review-closeout or exhaustive-review proof bar,
+`$review-fold` may decide whether a review source is normalized clean, dirty,
+blocking, or reset-worthy. The caller owns the clean-run counter, proof bar,
+backend, and terminal completion gate.
 
-A normalized clean review source means no new in-scope accepted liability, unresolved proof gap, unresolved refactor-kernel candidate, or human-owned blocker remains after `$review-fold` and the resolution fold.
+A normalized clean review source means no new in-scope accepted liability,
+unresolved proof gap, unresolved structural kernel candidate, unknown kernel,
+or human-owned blocker remains after `$review-fold` and the resolution fold.
 
-Duplicate, rejected, out-of-scope, already-proven proof-only, follow-up, already-resolved findings, and clean auxiliary evidence do not make the source dirty.
+Duplicate, rejected, out-of-scope, already-proven proof-only, follow-up,
+already-resolved findings, and clean auxiliary evidence do not make the source
+dirty.
 
-Reset conditions are caller-owned, but `$review-fold` should mark reset-worthy facts when review evidence shows them:
+Reset conditions are caller-owned, but `$review-fold` should mark reset-worthy
+facts when review evidence shows them:
 
 ```text
 artifact changed
@@ -337,7 +379,8 @@ accepted auxiliary remediation changed the artifact
 review source continuity is lost
 ```
 
-`$review-fold` may reject or mark findings proof-only, but it must not convert a caller-required exhaustive review gate into a no-review closure.
+`$review-fold` may reject or mark findings proof-only, but it must not convert a
+caller-required exhaustive review gate into a no-review closure.
 
 ## Procedure
 
@@ -345,19 +388,19 @@ review source continuity is lost
 2. If fresh/exhaustive workflow review is required and no source evidence is present, stop with a source blocker for the caller or review-source owner.
 3. Classify each finding before any implementation.
 4. Separate claim, observed fact, and suggested repair when review text includes all three.
-5. Reject, block, ask, or follow up before code whenever validity, liability, or scope is not established.
+5. Reject, block, ask, or follow up before code whenever validity, liability, scope, or kernel status is not established.
 6. Preserve source refs when present: backend, source batch, finding identity, review/thread identity, lane role, head SHA, and target fingerprint.
-7. Name falsified law, owner boundary, model state, and repair level when a finding is valid or unresolved.
-8. Emit full RF-v1.3 or the compact receipt floor before any material fold leaves `$review-fold`.
+7. Name falsified law, owner boundary, model state, and kernel fold when a finding is valid or unresolved.
+8. Emit full RF-v1.4 or the compact receipt floor before any material fold leaves `$review-fold`.
 9. Treat material fold classes as semantic triggers, not literal phrase matching.
 10. Treat each new review attempt, follow-up finding batch, reopened thread batch, thread disposition, or dirty clean-run attempt as a new receipt scope.
 11. Collapse duplicates and same-family comments across sources and lanes.
 12. Mark whether the current source is normalized clean and whether the caller's clean-run accounting should increment, reset, stay unchanged, or block.
 13. Recommend `triage`, `remediation-plan`, or `review-closeout` from the user's requested mode and accepted liabilities.
-14. Decide whether each finding's proper response is no code, proof, local fix, refactor, branch race, ask, or follow-up.
-15. Escalate high one-patch-per-comment risk to `refactor-kernel`, `branch-race`, `remediation-plan`, or `blocked` unless an explicit owner-boundary exception is recorded.
+14. Decide whether each finding's proper review response is no code, proof, accepted liability, ask, follow-up, or block.
+15. Emit `kernel_fold.status: structural` or `unknown` when repeated owner-boundary pressure cannot be safely proven point.
 16. Mark review-class fanout safe only for classification/investigation classes; raw findings must not fan out directly to patch workers.
-17. Produce work nodes only for accepted liabilities and only after the resolution fold accepts code-changing work.
+17. Produce resolution inputs only for accepted liabilities and only after the resolution fold accepts code-changing work.
 18. Preserve reviewer response drafts as drafts; do not post public comments unless explicitly asked.
 
 ## Default behavior in `$actuating`
@@ -421,12 +464,10 @@ uv run python -m unittest discover codex/skills/review-fold/tests
 - Raw review text is not executable.
 - Do not add code to satisfy style or speculation when proof or rejection is correct.
 - Do not accept scope expansion without user authority.
-- Do not miss the refactor when many comments share one owner boundary.
+- Do not miss the structural kernel when many comments share one owner boundary.
 - Do not make `$review-fold` a review-backend transcript parser.
 - Do not count auxiliary evidence as standard clean-review evidence.
 - Do not store caller-owned review profile policy only in source-transport fields.
 - Do not let accepted liabilities, blockers, clean-run decisions, or thread dispositions leave only as unjoinable prose.
 - Do not let one RF receipt for an earlier source batch stand in for later findings, dirty clean-run attempts, or reopened thread batches.
 - Do not claim review closure when the caller's terminal proof bar still requires review evidence, proof, delivery, or ATCG.
-- Do not resolve or reply to PR threads without explicit public-side-effect intent.
-- `$review-fold` owns active review adjudication; do not route findings through retired skill paths.

--- a/codex/skills/review-fold/agents/openai.yaml
+++ b/codex/skills/review-fold/agents/openai.yaml
@@ -2,7 +2,7 @@ policy:
   allow_implicit_invocation: true
 interface:
   display_name: "Review Fold"
-  short_description: "Classify review findings and choose reject, proof-only, minimal-fix, refactor-kernel, ask-human, follow-up, or blocked without granting mutation authority"
+  short_description: "Classify review findings, emit RF-v1.4 kernel-fold receipts, and keep mutation authority disabled"
   default_prompt: >-
     Use $review-fold for review findings, PR comments, reviewer suggestions,
     CAS-backed review evidence, human review, prior artifacts, local audit
@@ -14,19 +14,19 @@ interface:
     review_attempt_id, review_thread_id, review_turn_id, lane_role,
     head_sha, target_fingerprint, and backend_specific fields. CAS-specific
     fields are evidence references only; they do not decide validity,
-    liability, repair level, clean-run effect, or mutation authority.
+    liability, kernel status, clean-run effect, or mutation authority.
 
     Separate claim, observed_fact, and suggested_repair. Classify validity,
-    liability, intent_relation, novelty, disposition, and repair_level before
+    liability, intent_relation, novelty, disposition, and kernel_fold before
     any implementation. For valid or contested findings, name law_family,
     falsified_law, owner_boundary, model_state, alternatives_considered, and
     evidence_refs.
 
-    Return full RF-v1.3 when practical. When the full schema is too large,
-    emit an RF-v1.3 compact block before any material fold leaves review-fold:
+    Return full RF-v1.4 when practical. When the full schema is too large,
+    emit an RF-v1.4 compact block before any material fold leaves review-fold:
     source_ref with backend or explicit unknown source, lane_role when known,
     head_sha, target_fingerprint, validity, liability, intent_relation,
-    disposition, repair_level, owner_boundary, law_family, evidence_refs,
+    disposition, kernel_fold, owner_boundary, law_family, evidence_refs,
     clean_run effect when applicable, and finding_mutation_authority.allowed:
     no.
 
@@ -34,16 +34,16 @@ interface:
     acceptance shortcut, repair shortcut, proof-gap shortcut, clean-run
     accounting, thread disposition, grouped-liability / owner-boundary
     shortcut, and source-batch boundary. Shortcut prose is not a receipt.
-    Emit full RF-v1.3 or RF-v1.3 compact before accepted liabilities,
-    blockers, clean-run decisions, thread dispositions, refactor-kernel
-    decisions, or repair directions reach the resolution fold, mutation
-    planning, closeout accounting, or public review-thread handling.
+    Emit full RF-v1.4 or RF-v1.4 compact before accepted liabilities,
+    blockers, clean-run decisions, thread dispositions, kernel decisions, or
+    repair directions reach the resolution fold, mutation planning, closeout
+    accounting, or public review-thread handling.
 
     A finding is never mutation authority. A code-change candidate remains
     advisory until the resolution fold accepts a work node and the caller
     workflow has valid mutation authority. Prefer no-code outcomes when
-    correct: reject, proof-only, follow-up, ask-human, or blocked. If
-    one_patch_per_comment_risk is high, route to refactor-kernel, branch-race,
-    remediation-plan, or blocked unless an explicit owner-boundary exception is
-    recorded. Do not post PR comments, resolve threads, mutate files, choose a
-    fresh review backend, or claim terminal review closure.
+    correct: reject, proof-only, follow-up, ask-human, or blocked. If kernel
+    pressure is high, do not emit kernel_fold.status: point unless
+    point_safety is proven with evidence; otherwise use structural, unknown,
+    or blocked. Do not post PR comments, resolve threads, mutate files, choose
+    a fresh review backend, or claim terminal review closure.

--- a/codex/skills/review-fold/references/decision-contract.yaml
+++ b/codex/skills/review-fold/references/decision-contract.yaml
@@ -3,7 +3,7 @@ skill_decision_contract:
   skill:
     name: review-fold
     kind: mixed
-    source_fingerprint: review-fold-v1.5.0-backend-neutral-receipt-gate
+    source_fingerprint: review-fold-v1.6.0-kernel-fold-receipt-gate
   triggers:
     - trigger_id: RF-REVIEW-FINDING
       description: Review pressure from any backend needs classification against the accepted goal and current artifact.
@@ -16,13 +16,13 @@ skill_decision_contract:
       cue_regexes: []
       exclusions: [existing current review evidence supplied]
     - trigger_id: RF-MATERIAL-FOLD
-      description: A review-related statement accepts, rejects, blocks, repairs, accounts for clean-run state, or disposes of review threads.
+      description: A review-related statement accepts, rejects, blocks, accounts for clean-run state, or disposes of review threads.
       cue_literals: [accepted liability, valid finding, owner fix, clean fix, proof gap, clean run, clean streak, thread resolved, no unresolved threads, same owner boundary, same-class finding]
       cue_regexes: []
       exclusions: [non-decisional discussion]
-    - trigger_id: RF-REPEATED-OWNER-BOUNDARY
-      description: Multiple findings share an owner boundary, missing invariant, proof surface, or one-patch-per-comment risk.
-      cue_literals: [same owner boundary, same-class finding, repeated accepted liabilities, one-patch-per-comment, refactor-kernel]
+    - trigger_id: RF-KERNEL-PRESSURE
+      description: Multiple findings share an owner boundary, missing invariant, proof surface, or patch-per-comment risk.
+      cue_literals: [same owner boundary, same-class finding, repeated accepted liabilities, patch-per-comment, structural kernel, kernel pressure]
       cue_regexes: []
       exclusions: []
     - trigger_id: RF-SOURCE-BATCH-BOUNDARY
@@ -43,17 +43,13 @@ skill_decision_contract:
       description: Require evidence, inspection, or reviewer explanation rather than code.
       aliases: [proof-only]
       terminal: yes
-    - route_id: RF-MINIMAL-FIX
-      description: Accept one owner-correct local liability for resolution-fold consideration.
-      aliases: [minimal-fix]
+    - route_id: RF-ACCEPTED-LIABILITY
+      description: Accept an in-scope liability for resolution-fold consideration while preserving disabled mutation authority.
+      aliases: [accepted-liability]
       terminal: no
-    - route_id: RF-REFACTOR-KERNEL
-      description: Compress multiple same-boundary findings into one owner-level correction.
-      aliases: [refactor-kernel]
-      terminal: no
-    - route_id: RF-BRANCH-RACE
-      description: Compare plausible remediation strategies under the same verifier.
-      aliases: [branch-race]
+    - route_id: RF-KERNEL-FOLD
+      description: Attach point, structural, none, or unknown kernel status to every material finding.
+      aliases: [kernel-fold, structural-kernel, point-kernel, unknown-kernel]
       terminal: no
     - route_id: RF-ASK-HUMAN
       description: Ask for product, API, compatibility, UX, performance, security, or scope authority.
@@ -64,43 +60,43 @@ skill_decision_contract:
       aliases: [follow-up]
       terminal: yes
     - route_id: RF-BLOCK
-      description: Stop when validity, liability, scope, source, owner boundary, or current artifact state is unclear.
+      description: Stop when validity, liability, scope, source, owner boundary, kernel status, or current artifact state is unclear.
       aliases: [blocked]
       terminal: yes
   clauses:
     - clause_id: RF-SOURCE-001
       trigger_refs: [RF-REVIEW-SOURCE-NEEDED]
       expected_routes: [RF-SOURCE-BLOCK, RF-BLOCK]
-      prohibited_routes: [RF-MINIMAL-FIX, RF-REFACTOR-KERNEL]
+      prohibited_routes: [RF-ACCEPTED-LIABILITY]
       required_artifacts: [caller-owned review requirement, current review source evidence or explicit source blocker]
       success_signals: [review-fold does not invent fresh review output, backend policy remains owned by the caller workflow, absent current review evidence blocks classification-dependent mutation]
       failure_signals: [review-fold substitutes generic critique for required fresh review evidence, backend-specific transport details become review-fold policy, stale review source is treated as current]
       rationale: Review-fold classifies review evidence; it does not select or run the review backend.
     - clause_id: RF-CLASSIFY-001
       trigger_refs: [RF-REVIEW-FINDING]
-      expected_routes: [RF-REJECT, RF-PROOF-ONLY, RF-MINIMAL-FIX, RF-REFACTOR-KERNEL, RF-BRANCH-RACE, RF-ASK-HUMAN, RF-FOLLOW-UP, RF-BLOCK]
+      expected_routes: [RF-REJECT, RF-PROOF-ONLY, RF-ACCEPTED-LIABILITY, RF-ASK-HUMAN, RF-FOLLOW-UP, RF-BLOCK]
       prohibited_routes: []
-      required_artifacts: [source refs when present, validity, liability, intent relation, owner boundary for valid or unresolved findings, finding mutation authority disabled]
+      required_artifacts: [source refs when present, validity, liability, intent relation, owner boundary for valid or unresolved findings, kernel fold, finding mutation authority disabled]
       success_signals: [claim fact and suggested repair are separated, code-change candidates remain gated by the resolution fold, no-code dispositions remain available]
       failure_signals: [raw review prose directly drives mutation, style preference becomes code without accepted liability, accepted finding lacks owner boundary, finding_mutation_authority.allowed is yes]
-      rationale: The fold turns review pressure into dispositions, not implementation authority.
+      rationale: The fold turns review pressure into dispositions and kernel accounts, not implementation authority.
     - clause_id: RF-RECEIPT-001
       trigger_refs: [RF-MATERIAL-FOLD, RF-SOURCE-BATCH-BOUNDARY]
-      expected_routes: [RF-REJECT, RF-PROOF-ONLY, RF-MINIMAL-FIX, RF-REFACTOR-KERNEL, RF-BRANCH-RACE, RF-ASK-HUMAN, RF-FOLLOW-UP, RF-BLOCK]
+      expected_routes: [RF-REJECT, RF-PROOF-ONLY, RF-ACCEPTED-LIABILITY, RF-ASK-HUMAN, RF-FOLLOW-UP, RF-BLOCK]
       prohibited_routes: []
-      required_artifacts: [full RF-v1.3 or RF-v1.3 compact receipt for material folds, source_ref with backend or explicit unknown backend, clean-run count effect when applicable, fresh receipt for each new review source batch or thread disposition]
+      required_artifacts: [full RF-v1.4 or RF-v1.4 compact receipt for material folds, source_ref with backend or explicit unknown backend, kernel_fold on every finding, clean-run count effect when applicable, fresh receipt for each new review source batch or thread disposition]
       success_signals: [future seq tune audits can recover the decision episode, source refs are joinable without backend-specific prose parsing, later dirty attempts or follow-up batches have their own receipts]
-      failure_signals: [accepted liability appears only as terse prose, repair direction precedes a receipt, proof-gap or clean-run accounting appears without a receipt, thread disposition cannot be joined back to a source, follow-up findings reuse an earlier receipt]
+      failure_signals: [accepted liability appears only as terse prose, kernel status precedes a receipt, proof-gap or clean-run accounting appears without a receipt, thread disposition cannot be joined back to a source, follow-up findings reuse an earlier receipt]
       rationale: Material folds must remain observable after compaction and session shadowing.
     - clause_id: RF-KERNEL-001
-      trigger_refs: [RF-REPEATED-OWNER-BOUNDARY]
-      expected_routes: [RF-REFACTOR-KERNEL, RF-BRANCH-RACE, RF-MINIMAL-FIX, RF-BLOCK]
+      trigger_refs: [RF-KERNEL-PRESSURE]
+      expected_routes: [RF-KERNEL-FOLD, RF-BLOCK, RF-ASK-HUMAN]
       prohibited_routes: []
-      required_artifacts: [equivalence class or owner boundary, one-patch-per-comment risk, alternatives considered when choosing local minimal fixes]
-      success_signals: [same-class findings are compressed, minimal-fix exception explains why no kernel is preserved]
-      failure_signals: [repeated same-boundary findings continue as silent local fixes, refactor-kernel route is skipped without evidence, branch-race is skipped when local fix and kernel are both plausible under the same verifier]
+      required_artifacts: [equivalence class or owner boundary, kernel pressure, point safety when status is point, evidence refs for high-pressure point claims]
+      success_signals: [same-class findings are compressed, point kernel proves why no structural kernel remains, unknown kernel blocks mutation]
+      failure_signals: [repeated same-boundary findings continue as silent local fixes, structural kernel is skipped without evidence, high-pressure point status lacks proof]
       rationale: The skill prevents review pressure from becoming one patch per comment.
   instrumentation:
     decision_receipt: required
     validator: codex/skills/review-fold/tools/review_fold_receipt_gate.py
-    rationale: Emit full RF-v1.3 or the compact receipt floor for material folds, clean-run accounting, blockers, source-batch boundaries, and thread dispositions.
+    rationale: Emit full RF-v1.4 or the compact receipt floor for material folds, clean-run accounting, blockers, source-batch boundaries, and thread dispositions.

--- a/codex/skills/review-fold/references/material-fold-triggers.yaml
+++ b/codex/skills/review-fold/references/material-fold-triggers.yaml
@@ -1,28 +1,28 @@
 material_fold_triggers:
-  version: RF-MFT-v1
+  version: RF-MFT-v2
   purpose: >
     Keep review-fold receipt triggers semantic and backend-neutral. Examples are
     illustrative; do not tune the skill by adding every observed transcript
     phrase to the main prompt.
   receipt_rule: >
-    If the statement changes accepted validity, liability, scope, repair
-    direction, clean-run accounting, thread disposition, blocker state, or
-    closure state, emit full RF-v1.3 or RF-v1.3 compact before the decision
-    reaches resolution, mutation planning, closeout accounting, or public review
-    thread handling.
+    If the statement changes accepted validity, liability, scope, kernel
+    status, clean-run accounting, thread disposition, blocker state, or closure
+    state, emit full RF-v1.4 or RF-v1.4 compact before the decision reaches
+    resolution, mutation planning, closeout accounting, or public review thread
+    handling.
   classes:
     - id: acceptance_shortcut
       meaning: A terse statement accepts or rejects validity, liability, severity, or in-scope status.
       backend_neutral_examples: [valid finding, accepted liability, both findings are liabilities, severity label used as acceptance]
-      required_receipt_effect: finding disposition before repair planning
+      required_receipt_effect: finding disposition and kernel_fold before resolution planning
     - id: repair_shortcut
       meaning: A statement names the owner fix, clean fix, next patch, or mutation path.
       backend_neutral_examples: [owner-correct fix, clean fix, next patch, replacement strategy]
-      required_receipt_effect: repair_level and mutation_authority disabled before resolution fold
+      required_receipt_effect: kernel_fold and mutation_authority disabled before resolution fold
     - id: proof_gap_shortcut
       meaning: A statement decides that proof gaps remain, are resolved, or are sufficient for review accounting.
       backend_neutral_examples: [proof gaps remain, concrete gaps remain, proof is enough, no proof gap remains]
-      required_receipt_effect: proof-only or blocker disposition with evidence_refs
+      required_receipt_effect: proof-only or blocker disposition with evidence_refs and kernel_fold
     - id: clean_run_accounting
       meaning: A statement increments, resets, blocks, or leaves unchanged a caller-owned review closeout counter.
       backend_neutral_examples: [review attempt is clean, clean streak advances, clean streak resets, dirty review attempt]
@@ -32,9 +32,9 @@ material_fold_triggers:
       backend_neutral_examples: [no unresolved threads, thread sweep is clean, targeted threads resolved, reopened thread batch]
       required_receipt_effect: thread source_ref and disposition before public-side-effect handling
     - id: grouped_liability
-      meaning: A statement collapses multiple findings into a repeated class, owner boundary, or refactor-kernel candidate.
+      meaning: A statement collapses multiple findings into a repeated class, owner boundary, or structural kernel candidate.
       backend_neutral_examples: [same owner boundary, same class, larger repeated class, shared missing invariant]
-      required_receipt_effect: equivalence class, owner_boundary, one_patch_per_comment_risk, and repair_level
+      required_receipt_effect: equivalence class, owner_boundary, kernel pressure, point_safety, and kernel_fold
     - id: source_batch_boundary
       meaning: A later review source batch appears after an earlier receipt.
       backend_neutral_examples: [new review attempt, follow-up finding batch, reopened thread batch, dirty clean-run attempt]
@@ -42,4 +42,4 @@ material_fold_triggers:
   anti_patterns:
     - Adding a literal transcript phrase to the main skill when it fits an existing class.
     - Treating backend-specific wording as a new review-fold route.
-    - Treating source transport fields as validity, liability, or mutation authority.
+    - Treating source transport fields as validity, liability, kernel status, or mutation authority.

--- a/codex/skills/review-fold/references/review-modes.md
+++ b/codex/skills/review-fold/references/review-modes.md
@@ -10,19 +10,20 @@ Explicit review mode names carry the mutation rule:
 
 ```text
 triage -> classify findings and stop without implementation
-remediation-plan -> produce the fix plan and stop without implementation
-review-closeout -> fix accepted liabilities and prove closure
+remediation-plan -> produce resolution inputs and stop without implementation
+review-closeout -> hand accepted liabilities to resolution, then prove closure
 ```
 
-`review-closeout` still preserves no-code dispositions. A review with ten findings may close as:
+`review-closeout` still preserves no-code dispositions. A review with ten
+findings may close as:
 
 ```text
 2 rejected
 2 proof-only
 1 follow-up
 1 ask-human
-3 fixed by one refactor-kernel
-1 minimal local fix
+3 accepted under one structural kernel
+1 accepted under a proven point kernel
 ```
 
 It must not become ten local patches.
@@ -33,14 +34,23 @@ It must not become ten local patches.
 |---|---|---|
 | `reject` | False, duplicate, out-of-scope, or incompatible with the accepted goal. | No |
 | `proof-only` | The right answer is evidence, not code. | No by default |
-| `minimal-fix` | One valid liability has one owner-correct repair. | Yes |
-| `refactor-kernel` | Several findings share one missing abstraction, owner, or invariant. | Yes, one kernel |
+| `accepted-liability` | A valid in-scope liability may be considered by the resolution fold. | Advisory only |
 | `ask-human` | The review introduces a product/API/compatibility decision. | No |
 | `follow-up` | Valid but outside the intended change. | No in current PR |
+| `blocked` | Validity, scope, source, current artifact, or kernel status is unclear. | No |
+
+## Kernel status
+
+| Status | Meaning | Resolution implication |
+|---|---|---|
+| `none` | No in-scope code liability remains. | No code |
+| `point` | One owner boundary is enough and `point_safety: proven`. | May become one bounded work node |
+| `structural` | Same-family pressure needs one normal-form owner correction. | Must not split by comment |
+| `unknown` | The fold cannot prove point versus structural. | Inspect, ask, or block before mutation |
 
 ## Reabstraction tests
 
-Choose `refactor-kernel` when at least two are true:
+Choose `kernel_fold.status: structural` when at least two are true:
 
 - multiple comments mention the same state, transition, or boundary;
 - fixes would add similar guards/helpers in multiple files;
@@ -55,8 +65,9 @@ The minimal correct response may be:
 
 - a short proof note;
 - a no-code rejection;
-- a one-line owner fix;
-- a small adapter;
-- a deliberate reabstraction.
+- a proven point kernel;
+- a structural kernel;
+- a human-owned decision;
+- a blocker because the kernel status is unknown.
 
 It is not always the smallest diff.

--- a/codex/skills/review-fold/tests/test_contract.py
+++ b/codex/skills/review-fold/tests/test_contract.py
@@ -11,8 +11,10 @@ SKILL = (ROOT / "SKILL.md").read_text(encoding="utf-8")
 AGENT = (ROOT / "agents" / "openai.yaml").read_text(encoding="utf-8")
 CONTRACT = (ROOT / "references" / "decision-contract.yaml").read_text(encoding="utf-8")
 TRIGGERS = (ROOT / "references" / "material-fold-triggers.yaml").read_text(encoding="utf-8")
+MODES = (ROOT / "references" / "review-modes.md").read_text(encoding="utf-8")
 REDUCER = (CODEX_ROOT / "agents" / "review-reducer.toml").read_text(encoding="utf-8")
 NORMALIZED_PROMPTS = " ".join((AGENT + "\n" + REDUCER).split())
+LIVE_REVIEW_FOLD_SURFACES = "\n".join([SKILL, AGENT, CONTRACT, TRIGGERS, MODES, REDUCER])
 
 
 class ReviewFoldContractTests(unittest.TestCase):
@@ -33,9 +35,9 @@ class ReviewFoldContractTests(unittest.TestCase):
         self.assertNotIn("CAS review lanes", SKILL)
         self.assertNotIn("Supported CAS-backed review lanes", SKILL)
 
-    def test_rf_v13_schema_has_generic_joinable_source_refs(self) -> None:
+    def test_rf_v14_schema_has_generic_joinable_source_refs(self) -> None:
         required = [
-            "version: RF-v1.3",
+            "version: RF-v1.4",
             "source_ref:",
             "backend: cas|github-comments|human-review|prior-artifact|local-audit|other|unknown",
             "source_batch_id",
@@ -60,10 +62,10 @@ class ReviewFoldContractTests(unittest.TestCase):
             "liability != scope",
             "scope != code change",
             "code-change candidate != mutation authority",
+            "kernel fold != repair plan",
             "`reject`",
             "`proof-only`",
-            "`minimal-fix`",
-            "`refactor-kernel`",
+            "`accepted-liability`",
             "`ask-human`",
             "`follow-up`",
             "`blocked`",
@@ -75,13 +77,13 @@ class ReviewFoldContractTests(unittest.TestCase):
     def test_compact_receipt_floor_preserves_material_fold_observability(self) -> None:
         required = [
             "## Compact receipt floor",
-            "RF-v1.3 compact:",
+            "RF-v1.4 compact:",
             "source_ref:",
             "validity:",
             "liability:",
             "intent_relation:",
             "disposition:",
-            "repair_level:",
+            "kernel_fold:",
             "owner_boundary:",
             "law_family:",
             "clean_run:",
@@ -91,6 +93,18 @@ class ReviewFoldContractTests(unittest.TestCase):
         for token in required:
             with self.subTest(token=token):
                 self.assertIn(token, SKILL)
+
+    def test_live_review_fold_surfaces_forbid_retired_repair_routes(self) -> None:
+        forbidden = [
+            "minimal-fix",
+            "repair_level",
+            "RF-v1.3 compact",
+            "version: RF-v1.3",
+            "choose reject, proof-only",
+        ]
+        for token in forbidden:
+            with self.subTest(token=token):
+                self.assertNotIn(token, LIVE_REVIEW_FOLD_SURFACES)
 
     def test_material_fold_trigger_taxonomy_replaces_literal_phrase_catalog(self) -> None:
         required = [
@@ -164,8 +178,8 @@ class ReviewFoldContractTests(unittest.TestCase):
             "RF-RECEIPT-001",
             "RF-KERNEL-001",
             "RF-SOURCE-BLOCK",
-            "RF-MINIMAL-FIX",
-            "RF-REFACTOR-KERNEL",
+            "RF-ACCEPTED-LIABILITY",
+            "RF-KERNEL-FOLD",
             "decision_receipt: required",
             "validator: codex/skills/review-fold/tools/review_fold_receipt_gate.py",
         ]

--- a/codex/skills/review-fold/tests/test_receipt_gate.py
+++ b/codex/skills/review-fold/tests/test_receipt_gate.py
@@ -14,6 +14,21 @@ MODULE = importlib.util.module_from_spec(SPEC)
 SPEC.loader.exec_module(MODULE)
 
 
+def valid_kernel(**overrides):
+    kernel = {
+        "status": "point",
+        "pressure": "low",
+        "equivalence_class": "not-applicable",
+        "owner_boundary": "input validation",
+        "law_family": "validation-boundary",
+        "falsifier": "comment-1 shows missing owner validation",
+        "point_safety": "proven",
+        "evidence_refs": ["repo:file.py:10"],
+    }
+    kernel.update(overrides)
+    return kernel
+
+
 def valid_finding(**overrides):
     finding = {
         "id": "finding-1",
@@ -33,10 +48,10 @@ def valid_finding(**overrides):
         "validity": "valid",
         "liability": "blocks-goal",
         "intent_relation": "core",
-        "disposition": "minimal-fix",
-        "repair_level": "minimal-fix",
+        "disposition": "accepted-liability",
         "owner_boundary": "input validation",
         "law_family": "validation-boundary",
+        "kernel_fold": valid_kernel(),
         "evidence_refs": ["repo:file.py:10"],
         "code_change_candidate": "yes",
         "finding_mutation_authority": {"allowed": "no", "reason": "resolution fold owns mutation"},
@@ -49,17 +64,16 @@ class ReviewFoldReceiptGateTests(unittest.TestCase):
     def test_valid_full_receipt_passes(self) -> None:
         receipt = {
             "review_fold": {
-                "version": "RF-v1.3",
+                "version": "RF-v1.4",
                 "source": {"backend": "github-comments"},
                 "findings": [valid_finding()],
-                "compression": {"one_patch_per_comment_risk": "low"},
+                "compression": {"kernel_pressure": "low"},
                 "recommended_resolution": {
                     "clean_run_accounting": {
                         "normalized_clean_this_source": "no",
                         "count_effect": "reset",
                     }
                 },
-                "action_plan": {"mode": "minimal-fix"},
             }
         }
         report = MODULE.validate(receipt)["review_fold_receipt_gate"]
@@ -68,15 +82,16 @@ class ReviewFoldReceiptGateTests(unittest.TestCase):
 
     def test_compact_receipt_missing_source_ref_fails(self) -> None:
         receipt = {
-            "rf_v13_compact": {
+            "rf_v14_compact": {
                 "validity": "valid",
                 "liability": "blocks-goal",
                 "intent_relation": "core",
-                "disposition": "minimal-fix",
-                "repair_level": "minimal-fix",
+                "disposition": "accepted-liability",
                 "owner_boundary": "input validation",
                 "law_family": "validation-boundary",
+                "kernel_fold": valid_kernel(),
                 "evidence_refs": [],
+                "code_change_candidate": "yes",
                 "clean_run": {"normalized_clean": "not-applicable", "count_effect": "none"},
                 "finding_mutation_authority": {"allowed": "no", "reason": "not authority"},
             }
@@ -88,7 +103,7 @@ class ReviewFoldReceiptGateTests(unittest.TestCase):
     def test_mutation_authority_allowed_fails(self) -> None:
         receipt = {
             "review_fold": {
-                "version": "RF-v1.3",
+                "version": "RF-v1.4",
                 "findings": [
                     valid_finding(
                         finding_mutation_authority={"allowed": "yes", "reason": "bad"}
@@ -103,49 +118,100 @@ class ReviewFoldReceiptGateTests(unittest.TestCase):
             report["errors"],
         )
 
-    def test_refactor_kernel_requires_equivalence_class_or_owner_boundary(self) -> None:
+    def test_structural_kernel_requires_equivalence_class_or_owner_boundary(self) -> None:
+        receipt = {
+            "review_fold": {
+                "version": "RF-v1.4",
+                "findings": [
+                    valid_finding(
+                        kernel_fold=valid_kernel(
+                            status="structural",
+                            pressure="high",
+                            equivalence_class="",
+                            owner_boundary="",
+                            point_safety="not-applicable",
+                        )
+                    )
+                ],
+            }
+        }
+        report = MODULE.validate(receipt)["review_fold_receipt_gate"]
+        self.assertEqual(report["verdict"], "fail")
+        self.assertIn(
+            "review_fold.findings[0].kernel_fold.structural:missing-equivalence-class-or-owner-boundary",
+            report["errors"],
+        )
+
+    def test_high_pressure_point_requires_proven_point_safety(self) -> None:
+        receipt = {
+            "review_fold": {
+                "version": "RF-v1.4",
+                "findings": [
+                    valid_finding(
+                        kernel_fold=valid_kernel(
+                            pressure="high",
+                            point_safety="not-proven",
+                            evidence_refs=[],
+                        )
+                    )
+                ],
+            }
+        }
+        report = MODULE.validate(receipt)["review_fold_receipt_gate"]
+        self.assertEqual(report["verdict"], "fail")
+        self.assertIn(
+            "review_fold.findings[0].kernel_fold.point_safety:point-status-requires-proven",
+            report["errors"],
+        )
+        self.assertIn(
+            "review_fold.findings[0].kernel_fold.point_safety:high-pressure-point-requires-proof",
+            report["errors"],
+        )
+
+    def test_rf_v13_receipt_fails(self) -> None:
         receipt = {
             "review_fold": {
                 "version": "RF-v1.3",
-                "findings": [
-                    valid_finding(
-                        disposition="refactor-kernel",
-                        repair_level="refactor-kernel",
-                    )
-                ],
-                "compression": {"one_patch_per_comment_risk": "high"},
+                "findings": [valid_finding()],
+            }
+        }
+        report = MODULE.validate(receipt)["review_fold_receipt_gate"]
+        self.assertEqual(report["verdict"], "fail")
+        self.assertIn("review_fold.version:expected-RF-v1.4", report["errors"])
+
+    def test_repair_level_is_forbidden(self) -> None:
+        receipt = {
+            "review_fold": {
+                "version": "RF-v1.4",
+                "findings": [valid_finding(repair_level="minimal-fix")],
+            }
+        }
+        report = MODULE.validate(receipt)["review_fold_receipt_gate"]
+        self.assertEqual(report["verdict"], "fail")
+        self.assertIn("review_fold.findings[0].repair_level:forbidden-in-RF-v1.4", report["errors"])
+
+    def test_minimal_fix_disposition_fails(self) -> None:
+        receipt = {
+            "review_fold": {
+                "version": "RF-v1.4",
+                "findings": [valid_finding(disposition="minimal-fix")],
+            }
+        }
+        report = MODULE.validate(receipt)["review_fold_receipt_gate"]
+        self.assertEqual(report["verdict"], "fail")
+        self.assertIn("review_fold.findings[0].disposition:invalid", report["errors"])
+
+    def test_action_plan_is_forbidden(self) -> None:
+        receipt = {
+            "review_fold": {
+                "version": "RF-v1.4",
+                "findings": [valid_finding()],
                 "action_plan": {"mode": "refactor-kernel"},
             }
         }
         report = MODULE.validate(receipt)["review_fold_receipt_gate"]
         self.assertEqual(report["verdict"], "fail")
-        self.assertIn(
-            "compression.refactor-kernel:missing-equivalence-class-or-owner-boundary",
-            report["errors"],
-        )
-
-    def test_reject_cannot_be_code_change_candidate(self) -> None:
-        receipt = {
-            "review_fold": {
-                "version": "RF-v1.3",
-                "findings": [
-                    valid_finding(
-                        validity="invalid",
-                        liability="out-of-scope",
-                        intent_relation="unrelated",
-                        disposition="reject",
-                        repair_level="none",
-                        code_change_candidate="yes",
-                    )
-                ],
-            }
-        }
-        report = MODULE.validate(receipt)["review_fold_receipt_gate"]
-        self.assertEqual(report["verdict"], "fail")
-        self.assertIn(
-            "review_fold.findings[0].code_change_candidate:reject-cannot-be-code-change",
-            report["errors"],
-        )
+        self.assertIn("review_fold.action_plan:forbidden-in-RF-v1.4", report["errors"])
 
 
 if __name__ == "__main__":

--- a/codex/skills/review-fold/tools/review_fold_receipt_gate.py
+++ b/codex/skills/review-fold/tools/review_fold_receipt_gate.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env -S uv run python
-"""RF-v1.3 receipt validator for $review-fold.
+"""RF-v1.4 receipt validator for $review-fold.
 
-The gate validates JSON projections of full RF-v1.3 receipts and compact
-RF-v1.3 receipts. It intentionally avoids review-backend policy: source fields
-are evidence references, not validity or mutation authority.
+The gate validates JSON projections of full RF-v1.4 receipts and compact
+RF-v1.4 receipts. It intentionally avoids review-backend policy: source fields
+are evidence references, not validity, kernel status, or mutation authority.
 """
 from __future__ import annotations
 
@@ -39,26 +39,19 @@ VALID_INTENT = {"core", "adjacent", "unrelated", "expands-scope"}
 VALID_DISPOSITIONS = {
     "reject",
     "proof-only",
-    "minimal-fix",
-    "refactor-kernel",
+    "accepted-liability",
     "ask-human",
     "follow-up",
     "blocked",
 }
-VALID_REPAIR = {
-    "none",
-    "proof-only",
-    "minimal-fix",
-    "refactor-kernel",
-    "branch-race",
-    "ask-human",
-    "follow-up",
-    "blocked",
-}
-CODE_CHANGE_DISPOSITIONS = {"minimal-fix", "refactor-kernel"}
 MATERIAL_DISPOSITIONS = VALID_DISPOSITIONS
+VALID_KERNEL_STATUS = {"none", "point", "structural", "unknown"}
+VALID_KERNEL_PRESSURE = {"none", "low", "medium", "high"}
+VALID_POINT_SAFETY = {"proven", "not-proven", "not-applicable"}
 VALID_CLEAN = {"yes", "no", "not-applicable"}
 VALID_COUNT_EFFECT = {"increment", "reset", "none", "blocked", "unknown"}
+FORBIDDEN_FINDING_KEYS = {"repair_level"}
+FORBIDDEN_FULL_KEYS = {"action_plan"}
 
 
 class ReceiptGateError(ValueError):
@@ -76,14 +69,21 @@ def load_json(path: str) -> dict[str, Any]:
 def unwrap_receipt(value: dict[str, Any]) -> tuple[str, dict[str, Any]]:
     if isinstance(value.get("review_fold"), dict):
         return "full", value["review_fold"]
-    for key in ("rf_v13_compact", "RF-v1.3 compact", "RF-v1.3 compact:"):
+    for key in (
+        "rf_v14_compact",
+        "RF-v1.4 compact",
+        "RF-v1.4 compact:",
+        "rf_v13_compact",
+        "RF-v1.3 compact",
+        "RF-v1.3 compact:",
+    ):
         if isinstance(value.get(key), dict):
             return "compact", value[key]
-    if "findings" in value or value.get("version") == "RF-v1.3":
+    if "findings" in value or value.get("version") in {"RF-v1.4", "RF-v1.3"}:
         return "full", value
     if "validity" in value and "disposition" in value:
         return "compact", value
-    raise ReceiptGateError("receipt: expected review_fold or RF-v1.3 compact object")
+    raise ReceiptGateError("receipt: expected review_fold or RF-v1.4 compact object")
 
 
 def as_no(value: Any) -> bool:
@@ -92,6 +92,10 @@ def as_no(value: Any) -> bool:
 
 def object_from(value: Any) -> dict[str, Any]:
     return value if isinstance(value, dict) else {}
+
+
+def meaningful(value: Any) -> bool:
+    return isinstance(value, str) and value not in {"", "unknown", "not-applicable", "none"}
 
 
 def require_list(obj: dict[str, Any], key: str, errors: list[str], prefix: str) -> list[Any]:
@@ -158,10 +162,55 @@ def clean_run_errors(clean_run: dict[str, Any], prefix: str) -> list[str]:
     return errors
 
 
+def kernel_fold_errors(finding: dict[str, Any], prefix: str, disposition: str) -> list[str]:
+    errors: list[str] = []
+    kernel = object_from(finding.get("kernel_fold"))
+    if not kernel:
+        errors.append(f"{prefix}.kernel_fold:missing")
+        return errors
+
+    status = validate_enum(
+        kernel.get("status"), VALID_KERNEL_STATUS, "kernel_fold.status", errors, prefix
+    )
+    pressure = validate_enum(
+        kernel.get("pressure"), VALID_KERNEL_PRESSURE, "kernel_fold.pressure", errors, prefix
+    )
+    point_safety = validate_enum(
+        kernel.get("point_safety"), VALID_POINT_SAFETY, "kernel_fold.point_safety", errors, prefix
+    )
+
+    for key in ("equivalence_class", "owner_boundary", "law_family", "falsifier"):
+        value = kernel.get(key)
+        if not isinstance(value, str) or not value:
+            errors.append(f"{prefix}.kernel_fold.{key}:missing")
+
+    evidence_refs = require_list(kernel, "evidence_refs", errors, f"{prefix}.kernel_fold")
+    if evidence_refs and not all(isinstance(item, str) and item for item in evidence_refs):
+        errors.append(f"{prefix}.kernel_fold.evidence_refs:must-be-strings")
+
+    if disposition == "accepted-liability" and status not in {"point", "structural"}:
+        errors.append(f"{prefix}.kernel_fold.status:accepted-liability-requires-point-or-structural")
+    if status == "point" and point_safety != "proven":
+        errors.append(f"{prefix}.kernel_fold.point_safety:point-status-requires-proven")
+    if status == "structural" and not (
+        meaningful(kernel.get("equivalence_class")) or meaningful(kernel.get("owner_boundary"))
+    ):
+        errors.append(f"{prefix}.kernel_fold.structural:missing-equivalence-class-or-owner-boundary")
+    if pressure == "high" and status == "point" and (
+        point_safety != "proven" or not evidence_refs
+    ):
+        errors.append(f"{prefix}.kernel_fold.point_safety:high-pressure-point-requires-proof")
+
+    return errors
+
+
 def validate_finding(finding: dict[str, Any], prefix: str) -> list[str]:
     errors: list[str] = []
     if not finding:
         return [f"{prefix}:missing"]
+
+    for key in FORBIDDEN_FINDING_KEYS & finding.keys():
+        errors.append(f"{prefix}.{key}:forbidden-in-RF-v1.4")
 
     source_ref = object_from(finding.get("source_ref"))
     if not source_ref:
@@ -173,14 +222,16 @@ def validate_finding(finding: dict[str, Any], prefix: str) -> list[str]:
     validate_enum(finding.get("liability"), VALID_LIABILITY, "liability", errors, prefix)
     intent = validate_enum(finding.get("intent_relation"), VALID_INTENT, "intent_relation", errors, prefix)
     disposition = validate_enum(finding.get("disposition"), VALID_DISPOSITIONS, "disposition", errors, prefix)
-    repair = validate_enum(finding.get("repair_level"), VALID_REPAIR, "repair_level", errors, prefix)
 
-    if disposition in CODE_CHANGE_DISPOSITIONS and finding.get("code_change_candidate") not in {"yes", True}:
-        errors.append(f"{prefix}.code_change_candidate:expected-yes-for-code-change-disposition")
-    if disposition == "reject" and finding.get("code_change_candidate") in {"yes", True}:
-        errors.append(f"{prefix}.code_change_candidate:reject-cannot-be-code-change")
-    if disposition == "proof-only" and repair not in {"proof-only", "none"}:
-        errors.append(f"{prefix}.repair_level:proof-only-disposition-mismatch")
+    code_change = finding.get("code_change_candidate")
+    kernel = object_from(finding.get("kernel_fold"))
+    kernel_status = kernel.get("status")
+    if code_change in {"yes", True} and not (
+        disposition == "accepted-liability" and kernel_status in {"point", "structural"}
+    ):
+        errors.append(f"{prefix}.code_change_candidate:requires-accepted-liability-point-or-structural")
+    if disposition == "accepted-liability" and code_change not in {"yes", True}:
+        errors.append(f"{prefix}.code_change_candidate:expected-yes-for-accepted-liability")
     if disposition == "follow-up" and intent not in {"adjacent", "expands-scope", "unrelated"}:
         errors.append(f"{prefix}.intent_relation:follow-up-should-not-be-core")
 
@@ -196,6 +247,7 @@ def validate_finding(finding: dict[str, Any], prefix: str) -> list[str]:
         if not isinstance(law, str) or not law:
             errors.append(f"{prefix}.law_family:missing")
 
+    errors.extend(kernel_fold_errors(finding, prefix, disposition))
     errors.extend(mutation_authority_errors(finding, prefix))
     errors.extend(clean_run_errors(object_from(finding.get("clean_run")), prefix))
     return errors
@@ -220,8 +272,11 @@ def validate_full(receipt: dict[str, Any]) -> dict[str, Any]:
     errors: list[str] = []
     warnings: list[str] = []
 
-    if receipt.get("version") != "RF-v1.3":
-        errors.append("review_fold.version:expected-RF-v1.3")
+    if receipt.get("version") != "RF-v1.4":
+        errors.append("review_fold.version:expected-RF-v1.4")
+
+    for key in FORBIDDEN_FULL_KEYS & receipt.keys():
+        errors.append(f"review_fold.{key}:forbidden-in-RF-v1.4")
 
     source = object_from(receipt.get("source"))
     if source:
@@ -243,17 +298,11 @@ def validate_full(receipt: dict[str, Any]) -> dict[str, Any]:
         errors.extend(validate_finding(finding_value, f"review_fold.findings[{index}]"))
 
     compression = object_from(receipt.get("compression"))
-    risk = compression.get("one_patch_per_comment_risk")
-    recommended = object_from(receipt.get("recommended_resolution"))
-    action = object_from(receipt.get("action_plan"))
-    mode = action.get("mode")
-    if risk == "high" and mode not in {"refactor-kernel", "branch-race"}:
-        warnings.append("compression.one_patch_per_comment_risk:high-without-kernel-or-branch-route")
-    if mode == "refactor-kernel":
-        owner = compression.get("repeated_kernel") or compression.get("owner_boundary")
-        if not owner and not compression.get("equivalence_classes"):
-            errors.append("compression.refactor-kernel:missing-equivalence-class-or-owner-boundary")
+    pressure = compression.get("kernel_pressure")
+    if pressure is not None and pressure not in VALID_KERNEL_PRESSURE:
+        errors.append("review_fold.compression.kernel_pressure:invalid")
 
+    recommended = object_from(receipt.get("recommended_resolution"))
     clean = object_from(recommended.get("clean_run_accounting"))
     if clean:
         normalized = clean.get("normalized_clean_this_source", "not-applicable")
@@ -282,7 +331,7 @@ def validate(value: dict[str, Any]) -> dict[str, Any]:
 
 
 def main(argv: list[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(description="Validate RF-v1.3 full or compact review-fold receipts")
+    parser = argparse.ArgumentParser(description="Validate RF-v1.4 full or compact review-fold receipts")
     sub = parser.add_subparsers(dest="command", required=True)
     validate_parser = sub.add_parser("validate")
     validate_parser.add_argument("--receipt", required=True, help="Path to JSON receipt, or '-' for stdin")


### PR DESCRIPTION
## Summary
- replace review-fold repair-route outputs with RF-v1.4 kernel-fold receipts
- add validator and contract tests that reject retired repair-route fields
- update direct CAS/workgraph/reducer wording to consume kernel status instead of repair mode

## Proof
- uv run python -m unittest discover codex/skills/review-fold/tests
- uv run python -m unittest discover codex/skills/cas/tests
- uv run --with pyyaml -- python3 codex/skills/.system/skill-creator/scripts/quick_validate.py codex/skills/review-fold
- uv run --with pyyaml -- python3 codex/skills/.system/skill-creator/scripts/quick_validate.py codex/skills/cas
- uv run --with pyyaml -- python3 codex/skills/.system/skill-creator/scripts/quick_validate.py codex/skills/goal-workgraph
- uv run --with pyyaml -- python3 codex/skills/tune/tools/decision_contract_lint.py codex/skills/review-fold/references/decision-contract.yaml
- git diff --check