### PR TITLE
Enforce actuation interlock in terminal gate

### DIFF
--- a/codex/skills/actuating/SKILL.md
+++ b/codex/skills/actuating/SKILL.md
@@ -73,7 +73,7 @@ Before any material mutation, and before continuing after any material action,
 actuation_interlock:
   mutation_allowed: yes | no
   continuation_allowed: yes | no
-  blocker: none | blocked-loop-contract-missing | blocked-loop-contract-stale | blocked-hylo-frontier-missing | blocked-hylo-fold-missing
+  blocker: none | blocked-loop-contract-missing | blocked-loop-contract-stale | blocked-hylo-frontier-missing | blocked-hylo-fold-missing | blocked-unsupported-controller
   current_binding:
     branch:
     head:
@@ -81,9 +81,11 @@ actuation_interlock:
 ```
 
 `mutation_allowed: yes` requires either a valid FUSION-v1 receipt or a current
-ALSR-v1 + HYL-v1 + HSR-v1 chain with an unfolded work item/frontier. If the
-interlock is `no`, stop immediately with the blocker. Do not keep inspecting,
-patching, or relying on `update_plan` to make progress inside `$actuating`.
+ALSR-v1 + HYL-v1 with an unfolded work item/frontier. HSR-v1 is required once a
+material step exists, and `continuation_allowed: yes` requires the previous HSR
+fold to be current. If the interlock is `no`, stop immediately with the blocker.
+Do not keep inspecting, patching, or relying on `update_plan` to make progress
+inside `$actuating`.
 
 ## Removed controller path
 
@@ -156,7 +158,8 @@ For material runs, `$actuating` must establish one of:
 
 ```text
 valid FUSION-v1 direct-action receipt
-current ALSR-v1 + HYL-v1 + HSR-v1 chain
+current ALSR-v1 + HYL-v1 with an unfolded work item/frontier
+current HSR-v1 fold before continuation after any material action
 ```
 
 The receipt must bind the current branch, head, and diff. A prose declaration,

--- a/codex/skills/actuating/agents/openai.yaml
+++ b/codex/skills/actuating/agents/openai.yaml
@@ -9,10 +9,12 @@ interface:
     when one is not already available. Use $recursion-scheme-planner when the
     work shape is not simple. For material work, emit an actuation_interlock
     before mutation. mutation_allowed=yes requires either a valid FUSION-v1
-    direct-action receipt or current ALSR-v1, HYL-v1, and HSR-v1 receipts with
-    an unfolded work item/frontier bound to the current branch/head/diff.
+    direct-action receipt or current ALSR-v1 and HYL-v1 receipts with an
+    unfolded work item/frontier bound to the current branch/head/diff; HSR-v1 is
+    required for continuation after a material step.
     mutation_allowed=no stops immediately with blocked-loop-contract-missing,
-    blocked-loop-contract-stale, or blocked-hylo-frontier-missing. Do not use
+    blocked-loop-contract-stale, blocked-hylo-frontier-missing,
+    blocked-hylo-fold-missing, or blocked-unsupported-controller. Do not use
     update_plan, summaries, cached checks, or chat history as receipt evidence.
     $goal-actuating executes the selected work item or safe frontier and folds
     evidence after each material action before any continuation. Review requests default to

--- a/codex/skills/actuating/assets/terminal-context.hylo-complete.example.json
+++ b/codex/skills/actuating/assets/terminal-context.hylo-complete.example.json
@@ -10,6 +10,16 @@
       "diff_fingerprint": "diff:clean",
       "dirty_state": "clean"
     },
+    "actuation_interlock": {
+      "mutation_allowed": "yes",
+      "continuation_allowed": "yes",
+      "blocker": "none",
+      "current_binding": {
+        "branch": "feature/example",
+        "head": "abc123",
+        "diff_fingerprint": "diff:clean"
+      }
+    },
     "local_proof": {
       "evidence_fold_verdict": "done",
       "commands": [

--- a/codex/skills/actuating/references/pre-mutation-interlock.md
+++ b/codex/skills/actuating/references/pre-mutation-interlock.md
@@ -16,7 +16,8 @@ Before a material change, `$actuating` must have one of:
 
 ```text
 valid FUSION-v1 receipt for one simple direct action
-current ALSR-v1 + HYL-v1 + HSR-v1 receipt chain
+current ALSR-v1 + HYL-v1 with an unfolded work item/frontier
+current HSR-v1 fold before continuation after any material action
 ```
 
 The caller must make the decision explicit before mutation:

--- a/codex/skills/actuating/references/terminal-closure-gate.md
+++ b/codex/skills/actuating/references/terminal-closure-gate.md
@@ -62,7 +62,7 @@ ATCG-v1 consumes current receiver-owned evidence:
 
 ```text
 current branch/head/diff binding
-latest actuation_interlock decision
+latest actuation_interlock decision for material ALSR/HYL runs
 FUSION-v1 receipt or ALSR/HYL/HSR receipts
 optional goal-focus frame state
 local evidence-fold verdict and proof commands
@@ -81,7 +81,7 @@ For material work, ATCG requires one of:
 
 ```text
 valid FUSION-v1 receipt for one simple action
-current ALSR-v1 + HYL-v1 + terminal HSR-v1 chain
+current positive actuation_interlock + current ALSR-v1 + HYL-v1 + terminal HSR-v1 chain
 ```
 
 A raw boolean such as `direct_action_fused: yes` is not enough. A fused run must

--- a/codex/skills/actuating/tests/test_actuation_terminal_gate.py
+++ b/codex/skills/actuating/tests/test_actuation_terminal_gate.py
@@ -45,10 +45,25 @@ class ActuationTerminalGateTests(unittest.TestCase):
         decision = MODULE.make_decision(self.context("terminal-context.hylo-complete.example.json"))
         body = decision["actuation_terminal_decision"]
         self.assertEqual(body["verdict"], "complete")
+        self.assertIn("actuation_interlock", body["required_receipts"])
         self.assertIn("alsr", body["required_receipts"])
         self.assertIn("hyl", body["required_receipts"])
         self.assertIn("terminal_hsr", body["required_receipts"])
         self.assertIn("goal_focus_frame_chain", body["required_receipts"])
+
+    def test_hylo_context_without_interlock_blocks_completion(self) -> None:
+        context = deepcopy(self.context("terminal-context.hylo-complete.example.json"))
+        del context["actuation_interlock"]
+        self.assert_blocks_with(context, "actuation_interlock:missing", "$goal-actuating")
+
+    def test_interlock_continuation_denial_blocks_completion(self) -> None:
+        context = deepcopy(self.context("terminal-context.hylo-complete.example.json"))
+        context["actuation_interlock"]["continuation_allowed"] = "no"
+        context["actuation_interlock"]["blocker"] = "blocked-hylo-fold-missing"
+        self.assert_blocks_with(context, "blocked-hylo-fold-missing", "$goal-actuating")
+        decision = MODULE.make_decision(context)
+        body = decision["actuation_terminal_decision"]
+        self.assertIn("actuation_interlock.continuation_allowed:not-yes", body["blocked_reasons"])
 
     def test_material_run_without_hsr_chain_blocks(self) -> None:
         context = deepcopy(self.context("terminal-context.hylo-complete.example.json"))

--- a/codex/skills/actuating/tools/actuation_terminal_gate.py
+++ b/codex/skills/actuating/tools/actuation_terminal_gate.py
@@ -42,10 +42,19 @@ HARD_REASON_ORDER = [
     "blocked-hylo-frontier-missing",
     "blocked-hylo-fold-missing",
     "blocked-hylo-terminal-missing",
+    "blocked-unsupported-controller",
     "cas-review-blocked",
     "proof-stale",
     "side-effect-boundary-violated",
 ]
+INTERLOCK_BLOCKERS = {
+    "none",
+    "blocked-loop-contract-missing",
+    "blocked-loop-contract-stale",
+    "blocked-hylo-frontier-missing",
+    "blocked-hylo-fold-missing",
+    "blocked-unsupported-controller",
+}
 
 
 class TerminalGateError(ValueError):
@@ -213,6 +222,7 @@ def hard_completion_reasons_for(context: dict[str, Any]) -> list[str]:
         reasons.extend(hyl_reasons_for(hyl, artifact, alsr))
 
     if loop_required and not loop_receipts_exempt:
+        reasons.extend(actuation_interlock_reasons_for(context, loop, artifact))
         reasons.extend(hsr_reasons_for(loop, hsr, artifact))
 
     selected_loop = object_from(loop.get("selected_loop"))
@@ -272,6 +282,72 @@ def fusion_receipt_reasons_for(context: dict[str, Any], loop: dict[str, Any]) ->
     if not isinstance(receipt.get("proof_ref"), str) or not receipt.get("proof_ref"):
         reasons.append("fusion_receipt.proof_ref:missing")
     return reasons
+
+
+def actuation_interlock_reasons_for(context: dict[str, Any], loop: dict[str, Any], artifact: dict[str, Any]) -> list[str]:
+    interlock = object_from(context.get("actuation_interlock")) or object_from(loop.get("actuation_interlock"))
+    if not interlock:
+        return ["blocked-loop-contract-missing", "actuation_interlock:missing"]
+
+    reasons: list[str] = []
+    blocker = interlock.get("blocker")
+    if blocker not in INTERLOCK_BLOCKERS:
+        reasons.append("actuation_interlock.blocker:invalid")
+    elif blocker != "none":
+        append_reason(reasons, blocker)
+
+    binding = object_from(interlock.get("current_binding"))
+    if not binding:
+        append_reason(reasons, "blocked-loop-contract-missing")
+        reasons.append("actuation_interlock.current_binding:missing")
+    else:
+        compare_interlock_binding(reasons, binding, artifact)
+
+    if explicit_no(interlock.get("current")):
+        append_reason(reasons, "blocked-loop-contract-stale")
+        reasons.append("actuation_interlock.current:not-yes")
+
+    if not as_yes(interlock.get("mutation_allowed")):
+        if not interlock_has_hard_blocker(reasons):
+            append_reason(reasons, "blocked-hylo-frontier-missing")
+        reasons.append("actuation_interlock.mutation_allowed:not-yes")
+
+    if not as_yes(interlock.get("continuation_allowed")):
+        if not interlock_has_hard_blocker(reasons):
+            append_reason(reasons, "blocked-hylo-fold-missing")
+        reasons.append("actuation_interlock.continuation_allowed:not-yes")
+
+    return reasons
+
+
+def compare_interlock_binding(reasons: list[str], binding: dict[str, Any], artifact: dict[str, Any]) -> None:
+    branch = binding.get("branch")
+    if not isinstance(branch, str) or not branch:
+        append_reason(reasons, "blocked-loop-contract-missing")
+        reasons.append("actuation_interlock.current_binding.branch:missing")
+    elif artifact.get("branch") and branch != artifact.get("branch"):
+        append_reason(reasons, "blocked-loop-contract-stale")
+        reasons.append("actuation_interlock.current_binding.branch:artifact-mismatch")
+
+    head = first_present(binding, ("head", "head_sha"))
+    if not isinstance(head, str) or not head:
+        append_reason(reasons, "blocked-loop-contract-missing")
+        reasons.append("actuation_interlock.current_binding.head:missing")
+    elif artifact.get("head_sha") and head != artifact.get("head_sha"):
+        append_reason(reasons, "blocked-loop-contract-stale")
+        reasons.append("actuation_interlock.current_binding.head:artifact-mismatch")
+
+    diff = first_present(binding, ("diff_fingerprint", "diff_digest"))
+    if not isinstance(diff, str) or not diff:
+        append_reason(reasons, "blocked-loop-contract-missing")
+        reasons.append("actuation_interlock.current_binding.diff_fingerprint:missing")
+    elif artifact.get("diff_fingerprint") and diff != artifact.get("diff_fingerprint"):
+        append_reason(reasons, "blocked-loop-contract-stale")
+        reasons.append("actuation_interlock.current_binding.diff_fingerprint:artifact-mismatch")
+
+
+def interlock_has_hard_blocker(reasons: list[str]) -> bool:
+    return any(reason in INTERLOCK_BLOCKERS and reason != "none" for reason in reasons)
 
 
 def loop_receipts_required(loop: dict[str, Any], hsr: dict[str, Any]) -> bool:
@@ -1218,7 +1294,7 @@ def required_receipts_for(proof_patch: dict[str, Any], cas: dict[str, Any], prof
     if direct_action_fused_requested(loop):
         receipts.append("fusion_receipt")
     elif loop_receipts_required(loop, hsr):
-        receipts.extend(["alsr", "hyl", "terminal_hsr"])
+        receipts.extend(["actuation_interlock", "alsr", "hyl", "terminal_hsr"])
     if as_yes(object_from(loop.get("goal_focus")).get("required")):
         receipts.append("goal_focus_frame_chain")
     if object_from(loop.get("refactor_kernel")).get("selected") == "yes" or as_yes(object_from(loop.get("refactor_kernel")).get("selected")):
@@ -1256,6 +1332,8 @@ def next_owner_for(blocked: list[str], pending: list[str]) -> str:
         return "$goal-actuating"
     if any(reason == "side-effect-boundary-violated" for reason in combined):
         return "$ship"
+    if any(reason == "blocked-unsupported-controller" for reason in combined):
+        return "human"
     if any(reason.startswith("fusion_receipt") or reason.startswith("goal_focus") for reason in combined):
         return "$goal-actuating"
     if any(reason.startswith("blocked-loop-contract") or reason.startswith("blocked-hylo") or reason.startswith("alsr") or reason.startswith("hyl") or reason.startswith("hsr") or reason.startswith("material_mutations") or reason.startswith("selected_loop") for reason in combined):

--- a/codex/skills/goal-actuating/SKILL.md
+++ b/codex/skills/goal-actuating/SKILL.md
@@ -83,11 +83,13 @@ goal-artifact projections may show the current frontier, but they do not replace
 ALSR-v1, HYL-v1, HSR-v1, evidence-fold, proof-patch, review-fold, or ATCG-v1
 receipts.
 
-Before executing an HSR-v1 action, `$goal-actuating` must have a positive
-runtime interlock from `$actuating` or produce a blocked HSR-v1 step itself. A
-missing loop contract emits `blocked-loop-contract-missing`; stale branch/head
-or diff binding emits `blocked-loop-contract-stale`; a missing unfolded node
-emits `blocked-hylo-frontier-missing`; a missing previous fold emits
+Before executing an HSR-v1 action, `$goal-actuating` must have or emit a
+positive runtime interlock. If invoked through `$actuating`, consume the wrapper
+interlock. If invoked directly or implicitly, emit the interlock from the current
+ALSR/HYL/frontier state before acting. A missing loop contract emits
+`blocked-loop-contract-missing`; stale branch/head or diff binding emits
+`blocked-loop-contract-stale`; a missing unfolded node emits
+`blocked-hylo-frontier-missing`; a missing previous fold emits
 `blocked-hylo-fold-missing`.
 
 ## HYL-v1 interpreter

--- a/codex/skills/goal-actuating/agents/openai.yaml
+++ b/codex/skills/goal-actuating/agents/openai.yaml
@@ -11,10 +11,11 @@ interface:
     current ALSR/HYL exists, hand off to $agent-loop-schemes. Interpret HYL-v1 as
     a defunctionalized actuation machine: unfold a legal node/frontier, execute
     only that node/frontier, fold evidence, emit HSR-v1, and continue or stop.
-    If the runtime interlock is missing, stale, lacks an unfolded node, or lacks
-    a previous fold, emit the canonical blocked HSR-v1 state instead of
-    inspecting or patching further. update_plan and summaries are projections,
-    not receipt evidence.
+    If invoked directly or implicitly, emit a positive runtime interlock from
+    current ALSR/HYL/frontier state before action. If the runtime interlock is
+    missing, stale, lacks an unfolded node, or lacks a previous fold, emit the
+    canonical blocked HSR-v1 state instead of inspecting or patching further.
+    update_plan and summaries are projections, not receipt evidence.
     Review modes are triage, remediation-plan, and review-closeout; triage and
     remediation-plan do not implement, while review-closeout implements only
     accepted code-change liabilities. Fresh or exhaustive review must use $cas


### PR DESCRIPTION
## Summary
- Enforce `actuation_interlock` mechanically in ATCG for material ALSR/HYL runs.
- Align `$actuating` and `$goal-actuating` doctrine/prompts with the non-circular first-step rule.
- Add terminal-gate regression coverage for missing and fold-denied interlocks.

## Proof
- `uv run python codex/skills/actuating/tests/test_actuation_terminal_gate.py`: pass
- `uv run python codex/skills/actuating/tools/quick_validate.py`: pass
- `uv run python codex/skills/spec-pipeline/tools/quick_validate.py`: pass
- `uv run --with pyyaml python - <<'PY' ... PY`: pass
- `git diff --check`: pass

## Scope
- branch: codex/pr90-interlock-enforcement
- head: e1a7ed19fe5a966fb990ca36c4bc2a840e765f96
- base: main

## Readiness
- PR mode: ready
- Reason: Implementation is complete, focused validation passed, and no blockers remain.
- Caveats: No hosted checks had completed at PR creation time.
