### PR TITLE
Restore no-code actuating review modes

### DIFF
--- a/codex/skills/actuating/SKILL.md
+++ b/codex/skills/actuating/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: actuating
-description: "User-facing workflow for implementing approved work. It gets an accepted spec when needed, checks whether a loop receipt is required, runs the goal runtime, requires CAS-backed review when review is in scope, and closes only through proof plus ATCG."
+description: "User-facing workflow for implementing approved work and no-code review modes. It gets an accepted spec when needed, checks whether a loop receipt is required, runs the goal runtime, requires CAS-backed review when review is in scope, and closes material work only through proof plus ATCG."
 metadata:
   version: "7.1.0"
   activation_cost: medium
@@ -11,7 +11,8 @@ metadata:
 
 ## Mission
 
-Run implementation work without making the user manage the lower-level skills.
+Run implementation and review-routing work without making the user manage the
+lower-level skills.
 
 ```text
 implementation request or draft spec
@@ -27,6 +28,8 @@ Use it as:
 
 ```text
 /goal $actuating implement the accepted spec
+/goal $actuating triage this PR
+/goal $actuating remediation-plan this PR
 /goal $actuating review-closeout this PR
 /goal $actuating dry-plan the accepted spec
 ```
@@ -46,7 +49,7 @@ Do not claim completion until the terminal gate allows it.
 
 ## Essential governance spine
 
-The essential `$actuating` spine is:
+The essential material `$actuating` spine is:
 
 ```text
 accepted source
@@ -63,6 +66,18 @@ Everything else is supporting machinery. Work graphs, `update_plan`, summaries,
 progress projections, cached checks, stale review runs, and raw review text may
 help select the next action, but they are not receipt evidence and cannot
 replace the spine.
+
+No-code review modes have a smaller spine:
+
+```text
+current review source
+-> review-fold
+-> triage report or remediation plan
+-> stop without mutation, proof-patch, ATCG, or `$ship`
+```
+
+They do not claim implementation closure and must not be upgraded into material
+actuation merely because they inspect code, run review, or plan a fix.
 
 ## Runtime interlock
 
@@ -87,6 +102,13 @@ fold to be current. If the interlock is `no`, stop immediately with the blocker.
 Do not keep inspecting, patching, or relying on `update_plan` to make progress
 inside `$actuating`.
 
+The interlock gates material mutation and continuation only. In `triage` and
+`remediation-plan`, omit the interlock unless the workflow leaves no-code mode.
+Missing loop receipts or a missing interlock must not block review collection,
+classification, or plan production. If the next action would edit files, resolve
+public threads, push, publish, or claim implementation closure, first transition
+to `review-closeout`, `$ship`, or `$land` and satisfy that owner’s gates.
+
 ## Removed controller path
 
 The old transaction-controller/APMA path is not active in this workspace. If the
@@ -101,15 +123,18 @@ controller. It must not pretend that local edits are a fenced actuation run.
 2. Treat the accepted spec as the source of truth.
 3. Use `$recursion-scheme-planner` when the work has branching, repeated classes,
    review campaigns, migrations, proof fanout, or unclear stopping conditions.
-4. Use `$agent-loop-schemes` when material work needs ALSR/HYL loop receipts.
-5. Send the accepted work to `$goal-actuating`.
-6. Emit the runtime interlock before the first material mutation.
-7. Use `$cas` when workflow review is requested or required.
-8. Pass findings through `$review-fold` before any review-driven code change.
-9. Implement only accepted code-change liabilities.
-10. Fold current evidence after each material action before continuing.
-11. Run ATCG-v1 before any completion claim.
-12. Emit a proof-patch result or a `$ship` handoff when PR publication/update was requested.
+4. If the explicit mode is `triage` or `remediation-plan`, run the selected
+   review source, `$review-fold`, and the resolution fold when needed, then stop
+   with the report or plan.
+5. Use `$agent-loop-schemes` when material work needs ALSR/HYL loop receipts.
+6. Send the accepted material work to `$goal-actuating`.
+7. Emit the runtime interlock before the first material mutation.
+8. Use `$cas` when workflow review is requested or required.
+9. Pass findings through `$review-fold` before any review-driven code change.
+10. Implement only accepted code-change liabilities.
+11. Fold current evidence after each material action before continuing.
+12. Run ATCG-v1 before any material completion claim.
+13. Emit a proof-patch result or a `$ship` handoff when PR publication/update was requested.
 
 ## Source requirement
 
@@ -125,6 +150,10 @@ plan handoff for goal-artifact execution
 These sources authorize routing only. They do not authorize mutation unless the
 loop/fusion receipt, unfolded work item, and evidence-fold requirements below
 are also current for the branch/head/diff.
+
+For no-code review modes, a current review source authorizes inspection,
+classification, and planning only. It does not require or imply mutation
+authority.
 
 If none exists, run `$spec-pipeline` in gate-only/no-plan mode or stop with:
 
@@ -145,7 +174,7 @@ Require ALSR/HYL when the work has:
 ```text
 repeated failure or review classes
 many-file migration
-review closeout or CAS closure
+review-closeout or CAS closure
 branch choices or competing implementation strategies
 proof fanout
 parallel subagent opportunities
@@ -188,6 +217,11 @@ If the previous material action has no current evidence fold, stop with:
 ```text
 actuation verdict: blocked-hylo-fold-missing
 ```
+
+`triage` and `remediation-plan` do not require loop receipts solely because they
+use review or CAS. They become material only if the workflow accepts a
+code-change liability for implementation, performs a public side effect, or
+claims implementation closure.
 
 ## Direct-action fusion
 
@@ -268,6 +302,12 @@ $cas review
 ```
 
 Raw review text never reaches implementation directly.
+
+`triage` and `remediation-plan` are no-code control modes. They may read files,
+inspect diffs, run `$cas` or consume existing review evidence, fold findings,
+and produce reports or plans. They must not require ALSR/HYL/HSR, a positive
+actuation interlock, proof-patch, three clean review attempts, or ATCG unless
+they explicitly transition to `review-closeout`.
 
 ## Review lanes
 
@@ -354,10 +394,10 @@ proof closure, and `$ship` handoff.
 
 ## Terminal closure
 
-Before `$actuating` may report completion or call `update_goal complete`, run
-ATCG-v1 over the current branch/head/diff, loop receipts or fusion receipt,
-latest HSR/focus evidence, evidence fold, proof-patch, CAS state, delivery state,
-and side-effect boundary.
+Before `$actuating` may report material implementation completion or call
+`update_goal complete`, run ATCG-v1 over the current branch/head/diff, loop
+receipts or fusion receipt, latest HSR/focus evidence, evidence fold,
+proof-patch, CAS state, delivery state, and side-effect boundary.
 
 Completion is legal only when:
 
@@ -370,6 +410,9 @@ Do not substitute local proof, a proof-complete graph, cached CAS receipts, or
 ADD-v1 `handoff_to_ship` for terminal completion. A `$ship` result is delivery
 evidence, not completion evidence, until ATCG-v1 folds it into the terminal
 state.
+
+ATCG is not required for a `triage` report or `remediation-plan` because those
+outputs intentionally do not claim implementation completion.
 
 ## Stop rules
 
@@ -385,8 +428,8 @@ three clean standard CAS reviews are required but cannot be completed
 parallel fanout would cross shared invariants or conflicting resources
 ALSR/HYL/HSR is required but missing or stale
 FUSION-v1 is claimed but not proven
-actuation interlock returns `mutation_allowed: no`
-actuation interlock returns `continuation_allowed: no`
+actuation interlock returns `mutation_allowed: no` for a material action
+actuation interlock returns `continuation_allowed: no` for material continuation
 unfold is missing before material mutation
 fold is missing after material action
 goal-focus frames are missing, stale, or not folded to parent
@@ -394,6 +437,10 @@ verification regresses and the next action is not isolate/revert/prove
 public tracker or PR side effects would occur without explicit intent
 ATCG-v1 does not return can_mark_goal_complete=yes
 ```
+
+In no-code review modes, a missing interlock is not a blocker by itself. The
+blocker appears only when the workflow attempts mutation, public side effects,
+or implementation closure.
 
 ## Final report
 

--- a/codex/skills/actuating/SKILL.md
+++ b/codex/skills/actuating/SKILL.md
@@ -72,7 +72,7 @@ No-code review modes have a smaller spine:
 ```text
 current review source
 -> review-fold
--> triage report or remediation plan
+-> triage report or resolution fold -> remediation plan
 -> stop without mutation, proof-patch, ATCG, or `$ship`
 ```
 

--- a/codex/skills/actuating/agents/openai.yaml
+++ b/codex/skills/actuating/agents/openai.yaml
@@ -2,7 +2,7 @@ policy:
   allow_implicit_invocation: false
 interface:
   display_name: "Actuating"
-  short_description: "Explicit implementation workflow with proof, review, loop, and terminal closure checks"
+  short_description: "Explicit material implementation and no-code review workflow"
   default_prompt: >-
     Use $actuating only as the explicit /goal implementation workflow. First get
     an accepted implementation spec from $spec-pipeline in gate-only/no-plan mode
@@ -16,8 +16,11 @@ interface:
     blocked-loop-contract-stale, blocked-hylo-frontier-missing,
     blocked-hylo-fold-missing, or blocked-unsupported-controller. Do not use
     update_plan, summaries, cached checks, or chat history as receipt evidence.
-    $goal-actuating executes the selected work item or safe frontier and folds
-    evidence after each material action before any continuation. Review requests default to
+    Triage and remediation-plan are no-code review modes: they may inspect, run
+    review, fold findings, produce a report or plan, and stop without loop
+    receipts, interlock, HSR-v1, proof-patch, ATCG, or $ship. $goal-actuating
+    executes the selected work item or safe frontier and folds evidence after
+    each material action before any continuation. Review requests default to
     review-closeout unless the user asks for triage, remediation-plan, or another
     no-change mode. Fresh or exhaustive workflow review must use $cas; findings
     must pass through $review-fold; only accepted code-change liabilities may be

--- a/codex/skills/actuating/references/decision-contract.yaml
+++ b/codex/skills/actuating/references/decision-contract.yaml
@@ -65,6 +65,10 @@ skill_decision_contract:
       description: Run standard CAS review and selected auxiliary review lenses while preserving the standard-only clean streak.
       aliases: [cas-review-bundle, standard-review, footgun-finder, invariant-ace, complexity-mitigator]
       terminal: "no"
+    - route_id: ACT-REVIEW-NO-CODE
+      description: End triage or remediation-plan with a review disposition report or remediation plan and no material closure claim.
+      aliases: [triage-report, remediation-plan, no-code-review]
+      terminal: "yes"
     - route_id: ACT-ATCG
       description: Run terminal closure gate before completion.
       aliases: [ATCG-v1]
@@ -141,27 +145,29 @@ skill_decision_contract:
       rationale: Local focus frames may guide work but only the parent goal plus ATCG may close the run.
     - clause_id: ACT-REVIEW-001
       trigger_refs: [ACT-REVIEW]
-      expected_routes: [ACT-CAS-REVIEW, ACT-CAS-REVIEW-LANES, ACT-LOOP-CONTRACT, ACT-GOAL, ACT-ATCG, ACT-BLOCK]
+      expected_routes: [ACT-CAS-REVIEW, ACT-CAS-REVIEW-LANES, ACT-REVIEW-NO-CODE, ACT-LOOP-CONTRACT, ACT-GOAL, ACT-ATCG, ACT-BLOCK]
       prohibited_routes: []
       required_artifacts:
         - standard CAS review verdict when workflow code review is required
         - review-fold disposition
         - resolution fold for remediation-plan or review-closeout
-        - three clean normalized standard CAS review attempts unless explicitly lowered
+        - loop receipts, proof-patch, three clean normalized standard CAS review attempts, and ATCG only for review-closeout or material closure
       success_signals:
         - fresh or exhaustive workflow review comes from $cas
         - review findings are classified before implementation
+        - triage and remediation-plan stop without material mutation or completion claims
         - raw review findings are reduced into liabilities/classes before patching
         - only standard CAS review attempts count toward the three-clean-review closure bar
       failure_signals:
         - non-CAS critique substitutes for workflow code review
         - raw review prose directly drives code changes
+        - no-code review mode requires positive interlock, HSR-v1, proof-patch, or ATCG
         - cached CAS receipt counted as fresh repeated review
         - auxiliary review lens counted as a standard clean review
       rationale: Review stays strict while the resolution fold controls which findings become code changes.
     - clause_id: ACT-REVIEW-LANES-001
       trigger_refs: [ACT-REVIEW-LANES]
-      expected_routes: [ACT-CAS-REVIEW-LANES, ACT-GOAL, ACT-ATCG, ACT-BLOCK]
+      expected_routes: [ACT-CAS-REVIEW-LANES, ACT-REVIEW-NO-CODE, ACT-GOAL, ACT-ATCG, ACT-BLOCK]
       prohibited_routes: []
       required_artifacts:
         - review profile with standard plus selected auxiliary lanes
@@ -212,4 +218,4 @@ skill_decision_contract:
       rationale: Escalation should be visible before mutation and auditable afterward.
   instrumentation:
     decision_receipt: required
-    rationale: Material decisions include accepted-spec routing, scheme planning, loop receipt/fusion choice, review backend and lanes, repair-mode escalation, persistence mode, HYL/HSR execution legality, focus-frame closure, refactor-kernel outcome accounting, ATCG terminal closure, and proof/ship closure.
+    rationale: Material decisions include accepted-spec routing, scheme planning, loop receipt/fusion choice, review backend and lanes, repair-mode escalation, persistence mode, HYL/HSR execution legality, focus-frame closure, refactor-kernel outcome accounting, ATCG terminal closure, and proof/ship closure. No-code review decisions include review source, review-fold disposition, optional resolution fold, and an explicit stop without material closure.

--- a/codex/skills/actuating/references/pre-mutation-interlock.md
+++ b/codex/skills/actuating/references/pre-mutation-interlock.md
@@ -37,6 +37,12 @@ actuation_interlock:
 not continue by doing more inspection, applying a patch, or treating
 `update_plan` as a replacement frontier.
 
+This is a pre-mutation rule, not a review-only rule. `triage` and
+`remediation-plan` may inspect code, collect review evidence, fold findings, and
+produce reports or plans without an actuation interlock. If they would edit,
+publish, resolve public review state, or claim implementation closure, they must
+leave no-code mode and satisfy the material or delivery gate first.
+
 If the work needs durable claims, fencing, external worktrees, serialized
 integration, or multi-plan coordination, the local workflow must stop.
 

--- a/codex/skills/goal-actuating/SKILL.md
+++ b/codex/skills/goal-actuating/SKILL.md
@@ -191,13 +191,15 @@ if no accepted spec -> blocked
 if topology nontrivial and no Scheme Plan -> produce scheme-planner node
 if material and no ALSR/HYL -> produce agent-loop-schemes node
 if no goal contract -> produce goal-contract node
-if no-code review mode -> produce review-fold or resolution-fold node and stop before material execution
 if runtime interlock blocks material mutation -> emit blocked HSR-v1 node
+if no-code review mode and no current review source -> produce review-source node
 if review requested and no review profile -> produce review-profile node
 if review requested and no standard CAS result -> produce standard CAS review node
 if required auxiliary review lane missing or invalidated -> produce auxiliary review-lens evidence node
 if CAS lane findings unclassified -> produce review-fold node
-if review requested and no resolution agenda -> produce resolution-fold node
+if no-code triage and folded review source current -> terminal triage-report
+if remediation-plan or review-closeout and no resolution agenda -> produce resolution-fold node
+if no-code remediation-plan and resolution agenda current -> terminal remediation-plan
 if accepted liabilities remain -> produce patch/refactor/branch-race node
 if proof missing -> produce verifier/proof node
 if standard clean CAS count < 3 -> produce fresh standard CAS review node

--- a/codex/skills/goal-actuating/SKILL.md
+++ b/codex/skills/goal-actuating/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: goal-actuating
-description: "Run an accepted implementation spec or direct /goal through the goal runtime. Interprets HYL-v1 as a defunctionalized actuation machine, emits HSR-v1 step receipts, schedules bounded subagents when safe, requires $cas for workflow review, and closes through proof plus ATCG."
+description: "Run an accepted implementation spec, direct /goal, or no-code review mode through the goal runtime. Interprets HYL-v1 for material work, emits HSR-v1 step receipts, schedules bounded subagents when safe, requires $cas for workflow review, and closes material work through proof plus ATCG."
 metadata:
   version: "2.1.0"
   activation_cost: medium
@@ -14,7 +14,7 @@ metadata:
 Run approved work through the goal workflow.
 
 ```text
-accepted implementation spec or direct goal
+accepted implementation spec, direct goal, or no-code review mode
 -> optional Scheme Plan
 -> ALSR-v1/HYL-v1 when material loop governance is required
 -> goal contract
@@ -25,6 +25,8 @@ accepted implementation spec or direct goal
 -> terminal ATCG
 -> proof
 ```
+
+No-code review modes stop earlier with a triage report or remediation plan.
 
 `$actuating` is the user-facing wrapper. `$goal-actuating` is the runtime that interprets HYL-v1.
 
@@ -66,17 +68,21 @@ goal_actuating_mode:
 4. If material loop governance is required and no current ALSR/HYL exists, hand off to `$agent-loop-schemes`.
 5. Derive a goal contract with `$goal-contract`.
 6. Choose `update_plan` or `goal-artifacts` persistence.
-7. Interpret HYL-v1: unfold a legal work node/frontier, execute it, fold evidence, and emit HSR-v1.
-8. If the workflow performs fresh or exhaustive review, select a CAS review profile and run required CAS review lanes.
-9. Classify standard and auxiliary review-lane findings with `$review-fold`.
-10. Run a resolution fold when review work needs a resolution plan.
-11. Create a work list with `$goal-workgraph` only when decomposition changes execution.
-12. Schedule bounded subagents only for explicit safe frontier nodes.
-13. Execute one useful action at a time with `$goal-grind`.
-14. Fold verification, review, and subagent results with `$evidence-fold`, `$review-fold`, or the resolution fold as appropriate.
-15. For `review-closeout` and exhaustive review, require three consecutive clean normalized **standard** `$cas` review attempts on the same artifact scope before completion.
-16. Run ATCG-v1 before completion.
-17. Close with `$proof-patch`, or hand off to `$ship` only when publication is requested and ready.
+7. If the mode is `triage` or `remediation-plan`, run the selected review
+   source, classify findings with `$review-fold`, run the resolution fold when
+   planning is requested, and stop with `triage-report` or `remediation-plan`.
+8. Interpret HYL-v1 for material modes: unfold a legal work node/frontier,
+   execute it, fold evidence, and emit HSR-v1.
+9. If the workflow performs fresh or exhaustive review, select a CAS review profile and run required CAS review lanes.
+10. Classify standard and auxiliary review-lane findings with `$review-fold`.
+11. Run a resolution fold when review work needs a resolution plan.
+12. Create a work list with `$goal-workgraph` only when decomposition changes execution.
+13. Schedule bounded subagents only for explicit safe frontier nodes.
+14. Execute one useful action at a time with `$goal-grind`.
+15. Fold verification, review, and subagent results with `$evidence-fold`, `$review-fold`, or the resolution fold as appropriate.
+16. For `review-closeout` and exhaustive review, require three consecutive clean normalized **standard** `$cas` review attempts on the same artifact scope before completion.
+17. Run ATCG-v1 before material completion.
+18. Close with `$proof-patch`, or hand off to `$ship` only when publication is requested and ready.
 
 Persistence is projection, not authority. `update_plan`, work lists, and
 goal-artifact projections may show the current frontier, but they do not replace
@@ -91,6 +97,12 @@ ALSR/HYL/frontier state before acting. A missing loop contract emits
 `blocked-loop-contract-stale`; a missing unfolded node emits
 `blocked-hylo-frontier-missing`; a missing previous fold emits
 `blocked-hylo-fold-missing`.
+
+This interlock requirement applies to HSR-v1 material actions only. `triage`
+and `remediation-plan` may inspect, review, fold, and plan without emitting a
+positive interlock, HSR-v1, proof-patch, or ATCG. If a no-code review mode would
+edit files, mutate public review state, or claim implementation closure, it must
+transition to the appropriate material or delivery mode first.
 
 ## HYL-v1 interpreter
 
@@ -112,8 +124,9 @@ The minimum valid material transition is therefore `unfold -> action -> fold`.
 If any one of those fields is missing, the run is not governed actuation even
 when tests, summaries, or progress projections exist.
 
-Do not repair a missing interlock by performing more inspection or patching.
-Return the blocker as the next HSR-v1 state and wait for the correct owner.
+Do not repair a missing interlock for a material action by performing more
+inspection or patching. Return the blocker as the next HSR-v1 state and wait for
+the correct owner.
 
 ## Review lanes
 
@@ -178,7 +191,8 @@ if no accepted spec -> blocked
 if topology nontrivial and no Scheme Plan -> produce scheme-planner node
 if material and no ALSR/HYL -> produce agent-loop-schemes node
 if no goal contract -> produce goal-contract node
-if runtime interlock blocks mutation -> emit blocked HSR-v1 node
+if no-code review mode -> produce review-fold or resolution-fold node and stop before material execution
+if runtime interlock blocks material mutation -> emit blocked HSR-v1 node
 if review requested and no review profile -> produce review-profile node
 if review requested and no standard CAS result -> produce standard CAS review node
 if required auxiliary review lane missing or invalidated -> produce auxiliary review-lens evidence node
@@ -274,6 +288,27 @@ Explicit review mode names carry the mutation rule:
 - `triage`: classify findings and stop without implementation.
 - `remediation-plan`: classify findings, produce the fix plan, and stop without implementation.
 - `review-closeout`: classify findings, implement only accepted code-change liabilities, prove closure, and stop at ATCG or `$ship` handoff.
+
+For `triage`:
+
+```text
+workflow review source
+-> $review-fold
+-> review disposition report
+-> stop
+```
+
+For `remediation-plan`:
+
+```text
+workflow review source
+-> $review-fold
+-> resolution fold
+-> remediation plan
+-> stop
+```
+
+For `review-closeout`:
 
 ```text
 workflow review_profile selection

--- a/codex/skills/goal-actuating/agents/openai.yaml
+++ b/codex/skills/goal-actuating/agents/openai.yaml
@@ -2,7 +2,7 @@ policy:
   allow_implicit_invocation: true
 interface:
   display_name: "Goal Actuating"
-  short_description: "Interpret HYL-v1 goal loops, emit HSR-v1 steps, and close through evidence and ATCG"
+  short_description: "Interpret HYL-v1 material loops and no-code review modes"
   default_prompt: >-
     Use $goal-actuating to execute an accepted implementation spec, direct /goal,
     review remediation, or dry actuation plan. If no
@@ -11,10 +11,13 @@ interface:
     current ALSR/HYL exists, hand off to $agent-loop-schemes. Interpret HYL-v1 as
     a defunctionalized actuation machine: unfold a legal node/frontier, execute
     only that node/frontier, fold evidence, emit HSR-v1, and continue or stop.
-    If invoked directly or implicitly, emit a positive runtime interlock from
-    current ALSR/HYL/frontier state before action. If the runtime interlock is
-    missing, stale, lacks an unfolded node, or lacks a previous fold, emit the
-    canonical blocked HSR-v1 state instead of inspecting or patching further.
+    Triage and remediation-plan are no-code review modes: inspect/review, fold
+    findings, produce the report or plan, and stop without material interlock,
+    HSR-v1, proof-patch, ATCG, or $ship. If invoked directly or implicitly for a
+    material action, emit a positive runtime interlock from current
+    ALSR/HYL/frontier state before action. If the runtime interlock is missing,
+    stale, lacks an unfolded node, or lacks a previous fold for a material
+    action, emit the canonical blocked HSR-v1 state instead of patching further.
     update_plan and summaries are projections, not receipt evidence.
     Review modes are triage, remediation-plan, and review-closeout; triage and
     remediation-plan do not implement, while review-closeout implements only


### PR DESCRIPTION
## Summary

- Restore `triage` and `remediation-plan` as no-code `$actuating` / `$goal-actuating` review modes.
- Clarify that loop receipts, material interlock, HSR-v1, proof-patch, ATCG, and `$ship` are required only when the workflow implements, mutates public state, or claims material closure.
- Update the agent prompts, decision contract, and pre-mutation interlock reference so review-only inspection, classification, and planning can stop without material gates.
- Address PR review feedback by requiring current review-source evidence before no-code terminal stops and requiring the resolution fold before remediation-plan output.

## Proof

- `uv run python codex/skills/actuating/tools/quick_validate.py`: pass
- `uv run --with pyyaml python - <<'PY' ... PY`: pass
- `git diff --check`: pass

## Scope

- branch: `codex/actuating-no-code-review-modes`
- head: `60ae95819b6f930b3ccaf364c54514cf3d8f6f1a`
- base: `main`

## Readiness

- PR mode: ready
- Reason: Doctrine, prompt, and contract surfaces were updated and the local validation proof is green.
- Caveats: Hosted checks had not completed at PR creation time.
