### PR TITLE
Enforce actuation runtime interlock

### DIFF
--- a/codex/skills/actuating/SKILL.md
+++ b/codex/skills/actuating/SKILL.md
@@ -64,6 +64,27 @@ progress projections, cached checks, stale review runs, and raw review text may
 help select the next action, but they are not receipt evidence and cannot
 replace the spine.
 
+## Runtime interlock
+
+Before any material mutation, and before continuing after any material action,
+`$actuating` must make the interlock decision explicit:
+
+```yaml
+actuation_interlock:
+  mutation_allowed: yes | no
+  continuation_allowed: yes | no
+  blocker: none | blocked-loop-contract-missing | blocked-loop-contract-stale | blocked-hylo-frontier-missing | blocked-hylo-fold-missing
+  current_binding:
+    branch:
+    head:
+    diff_fingerprint:
+```
+
+`mutation_allowed: yes` requires either a valid FUSION-v1 receipt or a current
+ALSR-v1 + HYL-v1 + HSR-v1 chain with an unfolded work item/frontier. If the
+interlock is `no`, stop immediately with the blocker. Do not keep inspecting,
+patching, or relying on `update_plan` to make progress inside `$actuating`.
+
 ## Removed controller path
 
 The old transaction-controller/APMA path is not active in this workspace. If the
@@ -80,12 +101,13 @@ controller. It must not pretend that local edits are a fenced actuation run.
    review campaigns, migrations, proof fanout, or unclear stopping conditions.
 4. Use `$agent-loop-schemes` when material work needs ALSR/HYL loop receipts.
 5. Send the accepted work to `$goal-actuating`.
-6. Use `$cas` when workflow review is requested or required.
-7. Pass findings through `$review-fold` before any review-driven code change.
-8. Implement only accepted code-change liabilities.
-9. Fold current evidence after each material action.
-10. Run ATCG-v1 before any completion claim.
-11. Emit a proof-patch result or a `$ship` handoff when PR publication/update was requested.
+6. Emit the runtime interlock before the first material mutation.
+7. Use `$cas` when workflow review is requested or required.
+8. Pass findings through `$review-fold` before any review-driven code change.
+9. Implement only accepted code-change liabilities.
+10. Fold current evidence after each material action before continuing.
+11. Run ATCG-v1 before any completion claim.
+12. Emit a proof-patch result or a `$ship` handoff when PR publication/update was requested.
 
 ## Source requirement
 
@@ -360,6 +382,8 @@ three clean standard CAS reviews are required but cannot be completed
 parallel fanout would cross shared invariants or conflicting resources
 ALSR/HYL/HSR is required but missing or stale
 FUSION-v1 is claimed but not proven
+actuation interlock returns `mutation_allowed: no`
+actuation interlock returns `continuation_allowed: no`
 unfold is missing before material mutation
 fold is missing after material action
 goal-focus frames are missing, stale, or not folded to parent
@@ -375,6 +399,10 @@ Actuating:
 - source: direct goal | accepted spec | review
 - authority source:
 - scheme plan: none|required|present
+- actuation interlock:
+  - mutation_allowed:
+  - continuation_allowed:
+  - blocker:
 - loop receipt:
   - fusion receipt:
   - ALSR-v1:

--- a/codex/skills/actuating/agents/openai.yaml
+++ b/codex/skills/actuating/agents/openai.yaml
@@ -7,14 +7,20 @@ interface:
     Use $actuating only as the explicit /goal implementation workflow. First get
     an accepted implementation spec from $spec-pipeline in gate-only/no-plan mode
     when one is not already available. Use $recursion-scheme-planner when the
-    work shape is not simple. For material work, require either a valid FUSION-v1
-    direct-action receipt or current ALSR-v1, HYL-v1, and HSR-v1 receipts before
-    mutation. $goal-actuating executes the selected work item or safe frontier
-    and folds evidence after each material action. Review requests default to
+    work shape is not simple. For material work, emit an actuation_interlock
+    before mutation. mutation_allowed=yes requires either a valid FUSION-v1
+    direct-action receipt or current ALSR-v1, HYL-v1, and HSR-v1 receipts with
+    an unfolded work item/frontier bound to the current branch/head/diff.
+    mutation_allowed=no stops immediately with blocked-loop-contract-missing,
+    blocked-loop-contract-stale, or blocked-hylo-frontier-missing. Do not use
+    update_plan, summaries, cached checks, or chat history as receipt evidence.
+    $goal-actuating executes the selected work item or safe frontier and folds
+    evidence after each material action before any continuation. Review requests default to
     review-closeout unless the user asks for triage, remediation-plan, or another
     no-change mode. Fresh or exhaustive workflow review must use $cas; findings
     must pass through $review-fold; only accepted code-change liabilities may be
     implemented. Repeated accepted liabilities that share an owner boundary or
     missing abstraction require an AER-v1 decision before more mutation, and
     refactor-kernel work requires an RKO-v1 outcome after proof/review. Completion
-    requires ATCG-v1 with can_mark_goal_complete=yes.
+    requires ATCG-v1 with can_mark_goal_complete=yes; proof, ship handoff, or
+    green local commands are not completion until ATCG folds them.

--- a/codex/skills/actuating/references/compaction-resume.md
+++ b/codex/skills/actuating/references/compaction-resume.md
@@ -29,4 +29,12 @@ ASL state = return_to_frontier
 mutation_allowed = no
 ```
 
-Do not reconstruct the frontier from `update_plan` or chat prose.
+If the resume packet is missing or stale:
+
+```text
+mutation_allowed = no
+continuation_allowed = no
+```
+
+Do not reconstruct the frontier from `update_plan` or chat prose. Rebuild the
+loop contract through the owning skill or stop with the canonical blocker.

--- a/codex/skills/actuating/references/pre-mutation-interlock.md
+++ b/codex/skills/actuating/references/pre-mutation-interlock.md
@@ -19,6 +19,23 @@ valid FUSION-v1 receipt for one simple direct action
 current ALSR-v1 + HYL-v1 + HSR-v1 receipt chain
 ```
 
+The caller must make the decision explicit before mutation:
+
+```yaml
+actuation_interlock:
+  mutation_allowed: yes | no
+  continuation_allowed: yes | no
+  blocker: none | blocked-loop-contract-missing | blocked-loop-contract-stale | blocked-hylo-frontier-missing | blocked-hylo-fold-missing | blocked-unsupported-controller
+  current_binding:
+    branch:
+    head:
+    diff_fingerprint:
+```
+
+`mutation_allowed: no` is terminal for the current work item. The workflow must
+not continue by doing more inspection, applying a patch, or treating
+`update_plan` as a replacement frontier.
+
 If the work needs durable claims, fencing, external worktrees, serialized
 integration, or multi-plan coordination, the local workflow must stop.
 
@@ -42,6 +59,7 @@ The required shape is now:
 
 ```text
 approved source
+-> explicit interlock
 -> selected work item or safe frontier
 -> material action
 -> current evidence fold
@@ -73,5 +91,6 @@ The interlock is working when future audits show:
 mutations_without_unfold = 0
 continuations_without_fold = 0
 completion_without_ATCG = 0
+interlock_no_followed_by_mutation = 0
 local edits claiming retired APMA authority = 0
 ```

--- a/codex/skills/actuating/references/terminal-closure-gate.md
+++ b/codex/skills/actuating/references/terminal-closure-gate.md
@@ -62,6 +62,7 @@ ATCG-v1 consumes current receiver-owned evidence:
 
 ```text
 current branch/head/diff binding
+latest actuation_interlock decision
 FUSION-v1 receipt or ALSR/HYL/HSR receipts
 optional goal-focus frame state
 local evidence-fold verdict and proof commands
@@ -162,6 +163,10 @@ public side effect outside $ship boundary -> side-effect-boundary-violated, next
 proof verifier mismatch or stale current-artifact binding -> proof-stale, next_owner=$goal-grind
 all required receipts current -> complete
 ```
+
+ATCG-v1 must not infer a missing receipt from final report prose, `update_plan`,
+a PR body, or a proof summary. Those artifacts may reference evidence, but they
+are not the evidence owner.
 
 ## Hard blocker names
 

--- a/codex/skills/agent-loop-schemes/SKILL.md
+++ b/codex/skills/agent-loop-schemes/SKILL.md
@@ -54,6 +54,11 @@ The essential receipts are ALSR-v1, HYL-v1, HSR-v1, evidence fold, and ATCG-v1.
 Planning views, work graphs, `update_plan`, and prose summaries are projections
 over those receipts. They may guide attention, but they do not prove control.
 
+For material `$actuating` work, the loop scheme must also define the runtime
+interlock: the exact condition under which mutation is allowed, the condition
+under which continuation is allowed, and the canonical blocker emitted when
+either condition fails.
+
 ## Protocol objects
 
 ### ALSR-v1: Agent Loop Scheme Receipt
@@ -245,6 +250,11 @@ current HYL state, the HYL state wins and the projection must be refreshed.
 
 If work happens inside HYL, the work graph can be regenerated.
 If work happens outside HYL, it is invalid actuation.
+
+The HSR-v1 unfold is the mutation interlock. If the interpreter cannot bind the
+current branch/head/diff, selected node, and previous fold, it emits `blocked`
+instead of an action. It must not continue by reconstructing authority from chat
+history, `update_plan`, or a summary.
 
 ## Fusion law
 
@@ -512,6 +522,10 @@ missing packet -> blocked-loop-contract-missing
 artifact scope changed -> blocked-loop-contract-stale
 pending frontier invalid -> blocked-hylo-frontier-missing
 ```
+
+A resume without a packet is not recoverable inside `$actuating` by rereading
+chat. The only legal continuation is to rebuild the loop contract through the
+owning skill or stop with the blocker.
 
 ## Failure classes
 

--- a/codex/skills/agent-loop-schemes/agents/openai.yaml
+++ b/codex/skills/agent-loop-schemes/agents/openai.yaml
@@ -6,7 +6,9 @@ interface:
   default_prompt: >-
     Use $agent-loop-schemes to design, audit, or repair a coding-agent loop. For
     material $actuating work, emit ALSR-v1 and HYL-v1 before mutation unless the
-    work is direct-action fused. Audit HSR-v1 transitions with
-    the law: no mutation without unfold, no continuation without fold, no
+    work is direct-action fused. The loop contract must name the runtime
+    interlock: mutation_allowed, continuation_allowed, current branch/head/diff
+    binding, and the canonical blocker for failure. Audit HSR-v1 transitions
+    with the law: no mutation without unfold, no continuation without fold, no
     completion without terminal ATCG. Do not run this as ceremony for ordinary
     one-shot edits.

--- a/codex/skills/goal-actuating/SKILL.md
+++ b/codex/skills/goal-actuating/SKILL.md
@@ -83,6 +83,13 @@ goal-artifact projections may show the current frontier, but they do not replace
 ALSR-v1, HYL-v1, HSR-v1, evidence-fold, proof-patch, review-fold, or ATCG-v1
 receipts.
 
+Before executing an HSR-v1 action, `$goal-actuating` must have a positive
+runtime interlock from `$actuating` or produce a blocked HSR-v1 step itself. A
+missing loop contract emits `blocked-loop-contract-missing`; stale branch/head
+or diff binding emits `blocked-loop-contract-stale`; a missing unfolded node
+emits `blocked-hylo-frontier-missing`; a missing previous fold emits
+`blocked-hylo-fold-missing`.
+
 ## HYL-v1 interpreter
 
 A material action is legal only as an HSR-v1 transition:
@@ -102,6 +109,9 @@ No completion is valid without terminal ATCG-v1.
 The minimum valid material transition is therefore `unfold -> action -> fold`.
 If any one of those fields is missing, the run is not governed actuation even
 when tests, summaries, or progress projections exist.
+
+Do not repair a missing interlock by performing more inspection or patching.
+Return the blocker as the next HSR-v1 state and wait for the correct owner.
 
 ## Review lanes
 
@@ -166,6 +176,7 @@ if no accepted spec -> blocked
 if topology nontrivial and no Scheme Plan -> produce scheme-planner node
 if material and no ALSR/HYL -> produce agent-loop-schemes node
 if no goal contract -> produce goal-contract node
+if runtime interlock blocks mutation -> emit blocked HSR-v1 node
 if review requested and no review profile -> produce review-profile node
 if review requested and no standard CAS result -> produce standard CAS review node
 if required auxiliary review lane missing or invalidated -> produce auxiliary review-lens evidence node

--- a/codex/skills/goal-actuating/agents/openai.yaml
+++ b/codex/skills/goal-actuating/agents/openai.yaml
@@ -11,6 +11,10 @@ interface:
     current ALSR/HYL exists, hand off to $agent-loop-schemes. Interpret HYL-v1 as
     a defunctionalized actuation machine: unfold a legal node/frontier, execute
     only that node/frontier, fold evidence, emit HSR-v1, and continue or stop.
+    If the runtime interlock is missing, stale, lacks an unfolded node, or lacks
+    a previous fold, emit the canonical blocked HSR-v1 state instead of
+    inspecting or patching further. update_plan and summaries are projections,
+    not receipt evidence.
     Review modes are triage, remediation-plan, and review-closeout; triage and
     remediation-plan do not implement, while review-closeout implements only
     accepted code-change liabilities. Fresh or exhaustive review must use $cas


### PR DESCRIPTION
## Summary
- Add an explicit `actuation_interlock` decision before material mutation and continuation.
- Promote canonical blockers into `$actuating`, `$goal-actuating`, `$agent-loop-schemes`, and their agent prompts.
- Tighten pre-mutation, compaction/resume, and terminal closure references so projections, `update_plan`, PR bodies, and summaries cannot substitute for receipts.

## Proof
- `rg -n "actuation_interlock|mutation_allowed: yes \| no|continuation_allowed: yes \| no|blocked-loop-contract-missing|interlock_no_followed_by_mutation|latest actuation_interlock|not infer a missing receipt|resume packet is missing or stale|canonical blocked HSR-v1" ...`: pass
- prompt YAML parse for `actuating`, `goal-actuating`, and `agent-loop-schemes`: pass
- `git diff --check`: pass
- `uv run python codex/skills/actuating/tools/quick_validate.py`: pass
- `uv run python codex/skills/spec-pipeline/tools/quick_validate.py`: pass
- `uv run python codex/skills/plan/tests/test_policy_synthesis_receipt_gate.py && uv run python codex/skills/plan/tests/test_policy_tools.py`: pass

## Scope
- branch: `codex/runtime-discipline-enforcement`
- head: `efe429c7f275a0fdfffcd07c440b31943e511385`
- base: `main`

## Readiness
- PR mode: ready
- Reason: focused docs/prompt/reference runtime-discipline hardening with existing validation green.
- Caveats: intentionally no new tests, validators, fixtures, schemas, or Python tools per user direction.