### PR TITLE
Harden auxiliary review lane closure

### DIFF
--- a/codex/skills/actuating/SKILL.md
+++ b/codex/skills/actuating/SKILL.md
@@ -257,6 +257,24 @@ complexity-mitigator reviewability stalls, repeated owner-boundary churn, boolea
 When workflow review is required, `review_profile` must explicitly account for
 all auxiliary lanes as selected/folded or `not-required` with a reason.
 
+Auxiliary source validity matrix:
+
+```text
+valid clean             satisfies that auxiliary obligation; standard count unchanged
+valid findings-folded   may block or produce accepted liabilities; artifact changes reset standard count
+invalid clean           grants no closeout credit
+invalid findings        becomes candidate-pressure until owner-boundary validation resolves it
+selected-pending        blocks ATCG until run, waived, or resolved
+not-required            allowed only with a source-bound reason
+```
+
+Selected lanes in `clean` or `findings-folded` state must carry
+`source_validity=valid`, the expected lens contract, valid lens evidence, current
+`head_sha`, current `target_fingerprint`, and a current evidence reference.
+`base=unknown`, `target_identity_unavailable`, stale tuple binding, or missing
+target identity is `invalid-proof`: useful dirty findings may be quarantined as
+candidate pressure, but clean output cannot clear the lane.
+
 ## Refactor-kernel escalation
 
 When repeated accepted liabilities share one owner boundary, missing abstraction,
@@ -398,6 +416,9 @@ Actuating:
   - standard CAS clean-run counter reset: yes|no
 - review source / CAS verdict, if required:
 - normalized standard CAS clean runs: 0|1|2|3|not-required
+- auxiliary lanes:
+  - footgun-finder|invariant-ace|complexity-mitigator each not-required|selected-pending|candidate-pressure|clean|findings-folded|blocked|rerun-required
+  - selected lanes include `source_validity`, `lens_contract`, `lens_evidence_state`, `lens_evidence_ref`, `head_sha`, and `target_fingerprint`
 - goal contract / work list:
 - review-fold disposition:
 - actuation escalation receipt:

--- a/codex/skills/actuating/references/terminal-closure-gate.md
+++ b/codex/skills/actuating/references/terminal-closure-gate.md
@@ -141,8 +141,20 @@ invariant-ace        -> invariant-gate-v1
 complexity-mitigator -> complexity-preflight-v1
 ```
 
-`lens_evidence_state` must be `valid` for terminal completion. `not-required` is
-valid only for lanes explicitly not selected and still needs a reason.
+`lens_evidence_state` and `source_validity` must both be `valid` for terminal
+completion. `not-required` is valid only for lanes explicitly not selected and
+still needs a reason.
+
+Auxiliary source validity matrix:
+
+```text
+valid clean             satisfies auxiliary coverage; standard count unchanged
+valid findings-folded   folded evidence is current; accepted artifact changes reset standard count
+invalid clean           no closeout credit; lane remains unsatisfied
+invalid findings        candidate-pressure only until owner-boundary validation resolves it
+selected-pending        selected but not run; blocks ATCG
+candidate-pressure      non-certifying findings under validation; blocks ATCG
+```
 
 ## Common outcomes
 
@@ -155,7 +167,7 @@ previous material action without fold evidence -> blocked-hylo-fold-missing, nex
 completion without terminal HSR -> blocked-hylo-terminal-missing, next_owner=$goal-actuating
 goal-focus frame not folded to parent -> blocked-hylo-fold-missing, next_owner=$goal-actuating
 CAS required + standard clean runs < required -> blocked, next_owner=$cas
-required auxiliary lane missing|not-folded|blocked|rerun-required|stale -> cas-review-blocked, next_owner=$cas
+required auxiliary lane missing|not-folded|selected-pending|candidate-pressure|blocked|rerun-required|stale|invalid-proof -> cas-review-blocked, next_owner=$cas
 proof-patch required + missing/stale -> continue, next_owner=$proof-patch
 ADD-v1 handoff + ship result missing -> continue, next_owner=$ship
 public side effect outside $ship boundary -> side-effect-boundary-violated, next_owner=$ship

--- a/codex/skills/actuating/tests/test_actuation_terminal_gate.py
+++ b/codex/skills/actuating/tests/test_actuation_terminal_gate.py
@@ -133,6 +133,55 @@ class ActuationTerminalGateTests(unittest.TestCase):
         self.assertEqual(body["verdict"], "blocked")
         self.assertIn("review_profile.auxiliary_review_lanes.complexity-mitigator.lens_evidence_state:stale", body["blocked_reasons"])
 
+    def test_selected_pending_auxiliary_lane_blocks_completion(self) -> None:
+        context = deepcopy(self.context())
+        context["cas_review"] = satisfied_standard_cas()
+        context["review_profile"] = review_profile(**{"footgun-finder": {"state": "selected-pending", "reason": "Public API surface changed."}})
+        context["final_report_fields"]["standard_clean_cas_runs"] = 3
+        self.assert_blocks_with(context, "review_profile.auxiliary_review_lanes.footgun-finder:selected-pending", "$goal-actuating")
+
+    def test_invalid_clean_auxiliary_lane_does_not_clear_obligation(self) -> None:
+        context = deepcopy(self.context())
+        context["cas_review"] = satisfied_standard_cas()
+        context["review_profile"] = review_profile(
+            **{
+                "footgun-finder": {
+                    "state": "clean",
+                    **lens_evidence("footgun-finder", source_validity="invalid-proof"),
+                    "tuple": {"base_sha": "unknown", "head_sha": "abc123", "target_fingerprint": "diff:clean"},
+                }
+            }
+        )
+        context["final_report_fields"]["standard_clean_cas_runs"] = 3
+        decision = MODULE.make_decision(context)
+        body = decision["actuation_terminal_decision"]
+        self.assertEqual(body["verdict"], "blocked")
+        self.assertIn("review_profile.auxiliary_review_lanes.footgun-finder.source_validity:invalid-proof", body["blocked_reasons"])
+
+    def test_invalid_dirty_auxiliary_lane_remains_candidate_pressure(self) -> None:
+        context = deepcopy(self.context())
+        context["cas_review"] = satisfied_standard_cas()
+        context["review_profile"] = review_profile(
+            **{
+                "footgun-finder": {
+                    "state": "candidate-pressure",
+                    "source_validity": "invalid-proof",
+                    "reason": "Findings are quarantined until owner-boundary validation completes.",
+                }
+            }
+        )
+        context["final_report_fields"]["standard_clean_cas_runs"] = 3
+        self.assert_blocks_with(context, "review_profile.auxiliary_review_lanes.footgun-finder:candidate-pressure", "$goal-actuating")
+
+    def test_valid_folded_auxiliary_lane_can_complete(self) -> None:
+        context = deepcopy(self.context())
+        context["cas_review"] = satisfied_standard_cas()
+        context["review_profile"] = review_profile(**{"footgun-finder": {"state": "findings-folded", **lens_evidence("footgun-finder")}})
+        context["final_report_fields"]["standard_clean_cas_runs"] = 3
+        decision = MODULE.make_decision(context)
+        body = decision["actuation_terminal_decision"]
+        self.assertEqual(body["verdict"], "complete")
+
     def test_standard_review_profile_can_complete(self) -> None:
         context = deepcopy(self.context())
         context["cas_review"] = satisfied_standard_cas()
@@ -204,7 +253,7 @@ class ActuationTerminalGateTests(unittest.TestCase):
 
 def lens_evidence(lane: str, **overrides):
     contracts = {"footgun-finder": "footgun-lens-v1", "invariant-ace": "invariant-gate-v1", "complexity-mitigator": "complexity-preflight-v1"}
-    record = {"lens_contract": contracts[lane], "lens_evidence_state": "valid", "lens_evidence_ref": f"cas:{lane}:lens", "head_sha": "abc123", "target_fingerprint": "diff:clean"}
+    record = {"lens_contract": contracts[lane], "lens_evidence_state": "valid", "lens_evidence_ref": f"cas:{lane}:lens", "source_validity": "valid", "head_sha": "abc123", "target_fingerprint": "diff:clean"}
     record.update(overrides)
     return record
 

--- a/codex/skills/actuating/tools/actuation_terminal_gate.py
+++ b/codex/skills/actuating/tools/actuation_terminal_gate.py
@@ -35,7 +35,19 @@ OBLIGATION_TRIGGER_LANES = {
     "complexity-stall": "complexity-mitigator",
     "repeated-owner-boundary": "complexity-mitigator",
 }
-VALID_LENS_EVIDENCE_STATES = {"valid", "missing", "invalid", "stale", "blocked", "rerun-required", "not-required"}
+VALID_LENS_EVIDENCE_STATES = {"valid", "missing", "invalid", "invalid-proof", "stale", "blocked", "rerun-required", "not-required"}
+VALID_SOURCE_VALIDITY_STATES = {"valid", "invalid-proof", "stale", "missing", "not-required"}
+AUXILIARY_LANE_STATES = {
+    "not-required",
+    "missing",
+    "clean",
+    "findings-folded",
+    "blocked",
+    "rerun-required",
+    "selected-pending",
+    "candidate-pressure",
+}
+AUXILIARY_BLOCKING_STATES = {"blocked", "rerun-required", "selected-pending", "candidate-pressure"}
 HARD_REASON_ORDER = [
     "blocked-loop-contract-missing",
     "blocked-loop-contract-stale",
@@ -670,6 +682,22 @@ def lens_evidence_ref_for(record: dict[str, Any]) -> Any:
     return first_present(record, ("lens_evidence_ref", "evidence_ref", "verdict_ref", "review_fold_ref", "receipt_ref"))
 
 
+def source_validity_for(record: dict[str, Any]) -> str:
+    value = first_present(record, ("source_validity", "sourceValidity", "source_validity_state"), "")
+    return str(value).lower()
+
+
+def source_validity_reasons_for(record: dict[str, Any], prefix: str, *, required: bool) -> list[str]:
+    state = source_validity_for(record)
+    if not state:
+        return [f"{prefix}.source_validity:missing"] if required else []
+    if state not in VALID_SOURCE_VALIDITY_STATES:
+        return [f"{prefix}.source_validity:invalid"]
+    if state != "valid":
+        return [f"{prefix}.source_validity:{state}"]
+    return []
+
+
 def lens_contract_reasons_for(record: dict[str, Any], lane: str, prefix: str) -> list[str]:
     reasons: list[str] = []
     expected = AUXILIARY_LENS_CONTRACTS[lane]
@@ -690,6 +718,7 @@ def lens_contract_reasons_for(record: dict[str, Any], lane: str, prefix: str) ->
     evidence_ref = lens_evidence_ref_for(record)
     if not isinstance(evidence_ref, str) or not evidence_ref:
         reasons.append(f"{prefix}.lens_evidence_ref:missing")
+    reasons.extend(source_validity_reasons_for(record, prefix, required=True))
     return reasons
 
 
@@ -750,7 +779,7 @@ def review_obligation_router_reasons_for(profile: dict[str, Any], artifact: dict
         if not state:
             reasons.append(f"{prefix}.state:missing")
             continue
-        if state not in {"not-required", "clean", "findings-folded", "blocked", "rerun-required"}:
+        if state not in AUXILIARY_LANE_STATES:
             reasons.append(f"{prefix}.state:invalid")
             continue
         if state == "not-required":
@@ -758,7 +787,7 @@ def review_obligation_router_reasons_for(profile: dict[str, Any], artifact: dict
             if not isinstance(reason, str) or not reason.strip():
                 reasons.append(f"{prefix}.not_required_reason:missing")
             continue
-        if state in {"blocked", "rerun-required"}:
+        if state in AUXILIARY_BLOCKING_STATES:
             reasons.append(f"{prefix}:{state}")
             continue
         evidence_ref = lens_evidence_ref_for(value)
@@ -782,16 +811,19 @@ def auxiliary_lane_reasons_for(cas: dict[str, Any], artifact: dict[str, Any]) ->
             reasons.append(f"cas.auxiliary_lanes.{lane}:missing")
             continue
         state = str(record.get("status", record.get("state", ""))).lower()
+        if state and state not in AUXILIARY_LANE_STATES:
+            reasons.append(f"cas.auxiliary_lanes.{lane}.state:invalid")
+            continue
         folded = as_yes(record.get("folded")) or state in {"clean", "findings-folded"}
         if state == "missing":
             reasons.append(f"cas.auxiliary_lanes.{lane}:missing")
         if not folded:
             reasons.append(f"cas.auxiliary_lanes.{lane}:not-folded")
-        if as_yes(record.get("unresolved_blockers")) or state == "blocked":
-            reasons.append(f"cas.auxiliary_lanes.{lane}:blocked")
-        if as_yes(record.get("rerun_required")) or state == "rerun-required":
+        if as_yes(record.get("unresolved_blockers")) or state in AUXILIARY_BLOCKING_STATES:
+            reasons.append(f"cas.auxiliary_lanes.{lane}:{state if state in AUXILIARY_BLOCKING_STATES else 'blocked'}")
+        if as_yes(record.get("rerun_required")):
             reasons.append(f"cas.auxiliary_lanes.{lane}:rerun-required")
-        if folded and state not in {"blocked", "rerun-required"}:
+        if folded and state not in AUXILIARY_BLOCKING_STATES:
             reasons.extend(lens_contract_reasons_for(record, lane, f"cas.auxiliary_lanes.{lane}"))
         head_sha = lane_binding_value(record, "head_sha")
         if not isinstance(head_sha, str) or not head_sha:
@@ -829,7 +861,7 @@ def review_profile_reasons_for(profile: dict[str, Any], artifact: dict[str, Any]
         if not state:
             reasons.append(f"{prefix}.state:missing")
             continue
-        if state not in {"not-required", "clean", "findings-folded", "blocked", "rerun-required"}:
+        if state not in AUXILIARY_LANE_STATES:
             reasons.append(f"{prefix}.state:invalid")
             continue
         if state == "not-required":
@@ -841,7 +873,7 @@ def review_profile_reasons_for(profile: dict[str, Any], artifact: dict[str, Any]
             if lane == "complexity-mitigator" and complexity_pressure_requires_lens(profile):
                 reasons.append(f"{prefix}:complexity-pressure-required")
             continue
-        if state in {"blocked", "rerun-required"}:
+        if state in AUXILIARY_BLOCKING_STATES:
             reasons.append(f"{prefix}:{state}")
             continue
         reasons.extend(lens_contract_reasons_for(record, lane, prefix))

--- a/codex/skills/cas/SKILL.md
+++ b/codex/skills/cas/SKILL.md
@@ -321,12 +321,20 @@ findingFingerprint = best-effort same issue across attempts
 reviewAttemptId = stable attempt row or compatibility projection ID
 laneRole = standard only when the attempt is the ordinary standard lane
 contributesToStandardStreak = true only for normalized clean standard attempts, not finding rows
+source_validity = valid only when the attempt is tuple-bound to the intended current artifact
 ```
 
 If native CAS output cannot provide a source finding ID, compatibility
 normalization may synthesize `findingId` from review attempt identity, tuple,
 lane, normalized location, title/body hashes, and ordinal. It must still mark
 cross-attempt matching as best-effort through `findingFingerprint`.
+
+CAS transports identity; caller workflows own closure accounting. A custom lens
+with `base=unknown`, `target_identity_unavailable`, missing head, missing target
+fingerprint, or stale tuple binding must be projected as `invalid-proof` for
+auxiliary closeout. Dirty invalid-proof findings may still be useful review
+pressure after owner-boundary validation, but clean invalid-proof output must not
+clear an auxiliary lane or standard clean-review requirement.
 
 Downstream aliases may convert these fields to snake_case (`finding_id`,
 `finding_fingerprint`, `review_attempt_id`, and so on), but CAS should preserve

--- a/codex/skills/goal-actuating/SKILL.md
+++ b/codex/skills/goal-actuating/SKILL.md
@@ -124,7 +124,9 @@ Rules:
 - Auxiliary findings must be folded through `$review-fold` and may block closeout or become accepted liabilities.
 - Do not require unsupported `$cas` commands to produce semantic footgun/invariant/complexity lane labels. CAS transports and tuple-binds review evidence; the workflow owns auxiliary lens selection, folding, and blocker state.
 - A selected auxiliary lane must carry current `head_sha`, `target_fingerprint`, `lens_contract`, `lens_evidence_state`, and `lens_evidence_ref` before ATCG may complete. `clean` and `findings-folded` are not enough without the lane contract.
-- ATCG lane contracts are `footgun-lens-v1`, `invariant-gate-v1`, and `complexity-preflight-v1`. `lens_evidence_state` must be `valid` for completion.
+- ATCG lane contracts are `footgun-lens-v1`, `invariant-gate-v1`, and `complexity-preflight-v1`. `lens_evidence_state` and `source_validity` must both be `valid` for completion.
+- Auxiliary source validity is asymmetric: invalid dirty findings may become `candidate-pressure` after quarantine and owner-boundary validation, but invalid clean findings grant no closeout credit. `base=unknown`, `target_identity_unavailable`, stale tuple binding, or missing target identity is `invalid-proof`.
+- `selected-pending` and `candidate-pressure` block ATCG. Clear them only by obtaining valid folded lens evidence, resolving accepted liabilities and rerunning when needed, or explicitly marking the lane `not-required` with a source-bound reason.
 - When workflow review is required, `review_profile` must explicitly account for `footgun-finder`, `invariant-ace`, and `complexity-mitigator` as selected/folded evidence or `not-required` with a reason; absence is unknown coverage, not clean review.
 - Record `complexity_pressure` when standard or auxiliary reviews show repeated same-class findings, one-patch-per-comment pressure, review churn, or comprehension blockage. That pressure selects `complexity-mitigator` unless it is explicitly marked not applicable.
 - A code change from any lane resets the standard clean-review streak to zero.
@@ -371,7 +373,7 @@ Goal Actuation:
 - mode-terminal output:
 - review profile:
   - standard CAS review: required|not-required, current verdict:
-  - auxiliary lanes: footgun-finder|invariant-ace|complexity-mitigator each not-required|clean|findings-folded|blocked|rerun-required, with `lens_contract` / `lens_evidence_state` / `lens_evidence_ref` when selected
+  - auxiliary lanes: footgun-finder|invariant-ace|complexity-mitigator each not-required|selected-pending|candidate-pressure|clean|findings-folded|blocked|rerun-required, with `source_validity` / `lens_contract` / `lens_evidence_state` / `lens_evidence_ref` when selected
   - auxiliary blockers:
 - parallelism:
   - mode:

--- a/codex/skills/review-fold/SKILL.md
+++ b/codex/skills/review-fold/SKILL.md
@@ -372,6 +372,12 @@ Duplicate, rejected, out-of-scope, already-proven proof-only, follow-up,
 already-resolved findings, and clean auxiliary evidence do not make the source
 dirty.
 
+Clean auxiliary evidence is clean only when the caller can bind it to a valid
+auxiliary source: current artifact, expected lens contract, valid lens evidence,
+valid source identity, and current evidence reference. Invalid auxiliary clean
+output is not clearance. Invalid auxiliary findings may be folded only as
+`candidate-pressure` until the owner boundary validates or rejects them.
+
 Reset conditions are caller-owned, but `$review-fold` should mark reset-worthy
 facts when review evidence shows them:
 
@@ -382,6 +388,7 @@ base/head/diff changed
 proof bar changed
 artifact-changing auxiliary remediation changed the artifact
 review source continuity is lost
+auxiliary source validity is invalid-proof, missing, or stale
 ```
 
 `$review-fold` may reject or mark findings proof-only, but it must not convert a


### PR DESCRIPTION
## Summary
- Add an auxiliary review source-validity matrix to actuating, goal-actuating, ATCG, review-fold, and CAS doctrine.
- Enforce selected-pending, candidate-pressure, and invalid-proof auxiliary states in ATCG.
- Add terminal-gate regressions for invalid clean auxiliary evidence, invalid dirty candidate pressure, selected-pending lanes, and valid folded auxiliary evidence.

## Proof
- `uv run python codex/skills/actuating/tools/quick_validate.py`: pass
- `uv run python -m unittest discover codex/skills/review-fold/tests`: pass
- `uv run python -m unittest discover codex/skills/cas/tests`: pass
- `git diff --check`: pass

## Scope
- branch: codex/aux-review-source-validity
- head: c2fcf7f4452030d0d5ba35583796a30a2633438b
- base: main

## Readiness
- PR mode: ready
- Reason: focused and affected validation passed on the committed head.
- Caveats: broad `uv run python -m unittest discover codex/skills` is not a usable proof lane in this repo; it discovered zero tests and exited 5.