### PR TITLE
Make actuation governance spine essential

### DIFF
--- a/codex/skills/actuating/SKILL.md
+++ b/codex/skills/actuating/SKILL.md
@@ -44,6 +44,26 @@ Do not keep going unless the previous action was checked.
 Do not claim completion until the terminal gate allows it.
 ```
 
+## Essential governance spine
+
+The essential `$actuating` spine is:
+
+```text
+accepted source
+-> current loop receipt or valid FUSION-v1
+-> unfolded work item/frontier
+-> HSR-v1 material step
+-> current evidence fold
+-> proof/review closure
+-> ATCG-v1
+-> proof-patch or `$ship` handoff when publication was requested
+```
+
+Everything else is supporting machinery. Work graphs, `update_plan`, summaries,
+progress projections, cached checks, stale review runs, and raw review text may
+help select the next action, but they are not receipt evidence and cannot
+replace the spine.
+
 ## Removed controller path
 
 The old transaction-controller/APMA path is not active in this workspace. If the
@@ -77,6 +97,10 @@ direct user goal with enough scope, constraints, and proof checks
 review findings bound to the current diff and intended change
 plan handoff for goal-artifact execution
 ```
+
+These sources authorize routing only. They do not authorize mutation unless the
+loop/fusion receipt, unfolded work item, and evidence-fold requirements below
+are also current for the branch/head/diff.
 
 If none exists, run `$spec-pipeline` in gate-only/no-plan mode or stop with:
 
@@ -112,6 +136,9 @@ For material runs, `$actuating` must establish one of:
 valid FUSION-v1 direct-action receipt
 current ALSR-v1 + HYL-v1 + HSR-v1 chain
 ```
+
+The receipt must bind the current branch, head, and diff. A prose declaration,
+checklist item, or `update_plan` row is not a loop receipt.
 
 If none exists, stop with:
 
@@ -315,7 +342,9 @@ ATCG-v1 can_mark_goal_complete = yes
 ```
 
 Do not substitute local proof, a proof-complete graph, cached CAS receipts, or
-ADD-v1 `handoff_to_ship` for terminal completion.
+ADD-v1 `handoff_to_ship` for terminal completion. A `$ship` result is delivery
+evidence, not completion evidence, until ATCG-v1 folds it into the terminal
+state.
 
 ## Stop rules
 

--- a/codex/skills/agent-loop-schemes/SKILL.md
+++ b/codex/skills/agent-loop-schemes/SKILL.md
@@ -50,6 +50,10 @@ No continuation without fold.
 No completion without terminal algebra.
 ```
 
+The essential receipts are ALSR-v1, HYL-v1, HSR-v1, evidence fold, and ATCG-v1.
+Planning views, work graphs, `update_plan`, and prose summaries are projections
+over those receipts. They may guide attention, but they do not prove control.
+
 ## Protocol objects
 
 ### ALSR-v1: Agent Loop Scheme Receipt
@@ -236,6 +240,8 @@ current actuation state
 ```
 
 The work graph is a projection of this machine, not the source of truth.
+`update_plan` is also a projection. If either projection disagrees with the
+current HYL state, the HYL state wins and the projection must be refreshed.
 
 If work happens inside HYL, the work graph can be regenerated.
 If work happens outside HYL, it is invalid actuation.
@@ -478,6 +484,9 @@ proof complete + publication requested -> emit ShipHandoff effect
 ```
 
 `$ship` owns PR creation, update, promotion, and publication.
+
+Shipping is a terminal side effect handler, not proof of actuation completion.
+ATCG-v1 must fold the `$ship` evidence before a parent goal can complete.
 
 ## Compaction and resume
 

--- a/codex/skills/goal-actuating/SKILL.md
+++ b/codex/skills/goal-actuating/SKILL.md
@@ -78,6 +78,11 @@ goal_actuating_mode:
 16. Run ATCG-v1 before completion.
 17. Close with `$proof-patch`, or hand off to `$ship` only when publication is requested and ready.
 
+Persistence is projection, not authority. `update_plan`, work lists, and
+goal-artifact projections may show the current frontier, but they do not replace
+ALSR-v1, HYL-v1, HSR-v1, evidence-fold, proof-patch, review-fold, or ATCG-v1
+receipts.
+
 ## HYL-v1 interpreter
 
 A material action is legal only as an HSR-v1 transition:
@@ -93,6 +98,10 @@ state_before
 No mutation is valid without an unfolded work node.
 No continuation is valid without a fold verdict.
 No completion is valid without terminal ATCG-v1.
+
+The minimum valid material transition is therefore `unfold -> action -> fold`.
+If any one of those fields is missing, the run is not governed actuation even
+when tests, summaries, or progress projections exist.
 
 ## Review lanes
 
@@ -185,6 +194,10 @@ proof patch -> update proof state
 subagent result -> accept/reject/integrate through lead reducer
 ATCG -> complete|continue|blocked
 ```
+
+Supporting effects cannot skip the algebra. A clean command, cached review,
+proof summary, or `$ship` handoff updates state only after the owner reducer
+folds it against the current artifact.
 
 ## Parallel scheduler
 

--- a/codex/skills/plan/SKILL.md
+++ b/codex/skills/plan/SKILL.md
@@ -156,6 +156,10 @@ $actuating
 
 A semantic gap returns to `$spec-pipeline` or `$grill-me`.
 
+Plan artifacts are policy projections over accepted semantics. They can make the
+next action executable by `$actuating`, but they do not replace loop receipts,
+evidence folds, proof-patch, review-fold, or ATCG-v1.
+
 ## Planning regimes
 
 ```text
@@ -350,6 +354,10 @@ actuating_handoff:
 
 `$plan` never emits mutation authority.
 
+It also never emits completion evidence. The receiving `$actuating` run must
+bind the plan to current branch/head/diff and establish its own loop or fusion
+receipt before material mutation.
+
 ## Cross-plan relationships
 
 A plan may propose, but not create, cross-plan relations:
@@ -396,6 +404,10 @@ current direct-action exemption or ALSR/HYL loop contract
 review/proof closure evidence
 terminal ATCG-v1
 ```
+
+Treat these as blocking gates, not checklist labels. A plan is complete when
+PSR-v1 converges; execution is complete only after `$actuating` folds current
+evidence through ATCG-v1.
 
 ## Output
 

--- a/codex/skills/spec-pipeline/SKILL.md
+++ b/codex/skills/spec-pipeline/SKILL.md
@@ -534,6 +534,9 @@ plan_source_contract:
 `<proposed_plan>` block and performs its fixed-point planning loop with PSR-v1.
 `$plan` does not grant mutation authority.
 
+The PSC-v1 handoff is source authority only. It preserves accepted semantics for
+`$plan`; it is not an actuation receipt, an evidence fold, or completion proof.
+
 Do not auto-run `$plan` when any of these are true:
 
 ```text


### PR DESCRIPTION
## Summary
- Make the `$actuating` governance spine explicit: accepted source, loop/fusion receipt, unfolded work, HSR-v1, evidence fold, proof/review closure, ATCG-v1, then proof-patch/ship handoff.
- Clarify that `update_plan`, work graphs, projections, cached checks, stale review, PSC-v1, and `$ship` handoff cannot substitute for receipt evidence or terminal completion.
- Keep scope to docs/doctrine; no component reduction and no runtime enforcement change.

## Proof
- `uv run python codex/skills/plan/tools/plan_source_contract_gate.py .ledger/plan/actuating-governance-essentiality-repair-2026-07-07/source-contract.yaml`: pass
- `uv run python codex/skills/plan/tools/policy_synthesis_receipt_gate.py .ledger/plan/actuating-governance-essentiality-repair-2026-07-07/synthesis-receipt.json`: pass
- `uv run python codex/skills/actuating/tools/quick_validate.py`: pass
- `uv run python codex/skills/spec-pipeline/tools/quick_validate.py`: pass
- `uv run python codex/skills/plan/tests/test_policy_synthesis_receipt_gate.py`: pass
- `uv run python codex/skills/plan/tests/test_policy_tools.py`: pass
- `uv run python codex/skills/actuating/tests/test_actuating_tools.py`: pass
- `uv run python codex/skills/spec-pipeline/tests/test_spec_pipeline_tools.py`: pass
- `uv run python codex/skills/spec-pipeline/tests/test_auto_plan_handoff_gate.py`: pass
- `PYTHONPATH=codex/skills/actuating/tools uv run --with pytest pytest codex/skills/actuating/tests`: 36 passed
- `uv run --with pytest pytest codex/skills/plan/tests codex/skills/spec-pipeline/tests`: spec-pipeline tests passed; plan tests are script-style and collect 0 pytest items
- `git diff --check`: pass

## Scope
- branch: `codex/actuating-governance-essentiality`
- head: `2ed13711e6fc31e58bacb63bea2ad601a5d9513c`
- base: `main`

## Readiness
- PR mode: ready
- Reason: focused docs-only governance change with validation completed.
- Caveats: combined all-skill pytest collection has a known helper-module import collision; suites were validated with skill-owned commands and isolated PYTHONPATH where needed.