### PR TITLE
Make review-fold refactor-kernel only

### DIFF
--- a/codex/agents/review-reducer.toml
+++ b/codex/agents/review-reducer.toml
@@ -1,5 +1,5 @@
 name = "review_reducer"
-description = "Review-loop agent that classifies reviewer findings, compresses same-family claims, emits RF-v1.4 kernel-fold receipts, and keeps mutation authority disabled."
+description = "Review-loop agent that classifies reviewer findings, compresses same-family claims, emits RF-v1.5 refactor-kernel receipts, and keeps mutation authority disabled."
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 nickname_candidates = ["Review Reducer", "Review Folder", "Review Classifier"]
@@ -15,21 +15,21 @@ Mission:
 - Separate claim, observed_fact, and suggested_repair.
 - Collapse duplicates and same-family claims.
 - Name law_family, falsified_law, owner_boundary, model_state, kernel_fold, alternatives_considered, and evidence_refs for valid or contested findings.
-- Decide the correct review disposition: reject, proof-only, accepted-liability, ask-human, follow-up, or blocked.
-- Keep finding-level mutation authority disabled; a code-change candidate is not mutation authority.
+- Decide the correct review disposition: reject, proof-only, ask-human, follow-up, or blocked.
+- Keep finding-level mutation authority disabled; refactor-kernel pressure is not mutation authority.
 - Preserve blocked findings and resolution-fold gating fields when a liability needs follow-up before implementation.
 
 Prefer no-code proof or rejection when appropriate.
-Prefer kernel_fold.status: structural when many comments share one owner boundary.
-When kernel pressure is high, do not emit kernel_fold.status: point unless point_safety is proven with evidence; otherwise use structural, unknown, or blocked.
+Prefer kernel_fold.status: refactor-kernel when many comments share one owner boundary.
+When kernel pressure is high, use refactor-kernel with evidence or unknown with proof_gap and next_evidence_action; do not shrink it to a local patch.
 Do not post PR comments or resolve threads.
 Do not mutate files.
 Do not choose or run a fresh review backend.
 Do not claim terminal review closure.
 
-Return RF-v1.4 review_fold with source_ref, kernel_fold, code_change_candidate, and finding_mutation_authority on every finding. If the full schema would be too large for the current handoff, return an RF-v1.4 compact block with source_ref including backend or explicit unknown backend, lane_role when known, head_sha, target_fingerprint, validity, liability, intent_relation, disposition, kernel_fold, owner_boundary, law_family, evidence_refs, clean_run effect when applicable, and finding_mutation_authority.allowed: no.
+Return RF-v1.5 review_fold with source_ref, kernel_fold, and finding_mutation_authority on every finding. If the full schema would be too large for the current handoff, return an RF-v1.5 compact block with source_ref including backend or explicit unknown backend, lane_role when known, head_sha, target_fingerprint, validity, liability, intent_relation, disposition, kernel_fold, owner_boundary, law_family, evidence_refs, clean_run effect when applicable, and finding_mutation_authority.allowed: no.
 
-Shortcut prose is not a receipt. Material fold trigger classes are semantic, not literal phrase matching: acceptance shortcut, repair shortcut, proof-gap shortcut, clean-run accounting, thread disposition, grouped-liability / owner-boundary shortcut, and source-batch boundary. Emit full RF-v1.4 or RF-v1.4 compact before material decisions reach the resolution fold, mutation planning, closeout accounting, or public review-thread handling.
+Shortcut prose is not a receipt. Material fold trigger classes are semantic, not literal phrase matching: acceptance shortcut, repair shortcut, proof-gap shortcut, clean-run accounting, thread disposition, grouped-liability / owner-boundary shortcut, and source-batch boundary. Emit full RF-v1.5 or RF-v1.5 compact before material decisions reach the resolution fold, mutation planning, closeout accounting, or public review-thread handling.
 
-Earlier RF receipts do not cover later review attempts, follow-up finding batches, reopened thread batches, dirty clean-run attempts, or thread-disposition batches. Emit a fresh RF-v1.4 compact/full receipt for each new source batch.
+Earlier RF receipts do not cover later review attempts, follow-up finding batches, reopened thread batches, dirty clean-run attempts, or thread-disposition batches. Emit a fresh RF-v1.5 compact/full receipt for each new source batch.
 '''

--- a/codex/skills/cas/agents/openai.yaml
+++ b/codex/skills/cas/agents/openai.yaml
@@ -11,4 +11,5 @@ interface:
     identity fields such as findingId, findingFingerprint, reviewAttemptId,
     laneRole, reviewThreadId, reviewTurnId, headSha, and targetFingerprint.
     CAS records evidence; caller workflows certify meaning, clean streaks,
-    review-fold disposition, kernel status, and mutation authority.
+    review-fold disposition, refactor-kernel status, unknown quarantine, and
+    mutation authority.

--- a/codex/skills/goal-workgraph/SKILL.md
+++ b/codex/skills/goal-workgraph/SKILL.md
@@ -88,15 +88,15 @@ work_graph:
 1. Emit `parallel_safe: yes` only when dependencies are satisfied, paths/resources do not conflict, and the proof surface is known.
 2. Use `scout-fanout` only for read-only fact finding.
 3. Use `review-class-fanout` only after CAS findings have been grouped.
-4. Use `patch-fanout` only after the resolution fold accepts code-change liabilities.
+4. Use `patch-fanout` only after the resolution fold accepts refactor-kernel work nodes.
 5. Use `branch-race` only when all strategies share the same verifier.
 6. Mark shared invariants, shared files, or shared owner-boundary fixes as `parallel_safe: no`.
-7. Consume `$review-fold` `kernel_fold.status`: `structural` becomes one owner-level work node, `point` may become one bounded node, and `unknown` must inspect, ask, block, or branch-race before mutation.
+7. Consume `$review-fold` `kernel_fold.status`: `refactor-kernel` may become one owner-level work node, `none` cannot produce edit work, and `unknown` must inspect, ask, block, branch-race, or reclassify before mutation.
 8. Do not let subagents update public tracker state, resolve threads, or declare completion.
 
 ## Reabstraction trigger
 
-When review or failure nodes share any of the following, prefer a structural kernel node over local patches:
+When review or failure nodes share any of the following, prefer a refactor-kernel node over local patches:
 
 ```text
 same invariant violated in multiple places

--- a/codex/skills/review-fold/SKILL.md
+++ b/codex/skills/review-fold/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: review-fold
-description: "Compress review pressure into intent-anchored kernel-fold decisions: classify findings, reject non-liabilities, identify accepted liabilities, attach a kernel account to every material finding, and prevent review prose from becoming mutation authority. Use after reviewer comments, PR threads, CAS-backed review evidence, human review, prior artifacts, local audit output, or review-like claims. Owns active review finding classification for goal workflows; does not own review backend selection, closeout policy, resolution planning, or implementation authority."
+description: "Compress review pressure into intent-anchored kernel-fold decisions: classify findings, reject non-liabilities, attach a refactor-kernel account to every material finding, quarantine unknowns, and prevent review prose from becoming mutation authority. Use after reviewer comments, PR threads, CAS-backed review evidence, human review, prior artifacts, local audit output, or review-like claims. Owns active review finding classification for goal workflows; does not own review backend selection, closeout policy, resolution planning, or implementation authority."
 metadata:
-  version: "1.6.0"
+  version: "1.7.0"
   activation_cost: medium
   default_depth: high
 ---
@@ -17,8 +17,8 @@ patch queue.
 ```text
 review findings + goal contract + current artifact state
 -> review fold
--> reject | proof-only | accepted-liability | ask-human | follow-up | blocked
--> kernel_fold: none | point | structural | unknown
+-> reject | proof-only | ask-human | follow-up | blocked
+-> kernel_fold: none | refactor-kernel | unknown
 ```
 
 `$review-fold` is the review-specific evidence reducer for goal workflows. It
@@ -61,13 +61,13 @@ The normal review-closeout chain is:
 review source evidence
 -> $review-fold finding classification + kernel_fold
 -> resolution fold work-node decision
--> implementation only for accepted liabilities with valid mutation authority
+-> implementation only for refactor-kernel work with valid mutation authority
 -> evidence fold / proof / terminal closure gate
 ```
 
-A review finding never grants mutation authority by itself. A code-change
-candidate becomes implementation work only after the resolution fold accepts it
-and the actuation loop has valid mutation authority.
+A review finding never grants mutation authority by itself. A material
+`refactor-kernel` becomes implementation work only after the resolution fold
+accepts it and the actuation loop has valid mutation authority.
 
 ## Minimal review law
 
@@ -78,7 +78,7 @@ claim != fact
 fact != liability
 liability != scope
 scope != code change
-code-change candidate != mutation authority
+code-change pressure != mutation authority
 kernel fold != repair plan
 ```
 
@@ -88,7 +88,7 @@ Operationally:
 - A true observation is not automatically branch-liable.
 - A branch-liable observation is not automatically in accepted scope.
 - An in-scope liability is not automatically a code change.
-- A code-change candidate is not mutation authority until the resolution fold accepts it.
+- Code-change pressure is not mutation authority until the resolution fold accepts a work node.
 - A kernel account classifies shape and pressure; it does not choose the patch.
 
 This is a routing guard, not a counterexample compiler. Do not introduce CEX,
@@ -121,11 +121,11 @@ Rules:
 - PR thread IDs are source references only. Do not resolve threads, post replies, or mutate public review state without explicit public-side-effect intent.
 - If fresh workflow review is required but no review source evidence is present, `$review-fold` reports a source blocker and hands control to the caller or review-source owner.
 
-## RF-v1.4 schema
+## RF-v1.5 schema
 
 ```yaml
 review_fold:
-  version: RF-v1.4
+  version: RF-v1.5
   goal_id:
   source:
     backend: cas|github-comments|human-review|prior-artifact|local-audit|other|unknown
@@ -163,26 +163,27 @@ review_fold:
       law_family:
       falsified_law:
       owner_boundary:
-      model_state: intact|point-gap|structural-gap|unknown
+      model_state: intact|kernel-gap|unknown
       validity: valid|invalid|unproven|needs-owner
       liability: blocks-goal|regression-risk|style|new-requirement|out-of-scope|proof-gap|misuse-hazard|invariant-gap|complexity-stall
       intent_relation: core|adjacent|unrelated|expands-scope
       novelty: duplicate|same-class|new-class
-      disposition: reject|proof-only|accepted-liability|ask-human|follow-up|blocked
+      disposition: reject|proof-only|ask-human|follow-up|blocked
       kernel_fold:
-        status: none|point|structural|unknown
+        status: none|refactor-kernel|unknown
         pressure: none|low|medium|high
         equivalence_class:
         owner_boundary:
         law_family:
         falsifier:
-        point_safety: proven|not-proven|not-applicable
+        boundary_proof: proven|not-proven|not-applicable
+        proof_gap:
+        next_evidence_action: inspect-more|ask-human|blocked|branch-race|reclassify
         evidence_refs: []
       minimal_response:
       proof_needed:
       alternatives_considered: []
       evidence_refs: []
-      code_change_candidate: yes|no
       finding_mutation_authority:
         allowed: no
         reason:
@@ -197,8 +198,8 @@ review_fold:
     review_mode: triage|remediation-plan|review-closeout
     reason:
     no_code_modifier_detected: yes|no
-    accepted_liability_count:
-    structural_kernel_candidate_count:
+    refactor_kernel_count:
+    quarantined_unknown_count:
     clean_run_accounting:
       applies: yes|no
       normalized_clean_this_source: yes|no|not-applicable
@@ -213,24 +214,24 @@ review_fold:
     unsafe_parallel_reasons: []
 ```
 
-RF-v1.4 is a finding-classification and kernel-account receipt. It is not a
+RF-v1.5 is a finding-classification and kernel-account receipt. It is not a
 resolution plan, graph-control receipt, proof receipt, PR publication receipt,
 or terminal completion proof.
 
 ## Compact receipt floor
 
-Full RF-v1.4 is preferred for artifacts, handoffs, and review bundles. For
+Full RF-v1.5 is preferred for artifacts, handoffs, and review bundles. For
 progress updates or tight review-closeout loops, do not collapse a material
 fold to bare prose such as `valid liability` or `threads are clean`.
 
-Emit at least one joinable block headed `RF-v1.4 compact:` whenever a fold
+Emit at least one joinable block headed `RF-v1.5 compact:` whenever a fold
 affects mutation, clean-run accounting, thread disposition, blocker state, or
 closure state.
 
 Minimum compact fields:
 
 ```yaml
-RF-v1.4 compact:
+RF-v1.5 compact:
   source_ref:
     backend: cas|github-comments|human-review|prior-artifact|local-audit|other|unknown
     source_batch_id:
@@ -244,15 +245,17 @@ RF-v1.4 compact:
   validity: valid|invalid|unproven|needs-owner
   liability: blocks-goal|regression-risk|style|new-requirement|out-of-scope|proof-gap|misuse-hazard|invariant-gap|complexity-stall
   intent_relation: core|adjacent|unrelated|expands-scope
-  disposition: reject|proof-only|accepted-liability|ask-human|follow-up|blocked
+  disposition: reject|proof-only|ask-human|follow-up|blocked
   kernel_fold:
-    status: none|point|structural|unknown
+    status: none|refactor-kernel|unknown
     pressure: none|low|medium|high
     equivalence_class:
     owner_boundary:
     law_family:
     falsifier:
-    point_safety: proven|not-proven|not-applicable
+    boundary_proof: proven|not-proven|not-applicable
+    proof_gap:
+    next_evidence_action: inspect-more|ask-human|blocked|branch-race|reclassify
     evidence_refs: []
   owner_boundary:
   law_family:
@@ -290,7 +293,7 @@ source-batch boundary
 
 Examples:
 
-- “valid finding,” “accepted liability,” “both findings are liabilities,” or a severity label used as acceptance is an acceptance shortcut.
+- "valid finding," "in-scope liability," "both findings are liabilities," or a severity label used as acceptance is an acceptance shortcut.
 - “owner fix,” “clean fix,” or “next patch” is a repair shortcut when it points to mutation; the fold must record kernel status and disabled mutation authority before resolution.
 - “proof gaps remain” or “proof gaps resolved” is a proof-gap shortcut.
 - “review attempt is clean,” “clean streak advances,” or “counter resets” is clean-run accounting.
@@ -298,18 +301,17 @@ Examples:
 - “same owner boundary,” “same class,” or “larger repeated class” is grouped-liability pressure.
 - A later review attempt, follow-up finding batch, reopened thread batch, or dirty clean-run attempt is a new source-batch boundary.
 
-Emit a full or compact RF-v1.4 receipt before any such decision reaches the
+Emit a full or compact RF-v1.5 receipt before any such decision reaches the
 resolution fold, mutation planning, closeout accounting, or public review-thread
 handling.
 
 ## Disposition law
 
-- `reject`: claim is false, stale, duplicate with no new proof value, unrelated, already handled, incompatible with the goal, or merely preference/style without accepted liability.
+- `reject`: claim is false, stale, duplicate with no new proof value, unrelated, already handled, incompatible with the goal, or merely preference/style without goal authority.
 - `proof-only`: current code likely satisfies the goal and the right response is proof, inspection, or reviewer explanation before editing.
-- `accepted-liability`: one or more valid, in-scope liabilities may be considered by the resolution fold; the kernel account still decides whether the evidence is point, structural, or unknown.
 - `ask-human`: review introduces a product, compatibility, API, UX, performance, security, or scope decision.
 - `follow-up`: valid but not part of the intended change.
-- `blocked`: validity, liability, current artifact state, review source, accepted scope, or kernel status is unclear enough that implementation would be guesswork.
+- `blocked`: validity, liability, current artifact state, review source, accepted scope, kernel status, unresolved refactor-kernel pressure, or unknown quarantine prevents closure or direct implementation.
 
 Deterministic downroutes:
 
@@ -324,25 +326,27 @@ duplicate/same-class -> compress; do not create a new implementation distinction
 ```
 
 A finding row never grants mutation authority. It only marks whether the
-resolution fold may consider code-changing work.
+resolution fold may consider no-code/control disposition or a refactor-kernel.
+When `kernel_fold.status: refactor-kernel`, use `disposition: blocked` to mark
+the current review source closure-blocked until the resolution fold acts. When
+`kernel_fold.status: unknown`, use `blocked` or `ask-human`; no other
+disposition may carry unknown material pressure.
 
 ## Kernel fold law
 
 Every finding receives a `kernel_fold`.
 
 - `none`: no in-scope code liability remains after rejection, proof, follow-up, or human-owned scope handling.
-- `point`: the liability is owner-correct, bounded to one kernel boundary, has no live same-family pressure, and records `point_safety: proven`.
-- `structural`: multiple findings, repeated classes, shared owner boundaries, shared invariants, or repeated proof obligations require one normal-form owner correction.
-- `unknown`: the fold cannot prove whether the liability is point or structural; the next owner must block, inspect, ask, or branch-race before mutation.
+- `refactor-kernel`: material review pressure requires one owner-boundary kernel account before any code-changing work can be planned.
+- `unknown`: the fold cannot prove whether a material kernel is required; it must record `proof_gap` and `next_evidence_action`, and the next owner must block, inspect, ask, branch-race, or reclassify before mutation.
 
-When `kernel_fold.pressure: high`, do not silently emit `status: point`. A point
-kernel under high pressure is valid only with `point_safety: proven` and
-evidence that same-family pressure is absent or already owned by the selected
-boundary. Otherwise emit `structural`, `unknown`, or `blocked`.
+When `kernel_fold.pressure: high`, do not silently shrink material pressure to a
+local patch. Emit `status: refactor-kernel` with an owner boundary or
+equivalence class, or emit `unknown`/`blocked` with the missing proof named.
 
-Downstream implementation may realize `status: point` as a small owner-boundary
-change. That realization is not a review-fold output; it belongs to the
-resolution fold and the actuation loop.
+Downstream implementation may realize a refactor-kernel as a small
+owner-boundary change when `boundary_proof: proven`. That realization is not a
+separate review-fold route; it belongs to the resolution fold and actuation loop.
 
 ## Modes
 
@@ -350,7 +354,7 @@ resolution fold and the actuation loop.
 
 - `triage`: classify findings and stop without a remediation agenda or implementation.
 - `remediation-plan`: classify findings and produce resolution inputs without implementation.
-- `review-closeout`: classify findings, preserve no-code dispositions, hand accepted liabilities and kernel accounts to the resolution fold, and let the caller workflow prove closure.
+- `review-closeout`: classify findings, preserve no-code dispositions, hand refactor-kernel accounts to the resolution fold, and let the caller workflow prove closure.
 
 ## Clean-run and exhaustive-review behavior
 
@@ -359,9 +363,9 @@ When the caller has a review-closeout or exhaustive-review proof bar,
 blocking, or reset-worthy. The caller owns the clean-run counter, proof bar,
 backend, and terminal completion gate.
 
-A normalized clean review source means no new in-scope accepted liability,
-unresolved proof gap, unresolved structural kernel candidate, unknown kernel,
-or human-owned blocker remains after `$review-fold` and the resolution fold.
+A normalized clean review source means no new in-scope refactor-kernel,
+unresolved proof gap, unknown kernel, or human-owned blocker remains after
+`$review-fold` and the resolution fold.
 
 Duplicate, rejected, out-of-scope, already-proven proof-only, follow-up,
 already-resolved findings, and clean auxiliary evidence do not make the source
@@ -375,7 +379,7 @@ artifact changed
 review scope changed
 base/head/diff changed
 proof bar changed
-accepted auxiliary remediation changed the artifact
+artifact-changing auxiliary remediation changed the artifact
 review source continuity is lost
 ```
 
@@ -391,16 +395,16 @@ caller-required exhaustive review gate into a no-review closure.
 5. Reject, block, ask, or follow up before code whenever validity, liability, scope, or kernel status is not established.
 6. Preserve source refs when present: backend, source batch, finding identity, review/thread identity, lane role, head SHA, and target fingerprint.
 7. Name falsified law, owner boundary, model state, and kernel fold when a finding is valid or unresolved.
-8. Emit full RF-v1.4 or the compact receipt floor before any material fold leaves `$review-fold`.
+8. Emit full RF-v1.5 or the compact receipt floor before any material fold leaves `$review-fold`.
 9. Treat material fold classes as semantic triggers, not literal phrase matching.
 10. Treat each new review attempt, follow-up finding batch, reopened thread batch, thread disposition, or dirty clean-run attempt as a new receipt scope.
 11. Collapse duplicates and same-family comments across sources and lanes.
 12. Mark whether the current source is normalized clean and whether the caller's clean-run accounting should increment, reset, stay unchanged, or block.
-13. Recommend `triage`, `remediation-plan`, or `review-closeout` from the user's requested mode and accepted liabilities.
-14. Decide whether each finding's proper review response is no code, proof, accepted liability, ask, follow-up, or block.
-15. Emit `kernel_fold.status: structural` or `unknown` when repeated owner-boundary pressure cannot be safely proven point.
+13. Recommend `triage`, `remediation-plan`, or `review-closeout` from the user's requested mode and refactor-kernel pressure.
+14. Decide whether each finding's proper review response is no code, proof, refactor-kernel, ask, follow-up, or block.
+15. Emit `kernel_fold.status: refactor-kernel` or `unknown` when repeated owner-boundary pressure cannot be safely dismissed.
 16. Mark review-class fanout safe only for classification/investigation classes; raw findings must not fan out directly to patch workers.
-17. Produce resolution inputs only for accepted liabilities and only after the resolution fold accepts code-changing work.
+17. Produce resolution inputs only for refactor-kernel findings and only after the resolution fold accepts code-changing work.
 18. Preserve reviewer response drafts as drafts; do not post public comments unless explicitly asked.
 
 ## Default behavior in `$actuating`
@@ -464,10 +468,10 @@ uv run python -m unittest discover codex/skills/review-fold/tests
 - Raw review text is not executable.
 - Do not add code to satisfy style or speculation when proof or rejection is correct.
 - Do not accept scope expansion without user authority.
-- Do not miss the structural kernel when many comments share one owner boundary.
+- Do not miss the refactor-kernel when many comments share one owner boundary.
 - Do not make `$review-fold` a review-backend transcript parser.
 - Do not count auxiliary evidence as standard clean-review evidence.
 - Do not store caller-owned review profile policy only in source-transport fields.
-- Do not let accepted liabilities, blockers, clean-run decisions, or thread dispositions leave only as unjoinable prose.
+- Do not let refactor-kernel findings, blockers, clean-run decisions, or thread dispositions leave only as unjoinable prose.
 - Do not let one RF receipt for an earlier source batch stand in for later findings, dirty clean-run attempts, or reopened thread batches.
 - Do not claim review closure when the caller's terminal proof bar still requires review evidence, proof, delivery, or ATCG.

--- a/codex/skills/review-fold/agents/openai.yaml
+++ b/codex/skills/review-fold/agents/openai.yaml
@@ -2,7 +2,7 @@ policy:
   allow_implicit_invocation: true
 interface:
   display_name: "Review Fold"
-  short_description: "Classify review findings, emit RF-v1.4 kernel-fold receipts, and keep mutation authority disabled"
+  short_description: "Classify review findings, emit RF-v1.5 refactor-kernel receipts, and keep mutation authority disabled"
   default_prompt: >-
     Use $review-fold for review findings, PR comments, reviewer suggestions,
     CAS-backed review evidence, human review, prior artifacts, local audit
@@ -22,8 +22,8 @@ interface:
     falsified_law, owner_boundary, model_state, alternatives_considered, and
     evidence_refs.
 
-    Return full RF-v1.4 when practical. When the full schema is too large,
-    emit an RF-v1.4 compact block before any material fold leaves review-fold:
+    Return full RF-v1.5 when practical. When the full schema is too large,
+    emit an RF-v1.5 compact block before any material fold leaves review-fold:
     source_ref with backend or explicit unknown source, lane_role when known,
     head_sha, target_fingerprint, validity, liability, intent_relation,
     disposition, kernel_fold, owner_boundary, law_family, evidence_refs,
@@ -34,16 +34,16 @@ interface:
     acceptance shortcut, repair shortcut, proof-gap shortcut, clean-run
     accounting, thread disposition, grouped-liability / owner-boundary
     shortcut, and source-batch boundary. Shortcut prose is not a receipt.
-    Emit full RF-v1.4 or RF-v1.4 compact before accepted liabilities,
+    Emit full RF-v1.5 or RF-v1.5 compact before refactor-kernel findings,
     blockers, clean-run decisions, thread dispositions, kernel decisions, or
     repair directions reach the resolution fold, mutation planning, closeout
     accounting, or public review-thread handling.
 
-    A finding is never mutation authority. A code-change candidate remains
-    advisory until the resolution fold accepts a work node and the caller
-    workflow has valid mutation authority. Prefer no-code outcomes when
-    correct: reject, proof-only, follow-up, ask-human, or blocked. If kernel
-    pressure is high, do not emit kernel_fold.status: point unless
-    point_safety is proven with evidence; otherwise use structural, unknown,
-    or blocked. Do not post PR comments, resolve threads, mutate files, choose
+    A finding is never mutation authority. Material code pressure is represented
+    only by kernel_fold.status: refactor-kernel, and even that remains advisory
+    until the resolution fold accepts a work node and the caller workflow has
+    valid mutation authority. Prefer no-code outcomes when correct: reject,
+    proof-only, follow-up, ask-human, or blocked. If kernel pressure is high,
+    use refactor-kernel with evidence or unknown with proof_gap and
+    next_evidence_action; do not shrink it to a local patch. Do not post PR comments, resolve threads, mutate files, choose
     a fresh review backend, or claim terminal review closure.

--- a/codex/skills/review-fold/references/decision-contract.yaml
+++ b/codex/skills/review-fold/references/decision-contract.yaml
@@ -3,7 +3,7 @@ skill_decision_contract:
   skill:
     name: review-fold
     kind: mixed
-    source_fingerprint: review-fold-v1.6.0-kernel-fold-receipt-gate
+    source_fingerprint: review-fold-v1.7.0-refactor-kernel-receipt-gate
   triggers:
     - trigger_id: RF-REVIEW-FINDING
       description: Review pressure from any backend needs classification against the accepted goal and current artifact.
@@ -17,12 +17,12 @@ skill_decision_contract:
       exclusions: [existing current review evidence supplied]
     - trigger_id: RF-MATERIAL-FOLD
       description: A review-related statement accepts, rejects, blocks, accounts for clean-run state, or disposes of review threads.
-      cue_literals: [accepted liability, valid finding, owner fix, clean fix, proof gap, clean run, clean streak, thread resolved, no unresolved threads, same owner boundary, same-class finding]
+      cue_literals: [in-scope liability, valid finding, owner fix, clean fix, proof gap, clean run, clean streak, thread resolved, no unresolved threads, same owner boundary, same-class finding]
       cue_regexes: []
       exclusions: [non-decisional discussion]
     - trigger_id: RF-KERNEL-PRESSURE
       description: Multiple findings share an owner boundary, missing invariant, proof surface, or patch-per-comment risk.
-      cue_literals: [same owner boundary, same-class finding, repeated accepted liabilities, patch-per-comment, structural kernel, kernel pressure]
+      cue_literals: [same owner boundary, same-class finding, repeated in-scope liabilities, patch-per-comment, refactor-kernel, kernel pressure]
       cue_regexes: []
       exclusions: []
     - trigger_id: RF-SOURCE-BATCH-BOUNDARY
@@ -43,13 +43,9 @@ skill_decision_contract:
       description: Require evidence, inspection, or reviewer explanation rather than code.
       aliases: [proof-only]
       terminal: yes
-    - route_id: RF-ACCEPTED-LIABILITY
-      description: Accept an in-scope liability for resolution-fold consideration while preserving disabled mutation authority.
-      aliases: [accepted-liability]
-      terminal: no
     - route_id: RF-KERNEL-FOLD
-      description: Attach point, structural, none, or unknown kernel status to every material finding.
-      aliases: [kernel-fold, structural-kernel, point-kernel, unknown-kernel]
+      description: Attach none, refactor-kernel, or unknown kernel status to every finding.
+      aliases: [kernel-fold, refactor-kernel, unknown-kernel]
       terminal: no
     - route_id: RF-ASK-HUMAN
       description: Ask for product, API, compatibility, UX, performance, security, or scope authority.
@@ -67,36 +63,36 @@ skill_decision_contract:
     - clause_id: RF-SOURCE-001
       trigger_refs: [RF-REVIEW-SOURCE-NEEDED]
       expected_routes: [RF-SOURCE-BLOCK, RF-BLOCK]
-      prohibited_routes: [RF-ACCEPTED-LIABILITY]
+      prohibited_routes: [RF-KERNEL-FOLD]
       required_artifacts: [caller-owned review requirement, current review source evidence or explicit source blocker]
       success_signals: [review-fold does not invent fresh review output, backend policy remains owned by the caller workflow, absent current review evidence blocks classification-dependent mutation]
       failure_signals: [review-fold substitutes generic critique for required fresh review evidence, backend-specific transport details become review-fold policy, stale review source is treated as current]
       rationale: Review-fold classifies review evidence; it does not select or run the review backend.
     - clause_id: RF-CLASSIFY-001
       trigger_refs: [RF-REVIEW-FINDING]
-      expected_routes: [RF-REJECT, RF-PROOF-ONLY, RF-ACCEPTED-LIABILITY, RF-ASK-HUMAN, RF-FOLLOW-UP, RF-BLOCK]
+      expected_routes: [RF-REJECT, RF-PROOF-ONLY, RF-KERNEL-FOLD, RF-ASK-HUMAN, RF-FOLLOW-UP, RF-BLOCK]
       prohibited_routes: []
       required_artifacts: [source refs when present, validity, liability, intent relation, owner boundary for valid or unresolved findings, kernel fold, finding mutation authority disabled]
-      success_signals: [claim fact and suggested repair are separated, code-change candidates remain gated by the resolution fold, no-code dispositions remain available]
-      failure_signals: [raw review prose directly drives mutation, style preference becomes code without accepted liability, accepted finding lacks owner boundary, finding_mutation_authority.allowed is yes]
+      success_signals: [claim fact and suggested repair are separated, refactor-kernel pressure remains gated by the resolution fold, no-code dispositions remain available]
+      failure_signals: [raw review prose directly drives mutation, style preference becomes code without refactor-kernel, material finding lacks owner boundary, finding_mutation_authority.allowed is yes]
       rationale: The fold turns review pressure into dispositions and kernel accounts, not implementation authority.
     - clause_id: RF-RECEIPT-001
       trigger_refs: [RF-MATERIAL-FOLD, RF-SOURCE-BATCH-BOUNDARY]
-      expected_routes: [RF-REJECT, RF-PROOF-ONLY, RF-ACCEPTED-LIABILITY, RF-ASK-HUMAN, RF-FOLLOW-UP, RF-BLOCK]
+      expected_routes: [RF-REJECT, RF-PROOF-ONLY, RF-KERNEL-FOLD, RF-ASK-HUMAN, RF-FOLLOW-UP, RF-BLOCK]
       prohibited_routes: []
-      required_artifacts: [full RF-v1.4 or RF-v1.4 compact receipt for material folds, source_ref with backend or explicit unknown backend, kernel_fold on every finding, clean-run count effect when applicable, fresh receipt for each new review source batch or thread disposition]
+      required_artifacts: [full RF-v1.5 or RF-v1.5 compact receipt for material folds, source_ref with backend or explicit unknown backend, kernel_fold on every finding, clean-run count effect when applicable, fresh receipt for each new review source batch or thread disposition]
       success_signals: [future seq tune audits can recover the decision episode, source refs are joinable without backend-specific prose parsing, later dirty attempts or follow-up batches have their own receipts]
-      failure_signals: [accepted liability appears only as terse prose, kernel status precedes a receipt, proof-gap or clean-run accounting appears without a receipt, thread disposition cannot be joined back to a source, follow-up findings reuse an earlier receipt]
+      failure_signals: [material liability appears only as terse prose, kernel status precedes a receipt, proof-gap or clean-run accounting appears without a receipt, thread disposition cannot be joined back to a source, follow-up findings reuse an earlier receipt]
       rationale: Material folds must remain observable after compaction and session shadowing.
     - clause_id: RF-KERNEL-001
       trigger_refs: [RF-KERNEL-PRESSURE]
       expected_routes: [RF-KERNEL-FOLD, RF-BLOCK, RF-ASK-HUMAN]
       prohibited_routes: []
-      required_artifacts: [equivalence class or owner boundary, kernel pressure, point safety when status is point, evidence refs for high-pressure point claims]
-      success_signals: [same-class findings are compressed, point kernel proves why no structural kernel remains, unknown kernel blocks mutation]
-      failure_signals: [repeated same-boundary findings continue as silent local fixes, structural kernel is skipped without evidence, high-pressure point status lacks proof]
+      required_artifacts: [equivalence class or owner boundary, kernel pressure, boundary proof when boundedness is claimed, proof_gap and next_evidence_action when status is unknown]
+      success_signals: [same-class findings are compressed, refactor-kernel owns material pressure, unknown kernel blocks mutation]
+      failure_signals: [repeated same-boundary findings continue as silent local fixes, refactor-kernel is skipped without evidence, unknown kernel becomes patch authority]
       rationale: The skill prevents review pressure from becoming one patch per comment.
   instrumentation:
     decision_receipt: required
     validator: codex/skills/review-fold/tools/review_fold_receipt_gate.py
-    rationale: Emit full RF-v1.4 or the compact receipt floor for material folds, clean-run accounting, blockers, source-batch boundaries, and thread dispositions.
+    rationale: Emit full RF-v1.5 or the compact receipt floor for material folds, clean-run accounting, blockers, source-batch boundaries, and thread dispositions.

--- a/codex/skills/review-fold/references/material-fold-triggers.yaml
+++ b/codex/skills/review-fold/references/material-fold-triggers.yaml
@@ -5,15 +5,15 @@ material_fold_triggers:
     illustrative; do not tune the skill by adding every observed transcript
     phrase to the main prompt.
   receipt_rule: >
-    If the statement changes accepted validity, liability, scope, kernel
+    If the statement changes validity, liability, scope, kernel
     status, clean-run accounting, thread disposition, blocker state, or closure
-    state, emit full RF-v1.4 or RF-v1.4 compact before the decision reaches
+    state, emit full RF-v1.5 or RF-v1.5 compact before the decision reaches
     resolution, mutation planning, closeout accounting, or public review thread
     handling.
   classes:
     - id: acceptance_shortcut
       meaning: A terse statement accepts or rejects validity, liability, severity, or in-scope status.
-      backend_neutral_examples: [valid finding, accepted liability, both findings are liabilities, severity label used as acceptance]
+      backend_neutral_examples: [valid finding, in-scope liability, both findings are liabilities, severity label used as acceptance]
       required_receipt_effect: finding disposition and kernel_fold before resolution planning
     - id: repair_shortcut
       meaning: A statement names the owner fix, clean fix, next patch, or mutation path.
@@ -32,9 +32,9 @@ material_fold_triggers:
       backend_neutral_examples: [no unresolved threads, thread sweep is clean, targeted threads resolved, reopened thread batch]
       required_receipt_effect: thread source_ref and disposition before public-side-effect handling
     - id: grouped_liability
-      meaning: A statement collapses multiple findings into a repeated class, owner boundary, or structural kernel candidate.
+      meaning: A statement collapses multiple findings into a repeated class, owner boundary, or refactor-kernel candidate.
       backend_neutral_examples: [same owner boundary, same class, larger repeated class, shared missing invariant]
-      required_receipt_effect: equivalence class, owner_boundary, kernel pressure, point_safety, and kernel_fold
+      required_receipt_effect: equivalence class, owner_boundary, kernel pressure, boundary_proof, and kernel_fold
     - id: source_batch_boundary
       meaning: A later review source batch appears after an earlier receipt.
       backend_neutral_examples: [new review attempt, follow-up finding batch, reopened thread batch, dirty clean-run attempt]

--- a/codex/skills/review-fold/references/review-modes.md
+++ b/codex/skills/review-fold/references/review-modes.md
@@ -11,7 +11,7 @@ Explicit review mode names carry the mutation rule:
 ```text
 triage -> classify findings and stop without implementation
 remediation-plan -> produce resolution inputs and stop without implementation
-review-closeout -> hand accepted liabilities to resolution, then prove closure
+review-closeout -> hand refactor-kernel findings to resolution, then prove closure
 ```
 
 `review-closeout` still preserves no-code dispositions. A review with ten
@@ -22,8 +22,7 @@ findings may close as:
 2 proof-only
 1 follow-up
 1 ask-human
-3 accepted under one structural kernel
-1 accepted under a proven point kernel
+4 folded under one refactor-kernel
 ```
 
 It must not become ten local patches.
@@ -34,23 +33,21 @@ It must not become ten local patches.
 |---|---|---|
 | `reject` | False, duplicate, out-of-scope, or incompatible with the accepted goal. | No |
 | `proof-only` | The right answer is evidence, not code. | No by default |
-| `accepted-liability` | A valid in-scope liability may be considered by the resolution fold. | Advisory only |
 | `ask-human` | The review introduces a product/API/compatibility decision. | No |
 | `follow-up` | Valid but outside the intended change. | No in current PR |
-| `blocked` | Validity, scope, source, current artifact, or kernel status is unclear. | No |
+| `blocked` | Closure or direct implementation is blocked by unclear state, unresolved refactor-kernel pressure, or unknown quarantine. | No |
 
 ## Kernel status
 
 | Status | Meaning | Resolution implication |
 |---|---|---|
 | `none` | No in-scope code liability remains. | No code |
-| `point` | One owner boundary is enough and `point_safety: proven`. | May become one bounded work node |
-| `structural` | Same-family pressure needs one normal-form owner correction. | Must not split by comment |
-| `unknown` | The fold cannot prove point versus structural. | Inspect, ask, or block before mutation |
+| `refactor-kernel` | Material pressure needs one owner-boundary kernel account. | May become one owner-level work node |
+| `unknown` | The fold cannot prove whether a material kernel is required. | Inspect, ask, block, branch-race, or reclassify before mutation |
 
 ## Reabstraction tests
 
-Choose `kernel_fold.status: structural` when at least two are true:
+Choose `kernel_fold.status: refactor-kernel` when at least two are true:
 
 - multiple comments mention the same state, transition, or boundary;
 - fixes would add similar guards/helpers in multiple files;
@@ -65,8 +62,7 @@ The minimal correct response may be:
 
 - a short proof note;
 - a no-code rejection;
-- a proven point kernel;
-- a structural kernel;
+- a refactor-kernel with `boundary_proof: proven`;
 - a human-owned decision;
 - a blocker because the kernel status is unknown.
 

--- a/codex/skills/review-fold/tests/test_contract.py
+++ b/codex/skills/review-fold/tests/test_contract.py
@@ -13,8 +13,9 @@ CONTRACT = (ROOT / "references" / "decision-contract.yaml").read_text(encoding="
 TRIGGERS = (ROOT / "references" / "material-fold-triggers.yaml").read_text(encoding="utf-8")
 MODES = (ROOT / "references" / "review-modes.md").read_text(encoding="utf-8")
 REDUCER = (CODEX_ROOT / "agents" / "review-reducer.toml").read_text(encoding="utf-8")
+GOAL_WORKGRAPH = (CODEX_ROOT / "skills" / "goal-workgraph" / "SKILL.md").read_text(encoding="utf-8")
 NORMALIZED_PROMPTS = " ".join((AGENT + "\n" + REDUCER).split())
-LIVE_REVIEW_FOLD_SURFACES = "\n".join([SKILL, AGENT, CONTRACT, TRIGGERS, MODES, REDUCER])
+LIVE_REVIEW_FOLD_SURFACES = "\n".join([SKILL, AGENT, CONTRACT, TRIGGERS, MODES, REDUCER, GOAL_WORKGRAPH])
 
 
 class ReviewFoldContractTests(unittest.TestCase):
@@ -35,9 +36,9 @@ class ReviewFoldContractTests(unittest.TestCase):
         self.assertNotIn("CAS review lanes", SKILL)
         self.assertNotIn("Supported CAS-backed review lanes", SKILL)
 
-    def test_rf_v14_schema_has_generic_joinable_source_refs(self) -> None:
+    def test_rf_v15_schema_has_generic_joinable_source_refs(self) -> None:
         required = [
-            "version: RF-v1.4",
+            "version: RF-v1.5",
             "source_ref:",
             "backend: cas|github-comments|human-review|prior-artifact|local-audit|other|unknown",
             "source_batch_id",
@@ -55,20 +56,24 @@ class ReviewFoldContractTests(unittest.TestCase):
             with self.subTest(token=token):
                 self.assertIn(token, SKILL)
 
-    def test_minimal_review_law_and_dispositions_remain(self) -> None:
+    def test_minimal_review_law_and_control_dispositions_remain(self) -> None:
         required = [
             "claim != fact",
             "fact != liability",
             "liability != scope",
             "scope != code change",
-            "code-change candidate != mutation authority",
+            "code-change pressure != mutation authority",
             "kernel fold != repair plan",
             "`reject`",
             "`proof-only`",
-            "`accepted-liability`",
             "`ask-human`",
             "`follow-up`",
             "`blocked`",
+            "`refactor-kernel`",
+            "`unknown`",
+            "boundary_proof",
+            "proof_gap",
+            "next_evidence_action",
         ]
         for token in required:
             with self.subTest(token=token):
@@ -77,7 +82,7 @@ class ReviewFoldContractTests(unittest.TestCase):
     def test_compact_receipt_floor_preserves_material_fold_observability(self) -> None:
         required = [
             "## Compact receipt floor",
-            "RF-v1.4 compact:",
+            "RF-v1.5 compact:",
             "source_ref:",
             "validity:",
             "liability:",
@@ -96,10 +101,21 @@ class ReviewFoldContractTests(unittest.TestCase):
 
     def test_live_review_fold_surfaces_forbid_retired_repair_routes(self) -> None:
         forbidden = [
+            "accepted-liability",
+            "accepted liability",
             "minimal-fix",
             "repair_level",
+            "code_change_candidate",
             "RF-v1.3 compact",
+            "RF-v1.4 compact",
             "version: RF-v1.3",
+            "version: RF-v1.4",
+            "kernel_fold.status: point",
+            "kernel_fold.status: structural",
+            "status: point",
+            "status: structural",
+            "point_safety",
+            "structural kernel",
             "choose reject, proof-only",
         ]
         for token in forbidden:
@@ -162,6 +178,9 @@ class ReviewFoldContractTests(unittest.TestCase):
             "Shortcut prose is not a receipt",
             "finding_mutation_authority.allowed: no",
             "A finding is never mutation authority",
+            "kernel_fold.status: refactor-kernel",
+            "proof_gap",
+            "next_evidence_action",
             "Do not post PR comments, resolve threads, mutate files, choose a fresh review backend, or claim terminal review closure",
         ]
         for token in required:
@@ -178,8 +197,8 @@ class ReviewFoldContractTests(unittest.TestCase):
             "RF-RECEIPT-001",
             "RF-KERNEL-001",
             "RF-SOURCE-BLOCK",
-            "RF-ACCEPTED-LIABILITY",
             "RF-KERNEL-FOLD",
+            "refactor-kernel",
             "decision_receipt: required",
             "validator: codex/skills/review-fold/tools/review_fold_receipt_gate.py",
         ]

--- a/codex/skills/review-fold/tests/test_receipt_gate.py
+++ b/codex/skills/review-fold/tests/test_receipt_gate.py
@@ -16,15 +16,29 @@ SPEC.loader.exec_module(MODULE)
 
 def valid_kernel(**overrides):
     kernel = {
-        "status": "point",
+        "status": "refactor-kernel",
         "pressure": "low",
-        "equivalence_class": "not-applicable",
+        "equivalence_class": "input-validation-class",
         "owner_boundary": "input validation",
         "law_family": "validation-boundary",
         "falsifier": "comment-1 shows missing owner validation",
-        "point_safety": "proven",
+        "boundary_proof": "proven",
         "evidence_refs": ["repo:file.py:10"],
     }
+    kernel.update(overrides)
+    return kernel
+
+
+def unknown_kernel(**overrides):
+    kernel = valid_kernel(
+        status="unknown",
+        pressure="medium",
+        equivalence_class="unknown",
+        owner_boundary="unknown",
+        boundary_proof="not-proven",
+        proof_gap="missing owner-boundary evidence",
+        next_evidence_action="inspect-more",
+    )
     kernel.update(overrides)
     return kernel
 
@@ -48,13 +62,12 @@ def valid_finding(**overrides):
         "validity": "valid",
         "liability": "blocks-goal",
         "intent_relation": "core",
-        "disposition": "accepted-liability",
+        "disposition": "blocked",
         "owner_boundary": "input validation",
         "law_family": "validation-boundary",
         "kernel_fold": valid_kernel(),
         "evidence_refs": ["repo:file.py:10"],
-        "code_change_candidate": "yes",
-        "finding_mutation_authority": {"allowed": "no", "reason": "resolution fold owns mutation"},
+        "finding_mutation_authority": {"allowed": "no", "reason": "review fold is not mutation authority"},
     }
     finding.update(overrides)
     return finding
@@ -64,7 +77,7 @@ class ReviewFoldReceiptGateTests(unittest.TestCase):
     def test_valid_full_receipt_passes(self) -> None:
         receipt = {
             "review_fold": {
-                "version": "RF-v1.4",
+                "version": "RF-v1.5",
                 "source": {"backend": "github-comments"},
                 "findings": [valid_finding()],
                 "compression": {"kernel_pressure": "low"},
@@ -80,22 +93,20 @@ class ReviewFoldReceiptGateTests(unittest.TestCase):
         self.assertEqual(report["verdict"], "pass")
         self.assertEqual(report["finding_count"], 1)
 
-    def test_compact_receipt_missing_source_ref_fails(self) -> None:
+    def test_valid_compact_unknown_quarantine_passes(self) -> None:
         receipt = {
-            "rf_v14_compact": {
-                "validity": "valid",
-                "liability": "blocks-goal",
-                "intent_relation": "core",
-                "disposition": "accepted-liability",
-                "owner_boundary": "input validation",
-                "law_family": "validation-boundary",
-                "kernel_fold": valid_kernel(),
-                "evidence_refs": [],
-                "code_change_candidate": "yes",
-                "clean_run": {"normalized_clean": "not-applicable", "count_effect": "none"},
-                "finding_mutation_authority": {"allowed": "no", "reason": "not authority"},
-            }
+            "rf_v15_compact": valid_finding(
+                kernel_fold=unknown_kernel(),
+                clean_run={"normalized_clean": "no", "count_effect": "blocked"},
+            )
         }
+        report = MODULE.validate(receipt)["review_fold_receipt_gate"]
+        self.assertEqual(report["verdict"], "pass")
+
+    def test_compact_receipt_missing_source_ref_fails(self) -> None:
+        finding = valid_finding(clean_run={"normalized_clean": "not-applicable", "count_effect": "none"})
+        del finding["source_ref"]
+        receipt = {"rf_v15_compact": finding}
         report = MODULE.validate(receipt)["review_fold_receipt_gate"]
         self.assertEqual(report["verdict"], "fail")
         self.assertIn("compact.source_ref:missing", report["errors"])
@@ -103,7 +114,7 @@ class ReviewFoldReceiptGateTests(unittest.TestCase):
     def test_mutation_authority_allowed_fails(self) -> None:
         receipt = {
             "review_fold": {
-                "version": "RF-v1.4",
+                "version": "RF-v1.5",
                 "findings": [
                     valid_finding(
                         finding_mutation_authority={"allowed": "yes", "reason": "bad"}
@@ -118,18 +129,17 @@ class ReviewFoldReceiptGateTests(unittest.TestCase):
             report["errors"],
         )
 
-    def test_structural_kernel_requires_equivalence_class_or_owner_boundary(self) -> None:
+    def test_refactor_kernel_requires_equivalence_class_or_owner_boundary(self) -> None:
         receipt = {
             "review_fold": {
-                "version": "RF-v1.4",
+                "version": "RF-v1.5",
                 "findings": [
                     valid_finding(
                         kernel_fold=valid_kernel(
-                            status="structural",
                             pressure="high",
                             equivalence_class="",
                             owner_boundary="",
-                            point_safety="not-applicable",
+                            boundary_proof="not-applicable",
                         )
                     )
                 ],
@@ -138,62 +148,161 @@ class ReviewFoldReceiptGateTests(unittest.TestCase):
         report = MODULE.validate(receipt)["review_fold_receipt_gate"]
         self.assertEqual(report["verdict"], "fail")
         self.assertIn(
-            "review_fold.findings[0].kernel_fold.structural:missing-equivalence-class-or-owner-boundary",
+            "review_fold.findings[0].kernel_fold.refactor-kernel:missing-equivalence-class-or-owner-boundary",
             report["errors"],
         )
 
-    def test_high_pressure_point_requires_proven_point_safety(self) -> None:
+    def test_refactor_kernel_requires_blocked_control_disposition(self) -> None:
+        receipt = {
+            "review_fold": {
+                "version": "RF-v1.5",
+                "findings": [valid_finding(disposition="proof-only")],
+            }
+        }
+        report = MODULE.validate(receipt)["review_fold_receipt_gate"]
+        self.assertEqual(report["verdict"], "fail")
+        self.assertIn(
+            "review_fold.findings[0].disposition:refactor-kernel-requires-blocked-control",
+            report["errors"],
+        )
+
+    def test_unknown_requires_proof_gap_and_next_evidence_action(self) -> None:
+        receipt = {
+            "review_fold": {
+                "version": "RF-v1.5",
+                "findings": [
+                    valid_finding(
+                        kernel_fold=unknown_kernel(proof_gap="", next_evidence_action="")
+                    )
+                ],
+            }
+        }
+        report = MODULE.validate(receipt)["review_fold_receipt_gate"]
+        self.assertEqual(report["verdict"], "fail")
+        self.assertIn(
+            "review_fold.findings[0].kernel_fold.proof_gap:required-for-unknown",
+            report["errors"],
+        )
+        self.assertIn(
+            "review_fold.findings[0].kernel_fold.next_evidence_action:missing",
+            report["errors"],
+        )
+
+    def test_unknown_requires_blocked_or_ask_human_control_disposition(self) -> None:
+        receipt = {
+            "review_fold": {
+                "version": "RF-v1.5",
+                "findings": [
+                    valid_finding(
+                        disposition="follow-up",
+                        intent_relation="adjacent",
+                        kernel_fold=unknown_kernel(),
+                    )
+                ],
+            }
+        }
+        report = MODULE.validate(receipt)["review_fold_receipt_gate"]
+        self.assertEqual(report["verdict"], "fail")
+        self.assertIn(
+            "review_fold.findings[0].disposition:unknown-requires-blocked-or-ask-human",
+            report["errors"],
+        )
+
+    def test_unknown_cannot_be_clean_or_increment_clean_run(self) -> None:
+        receipt = {
+            "review_fold": {
+                "version": "RF-v1.5",
+                "findings": [
+                    valid_finding(
+                        kernel_fold=unknown_kernel(),
+                        clean_run={"normalized_clean": "yes", "count_effect": "increment"},
+                    )
+                ],
+                "recommended_resolution": {
+                    "clean_run_accounting": {
+                        "normalized_clean_this_source": "yes",
+                        "count_effect": "increment",
+                    }
+                },
+            }
+        }
+        report = MODULE.validate(receipt)["review_fold_receipt_gate"]
+        self.assertEqual(report["verdict"], "fail")
+        self.assertIn(
+            "review_fold.findings[0].clean_run.normalized_clean:unknown-cannot-be-clean",
+            report["errors"],
+        )
+        self.assertIn(
+            "review_fold.findings[0].clean_run.count_effect:unknown-cannot-increment-clean-run",
+            report["errors"],
+        )
+        self.assertIn(
+            "recommended_resolution.clean_run_accounting.normalized_clean_this_source:unknown-cannot-be-clean",
+            report["errors"],
+        )
+        self.assertIn(
+            "recommended_resolution.clean_run_accounting.count_effect:unknown-cannot-increment-clean-run",
+            report["errors"],
+        )
+
+    def test_rf_v14_receipt_fails(self) -> None:
         receipt = {
             "review_fold": {
                 "version": "RF-v1.4",
-                "findings": [
-                    valid_finding(
-                        kernel_fold=valid_kernel(
-                            pressure="high",
-                            point_safety="not-proven",
-                            evidence_refs=[],
-                        )
-                    )
-                ],
-            }
-        }
-        report = MODULE.validate(receipt)["review_fold_receipt_gate"]
-        self.assertEqual(report["verdict"], "fail")
-        self.assertIn(
-            "review_fold.findings[0].kernel_fold.point_safety:point-status-requires-proven",
-            report["errors"],
-        )
-        self.assertIn(
-            "review_fold.findings[0].kernel_fold.point_safety:high-pressure-point-requires-proof",
-            report["errors"],
-        )
-
-    def test_rf_v13_receipt_fails(self) -> None:
-        receipt = {
-            "review_fold": {
-                "version": "RF-v1.3",
                 "findings": [valid_finding()],
             }
         }
         report = MODULE.validate(receipt)["review_fold_receipt_gate"]
         self.assertEqual(report["verdict"], "fail")
-        self.assertIn("review_fold.version:expected-RF-v1.4", report["errors"])
+        self.assertIn("review_fold.version:expected-RF-v1.5", report["errors"])
+
+    def test_rf_v14_compact_fails(self) -> None:
+        report = MODULE.validate({"rf_v14_compact": valid_finding()})["review_fold_receipt_gate"]
+        self.assertEqual(report["verdict"], "fail")
+        self.assertIn("receipt: expected RF-v1.5 compact object", report["errors"])
 
     def test_repair_level_is_forbidden(self) -> None:
         receipt = {
             "review_fold": {
-                "version": "RF-v1.4",
+                "version": "RF-v1.5",
                 "findings": [valid_finding(repair_level="minimal-fix")],
             }
         }
         report = MODULE.validate(receipt)["review_fold_receipt_gate"]
         self.assertEqual(report["verdict"], "fail")
-        self.assertIn("review_fold.findings[0].repair_level:forbidden-in-RF-v1.4", report["errors"])
+        self.assertIn("review_fold.findings[0].repair_level:forbidden-in-RF-v1.5", report["errors"])
+
+    def test_code_change_candidate_is_forbidden(self) -> None:
+        receipt = {
+            "review_fold": {
+                "version": "RF-v1.5",
+                "findings": [valid_finding(code_change_candidate="yes")],
+            }
+        }
+        report = MODULE.validate(receipt)["review_fold_receipt_gate"]
+        self.assertEqual(report["verdict"], "fail")
+        self.assertIn(
+            "review_fold.findings[0].code_change_candidate:forbidden-in-RF-v1.5",
+            report["errors"],
+        )
+
+    def test_retired_disposition_and_kernel_statuses_fail(self) -> None:
+        cases = [
+            ("accepted-liability", valid_finding(disposition="accepted-liability"), "review_fold.findings[0].disposition:invalid"),
+            ("point", valid_finding(kernel_fold=valid_kernel(status="point")), "review_fold.findings[0].kernel_fold.status:invalid"),
+            ("structural", valid_finding(kernel_fold=valid_kernel(status="structural")), "review_fold.findings[0].kernel_fold.status:invalid"),
+        ]
+        for _label, finding, expected in cases:
+            with self.subTest(expected=expected):
+                receipt = {"review_fold": {"version": "RF-v1.5", "findings": [finding]}}
+                report = MODULE.validate(receipt)["review_fold_receipt_gate"]
+                self.assertEqual(report["verdict"], "fail")
+                self.assertIn(expected, report["errors"])
 
     def test_minimal_fix_disposition_fails(self) -> None:
         receipt = {
             "review_fold": {
-                "version": "RF-v1.4",
+                "version": "RF-v1.5",
                 "findings": [valid_finding(disposition="minimal-fix")],
             }
         }
@@ -204,14 +313,14 @@ class ReviewFoldReceiptGateTests(unittest.TestCase):
     def test_action_plan_is_forbidden(self) -> None:
         receipt = {
             "review_fold": {
-                "version": "RF-v1.4",
+                "version": "RF-v1.5",
                 "findings": [valid_finding()],
                 "action_plan": {"mode": "refactor-kernel"},
             }
         }
         report = MODULE.validate(receipt)["review_fold_receipt_gate"]
         self.assertEqual(report["verdict"], "fail")
-        self.assertIn("review_fold.action_plan:forbidden-in-RF-v1.4", report["errors"])
+        self.assertIn("review_fold.action_plan:forbidden-in-RF-v1.5", report["errors"])
 
 
 if __name__ == "__main__":

--- a/codex/skills/review-fold/tools/review_fold_receipt_gate.py
+++ b/codex/skills/review-fold/tools/review_fold_receipt_gate.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env -S uv run python
-"""RF-v1.4 receipt validator for $review-fold.
+"""RF-v1.5 receipt validator for $review-fold.
 
-The gate validates JSON projections of full RF-v1.4 receipts and compact
-RF-v1.4 receipts. It intentionally avoids review-backend policy: source fields
+The gate validates JSON projections of full RF-v1.5 receipts and compact
+RF-v1.5 receipts. It intentionally avoids review-backend policy: source fields
 are evidence references, not validity, kernel status, or mutation authority.
 """
 from __future__ import annotations
@@ -39,18 +39,18 @@ VALID_INTENT = {"core", "adjacent", "unrelated", "expands-scope"}
 VALID_DISPOSITIONS = {
     "reject",
     "proof-only",
-    "accepted-liability",
     "ask-human",
     "follow-up",
     "blocked",
 }
 MATERIAL_DISPOSITIONS = VALID_DISPOSITIONS
-VALID_KERNEL_STATUS = {"none", "point", "structural", "unknown"}
+VALID_KERNEL_STATUS = {"none", "refactor-kernel", "unknown"}
 VALID_KERNEL_PRESSURE = {"none", "low", "medium", "high"}
-VALID_POINT_SAFETY = {"proven", "not-proven", "not-applicable"}
+VALID_BOUNDARY_PROOF = {"proven", "not-proven", "not-applicable"}
+VALID_NEXT_EVIDENCE_ACTION = {"inspect-more", "ask-human", "blocked", "branch-race", "reclassify"}
 VALID_CLEAN = {"yes", "no", "not-applicable"}
 VALID_COUNT_EFFECT = {"increment", "reset", "none", "blocked", "unknown"}
-FORBIDDEN_FINDING_KEYS = {"repair_level"}
+FORBIDDEN_FINDING_KEYS = {"repair_level", "code_change_candidate"}
 FORBIDDEN_FULL_KEYS = {"action_plan"}
 
 
@@ -69,6 +69,9 @@ def load_json(path: str) -> dict[str, Any]:
 def unwrap_receipt(value: dict[str, Any]) -> tuple[str, dict[str, Any]]:
     if isinstance(value.get("review_fold"), dict):
         return "full", value["review_fold"]
+    for key in ("rf_v15_compact", "RF-v1.5 compact", "RF-v1.5 compact:"):
+        if isinstance(value.get(key), dict):
+            return "compact", value[key]
     for key in (
         "rf_v14_compact",
         "RF-v1.4 compact",
@@ -78,12 +81,12 @@ def unwrap_receipt(value: dict[str, Any]) -> tuple[str, dict[str, Any]]:
         "RF-v1.3 compact:",
     ):
         if isinstance(value.get(key), dict):
-            return "compact", value[key]
-    if "findings" in value or value.get("version") in {"RF-v1.4", "RF-v1.3"}:
+            raise ReceiptGateError("receipt: expected RF-v1.5 compact object")
+    if "findings" in value or value.get("version") in {"RF-v1.5", "RF-v1.4", "RF-v1.3"}:
         return "full", value
     if "validity" in value and "disposition" in value:
         return "compact", value
-    raise ReceiptGateError("receipt: expected review_fold or RF-v1.4 compact object")
+    raise ReceiptGateError("receipt: expected review_fold or RF-v1.5 compact object")
 
 
 def as_no(value: Any) -> bool:
@@ -146,7 +149,7 @@ def mutation_authority_errors(finding: dict[str, Any], prefix: str) -> list[str]
     return errors
 
 
-def clean_run_errors(clean_run: dict[str, Any], prefix: str) -> list[str]:
+def clean_run_errors(clean_run: dict[str, Any], prefix: str, kernel_status: str = "") -> list[str]:
     errors: list[str] = []
     if not clean_run:
         return errors
@@ -156,6 +159,11 @@ def clean_run_errors(clean_run: dict[str, Any], prefix: str) -> list[str]:
     effect = clean_run.get("count_effect", "unknown")
     if effect not in VALID_COUNT_EFFECT and not isinstance(effect, int):
         errors.append(f"{prefix}.clean_run.count_effect:invalid")
+    if kernel_status == "unknown":
+        if normalized == "yes":
+            errors.append(f"{prefix}.clean_run.normalized_clean:unknown-cannot-be-clean")
+        if effect in {"increment"} or (isinstance(effect, int) and effect > 0):
+            errors.append(f"{prefix}.clean_run.count_effect:unknown-cannot-increment-clean-run")
     reason = clean_run.get("reason")
     if reason is not None and not isinstance(reason, str):
         errors.append(f"{prefix}.clean_run.reason:must-be-string")
@@ -175,8 +183,8 @@ def kernel_fold_errors(finding: dict[str, Any], prefix: str, disposition: str) -
     pressure = validate_enum(
         kernel.get("pressure"), VALID_KERNEL_PRESSURE, "kernel_fold.pressure", errors, prefix
     )
-    point_safety = validate_enum(
-        kernel.get("point_safety"), VALID_POINT_SAFETY, "kernel_fold.point_safety", errors, prefix
+    boundary_proof = validate_enum(
+        kernel.get("boundary_proof"), VALID_BOUNDARY_PROOF, "kernel_fold.boundary_proof", errors, prefix
     )
 
     for key in ("equivalence_class", "owner_boundary", "law_family", "falsifier"):
@@ -188,18 +196,25 @@ def kernel_fold_errors(finding: dict[str, Any], prefix: str, disposition: str) -
     if evidence_refs and not all(isinstance(item, str) and item for item in evidence_refs):
         errors.append(f"{prefix}.kernel_fold.evidence_refs:must-be-strings")
 
-    if disposition == "accepted-liability" and status not in {"point", "structural"}:
-        errors.append(f"{prefix}.kernel_fold.status:accepted-liability-requires-point-or-structural")
-    if status == "point" and point_safety != "proven":
-        errors.append(f"{prefix}.kernel_fold.point_safety:point-status-requires-proven")
-    if status == "structural" and not (
+    if status == "refactor-kernel" and not (
         meaningful(kernel.get("equivalence_class")) or meaningful(kernel.get("owner_boundary"))
     ):
-        errors.append(f"{prefix}.kernel_fold.structural:missing-equivalence-class-or-owner-boundary")
-    if pressure == "high" and status == "point" and (
-        point_safety != "proven" or not evidence_refs
-    ):
-        errors.append(f"{prefix}.kernel_fold.point_safety:high-pressure-point-requires-proof")
+        errors.append(f"{prefix}.kernel_fold.refactor-kernel:missing-equivalence-class-or-owner-boundary")
+    if boundary_proof == "proven" and not evidence_refs:
+        errors.append(f"{prefix}.kernel_fold.boundary_proof:proven-requires-evidence")
+    if status == "unknown":
+        if boundary_proof == "proven":
+            errors.append(f"{prefix}.kernel_fold.boundary_proof:unknown-cannot-be-proven")
+        proof_gap = kernel.get("proof_gap")
+        if not meaningful(proof_gap):
+            errors.append(f"{prefix}.kernel_fold.proof_gap:required-for-unknown")
+        validate_enum(
+            kernel.get("next_evidence_action"),
+            VALID_NEXT_EVIDENCE_ACTION,
+            "kernel_fold.next_evidence_action",
+            errors,
+            prefix,
+        )
 
     return errors
 
@@ -210,7 +225,7 @@ def validate_finding(finding: dict[str, Any], prefix: str) -> list[str]:
         return [f"{prefix}:missing"]
 
     for key in FORBIDDEN_FINDING_KEYS & finding.keys():
-        errors.append(f"{prefix}.{key}:forbidden-in-RF-v1.4")
+        errors.append(f"{prefix}.{key}:forbidden-in-RF-v1.5")
 
     source_ref = object_from(finding.get("source_ref"))
     if not source_ref:
@@ -223,15 +238,12 @@ def validate_finding(finding: dict[str, Any], prefix: str) -> list[str]:
     intent = validate_enum(finding.get("intent_relation"), VALID_INTENT, "intent_relation", errors, prefix)
     disposition = validate_enum(finding.get("disposition"), VALID_DISPOSITIONS, "disposition", errors, prefix)
 
-    code_change = finding.get("code_change_candidate")
     kernel = object_from(finding.get("kernel_fold"))
     kernel_status = kernel.get("status")
-    if code_change in {"yes", True} and not (
-        disposition == "accepted-liability" and kernel_status in {"point", "structural"}
-    ):
-        errors.append(f"{prefix}.code_change_candidate:requires-accepted-liability-point-or-structural")
-    if disposition == "accepted-liability" and code_change not in {"yes", True}:
-        errors.append(f"{prefix}.code_change_candidate:expected-yes-for-accepted-liability")
+    if kernel_status == "refactor-kernel" and disposition != "blocked":
+        errors.append(f"{prefix}.disposition:refactor-kernel-requires-blocked-control")
+    if kernel_status == "unknown" and disposition not in {"blocked", "ask-human"}:
+        errors.append(f"{prefix}.disposition:unknown-requires-blocked-or-ask-human")
     if disposition == "follow-up" and intent not in {"adjacent", "expands-scope", "unrelated"}:
         errors.append(f"{prefix}.intent_relation:follow-up-should-not-be-core")
 
@@ -249,7 +261,7 @@ def validate_finding(finding: dict[str, Any], prefix: str) -> list[str]:
 
     errors.extend(kernel_fold_errors(finding, prefix, disposition))
     errors.extend(mutation_authority_errors(finding, prefix))
-    errors.extend(clean_run_errors(object_from(finding.get("clean_run")), prefix))
+    errors.extend(clean_run_errors(object_from(finding.get("clean_run")), prefix, kernel_status))
     return errors
 
 
@@ -272,11 +284,11 @@ def validate_full(receipt: dict[str, Any]) -> dict[str, Any]:
     errors: list[str] = []
     warnings: list[str] = []
 
-    if receipt.get("version") != "RF-v1.4":
-        errors.append("review_fold.version:expected-RF-v1.4")
+    if receipt.get("version") != "RF-v1.5":
+        errors.append("review_fold.version:expected-RF-v1.5")
 
     for key in FORBIDDEN_FULL_KEYS & receipt.keys():
-        errors.append(f"review_fold.{key}:forbidden-in-RF-v1.4")
+        errors.append(f"review_fold.{key}:forbidden-in-RF-v1.5")
 
     source = object_from(receipt.get("source"))
     if source:
@@ -296,6 +308,11 @@ def validate_full(receipt: dict[str, Any]) -> dict[str, Any]:
             errors.append(f"review_fold.findings[{index}]:must-be-object")
             continue
         errors.extend(validate_finding(finding_value, f"review_fold.findings[{index}]"))
+    has_unknown_kernel = any(
+        isinstance(finding_value, dict)
+        and object_from(finding_value.get("kernel_fold")).get("status") == "unknown"
+        for finding_value in findings
+    )
 
     compression = object_from(receipt.get("compression"))
     pressure = compression.get("kernel_pressure")
@@ -311,6 +328,11 @@ def validate_full(receipt: dict[str, Any]) -> dict[str, Any]:
         effect = clean.get("count_effect", "unknown")
         if effect not in VALID_COUNT_EFFECT:
             errors.append("recommended_resolution.clean_run_accounting.count_effect:invalid")
+        if has_unknown_kernel:
+            if normalized == "yes":
+                errors.append("recommended_resolution.clean_run_accounting.normalized_clean_this_source:unknown-cannot-be-clean")
+            if effect == "increment":
+                errors.append("recommended_resolution.clean_run_accounting.count_effect:unknown-cannot-increment-clean-run")
 
     return {
         "review_fold_receipt_gate": {
@@ -324,14 +346,24 @@ def validate_full(receipt: dict[str, Any]) -> dict[str, Any]:
 
 
 def validate(value: dict[str, Any]) -> dict[str, Any]:
-    receipt_type, body = unwrap_receipt(value)
+    try:
+        receipt_type, body = unwrap_receipt(value)
+    except ReceiptGateError as exc:
+        return {
+            "review_fold_receipt_gate": {
+                "verdict": "fail",
+                "receipt_type": "unknown",
+                "errors": [str(exc)],
+                "warnings": [],
+            }
+        }
     if receipt_type == "compact":
         return validate_compact(body)
     return validate_full(body)
 
 
 def main(argv: list[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(description="Validate RF-v1.4 full or compact review-fold receipts")
+    parser = argparse.ArgumentParser(description="Validate RF-v1.5 full or compact review-fold receipts")
     sub = parser.add_subparsers(dest="command", required=True)
     validate_parser = sub.add_parser("validate")
     validate_parser.add_argument("--receipt", required=True, help="Path to JSON receipt, or '-' for stdin")


### PR DESCRIPTION
## Summary
- Bump review-fold receipts to RF-v1.5.
- Remove accepted-liability, point, structural, and code_change_candidate from live review-fold semantics.
- Make refactor-kernel the only material fold and make unknown a quarantine state with proof_gap and next_evidence_action.
- Align reducer, CAS prompt, goal-workgraph consumer, docs, references, validator, and contract tests.

## Proof
- `uv run python -m unittest discover codex/skills/review-fold/tests`: pass
- `uv run python -m unittest discover codex/skills/cas/tests`: pass
- `uv run --with pyyaml -- python3 codex/skills/.system/skill-creator/scripts/quick_validate.py codex/skills/review-fold`: pass
- `uv run --with pyyaml -- python3 codex/skills/.system/skill-creator/scripts/quick_validate.py codex/skills/cas`: pass
- `uv run --with pyyaml -- python3 codex/skills/.system/skill-creator/scripts/quick_validate.py codex/skills/goal-workgraph`: pass
- `uv run --with pyyaml -- python3 codex/skills/tune/tools/decision_contract_lint.py codex/skills/review-fold/references/decision-contract.yaml`: pass
- live retired-token audit over review-fold, reducer, CAS prompt, and goal-workgraph surfaces: no matches
- `git diff --check`: pass

## Scope
- branch: `rf-v15-refactor-kernel-only`
- head: `75bec892f8a9e728be6cf704f495eb982718ee61`
- base: `main`

## Readiness
- PR mode: ready
- Reason: local proof bar passed and no blockers remain for review.
- Caveats: none
