### PR TITLE
Close ATCG interlock validation bypasses

### DIFF
--- a/codex/skills/actuating/tests/test_actuation_terminal_gate.py
+++ b/codex/skills/actuating/tests/test_actuation_terminal_gate.py
@@ -65,6 +65,18 @@ class ActuationTerminalGateTests(unittest.TestCase):
         body = decision["actuation_terminal_decision"]
         self.assertIn("actuation_interlock.continuation_allowed:not-yes", body["blocked_reasons"])
 
+    def test_malformed_top_level_interlock_does_not_fall_back_to_loop_copy(self) -> None:
+        context = deepcopy(self.context("terminal-context.hylo-complete.example.json"))
+        context["loop_governance"]["actuation_interlock"] = deepcopy(context["actuation_interlock"])
+        context["actuation_interlock"] = "malformed"
+        self.assert_blocks_with(context, "actuation_interlock:must-be-object", "$goal-actuating")
+
+    def test_empty_top_level_interlock_does_not_fall_back_to_loop_copy(self) -> None:
+        context = deepcopy(self.context("terminal-context.hylo-complete.example.json"))
+        context["loop_governance"]["actuation_interlock"] = deepcopy(context["actuation_interlock"])
+        context["actuation_interlock"] = {}
+        self.assert_blocks_with(context, "actuation_interlock:missing", "$goal-actuating")
+
     def test_material_run_without_hsr_chain_blocks(self) -> None:
         context = deepcopy(self.context("terminal-context.hylo-complete.example.json"))
         loop = context["loop_governance"]
@@ -189,6 +201,13 @@ class ActuationTerminalGateTests(unittest.TestCase):
         body = allowance["actuation_completion_allowance"]
         self.assertEqual(body["verdict"], "denied")
         self.assertEqual(body["next_owner"], "$goal-actuating")
+
+    def test_completion_allowance_rejects_material_decision_without_interlock_receipt(self) -> None:
+        decision = MODULE.make_decision(self.context("terminal-context.hylo-complete.example.json"))
+        receipts = decision["actuation_terminal_decision"]["required_receipts"]
+        receipts.remove("actuation_interlock")
+        with self.assertRaisesRegex(MODULE.TerminalGateError, "complete.required_receipts.actuation_interlock:missing"):
+            MODULE.make_completion_allowance(decision)
 
     def test_check_rejects_complete_without_artifact_binding(self) -> None:
         decision = self.decision("atcg-v1.complete.example.json")

--- a/codex/skills/actuating/tests/test_actuation_terminal_gate.py
+++ b/codex/skills/actuating/tests/test_actuation_terminal_gate.py
@@ -209,6 +209,12 @@ class ActuationTerminalGateTests(unittest.TestCase):
         with self.assertRaisesRegex(MODULE.TerminalGateError, "complete.required_receipts.actuation_interlock:missing"):
             MODULE.make_completion_allowance(decision)
 
+    def test_completion_allowance_rejects_goal_focus_decision_without_interlock_receipt(self) -> None:
+        decision = self.decision("atcg-v1.complete.example.json")
+        decision["actuation_terminal_decision"]["required_receipts"].append("goal_focus_frame_chain")
+        with self.assertRaisesRegex(MODULE.TerminalGateError, "complete.required_receipts.actuation_interlock:missing"):
+            MODULE.make_completion_allowance(decision)
+
     def test_check_rejects_complete_without_artifact_binding(self) -> None:
         decision = self.decision("atcg-v1.complete.example.json")
         decision["actuation_terminal_decision"]["current_artifact_binding"]["head_sha"] = ""

--- a/codex/skills/actuating/tools/actuation_terminal_gate.py
+++ b/codex/skills/actuating/tools/actuation_terminal_gate.py
@@ -285,7 +285,14 @@ def fusion_receipt_reasons_for(context: dict[str, Any], loop: dict[str, Any]) ->
 
 
 def actuation_interlock_reasons_for(context: dict[str, Any], loop: dict[str, Any], artifact: dict[str, Any]) -> list[str]:
-    interlock = object_from(context.get("actuation_interlock")) or object_from(loop.get("actuation_interlock"))
+    if "actuation_interlock" in context:
+        raw_interlock = context.get("actuation_interlock")
+    else:
+        raw_interlock = loop.get("actuation_interlock")
+    if raw_interlock is not None and not isinstance(raw_interlock, dict):
+        return ["blocked-loop-contract-missing", "actuation_interlock:must-be-object"]
+
+    interlock = object_from(raw_interlock)
     if not interlock:
         return ["blocked-loop-contract-missing", "actuation_interlock:missing"]
 
@@ -1310,6 +1317,10 @@ def required_receipts_for(proof_patch: dict[str, Any], cas: dict[str, Any], prof
     return unique(receipts)
 
 
+def receipts_require_interlock(receipts: list[Any]) -> bool:
+    return any(receipt in receipts for receipt in ("alsr", "hyl", "terminal_hsr"))
+
+
 def next_owner_for(blocked: list[str], pending: list[str]) -> str:
     combined = blocked + pending
     if any("ask-human" in reason for reason in combined):
@@ -1390,6 +1401,8 @@ def validate_decision(value: dict[str, Any]) -> dict[str, Any]:
         receipts = d.get("required_receipts") if isinstance(d.get("required_receipts"), list) else []
         if d.get("closure_candidate") == "proof-patch" and "proof_patch" not in receipts:
             errors.append("complete.required_receipts.proof_patch:missing")
+        if receipts_require_interlock(receipts) and "actuation_interlock" not in receipts:
+            errors.append("complete.required_receipts.actuation_interlock:missing")
         if d.get("closure_candidate") == "ship-complete":
             if "add_v1_delivery_decision" not in receipts:
                 errors.append("complete.required_receipts.add_v1_delivery_decision:missing")

--- a/codex/skills/actuating/tools/actuation_terminal_gate.py
+++ b/codex/skills/actuating/tools/actuation_terminal_gate.py
@@ -1318,7 +1318,7 @@ def required_receipts_for(proof_patch: dict[str, Any], cas: dict[str, Any], prof
 
 
 def receipts_require_interlock(receipts: list[Any]) -> bool:
-    return any(receipt in receipts for receipt in ("alsr", "hyl", "terminal_hsr"))
+    return any(receipt in receipts for receipt in ("alsr", "hyl", "terminal_hsr", "goal_focus_frame_chain"))
 
 
 def next_owner_for(blocked: list[str], pending: list[str]) -> str:


### PR DESCRIPTION
## Summary
- Address post-merge review feedback from PR #91.
- Reject malformed top-level `actuation_interlock` values instead of falling back to an older loop copy.
- Require persisted complete material ATCG decisions to list `actuation_interlock` before `allow-complete` can grant completion.
- Extend the persisted-decision interlock requirement to `goal_focus_frame_chain` receipts.

## Review Threads Addressed
- PR #91 `PRRT_kwDOAdi34s6O_b8K`: persisted material decisions missing the interlock receipt are now rejected by `validate_decision`.
- PR #91 `PRRT_kwDOAdi34s6O_b8P`: supplied-but-invalid top-level interlocks now block instead of falling through to `loop_governance.actuation_interlock`.
- PR #92 `PRRT_kwDOAdi34s6O_map`: goal-focus persisted decisions now require `actuation_interlock`.

## Proof
- `uv run python codex/skills/actuating/tests/test_actuation_terminal_gate.py`: pass
- `uv run python codex/skills/actuating/tools/quick_validate.py`: pass
- `uv run python codex/skills/spec-pipeline/tools/quick_validate.py`: pass
- `git diff --check`: pass

## Scope
- branch: codex/pr91-review-fixes
- head: ad02f4d2c8dae6b2269aa3b05469c24eb578b70e
- base: main

## Readiness
- PR mode: ready
- Reason: Accepted review liabilities are fixed with focused regressions and validation passed.
- Caveats: Original PR #91 is already merged; this is a follow-up PR.
