### PR TITLE
Expand logophile with computer science doctrine operators

### DIFF
--- a/codex/skills/logophile/references/computer_science_doctrine.md
+++ b/codex/skills/logophile/references/computer_science_doctrine.md
@@ -1,0 +1,255 @@
+# Computer Science Doctrine
+
+Use this reference when a computer-science term can function as an agent doctrine operator.
+
+The goal is not technical-sounding prose. Each word must induce a distinct procedure, constraint, proof obligation, search posture, or stopping rule.
+
+For every candidate, identify:
+
+```text
+trigger -> operator -> artifact -> proof burden -> lighter fallback
+```
+
+Do not claim a formal guarantee merely because the word is evocative.
+
+## Rewrite systems and convergence
+
+| Word | Activated behavior | Cash-out | Critical distinction |
+|---|---|---|---|
+| `confluent` | permit multiple paths but require them to join at one canonical result | Confluence Matrix | unlike `deterministic`, many paths may be valid |
+| `terminating` | require rewrites, retries, recursion, or loops to stop | ranking function / termination measure | stopping does not prove the right fixed point |
+| `critical-pair-aware` | inspect overlapping rules whose independent application may diverge | Critical-Pair Ledger | local rule validity does not imply global confluence |
+| `contractive` | require every pass to shrink a named distance to closure | Contraction Measure | stronger than generic progress |
+| `monotone` | preserve an explicit information, authority, or state order | Information-Order Map | formal order law, not merely “improving” |
+| `inflationary` | preserve prior state while moving upward in the order | inflationary transition proof | can over-accumulate when supersession is required |
+| `congruence-preserving` | preserve equivalence under every permitted context | congruence checks | quotienting is unsafe without congruence |
+| `conservative-extending` | add expressive power without changing existing valid meaning | conservative-extension certificate | extension is not ordinary backward compatibility |
+| `commutative` | make independent operation order irrelevant | commutativity matrix | does not imply idempotence |
+| `associative` | make grouping irrelevant | law tests | enables batching/folding, not arbitrary reordering |
+| `distributive` | expose lawful interaction between two operations | distributive-law tests | useful for decomposition and incrementalization |
+
+## Semantics, abstraction, and equivalence
+
+| Word | Activated behavior | Cash-out | Critical distinction |
+|---|---|---|---|
+| `principal` | find the most general solution satisfying the constraints | Principal Solution + Instantiation Map | unlike `optimal`, no objective function is required |
+| `parametric` | behave uniformly across admissible representations | Parametricity Matrix | rejects hidden type cases and example overfitting |
+| `extensional` | judge equality by declared observations | Observation Contract | ignores internal construction unless observable |
+| `representation-independent` | prevent clients from depending on hidden representation | client-observation audit | module boundary guarantee |
+| `bisimulative` | match observable transitions in both directions | Bisimulation Relation | behavioral and stepwise, not structural isomorphism |
+| `coinductive` | reason about ongoing/infinite behavior through observations | coinductive invariant | appropriate for streams, servers, protocols |
+| `inductive` | build/prove from constructors and smaller cases | constructor coverage | appropriate for finite recursive construction |
+| `lawful` | require an abstraction to satisfy its claimed laws | Law Suite | signatures alone are insufficient |
+| `decidable` | provide a terminating judgment procedure for every valid input | Decision Procedure | totality does not itself imply termination |
+| `complete` | include or derive every semantically valid case | completeness argument | pair with soundness |
+| `effect-explicit` | expose effects in types, protocols, or interpreters | Effect Signature + Handler Map | rejects ambient hidden effects |
+| `referentially-transparent` | permit substitution by value without behavior change | side-effect/capture audit | useful for caching and equational reasoning |
+
+## Program analysis and refinement
+
+| Word | Activated behavior | Cash-out | Critical distinction |
+|---|---|---|---|
+| `abstract-interpreting` | reason soundly over a tractable over-approximation | abstract domain + transfer functions | over-approximation trades precision for soundness |
+| `symbolic` | reason over variables and path constraints | Path-Condition Ledger | not merely broad concrete testing |
+| `counterexample-guided` | refine the model from failures instead of patching instances | Counterexample Refinement Ledger | canonical CEGAR posture |
+| `refinement-driven` | add distinctions only when forced by observations/proof | refinement chain | fights speculative state growth |
+| `proof-carrying` | make evidence travel with the result | Certificate-Bearing Handoff | stronger boundary rule than traceability |
+| `type-directed` | let type and inhabitation obligations steer construction | type-obligation map | useful for synthesis and refactoring |
+| `taint-aware` | track untrusted influence from sources to sinks | source-to-sink map | information-flow discipline |
+
+## Verification and test-oracle design
+
+| Word | Activated behavior | Cash-out | Critical distinction |
+|---|---|---|---|
+| `shrinking` | minimize a failing input, state, trace, or diff | Minimal Counterexample | removes noise while preserving failure |
+| `metamorphic` | test invariant relations when no exact oracle exists | Metamorphic Relation Suite | relation-based, not guessed golden output |
+| `differential` | compare independent implementations/versions | Differential Matrix | disagreement is evidence, not automatic blame |
+| `property-based` | generate input families from invariants | generators + properties + shrinkers | broader than example tests |
+| `oracle-aware` | name exact, partial, relational, statistical, or absent oracles | Oracle Map | prevents invented certainty |
+| `coverage-guided` | steer generation toward unexplored regions | coverage frontier | coverage is guidance, not correctness |
+| `mutation-resistant` | require tests to kill plausible injected defects | mutation score / surviving-mutant ledger | measures defect sensitivity |
+| `model-checking` | explore bounded state space against properties | counterexample trace | requires explicit model and properties |
+| `replayable` | capture enough state/order to reproduce behavior | Replay Receipt | different from merely traceable |
+| `fault-injecting` | deliberately test containment and recovery | fault matrix | proves failure behavior, not happy path |
+
+## Concurrency and distributed systems
+
+| Word | Activated behavior | Cash-out | Critical distinction |
+|---|---|---|---|
+| `linearizable` | make operations appear atomic and respect real-time order | concurrent history + linearization points | stronger/different than transaction serializability |
+| `serializable` | make concurrent transactions equivalent to some serial order | serialization graph | need not respect operation real-time order |
+| `causally-consistent` | preserve cause-before-effect ordering | happens-before graph | unrelated events may remain unordered |
+| `eventually-consistent` | permit temporary divergence under a real convergence contract | convergence/conflict contract | “eventual” without a condition is empty |
+| `quorum-aware` | reason about read/write overlap and failure thresholds | quorum matrix | avoids hand-wavy replica claims |
+| `consensus-backed` | require agreement protocol before claiming one authoritative order | consensus authority map | authority is not consensus |
+| `self-stabilizing` | converge from reachable dirty/partial states to a valid state | Recovery Certificate | does not require perfect reset |
+| `fault-contained` | bound failure propagation to explicit regions | containment map | isolation must be demonstrated |
+| `partition-aware` | name availability/consistency behavior under communication loss | partition table | makes degraded modes explicit |
+| `backpressure-aware` | make production respond to downstream capacity | demand/capacity contract | queues are not backpressure |
+| `transactional` | bind multi-step mutation under an explicit consistency/rollback contract | transaction boundary | name the actual isolation/durability level |
+| `atomic` | make an operation indivisible at the declared observation boundary | atomicity proof | scope of observation matters |
+| `deduplicating` | make repeated delivery converge on one logical effect | dedupe key + retry proof | often paired with idempotence |
+
+## Algorithms, search, and optimization
+
+| Word | Activated behavior | Cash-out | Critical distinction |
+|---|---|---|---|
+| `anytime` | maintain a valid best-so-far answer at every interruption point | Incumbent + Remaining-Gap Receipt | unlike exhaustive search, useful before completion |
+| `admissible` | use a heuristic that never overestimates remaining cost | admissibility argument | required for some optimal-search guarantees |
+| `consistent-heuristic` | make heuristic estimates respect transition costs | consistency checks | prevents reopened states in A* |
+| `branch-and-bound` | prune branches unable to beat the incumbent | bound/pruning ledger | needs a valid bound |
+| `best-first` | expand the most promising frontier under an explicit score | frontier ordering | score must be named |
+| `pruning` | remove branches proven unable to affect the answer | pruning rule + completeness impact | unsupported pruning can lose solutions |
+| `kernelizing` | reduce a hard problem to a smaller equivalent instance | kernel + equivalence proof | parameterized preprocessing |
+| `parameterized` | expose the structural parameter governing difficulty | parameter map | input size alone may mislead |
+| `output-sensitive` | measure work relative to input plus output size | complexity bound | useful for enumeration/query tasks |
+| `amortized` | distribute cost across an operation sequence | potential/accounting proof | not an average-case claim |
+| `competitive` | compare online strategy with offline optimum | competitive ratio | online-algorithm notion |
+| `worst-case-aware` | test catastrophic inputs or adversarial schedules | worst-case bound/test | complements average behavior |
+| `approximation-aware` | state quality bounds when exact optimum is infeasible | approximation ratio/envelope | “good enough” must be bounded |
+| `randomized` | state probability, seedability, and failure bounds | probabilistic guarantee | randomness is a contract |
+| `derandomizing` | replace probabilistic choice with deterministic structure | substitute + comparison | useful for repeatability/proof |
+
+## Performance and dataflow
+
+| Word | Activated behavior | Cash-out |
+|---|---|---|
+| `incremental` | recompute only invalidated dependency closure | invalidation graph |
+| `demand-driven` | compute/retrieve only what downstream observations require | demand map |
+| `locality-aware` | place data/computation near reuse, ownership, or failure boundaries | locality map |
+| `cache-conscious` | account for working-set and cache behavior | cache evidence |
+| `zero-copy` | avoid materialization while preserving ownership/lifetimes | copy count + lifetime proof |
+| `streaming` | process bounded chunks without full materialization | memory/chunk contract |
+| `batching` | amortize fixed costs while preserving ordering/failure semantics | batch contract |
+| `fusion-oriented` | combine adjacent passes and remove intermediates | fused pipeline |
+| `work-efficient` | keep parallel work near best sequential work | work analysis |
+| `span-efficient` | minimize the critical path | span analysis |
+| `asymptotic` | reason about scaling, then validate constants/crossover | complexity model |
+| `bounded` | enforce explicit resource limits | resource budget |
+
+## Security, authority, and boundaries
+
+| Word | Activated behavior | Cash-out | Critical distinction |
+|---|---|---|---|
+| `hygienic` | prevent unintended capture of names/context/authority/state | Capture Audit | unlike hermetic isolation, this governs transformation capture |
+| `end-to-end` | place verification at the endpoint that can actually check it | endpoint map | intermediaries cannot guarantee everything |
+| `least-authority` | give each component only required capabilities | capability matrix | sharper than generic least privilege |
+| `capability-secure` | represent authority through explicit unforgeable capabilities | capability graph | rejects ambient authority |
+| `complete-mediation` | check every access path | mediation coverage | entrypoint-only checks are incomplete |
+| `privilege-separated` | split high-risk authority from ordinary computation | privilege map | limits compromise blast radius |
+| `noninterfering` | prevent forbidden influence on protected observations | Information-Flow Matrix | stronger than simple isolation |
+| `constant-time` | prevent secrets from affecting timing/control/resource behavior | timing audit | formal/empirical burden is high |
+| `side-channel-aware` | account for leakage through timing, caches, logs, errors, resources | side-channel inventory | broader than constant time |
+| `memory-safe` | prevent invalid memory access and ownership violations | unsafe-boundary audit | do not claim casually |
+| `attack-surface-minimizing` | reduce exposed operations, parsers, privileges, protocols, dependencies | attack-surface delta | security-focused ablation |
+| `sandboxed` | confine untrusted execution under explicit limits | sandbox policy + escape tests | policy is not proof of confinement |
+
+## Data and schema evolution
+
+| Word | Activated behavior | Cash-out |
+|---|---|---|
+| `lossless` | preserve information required by the live contract | round-trip/losslessness proof |
+| `dependency-preserving` | keep constraints locally checkable after decomposition | dependency matrix |
+| `referential-integrity-preserving` | maintain valid references across lifecycle changes | reference audit |
+| `schema-evolution-aware` | make versions/defaults/unknown fields/migrations explicit | evolution matrix |
+| `append-only` | express history through additions and supersession | append contract |
+| `event-sourced` | treat events as authority and state as replayable projection | event schema + reducer + replay |
+| `lineage-preserving` | retain derivation from source to result | lineage graph |
+
+## High-value distinctions
+
+```text
+deterministic        = one prescribed path
+confluent            = many paths, one joinable result
+
+fixed-point          = stable endpoint
+contractive          = each pass shrinks distance to it
+terminating          = the process cannot continue forever
+
+optimal              = best under an objective
+principal            = most general under constraints
+admissible           = heuristic does not overestimate
+anytime              = valid incumbent at every interruption point
+
+isomorphic           = invertible structural correspondence
+bisimulative         = mutually matching observable transitions
+extensional          = equal by selected observations
+refinement-preserving = required behavior remains while obsolete/invalid behavior may disappear
+
+total                = defined for every valid input
+decidable            = terminates with a judgment for every valid input
+sound                = no invalid conclusions
+complete             = every valid conclusion is reachable
+
+traceable            = evidence can be followed
+proof-carrying       = evidence travels with the result
+replayable           = captured state reproduces behavior
+
+hermetic             = isolated from ambient dependencies
+hygienic             = protected from unintended capture
+noninterfering       = forbidden influence cannot affect observations
+
+serializable         = transactions equal some serial order
+linearizable         = operations also respect real-time order
+causally-consistent  = cause precedes effect; unrelated events may remain unordered
+```
+
+## High-leverage doctrine stacks
+
+### Review and remediation
+
+```text
+COUNTEREXAMPLE-GUIDED + SHRINKING + CONTRACTIVE + PROOF-CARRYING
+```
+
+### Rewrite and canonicalization
+
+```text
+CONFLUENT + TERMINATING + CRITICAL-PAIR-AWARE + NORMALIZING
+```
+
+### Architecture and API design
+
+```text
+PRINCIPAL + PARAMETRIC + HYGIENIC + CONSERVATIVE-EXTENDING
+```
+
+### State machines and protocols
+
+```text
+BISIMULATIVE + COINDUCTIVE + TOTALIZING + PROGRESS-AWARE
+```
+
+### Verification without a direct oracle
+
+```text
+ORACLE-AWARE + METAMORPHIC + DIFFERENTIAL + SHRINKING
+```
+
+### Durable agent workflows
+
+```text
+MONOTONE + CONTRACTIVE + ANYTIME + SELF-STABILIZING
+```
+
+### Distributed correctness
+
+```text
+CAUSALLY-CONSISTENT + PARTITION-AWARE + QUORUM-AWARE + DEDUPLICATING
+```
+
+### Security boundaries
+
+```text
+LEAST-AUTHORITY + CAPABILITY-SECURE + COMPLETE-MEDIATION + NONINTERFERING
+```
+
+## Selection discipline
+
+More vocabulary is useful only while the distinctions remain sharp.
+
+- Prefer the exact technical term when the task carries its proof obligation.
+- Do not use a concurrency guarantee as a metaphor for ordinary coordination.
+- Do not claim `optimal`, `complete`, `linearizable`, `constant-time`, or `proof-carrying` without proportionate evidence.
+- Use a lighter adjacent term when the full formal claim cannot be supported.
+- In runtime prompts, select the smallest non-overlapping stack; the catalog is for discovery, not simultaneous invocation.

--- a/codex/skills/logophile/references/doctrine_compiler.md
+++ b/codex/skills/logophile/references/doctrine_compiler.md
@@ -8,24 +8,28 @@ Use this pipeline:
 trigger -> operator -> artifact -> receipt -> proof
 ```
 
+For activation phrases, use the lighter pipeline in [doctrine_phrases.md](doctrine_phrases.md). For formal computer-science operators and distinctions, use [computer_science_doctrine.md](computer_science_doctrine.md).
+
 ## Compiler fields
 
 For each candidate word, identify:
 
 - `trigger`: the task pressure that should activate it.
 - `operator`: the behavior it makes the agent perform.
-- `artifact`: the ledger, gate, receipt, card, map, certificate, or output section it produces.
+- `artifact`: the ledger, gate, receipt, card, map, certificate, procedure, relation, or output section it produces.
 - `proof`: the evidence that the operator actually changed behavior or state.
 - `failure mode`: what goes wrong if the word is omitted or used decoratively.
+- `formal burden`: what the term would require if interpreted literally.
+- `lighter fallback`: the adjacent term to use when the full formal guarantee cannot be supported.
 
 ## Mode, persona, command, and artifact
 
 Keep these grammatical roles separate:
 
-- **mode**: adjective or gerund describing the operating posture, such as `ACTUATING`, `ADJUDICATIVE`, `NOMOTHETIC`, or `EMULATIVE`;
+- **mode**: adjective or gerund describing the operating posture, such as `ACTUATING`, `ADJUDICATIVE`, `NOMOTHETIC`, `EMULATIVE`, `CONFLUENT`, or `CONTRACTIVE`;
 - **persona**: noun naming the role, such as `Arbiter` or `Nomothete`;
-- **command**: imperative phrase inside the doctrine, such as `actuate the lever` or `issue a criteria-backed ruling`;
-- **artifact**: receipt, ledger, map, card, certificate, or gate proving the mode fired.
+- **command**: imperative phrase inside the doctrine, such as `actuate the lever`, `make every pass shrink the gap`, or `issue a criteria-backed ruling`;
+- **artifact**: receipt, ledger, relation, procedure, map, certificate, or gate proving the mode fired.
 
 Do not use a persona noun as the mode when a precise adjective or gerund exists.
 
@@ -36,11 +40,23 @@ Do not use a persona noun as the mode when a precise adjective or gerund exists.
 | Action | move the system | `actuating`, `lever-seeking` | Actuation Receipt |
 | Problem shaping | make the problem solvable | `tractabilizing`, `factorizing`, `orthogonalizing` | Tractability Receipt / Factorization Map |
 | Reduction | remove unearned surface | `ablative`, `winnowing`, `quotienting` | Ablation Ledger / Reduction Certificate |
+| Rewrite / convergence | make routes reconcile and stop | `confluent`, `terminating`, `contractive`, `critical-pair-aware` | Confluence Matrix / Contraction Measure |
+| Semantics / equivalence | define what sameness means | `extensional`, `bisimulative`, `representation-independent` | Observation Contract / Bisimulation Relation |
+| Generality | avoid special-case overfitting | `principal`, `parametric`, `conservative-extending` | Principal Solution / Parametricity Matrix |
+| Program analysis | reason beyond sampled executions | `abstract-interpreting`, `symbolic`, `counterexample-guided` | Abstract Domain / Path Ledger / Refinement Ledger |
+| Verification / oracles | test when expected output is partial or absent | `metamorphic`, `differential`, `shrinking`, `oracle-aware` | Oracle Map / Relation Suite / Minimal Counterexample |
+| Concurrency | state the concurrent correctness model | `linearizable`, `serializable`, `atomic`, `commutative` | History / Serialization Graph |
+| Distributed systems | state replication and partition semantics | `causally-consistent`, `eventually-consistent`, `quorum-aware`, `consensus-backed` | Consistency Contract |
+| Recovery | converge from partial or dirty state | `self-stabilizing`, `transactional`, `idempotent`, `replayable` | Recovery Certificate |
+| Search / optimization | search with bounds and incumbents | `anytime`, `admissible`, `branch-and-bound`, `approximation-aware` | Incumbent Receipt / Bound Ledger |
+| Performance / dataflow | control recomputation and resource cost | `incremental`, `demand-driven`, `locality-aware`, `work-efficient` | Invalidation Graph / Work-Span Model |
+| Security / authority | constrain influence and privilege | `least-authority`, `capability-secure`, `noninterfering`, `hygienic` | Capability Graph / Information-Flow Matrix |
+| Data / schema | preserve information and constraints | `lossless`, `dependency-preserving`, `schema-evolution-aware`, `lineage-preserving` | Schema Evolution / Lineage Certificate |
 | Soundness | reject invalid guarantees | `unsound`, `unwitnessed`, `totalizing` | Soundness Ledger / Totality Table |
 | Reset | restart from authority | `rebaselining`, `epoching` | Baseline Receipt / Epoch Boundary |
 | Knowledge | extract truth from traces | `forensic`, `cartographic`, `saturating` | Provenance Map / System Map |
 | Systems | model feedback and control | `cybernetic`, `leverage-seeking` | Cybernetic Map |
-| Architecture | make hidden structure explicit | `reifying`, `algebraic`, `closed-world` | Behavior Algebra |
+| Architecture | make hidden structure explicit | `reifying`, `algebraic`, `closed-world`, `effect-explicit` | Behavior Algebra / Effect Signature |
 | Review | discriminate claims | `rebuttal-first`, `anti-rubber-stamp`, `invariant-seeking` | Resolve Selection / Countercase |
 | Precedent | apply or establish governing rules | `precedential`, `nomothetic`, `constitutive` | Precedent Ledger / Nomothetic Receipt |
 | Simulation | build and bound an executable surrogate | `emulative`, `counterfactual`, `dynamical`, `fidelity-bounded` | Emulation Receipt / Fidelity Boundary |
@@ -98,7 +114,7 @@ reduction_certificate:
     canonical_owners: []
     orphan_surfaces: []
   preservation:
-    relation: isomorphic | observationally-equivalent | refinement-preserving | intentional-contract-change
+    relation: isomorphic | bisimulative | observationally-equivalent | refinement-preserving | intentional-contract-change
     proof_refs: []
   gate:
     every_live_obligation_covered: pass | fail
@@ -106,6 +122,205 @@ reduction_certificate:
     quotient_is_congruent: pass | fail
     recomposition_proved: pass | fail
     no_orphan_surface: pass | fail
+```
+
+## Confluence Matrix
+
+```yaml
+confluence_matrix:
+  initial_state: "..."
+  rewrite_or_execution_paths:
+    - path_id: "..."
+      rules_or_actions: []
+      result: "..."
+  critical_pairs:
+    - pair_id: "..."
+      overlap: "..."
+      left_result: "..."
+      right_result: "..."
+      join_state: "..."
+      status: joinable | divergent | order-required | blocked
+  canonical_normal_form: "..."
+  termination_measure: "..."
+```
+
+## Contraction Measure
+
+```md
+Contraction Measure:
+- target fixed point:
+- distance metric:
+- prior distance:
+- current distance:
+- strict decrease: yes | no
+- non-contracting pass:
+- reroute if non-contracting:
+```
+
+## Principal Solution
+
+```yaml
+principal_solution:
+  constraints: []
+  general_solution: "..."
+  free_parameters: []
+  instantiations:
+    - case: "..."
+      substitution: "..."
+  rejected_special_cases: []
+  proof_of_generality: "..."
+```
+
+## Behavioral Equivalence Certificate
+
+```yaml
+behavioral_equivalence:
+  relation: isomorphic | bisimulative | observationally-equivalent | refinement-preserving
+  state_or_value_relation: "..."
+  observations: []
+  forward_obligations: []
+  backward_obligations: []
+  unmatched_transitions: []
+  proof_refs: []
+  result: pass | validate-first | fail | blocked
+```
+
+## Counterexample Refinement Ledger
+
+```yaml
+counterexample_refinement:
+  current_model_or_invariant: "..."
+  counterexamples:
+    - id: "..."
+      minimal_form: "..."
+      violated_claim: "..."
+      abstraction_gap: "..."
+      refinement: "..."
+      new_distinction_witness: "..."
+  wound_specific_patch_rejected: true | false
+  resulting_model: "..."
+```
+
+## Oracle Map
+
+```yaml
+oracle_map:
+  subject: "..."
+  oracle_kind: exact | partial | relational | differential | statistical | human | absent
+  direct_checks: []
+  metamorphic_relations: []
+  differential_peers: []
+  unsupported_claims: []
+  confidence_boundary: "..."
+```
+
+## Minimal Counterexample
+
+```md
+Minimal Counterexample:
+- original failure:
+- reduction dimensions:
+- minimized input / state / trace / diff:
+- failure still present:
+- removed noise:
+- governing mechanism:
+```
+
+## Concurrent History Contract
+
+```yaml
+concurrent_history:
+  required_model: linearizable | serializable | causal | eventual | custom
+  operations_or_transactions: []
+  real_time_constraints: []
+  candidate_order: []
+  conflicts: []
+  proof_or_counterexample: "..."
+```
+
+## Distributed Consistency Contract
+
+```yaml
+consistency_contract:
+  model: linearizable | serializable | causal | eventual | quorum-based | consensus-backed
+  authority: "..."
+  partition_behavior: "..."
+  stale_read_policy: "..."
+  convergence_condition: "..."
+  conflict_resolution: "..."
+  visibility_or_lag_bound: "..."
+  proof_or_test: "..."
+```
+
+## Recovery Certificate
+
+```yaml
+recovery_certificate:
+  dirty_or_partial_states: []
+  recovery_invariant: "..."
+  retry_semantics: "..."
+  idempotence_or_deduplication: "..."
+  replay_source: "..."
+  convergence_measure: "..."
+  rollback_or_forward_repair: "..."
+  proof_refs: []
+```
+
+## Anytime Incumbent Receipt
+
+```md
+Anytime Incumbent Receipt:
+- current incumbent:
+- validity proof:
+- objective:
+- current bound / quality:
+- remaining gap:
+- next search frontier:
+- interruption-safe: yes | no
+```
+
+## Proof-Carrying Handoff
+
+```yaml
+proof_carrying_handoff:
+  result: "..."
+  assumptions: []
+  applicability_boundary: "..."
+  certificate_refs: []
+  verifier: "..."
+  stale_if: []
+  downstream_authority: "..."
+```
+
+## Security Boundary Contract
+
+```yaml
+security_boundary:
+  principals_or_components: []
+  capabilities: []
+  forbidden_influences: []
+  mediation_points: []
+  privilege_separation: []
+  sandbox_limits: []
+  side_channels_considered: []
+  proof_or_test: "..."
+```
+
+## Schema Evolution Certificate
+
+```yaml
+schema_evolution:
+  old_schema: "..."
+  new_schema: "..."
+  information_preserved: []
+  information_retired: []
+  defaults_or_unknown_fields: []
+  compatibility:
+    backward: pass | fail | not-required
+    forward: pass | fail | not-required
+  constraints_preserved: []
+  migration_owner: "..."
+  rollback_or_replay: "..."
 ```
 
 ## Behavior Algebra
@@ -117,6 +332,7 @@ Behavior Algebra:
 - payload per case:
 - interpreter / eliminator:
 - totality table:
+- effect signature:
 - preservation proof:
 - why polymorphism/callbacks are insufficient or still better:
 ```
@@ -199,15 +415,79 @@ Reconciliation Ledger:
 - disposition:
 ```
 
+## Formal-distinction checks
+
+### Deterministic vs confluent
+
+- `deterministic`: one prescribed next step or output for the same state/input.
+- `confluent`: multiple valid paths may exist, but every divergence is joinable.
+- Do not use `deterministic` when the system intentionally allows concurrent or reordered paths.
+
+### Fixed-point vs contractive vs terminating
+
+- `fixed-point`: describes a stable endpoint.
+- `contractive`: each pass reduces a distance to that endpoint.
+- `terminating`: the process cannot continue forever.
+- A terminating process need not reach the desired fixed point; a fixed-point iteration need not be visibly contractive without a metric.
+
+### Principal vs optimal
+
+- `principal`: most general solution satisfying the constraints.
+- `optimal`: best solution under a declared objective.
+- Do not call a solution optimal when the objective, horizon, or search bound is missing.
+
+### Isomorphic vs bisimulative vs extensional
+
+- `isomorphic`: invertible structural correspondence.
+- `bisimulative`: mutually matching observable transitions.
+- `extensional` / `observationally-equivalent`: equal under selected observations.
+- `refinement-preserving`: preserves required behavior while allowing forbidden or obsolete behavior to disappear.
+
+### Sound vs complete vs total vs decidable
+
+- `sound`: no invalid conclusions.
+- `complete`: every valid conclusion is reachable.
+- `total`: defined for every valid input.
+- `decidable`: terminates with a judgment for every valid input.
+
+### Traceable vs proof-carrying vs replayable
+
+- `traceable`: evidence can be followed.
+- `proof-carrying`: evidence travels with the artifact.
+- `replayable`: captured state can reproduce behavior.
+
+### Hermetic vs hygienic vs noninterfering
+
+- `hermetic`: isolated from ambient dependencies.
+- `hygienic`: transformations avoid unintended capture.
+- `noninterfering`: forbidden influences cannot affect protected observations.
+
+### Serializable vs linearizable
+
+- `serializable`: concurrent transactions equal some serial transaction order.
+- `linearizable`: individual operations also respect real-time order.
+
+### Anytime vs exhaustive
+
+- `anytime`: a valid best-so-far result exists at every interruption point.
+- `exhaustive`: all material cases or branches are covered.
+- An anytime process may be incomplete; an exhaustive process may offer no useful intermediate result.
+
 ## Mode collision examples
 
 - `isomorphic` + `ablative`: OK when deletion/collapse must preserve all observable behavior; not OK when the task intentionally retires invalid or obsolete behavior.
 - `saturating` + `actuating`: OK when search stops after identifying the lever; not OK if saturation prevents action after enough evidence exists.
-- `accretive` + `ablative`: OK because deleting unearned surface can improve the future state; resolve by saying “subtractive work is accretive when it reduces obligations while preserving the live contract.”
+- `accretive` + `ablative`: OK because deleting unearned surface can improve the future state.
 - `forensic` + `synthetic`: OK when provenance is preserved; not OK if synthesis drops source quality.
 - `precedential` + `nomothetic`: OK when prior precedent informs a new scoped rule; not OK if the new rule silently inherits stale precedent.
-- `emulative` + `counterfactual`: OK when the surrogate’s fidelity boundary covers the intervention; not OK when unsupported scenarios are presented as predictions.
-- `adjudicative` + `actuating`: OK when a ruling authorizes an action; not OK when the evaluator also invents the criteria after seeing the preferred outcome.
+- `emulative` + `counterfactual`: OK when the fidelity boundary covers the intervention.
+- `adjudicative` + `actuating`: OK when a ruling authorizes action; not OK when the evaluator invents criteria after seeing the preferred outcome.
+- `deterministic` + `confluent`: often redundant or conceptually wrong; choose based on whether multiple valid paths are allowed.
+- `principal` + `optimal`: compatible only when the principal solution is also evaluated under an explicit objective.
+- `monotone` + `ablative`: compatible only when the order includes explicit supersession/tombstones or the deletion occurs outside the monotone accumulation layer.
+- `eventually-consistent` + `linearizable`: contradictory for the same operation surface unless separate boundaries or modes are named.
+- `anytime` + `fixed-point`: useful when every interrupted state is valid and the final state still has a fixed-point gate.
+- `hygienic` + `hermetic`: complementary; one prevents capture, the other ambient dependency.
 
 ## Quality bar
 
@@ -218,4 +498,8 @@ A recommended doctrine stack is good only if:
 3. the artifacts are visible enough for the receiving agent;
 4. the proof/receipt is clear;
 5. near-miss words were rejected for a reason;
-6. mode, persona, command, and artifact are not conflated.
+6. mode, persona, command, and artifact are not conflated;
+7. formal computer-science terms retain their actual distinction;
+8. the requested proof burden is proportionate to the strength of the word;
+9. a lighter fallback is used when the formal guarantee cannot be established;
+10. the stack remains small enough to steer rather than enumerate the whole glossary.

--- a/codex/skills/logophile/references/doctrine_probe_cases.md
+++ b/codex/skills/logophile/references/doctrine_probe_cases.md
@@ -9,9 +9,10 @@ Find doctrine words for reviewing PR comments more discriminately.
 Expected:
 - `rebuttal-first`
 - `discriminative`
+- `criterial`
 - `invariant-seeking`
 - `ablative`
-- artifacts: Resolve Selection, no-change countercase, Ablation Activation Receipt.
+- artifacts: Resolve Selection, no-change countercase, Criteria Matrix, Ablation Activation Receipt.
 
 ```text
 What doctrine word captures moving from plan to PR?
@@ -92,6 +93,309 @@ Expected:
 - companion: `conservation-aware`.
 - artifact: Reconciliation Ledger or Conservation Ledger.
 
+## Computer-science doctrine probes
+
+```text
+I have several valid rewrite paths. I need them all to converge to one canonical result.
+```
+
+Expected:
+- `confluent`
+- companions: `critical-pair-aware`, `normalizing`, `terminating`.
+- artifact: Confluence Matrix or Critical-Pair Ledger.
+- near miss: `deterministic` is wrong if several paths are intentionally valid.
+
+```text
+My fixed-point loop keeps running but I cannot tell whether each pass gets closer.
+```
+
+Expected:
+- `contractive`
+- companions: `fixed-point`, `terminating`, `saturating`.
+- artifact: Contraction Measure.
+- distinction: `fixed-point` names the endpoint; `contractive` names progress toward it.
+
+```text
+I want the most general solution that satisfies these constraints, not another pile of special cases.
+```
+
+Expected:
+- `principal`
+- companions: `parametric`, `constructive`, `conservative-extending`.
+- artifact: Principal Solution + Instantiation Map.
+- near miss: `optimal` requires an objective and is not synonymous with principal.
+
+```text
+I need to prove these two state machines have the same behavior, including every transition.
+```
+
+Expected:
+- `bisimulative`
+- companions: `coinductive`, `observational`, `totalizing`.
+- artifact: Bisimulation Relation.
+- near miss: `isomorphic` is not the default behavioral relation.
+
+```text
+Every new failing example causes another local patch. I want the failures to refine the model instead.
+```
+
+Expected:
+- `counterexample-guided`
+- companions: `refinement-driven`, `shrinking`, `invariant-seeking`.
+- artifact: Counterexample Refinement Ledger.
+
+```text
+There is no exact expected output. How should the agent design verification?
+```
+
+Expected:
+- `oracle-aware`
+- companions: `metamorphic`, `differential`, `property-based`.
+- artifacts: Oracle Map and Metamorphic Relation Suite.
+- do not invent a golden output.
+
+```text
+I want the smallest input or trace that still reproduces the bug.
+```
+
+Expected:
+- `shrinking`
+- artifact: Minimal Counterexample.
+
+```text
+I want tests that prove they would catch plausible defects, not merely execute the lines.
+```
+
+Expected:
+- `mutation-resistant`
+- companion: `coverage-guided`.
+- artifact: mutation score and surviving-mutant ledger.
+
+```text
+The implementation should remain uniform across all admissible types and not special-case known examples.
+```
+
+Expected:
+- `parametric`
+- artifact: Parametricity Matrix.
+
+```text
+A result crosses from one subagent to another. The evidence needed to trust it must travel with it.
+```
+
+Expected:
+- `proof-carrying`
+- companion: `traceable`.
+- artifact: Certificate-Bearing Handoff.
+- distinction: traceability alone does not require the proof to travel with the result.
+
+```text
+A source transformation must not capture ambient names, authority, or context.
+```
+
+Expected:
+- `hygienic`
+- artifact: Capture Audit.
+- near miss: `hermetic` is about ambient dependencies, not capture.
+
+```text
+This operation may run several times because delivery is at least once, but it must have one logical effect.
+```
+
+Expected:
+- `idempotent`
+- companion: `deduplicating`.
+- artifact: repeat-delivery proof and deduplication key.
+
+```text
+I need concurrent operations on one object to appear atomic and respect real-time order.
+```
+
+Expected:
+- `linearizable`
+- artifact: concurrent history and linearization points.
+- near miss: `serializable` is weaker/different and applies to transaction equivalence.
+
+```text
+I need concurrent database transactions to equal some serial execution, but real-time operation order is not the claim.
+```
+
+Expected:
+- `serializable`
+- artifact: serialization graph.
+
+```text
+Replicas may diverge temporarily, but I need a real convergence and conflict-resolution contract.
+```
+
+Expected:
+- `eventually-consistent`
+- companions: `partition-aware`, `quorum-aware`, `deduplicating`.
+- artifact: Distributed Consistency Contract.
+- reject vague “eventual” claims without a convergence condition.
+
+```text
+The workflow may resume from partial or dirty state and should converge back to a valid state.
+```
+
+Expected:
+- `self-stabilizing`
+- companions: `rebaselining`, `idempotent`, `replayable`.
+- artifact: Recovery Certificate.
+
+```text
+The search may be interrupted at any time, but I still need a valid best-so-far answer.
+```
+
+Expected:
+- `anytime`
+- artifact: Anytime Incumbent Receipt.
+- near miss: `exhaustive` does not guarantee useful intermediate answers.
+
+```text
+I want to prune design branches whose best possible outcome cannot beat the current candidate.
+```
+
+Expected:
+- `branch-and-bound`
+- companions: `pruning`, `best-first`, `admissible`.
+- artifact: incumbent, bound, and pruned-branch ledger.
+
+```text
+This expensive operation is occasionally slow, but I care about the cost across a long sequence.
+```
+
+Expected:
+- `amortized`
+- artifact: potential or accounting argument.
+
+```text
+Only a small structural parameter makes the problem difficult; total input size is misleading.
+```
+
+Expected:
+- `parameterized`
+- companion: `kernelizing`.
+- artifact: parameter map and reduced kernel instance.
+
+```text
+The system should recompute only what the changed dependency invalidates.
+```
+
+Expected:
+- `incremental`
+- artifact: invalidation graph.
+
+```text
+The system should produce only what downstream observations demand.
+```
+
+Expected:
+- `demand-driven`
+- artifact: demand/observation map.
+
+```text
+I need to minimize the critical path of a parallel workflow, not just total work.
+```
+
+Expected:
+- `span-efficient`
+- companion: `work-efficient`.
+- artifact: work/span analysis.
+
+```text
+Each plugin should receive only the authority it needs, represented explicitly rather than ambiently.
+```
+
+Expected:
+- `least-authority`
+- companion: `capability-secure`.
+- artifact: capability graph.
+
+```text
+Protected state must not influence these outputs, even indirectly.
+```
+
+Expected:
+- `noninterfering`
+- artifact: Information-Flow Matrix.
+
+```text
+The cryptographic routine must not leak secret-dependent timing.
+```
+
+Expected:
+- `constant-time`
+- companion: `side-channel-aware`.
+- artifact: timing/branch audit.
+
+```text
+A schema decomposition must preserve all information and allow constraints to be checked locally.
+```
+
+Expected:
+- `lossless`
+- companion: `dependency-preserving`.
+- artifacts: losslessness proof and dependency-preservation matrix.
+
+```text
+Events should be the authority and current state should be replayable from them.
+```
+
+Expected:
+- `event-sourced`
+- companions: `append-only`, `replayable`, `lineage-preserving`.
+- artifact: event schema, reducer, and replay proof.
+
+## Formal-distinction probes
+
+```text
+Should I call this deterministic or confluent?
+```
+
+Expected:
+- ask whether multiple valid paths exist.
+- choose `deterministic` when one next path/output is prescribed.
+- choose `confluent` when multiple paths may exist but must join.
+
+```text
+Is this isomorphic, bisimilar, or observationally equivalent?
+```
+
+Expected:
+- `isomorphic`: invertible structural mapping.
+- `bisimulative`: mutually matching transitions.
+- `observationally-equivalent`: equal under declared observations.
+- do not use them interchangeably.
+
+```text
+Should I say complete, total, decidable, or sound?
+```
+
+Expected:
+- `sound`: no invalid conclusions.
+- `complete`: every valid conclusion is reachable.
+- `total`: defined for every valid input.
+- `decidable`: terminates with a judgment for every valid input.
+
+```text
+Is principal the same thing as optimal?
+```
+
+Expected:
+- no.
+- `principal`: most general under constraints.
+- `optimal`: best under an objective.
+
+```text
+Is proof-carrying just a stronger way to say traceable?
+```
+
+Expected:
+- no.
+- `traceable`: evidence can be followed.
+- `proof-carrying`: evidence travels with the result.
+
 ## Should trigger activation-phrase mode
 
 ```text
@@ -105,7 +409,7 @@ Be bolder.
 Be Optimal.
 ```
 
-Do not automatically append a rubric, receipt, or explanation. The reference may record that `Be bolder.` widens the candidate set and `Be Optimal.` selects against the real objective and constraints.
+Do not automatically append a rubric, receipt, or explanation.
 
 ```text
 Give me an exemplar phrase for elite fundamentals, competitive intensity, and finishing under pressure.
@@ -163,22 +467,36 @@ This belongs to execution/shipping workflows.
 Simulate this protocol and tell me what happens.
 ```
 
-This is an operational simulation request, not a doctrine-word request. Do not use logophile unless the user asks for simulator terminology or doctrine.
+This is an operational simulation request, not a doctrine-word request.
 
 ```text
 Grade these submissions against the rubric.
 ```
 
-This is an evaluation workflow, not a doctrine naming request. Do not use logophile unless wording or doctrine output is requested.
+This is an evaluation workflow, not a doctrine naming request.
+
+```text
+Prove this history is linearizable.
+```
+
+This is an operational concurrency-verification task, not a terminology request.
+
+```text
+Run symbolic execution over this binary.
+```
+
+This is operational program analysis, not doctrine synthesis.
 
 ## Quality checks
 
 A doctrine-word answer must:
 - name the pressure;
 - choose words with distinct jobs;
+- preserve formal computer-science distinctions;
 - separate mode, persona, command, and artifact when relevant;
 - explain near misses when useful;
 - include artifacts when correctness, handoff, or closure depends on them;
+- state a lighter fallback when the strongest formal term cannot be proven;
 - end with `Use This:` and `Operationalization:` in full doctrine mode.
 
 An activation-phrase answer must:
@@ -194,5 +512,9 @@ Reject answers that:
 - fail to say what a doctrine word should make the receiving agent do differently;
 - confuse a persona noun with an operating mode;
 - use a proof relation such as `isomorphic` as though it were a reduction operator;
-- turn `Be bolder.`, `Be Optimal.`, or `Be like Mike.` into a long runtime checklist by default;
+- use `deterministic` when the actual guarantee is confluence;
+- use `optimal` when only a principal or admissible solution is supported;
+- use `linearizable` when only transaction serializability was checked;
+- use `complete`, `constant-time`, `proof-carrying`, or `self-stabilizing` without the matching proof burden;
+- turn activation phrases into a long runtime checklist by default;
 - require a receipt merely to prove that an activation phrase was used.

--- a/codex/skills/logophile/references/doctrine_word_bank.md
+++ b/codex/skills/logophile/references/doctrine_word_bank.md
@@ -2,7 +2,9 @@
 
 Use these as defaults, not mandates. Pick words for procedural gain, not prestige.
 
-A good doctrine word activates an operator and leaves an artifact. A weak doctrine word only improves tone.
+A good doctrine word activates an operator and leaves an observable behavioral consequence. A weak doctrine word only improves tone.
+
+For the expanded computer-science catalog and formal distinctions, see [computer_science_doctrine.md](computer_science_doctrine.md).
 
 ## Action / execution operators
 
@@ -55,6 +57,231 @@ A good doctrine word activates an operator and leaves an artifact. A weak doctri
   - Cash-out: Isomorphism Card.
   - Warning: not a reduction operator by itself.
 
+## Rewrite systems / convergence operators
+
+- `confluent`: permit many paths but require them to join at one canonical result.
+  - Cash-out: Confluence Matrix or Critical-Pair Ledger.
+- `terminating`: require rewrites, retries, recursion, or workflow chains to reach a stopping state.
+  - Cash-out: termination measure or ranking function.
+- `critical-pair-aware`: find overlapping rules whose independent application may diverge.
+  - Cash-out: Critical-Pair Ledger.
+- `contractive`: require every iteration to reduce a named distance to closure.
+  - Cash-out: Contraction Measure.
+- `monotone`: preserve an explicit information, authority, or state order.
+  - Cash-out: Information-Order Map.
+- `inflationary`: preserve the prior state while moving upward in the declared order.
+  - Cash-out: inflationary transition proof.
+- `congruence-preserving`: preserve equivalence under every permitted context.
+  - Cash-out: context/congruence checks.
+- `conservative-extending`: add expressive power without changing existing valid meaning.
+  - Cash-out: conservative-extension certificate.
+- `commutative`: make independent operation order irrelevant.
+  - Cash-out: commutativity matrix.
+- `associative`: make grouping irrelevant.
+  - Cash-out: associativity law tests.
+- `distributive`: expose valid interaction and decomposition between operations.
+  - Cash-out: distributive-law tests.
+
+## Semantics / abstraction operators
+
+- `principal`: seek the most general solution satisfying the constraints.
+  - Cash-out: Principal Solution and Instantiation Map.
+- `parametric`: require uniform behavior across admissible representations.
+  - Cash-out: Parametricity Matrix.
+- `extensional`: judge equality by selected observations rather than internal construction.
+  - Cash-out: Observation Contract.
+- `representation-independent`: prevent clients from depending on hidden representation choices.
+  - Cash-out: client-observation audit.
+- `bisimulative`: require mutually matching observable transitions.
+  - Cash-out: Bisimulation Relation.
+- `coinductive`: reason about ongoing or infinite behavior through observations.
+  - Cash-out: coinductive invariant.
+- `inductive`: construct or prove from constructors and structurally smaller cases.
+  - Cash-out: constructor coverage and induction hypothesis.
+- `lawful`: require an abstraction to satisfy its claimed laws.
+  - Cash-out: Law Suite.
+- `decidable`: define a terminating decision procedure for every admissible input.
+  - Cash-out: Decision Procedure.
+- `complete`: cover every semantically valid case.
+  - Cash-out: completeness argument or missing-case inventory.
+- `effect-explicit`: expose effects in the type, protocol, or interpreter.
+  - Cash-out: Effect Signature and Handler Map.
+- `referentially-transparent`: make substitution by value behavior-preserving.
+  - Cash-out: side-effect/capture audit.
+
+## Program-analysis / refinement operators
+
+- `abstract-interpreting`: reason soundly over a tractable over-approximation of concrete execution.
+  - Cash-out: abstract domain and sound transfer functions.
+- `symbolic`: reason over variables and path constraints instead of only concrete examples.
+  - Cash-out: path-condition ledger.
+- `counterexample-guided`: let failures refine the abstraction or invariant rather than create wound-specific patches.
+  - Cash-out: Counterexample Refinement Ledger.
+- `refinement-driven`: add distinctions only when forced by accepted observations or failed proof.
+  - Cash-out: refinement chain.
+- `proof-carrying`: make validation evidence travel with the result across boundaries.
+  - Cash-out: Certificate-Bearing Handoff.
+- `type-directed`: let type and inhabitation obligations drive construction and search.
+  - Cash-out: type-obligation map.
+- `taint-aware`: track untrusted influence from sources to sinks.
+  - Cash-out: source-to-sink flow map.
+
+## Verification / oracle operators
+
+- `shrinking`: reduce a failure to the smallest counterexample that still exhibits it.
+  - Cash-out: Minimal Counterexample.
+- `metamorphic`: test invariant relations when no exact expected output exists.
+  - Cash-out: Metamorphic Relation Suite.
+- `differential`: compare independent implementations or versions and investigate disagreement.
+  - Cash-out: Differential Result Matrix.
+- `property-based`: generate broad input families from invariants.
+  - Cash-out: generators, properties, and shrinkers.
+- `oracle-aware`: name what makes a result checkable and where no direct oracle exists.
+  - Cash-out: Oracle Map.
+- `coverage-guided`: steer generation toward unexplored control-flow, state, or semantic regions.
+  - Cash-out: coverage frontier.
+- `mutation-resistant`: require tests to detect plausible injected defects.
+  - Cash-out: mutation score and surviving-mutant ledger.
+- `model-checking`: explore a bounded state space against safety or temporal properties.
+  - Cash-out: model, properties, and counterexample trace.
+- `replayable`: capture enough state and ordering to reproduce behavior.
+  - Cash-out: Replay Receipt.
+- `fault-injecting`: deliberately test failure containment and recovery.
+  - Cash-out: fault matrix.
+
+## Concurrency / distributed operators
+
+- `linearizable`: make each operation appear atomic while respecting real-time order.
+  - Cash-out: concurrent history and linearization points.
+- `serializable`: make concurrent transactions equivalent to some serial execution.
+  - Cash-out: serialization graph.
+- `causally-consistent`: preserve cause-before-effect ordering.
+  - Cash-out: happens-before graph.
+- `eventually-consistent`: permit bounded divergence only with a convergence and visibility contract.
+  - Cash-out: convergence condition and conflict policy.
+- `quorum-aware`: reason about overlap, stale reads, and failure thresholds.
+  - Cash-out: quorum matrix.
+- `consensus-backed`: require an agreement protocol before claiming one authoritative order or value.
+  - Cash-out: consensus authority map.
+- `self-stabilizing`: converge back to a valid state from reachable dirty or partial states.
+  - Cash-out: recovery variant and convergence proof.
+- `fault-contained`: bound failure propagation to explicit regions.
+  - Cash-out: fault-containment map.
+- `partition-aware`: name behavior under communication partitions.
+  - Cash-out: partition behavior table.
+- `backpressure-aware`: make upstream production respond to downstream capacity.
+  - Cash-out: demand/capacity contract.
+- `transactional`: bind a multi-step mutation under an explicit atomicity/isolation/durability contract.
+  - Cash-out: transaction boundary.
+- `atomic`: make an operation indivisible at the relevant observation boundary.
+  - Cash-out: atomicity proof.
+- `deduplicating`: make repeated delivery converge on one logical effect.
+  - Cash-out: deduplication key and retry proof.
+
+## Algorithm / search operators
+
+- `anytime`: maintain a valid incumbent at every interruption point and improve it with more budget.
+  - Cash-out: Incumbent + Remaining-Gap Receipt.
+- `admissible`: use a heuristic that does not overestimate remaining cost.
+  - Cash-out: admissibility argument.
+- `consistent-heuristic`: require heuristic values to obey transition consistency.
+  - Cash-out: heuristic consistency checks.
+- `branch-and-bound`: prune branches whose best possible result cannot beat the incumbent.
+  - Cash-out: incumbent, bounds, and pruned-branch ledger.
+- `best-first`: expand the most promising frontier item under an explicit score.
+  - Cash-out: frontier ordering.
+- `pruning`: remove search branches proven unable to affect the answer.
+  - Cash-out: pruning rule and completeness impact.
+- `kernelizing`: reduce a hard problem to a smaller equivalent instance.
+  - Cash-out: kernel instance and equivalence proof.
+- `parameterized`: expose the structural parameter that governs difficulty.
+  - Cash-out: parameter map and complexity claim.
+- `output-sensitive`: measure work relative to input plus produced output.
+  - Cash-out: output-sensitive complexity bound.
+- `amortized`: evaluate cost over an operation sequence.
+  - Cash-out: potential or accounting argument.
+- `competitive`: compare an online strategy with the best offline strategy.
+  - Cash-out: competitive ratio.
+- `worst-case-aware`: test catastrophic inputs or adversarial schedules.
+  - Cash-out: worst-case bound or adversarial test.
+- `approximation-aware`: state the quality bound when exact optimization is infeasible.
+  - Cash-out: approximation ratio or quality envelope.
+- `randomized`: state probability, seedability, and failure bounds.
+  - Cash-out: probabilistic guarantee.
+- `derandomizing`: replace randomness with deterministic structure when proof or repeatability requires it.
+  - Cash-out: deterministic substitute and comparison.
+
+## Performance / dataflow operators
+
+- `incremental`: recompute only the dependency closure invalidated by change.
+  - Cash-out: invalidation graph.
+- `demand-driven`: compute or retrieve only what downstream observations require.
+  - Cash-out: demand map.
+- `locality-aware`: keep data and computation near reuse, ownership, or failure boundaries.
+  - Cash-out: locality map.
+- `cache-conscious`: account for working-set and cache behavior.
+  - Cash-out: cache evidence.
+- `zero-copy`: avoid unnecessary materialization while preserving ownership/lifetime safety.
+  - Cash-out: copy count and lifetime proof.
+- `streaming`: process bounded chunks without requiring the full input in memory.
+  - Cash-out: memory bound and chunk contract.
+- `batching`: amortize fixed costs while preserving ordering and failure semantics.
+  - Cash-out: batch contract.
+- `fusion-oriented`: combine adjacent passes and remove intermediate structures.
+  - Cash-out: fused pipeline and preservation proof.
+- `work-efficient`: keep total parallel work near the best sequential work.
+  - Cash-out: work analysis.
+- `span-efficient`: minimize the critical path.
+  - Cash-out: span/critical-path analysis.
+- `asymptotic`: choose by scaling behavior, then validate constants against the workload.
+  - Cash-out: complexity model and measured crossover.
+- `bounded`: enforce explicit limits on time, memory, retries, queues, fanout, or state.
+  - Cash-out: resource budget.
+
+## Security / authority operators
+
+- `hygienic`: prevent unintended capture of names, context, authority, state, or assumptions.
+  - Cash-out: Capture Audit.
+- `end-to-end`: put the guarantee at the endpoint capable of verifying it.
+  - Cash-out: endpoint verification map.
+- `least-authority`: give each component only the capabilities required.
+  - Cash-out: authority/capability matrix.
+- `capability-secure`: represent authority as explicit unforgeable capabilities.
+  - Cash-out: capability graph.
+- `complete-mediation`: check authority on every access path.
+  - Cash-out: mediation coverage map.
+- `privilege-separated`: split high-risk authority from ordinary computation.
+  - Cash-out: privilege boundary map.
+- `noninterfering`: prevent forbidden inputs or principals from influencing protected observations.
+  - Cash-out: Information-Flow Matrix.
+- `constant-time`: prevent secrets from influencing timing or comparable resource behavior.
+  - Cash-out: timing/branch audit.
+- `side-channel-aware`: inventory information leakage through timing, memory, logs, caches, errors, or resources.
+  - Cash-out: side-channel inventory.
+- `memory-safe`: prevent invalid memory access and ownership violations.
+  - Cash-out: memory-safety boundary.
+- `attack-surface-minimizing`: reduce exposed operations, parsers, privileges, protocols, and dependencies.
+  - Cash-out: attack-surface delta.
+- `sandboxed`: confine untrusted execution with explicit resource and capability limits.
+  - Cash-out: sandbox policy and escape tests.
+
+## Data / schema operators
+
+- `lossless`: preserve all information required by the live contract.
+  - Cash-out: round-trip or losslessness proof.
+- `dependency-preserving`: preserve constraints needed for local validation after decomposition.
+  - Cash-out: dependency-preservation matrix.
+- `referential-integrity-preserving`: maintain valid references across lifecycle transitions.
+  - Cash-out: reference lifecycle audit.
+- `schema-evolution-aware`: make versioning, defaults, unknown fields, and migration ownership explicit.
+  - Cash-out: schema evolution matrix.
+- `append-only`: express history through additions and supersession rather than destructive rewrite.
+  - Cash-out: append/supersession contract.
+- `event-sourced`: treat events as authority and state as replayable projection.
+  - Cash-out: event schema, reducer, and replay proof.
+- `lineage-preserving`: keep the derivation path from source to result.
+  - Cash-out: lineage graph.
+
 ## Reset / stale-state control
 
 - `rebaselining`: bind to the current authoritative state and invalidate stale assumptions or receipts.
@@ -72,45 +299,45 @@ A good doctrine word activates an operator and leaves an artifact. A weak doctri
 
 - `precedential`: recover a prior case, extract its rule, distinguish the current facts, and apply only what still governs.
   - Cash-out: Precedent Ledger with provenance, analogy, distinctions, freshness, supersession, and action delta.
-- `distinguishing`: identify the facts that prevent a superficially similar precedent from controlling the current case.
+- `distinguishing`: identify facts that prevent a superficially similar precedent from controlling.
   - Cash-out: distinguishing-facts row.
-- `supersession-aware`: reject a prior rule when newer evidence, policy, architecture, or proof has replaced it.
+- `supersession-aware`: reject a prior rule when newer evidence or policy has replaced it.
   - Cash-out: supersession chain.
 - `nomothetic`: deliberately establish a scoped rule that future cases may inherit.
-  - Cash-out: Nomothetic Receipt with rule, scope, exceptions, authority, and supersession condition.
-- `constitutive`: make a decision that creates or changes the governing structure rather than merely applying it.
+  - Cash-out: Nomothetic Receipt.
+- `constitutive`: create or change the governing structure rather than merely applying it.
   - Cash-out: Constitutive Receipt.
 
 ## Simulation / world-modeling operators
 
-- `emulative`: build an executable surrogate that preserves the behavior relevant to the decision.
+- `emulative`: build an executable surrogate that preserves behavior relevant to the decision.
   - Cash-out: Emulation Receipt.
-- `counterfactual`: vary one intervention while naming held-constant assumptions and projected consequences.
+- `counterfactual`: vary one intervention while naming held-constant assumptions.
   - Cash-out: Counterfactual Ledger.
-- `dynamical`: model state, transitions, time, delays, feedback, and attractors rather than a static input/output relation.
+- `dynamical`: model state, transitions, time, delays, feedback, and attractors.
   - Cash-out: Dynamics Map.
-- `observational`: define the measurements or outputs by which the model and real system are compared.
+- `observational`: define measurements by which model and reality are compared.
   - Cash-out: Observation Contract.
 - `fidelity-bounded`: state where the surrogate is validated, approximate, unknown, or unsupported.
   - Cash-out: Fidelity Boundary.
-- `surrogative`: provide a lower-cost or safer stand-in for an expensive, unavailable, slow, or dangerous real system.
+- `surrogative`: provide a lower-cost or safer stand-in for a real system.
   - Cash-out: Surrogate Contract.
 - `agentic`: model actors as goal-seeking entities with policies, information, incentives, and adaptation.
   - Cash-out: actor/policy map.
-- `world-modeling`: represent environment, actors, state, actions, observations, constraints, and transition rules explicitly.
+- `world-modeling`: represent environment, actors, state, actions, observations, constraints, and transition rules.
   - Cash-out: World Model.
 
 ## Evaluation / judgment operators
 
-- `adjudicative`: judge claims, artifacts, or options against explicit criteria and issue a reasoned disposition.
+- `adjudicative`: judge claims, artifacts, or options against explicit criteria and issue a disposition.
   - Cash-out: Adjudication Ledger.
 - `criterial`: declare the standard before scoring, comparing, or ruling.
   - Cash-out: Criteria Matrix.
-- `evidence-weighted`: weight current evidence and counterevidence rather than authority, fluency, or preference.
+- `evidence-weighted`: weight evidence and counterevidence rather than authority, fluency, or preference.
   - Cash-out: Evidence Weighting table.
-- `dispositive`: identify the fact, rule, or test that actually determines the outcome.
+- `dispositive`: identify the fact, rule, or test that determines the outcome.
   - Cash-out: Dispositive Factor row.
-- `calibrated`: match confidence, severity, and finality to the evidence.
+- `calibrated`: match confidence, severity, and finality to evidence.
   - Cash-out: confidence/disposition ledger.
 
 ## Systems / knowledge extraction
@@ -121,7 +348,7 @@ A good doctrine word activates an operator and leaves an artifact. A weak doctri
   - Cash-out: System Map.
 - `cybernetic`: model feedback loops, control points, signals, delays, adaptation, and second-order effects.
   - Cash-out: Cybernetic Map.
-- `provenance-preserving`: keep source, freshness, and confidence attached to material claims.
+- `provenance-preserving`: keep source, freshness, and confidence attached to claims.
   - Cash-out: evidence/source ledger.
 - `stratified`: rank evidence by authority, freshness, and closeness to event.
   - Cash-out: source stratification table.
@@ -129,36 +356,36 @@ A good doctrine word activates an operator and leaves an artifact. A weak doctri
   - Cash-out: triangulation ledger.
 - `abductive`: infer the best explanatory model, then test disconfirming evidence.
   - Cash-out: hypothesis ledger with falsifiers.
-- `saturating`: keep searching until marginal evidence no longer changes the route or model.
+- `saturating`: search until marginal evidence no longer changes the route or model.
   - Cash-out: saturation stop rule.
 
 ## Hidden behavior / type-theoretic architecture
 
 - `reifying`: make hidden behavior explicit as data.
-  - Cash-out: behavior algebra: constructors, payloads, total interpreter, preservation proof.
+  - Cash-out: behavior algebra with constructors, payloads, total interpreter, and preservation proof.
 - `totalizing`: make the interpreter, handler, or eliminator total over legal constructors.
   - Cash-out: totality table.
 - `algebraic`: represent behavior as carriers, operations, observations, and laws.
   - Cash-out: law catalog or behavior algebra.
-- `closed-world`: the behavior space is finite/enumerable enough to make cases explicit.
+- `closed-world`: make an enumerable behavior space explicit.
   - Cash-out: closed case inventory.
-- `inspectable`: behavior can be logged, replayed, serialized, diffed, cached, routed, or tested.
+- `inspectable`: make behavior loggable, replayable, serializable, diffable, cacheable, routable, or testable.
   - Cash-out: inspection/replay proof.
 
 ## Failure-mode words
 
 - `unsound`: reject unsupported inferences; surface missing premises and invalid guarantees.
-- `unwitnessed`: a guarantee lacks a concrete witness: invariant, check, construction, type restriction, or test.
-- `ill-typed`: the representation admits states, transitions, or values that do not fit the claimed domain.
+- `unwitnessed`: a guarantee lacks a concrete witness.
+- `ill-typed`: the representation admits values or transitions outside the claimed domain.
 - `illegal inhabitant`: an impossible state is representable.
-- `partial`: an eliminator, handler, or case split only works for part of the intended domain.
+- `partial`: a handler or case split covers only part of the intended domain.
 - `non-total`: a required path can fail to produce a legal continuation.
-- `incoherent`: layers disagree about what an abstraction, state, or protocol means.
-- `non-compositional`: behavior works locally but fails when combined with adjacent paths.
-- `ill-founded`: retries, recursion, dependency chains, or state transitions lack a terminating/progress-preserving structure.
+- `incoherent`: layers disagree about an abstraction, state, or protocol.
+- `non-compositional`: behavior works locally but fails under composition.
+- `ill-founded`: recursion, retries, or dependency chains lack a terminating/progress-preserving shape.
 - `vacuous`: reject empty, tautological, or content-free claims.
 - `spurious`: challenge accidental patterns and misleading correlations.
-- `pathological`: hunt edge cases and weird failure surfaces.
+- `pathological`: hunt edge cases and strange failure surfaces.
 - `ill-posed`: question whether the task is specified tightly enough.
 - `confounded`: look for mixed causes or ambiguous attribution.
 - `hazard-seeking`: hunt misuse traps and foot-guns.
@@ -209,7 +436,7 @@ A good doctrine word activates an operator and leaves an artifact. A weak doctri
 - `reproducible`: make the result checkable by rerunning.
 - `fixed-point`: stop only when a fresh pass finds no material change.
 - `saturating`: keep iterating while new material findings still appear.
-- `tail-proof`: put the proof and next action where the CLI user will see it.
+- `tail-proof`: put proof and next action where the CLI user will see them.
 
 ## Persona nouns
 

--- a/codex/skills/logophile/references/precision_lexicon.md
+++ b/codex/skills/logophile/references/precision_lexicon.md
@@ -2,31 +2,119 @@
 
 Use these as guarded phrase replacements. A replacement is valid only when it preserves meaning, obligation, uncertainty, agency, and copy-paste safety.
 
+For formal computer-science terms, preserve the proof burden. A sharper term is invalid when the surrounding task cannot support its actual guarantee.
+
 ## Generic -> sharper defaults
 
-- `improve` -> `tighten`, `harden`, `simplify`, `stabilize`, `clarify`, `validate`, `defuse`, `accelerate`, `actuate`, or `normalize` when the local gain is clear.
-- `handle` -> `reject`, `normalize`, `parse`, `route`, `validate`, `recover`, `surface`, `fail-closed`, `totalize`, or `reconcile` when the behavior is known.
-- `deal with` -> name the action: `triage`, `isolate`, `resolve`, `defer`, `route`, `instrument`, `prove`, `document`, `rebaseline`, or `decommission`.
-- `make better` -> name the axis: `more deterministic`, `more traceable`, `less coupled`, `more canonical`, `lower blast radius`, `more witness-backed`, or `less surface-bearing`.
-- `things` / `stuff` -> name the object: `comments`, `invariants`, `handlers`, `paths`, `checks`, `risks`, `artifacts`, `surfaces`, `obligations`, `receipts`.
-- `issue` -> `defect`, `risk`, `regression`, `invariant break`, `foot-gun`, `mismatch`, `gap`, `unreconciled residual`, or `soundness gap` when the class is known.
-- `problem` -> `failure mode`, `constraint conflict`, `soundness gap`, `scope mismatch`, `evidence gap`, `routing gap`, `unwitnessed guarantee`, or `state-space mismatch` when known.
+- `improve` -> `tighten`, `harden`, `simplify`, `stabilize`, `clarify`, `validate`, `defuse`, `accelerate`, `actuate`, `normalize`, `converge`, or `incrementalize` when the local gain is clear.
+- `handle` -> `reject`, `normalize`, `parse`, `route`, `validate`, `recover`, `surface`, `fail-closed`, `totalize`, `reconcile`, `deduplicate`, or `mediate` when the behavior is known.
+- `deal with` -> name the action: `triage`, `isolate`, `resolve`, `defer`, `route`, `instrument`, `prove`, `document`, `rebaseline`, `decommission`, `serialize`, or `stabilize`.
+- `make better` -> name the axis: `more deterministic`, `more confluent`, `more traceable`, `less coupled`, `more canonical`, `lower blast radius`, `more witness-backed`, `less surface-bearing`, `more incremental`, or `more fault-contained`.
+- `things` / `stuff` -> name the object: `comments`, `invariants`, `handlers`, `paths`, `checks`, `risks`, `artifacts`, `surfaces`, `obligations`, `receipts`, `transitions`, `replicas`, `capabilities`, or `oracles`.
+- `issue` -> `defect`, `risk`, `regression`, `invariant break`, `foot-gun`, `mismatch`, `gap`, `unreconciled residual`, `soundness gap`, `critical pair`, `race`, or `oracle gap` when the class is known.
+- `problem` -> `failure mode`, `constraint conflict`, `soundness gap`, `scope mismatch`, `evidence gap`, `routing gap`, `unwitnessed guarantee`, `state-space mismatch`, `tractability bottleneck`, or `consistency violation` when known.
 - `review feedback` -> `review claim`, `review finding`, `review suggestion`, `review disposition`, `counterexample`, or `warrant` depending on context.
-- `solve` -> `tractabilize`, `actuate`, `remediate`, `adjudicate`, `construct`, or `prove` when the task shape is known.
+- `solve` -> `tractabilize`, `actuate`, `remediate`, `adjudicate`, `construct`, `prove`, `search`, `synthesize`, or `decide` when the task shape is known.
 - `reset` -> `rebaseline`, `epoch`, `reinitialize`, or `renormalize` depending whether authority, generation, runtime state, or canonical form is changing.
-- `decompose` -> `factorize` or `orthogonalize` when the factors and coupling matter.
-- `reduce` / `remove what is unnecessary` -> `winnow`, `quotient`, `ablate`, or `normalize` depending whether the task retains live obligations, collapses indistinguishable distinctions, removes unearned surface, or reaches canonical form.
-- `account for` -> `reconcile`, `attribute`, or `conserve` depending whether the task balances surfaces, assigns causes/owners, or proves nothing appeared/disappeared without a transition.
+- `decompose` -> `factorize`, `orthogonalize`, `partition`, or `kernelize` depending whether the task exposes factors, independent axes, distributed regions, or a smaller equivalent instance.
+- `reduce` / `remove what is unnecessary` -> `winnow`, `quotient`, `ablate`, `prune`, `deforest`, or `normalize` depending whether the task retains live obligations, collapses indistinguishable distinctions, removes unearned surface, eliminates search branches, removes intermediates, or reaches canonical form.
+- `account for` -> `reconcile`, `attribute`, `conserve`, or `amortize` depending whether the task balances surfaces, assigns causes/owners, proves nothing appeared/disappeared without a transition, or distributes cost across a sequence.
 
 ## Coding and review language
 
-- `works` -> `passes the targeted check`, `preserves the contract`, `closes the gate`, `satisfies the invariant`, or `moves the system state`.
-- `safe` -> `fail-closed`, `bounded`, `reversible`, `invariant-preserving`, `permission-checked`, `witness-backed`, or `no broader blast radius`.
-- `test it` -> `verify the changed path`, `reproduce the failure`, `exercise the invariant`, `run the closure gate`, or `prove movement`.
-- `fix this` -> `remediate the material finding`, `close the invariant break`, `apply the narrowest sufficient change`, or `actuate the selected lever`.
-- `review this` -> `adjudicate the claim`, `stress the changeset`, `audit invariants`, `verify readiness`, or `test the strongest countercase`.
-- `simplify` -> `factor`, `winnow`, `quotient`, `ablate`, `normalize`, or `reduce surface` when that is the real operation.
+- `works` -> `passes the targeted check`, `preserves the contract`, `closes the gate`, `satisfies the invariant`, `converges to the canonical result`, or `moves the system state`.
+- `safe` -> `fail-closed`, `bounded`, `reversible`, `invariant-preserving`, `permission-checked`, `witness-backed`, `memory-safe`, `noninterfering`, or `no broader blast radius`.
+- `test it` -> `verify the changed path`, `reproduce the failure`, `exercise the invariant`, `run the closure gate`, `prove movement`, `check the metamorphic relation`, or `differentially compare implementations`.
+- `fix this` -> `remediate the material finding`, `close the invariant break`, `refine the model from the counterexample`, `apply the narrowest sufficient change`, or `actuate the selected lever`.
+- `review this` -> `adjudicate the claim`, `stress the changeset`, `audit invariants`, `verify readiness`, `test the strongest countercase`, or `check conformance to the declared consistency model`.
+- `simplify` -> `factor`, `winnow`, `quotient`, `ablate`, `prune`, `deforest`, `normalize`, or `reduce surface` when that is the real operation.
 - `delete code` -> `ablate`, `decommission`, `collapse`, `privatize`, `canonicalize`, or `remove a vestigial surface` depending on proof and contract.
+- `same behavior` -> `isomorphic`, `bisimulative`, `observationally equivalent`, or `refinement-preserving` only after naming the intended relation.
+- `general solution` -> `principal solution` when special cases should be instantiations of one most-general construction.
+- `keep improving` -> `contract toward the fixed point`, `saturate until the model stops changing`, or `run as an anytime procedure` depending on the stop and interruption contract.
+- `make consistent` -> `make confluent`, `serializable`, `linearizable`, `causally consistent`, or `eventually convergent` only after naming the surface and guarantee.
+- `make retries safe` -> `make the operation idempotent and deduplicating`.
+- `recover automatically` -> `make the workflow self-stabilizing` only when convergence from reachable dirty states is actually required.
+- `carry evidence` -> `make the handoff proof-carrying` when the certificate must travel with the result.
+
+## Verification and testing language
+
+- `test without knowing the exact answer` -> `define an Oracle Map and metamorphic relations`.
+- `compare two versions` -> `run differential verification` when disagreement should be treated as a finding.
+- `find the smallest failing case` -> `shrink to a minimal counterexample`.
+- `test broadly` -> `use property-based or coverage-guided generation` when input families or state regions matter.
+- `make tests meaningful` -> `make the suite mutation-resistant` when defect sensitivity is the criterion.
+- `explore all states` -> `model-check the bounded state space` when a finite model and properties exist.
+- `reproduce it` -> `capture a replayable trace` when state and ordering must be restored.
+- `test recovery` -> `inject faults and verify containment and convergence`.
+
+## Concurrency and distributed language
+
+- `atomic operation` -> `linearizable operation` only when real-time order is part of the claim; otherwise `atomic at the declared observation boundary`.
+- `transactions are correct` -> `serializable`, `snapshot-isolated`, or another named isolation level after checking the actual history guarantee.
+- `events stay in order` -> `causally consistent` when cause-before-effect is the intended relation.
+- `replicas eventually agree` -> `eventually consistent with a named convergence condition and conflict policy`.
+- `use a quorum` -> `quorum-aware` with explicit read/write overlap and failure thresholds.
+- `one authoritative value` -> `consensus-backed` when distributed agreement is required.
+- `handle partitions` -> `partition-aware` with availability, consistency, and degradation behavior named.
+- `avoid duplicate effects` -> `deduplicate repeated delivery under an explicit key`.
+- `control overload` -> `apply backpressure and bound queue growth`.
+- `isolate failure` -> `fault-contain the subsystem`.
+
+## Algorithms and optimization language
+
+- `best solution` -> `optimal` only when objective, constraints, horizon, and proof/search bound are explicit; otherwise use `dominant`, `best-known`, or `principal`.
+- `most general solution` -> `principal`.
+- `good heuristic` -> `admissible`, `consistent`, or empirically effective depending on the actual guarantee.
+- `search efficiently` -> `best-first`, `branch-and-bound`, `prune`, or `kernelize` depending on frontier, bounds, elimination, or preprocessing.
+- `can stop anytime` -> `anytime` only when a valid incumbent exists at every interruption point.
+- `complexity depends on one factor` -> `parameterized by <factor>`.
+- `average cost is low` -> `amortized` when the sequence argument exists.
+- `runtime depends on result size` -> `output-sensitive`.
+- `works well online` -> `competitive` when compared against an offline optimum.
+- `close enough` -> `approximation-aware` with a ratio or quality envelope.
+- `uses randomness` -> `randomized with seedability and failure bounds`.
+- `make reproducible` -> `derandomize` or expose the seed, depending on intent.
+
+## Performance and dataflow language
+
+- `update efficiently` -> `incrementalize from the invalidation graph`.
+- `compute only what is needed` -> `make demand-driven`.
+- `keep related work together` -> `make locality-aware`.
+- `optimize memory behavior` -> `make cache-conscious`.
+- `avoid copies` -> `make zero-copy with ownership and lifetime proof`.
+- `handle large inputs` -> `stream under an explicit memory bound`.
+- `reduce overhead` -> `batch while preserving ordering and failure semantics`.
+- `combine passes` -> `fuse adjacent traversals and remove intermediate materialization`.
+- `parallelize efficiently` -> `optimize both work and span`.
+- `scale better` -> `improve asymptotic behavior and validate the crossover`.
+- `limit resource use` -> `bound time, memory, retries, queues, fanout, or state explicitly`.
+
+## Security and authority language
+
+- `avoid accidental capture` -> `make the transformation hygienic`.
+- `isolate dependencies` -> `make the process hermetic`.
+- `limit permissions` -> `apply least authority`.
+- `make authority explicit` -> `use capabilities`.
+- `check every access` -> `apply complete mediation`.
+- `separate risky code` -> `privilege-separate it`.
+- `prevent information leaks` -> `establish noninterference` when the influence relation can be stated.
+- `avoid timing leaks` -> `make the operation constant-time` only with timing/control-flow evidence.
+- `consider side channels` -> `perform a side-channel audit`.
+- `make low-level code safe` -> `establish a memory-safety boundary`.
+- `reduce security exposure` -> `minimize attack surface`.
+- `run untrusted code safely` -> `sandbox it with explicit resource and capability limits`.
+- `track untrusted input` -> `perform taint-aware source-to-sink analysis`.
+
+## Data and schema language
+
+- `preserve all information` -> `prove the transformation lossless`.
+- `keep constraints checkable` -> `preserve dependencies after decomposition`.
+- `keep references valid` -> `preserve referential integrity`.
+- `evolve the schema safely` -> `use a schema-evolution matrix`.
+- `keep history` -> `append with explicit supersession`.
+- `derive state from events` -> `event-source the state`.
+- `show where data came from` -> `preserve lineage`.
 
 ## Precedent and policy language
 
@@ -64,6 +152,10 @@ Use these as guarded phrase replacements. A replacement is valid only when it pr
 - `learn from prior work` -> `build a Precedent Ledger and apply only current, non-superseded precedent with an action delta`.
 - `make a simulator` -> `build a fidelity-bounded emulation with an Observation Contract`.
 - `grade it` -> `adjudicate it against declared criteria and issue a disposition`.
+- `make the routes agree` -> `make the system confluent and resolve critical pairs`.
+- `make every pass count` -> `make the loop contractive under a named distance metric`.
+- `avoid special cases` -> `seek a principal, parametric solution`.
+- `reason beyond examples` -> `use symbolic or abstract interpretation with an explicit soundness boundary`.
 - `use better words` -> `choose doctrine words that change procedure, not tone`.
 
 ## Guardrails
@@ -75,4 +167,6 @@ Do not replace if:
 - the domain has a canonical term;
 - the substitution changes agency or obligation;
 - the phrase is code, an identifier, a flag, a path, a schema field, or machine-consumed syntax;
-- the new word would activate a workflow or proof obligation the task does not support.
+- the new word would activate a workflow or proof obligation the task does not support;
+- the formal term would imply a guarantee that has not been checked;
+- a lighter adjacent term is more honest.

--- a/codex/skills/logophile/references/task_pressure_map.md
+++ b/codex/skills/logophile/references/task_pressure_map.md
@@ -2,6 +2,8 @@
 
 Infer pressures from the task first. Use these defaults only when the task underspecifies them.
 
+For formal computer-science operators, preserve the technical distinction. Do not use a strong term such as `linearizable`, `complete`, `optimal`, or `constant-time` unless the task can support its proof burden.
+
 ## Bug fix / regression / review response
 
 Dominant pressures:
@@ -13,11 +15,14 @@ Dominant pressures:
 Default stack candidates:
 - `unsound`
 - `mechanistic`
+- `counterexample-guided`
 - `accretive`
 - `traceable`
 
 Artifacts:
 - Soundness Ledger
+- Minimal Counterexample
+- Counterexample Refinement Ledger
 - Chosen Cut
 - proof receipt
 
@@ -28,15 +33,19 @@ Dominant pressures:
 - scope creep
 - unnecessary complexity
 - weak verification
+- special cases replacing a principal solution
 
 Default stack candidates:
 - `canonical`
+- `principal`
+- `parametric`
 - `accretive`
 - `invariant-preserving`
 - `traceable`
 
 Artifacts:
 - contract / invariant row
+- Principal Solution + Instantiation Map
 - implementation seam
 - verification receipt
 
@@ -47,16 +56,20 @@ Dominant pressures:
 - stale plan graph
 - missing proof before ship
 - incomplete task closure
+- loops that do not reduce the remaining gap
 
 Default stack candidates:
 - `actuating`
+- `contractive`
 - `fixed-point`
-- `proof-gated`
+- `proof-carrying`
 - `traceable`
 
 Artifacts:
 - Actuation Receipt
+- Contraction Measure
 - task graph / completion receipts
+- Certificate-Bearing Handoff
 - closure gate
 
 ## Code review / adversarial audit
@@ -66,9 +79,11 @@ Dominant pressures:
 - untested assumptions
 - regression risk
 - misuse hazards
+- equivalent-looking states that are not behaviorally equivalent
 
 Default stack candidates:
 - `adversarial`
+- `counterexample-guided`
 - `exhaustive`
 - `hazard-seeking`
 - `traceable`
@@ -76,6 +91,7 @@ Default stack candidates:
 Artifacts:
 - candidate inventory
 - strongest countercase
+- Counterexample Refinement Ledger
 - change agenda
 
 ## Review adjudication / should we act?
@@ -85,10 +101,12 @@ Dominant pressures:
 - reviewer authority bias
 - local-validity trap
 - additive mutation from comments
+- criteria chosen after seeing the preferred answer
 
 Default stack candidates:
 - `discriminative`
 - `rebuttal-first`
+- `criterial`
 - `invariant-seeking`
 - `ablative`
 - `evidence-weighted`
@@ -96,6 +114,7 @@ Default stack candidates:
 Artifacts:
 - resolve-selection map
 - no-change countercase
+- Criteria Matrix
 - governing invariant candidate
 - ablation activation receipt
 
@@ -107,19 +126,23 @@ Dominant pressures:
 - partial eliminators
 - broken preservation/progress
 - incoherent abstractions
+- soundness/completeness confusion
 
 Default stack candidates:
 - `unsound`
 - `unwitnessed`
 - `ill-typed`
 - `total`
+- `decidable`
 - `preservation-aware`
 - `progress-aware`
 
 Artifacts:
 - Soundness Ledger
 - totality table
+- Decision Procedure
 - witness receipt
+- completeness gap inventory when relevant
 
 ## Abstraction teardown / technical debt / deletion
 
@@ -129,11 +152,13 @@ Dominant pressures:
 - vestigial scaffolding
 - accidental-rhyme merges
 - over-preservation
+- clients depending on representation accidents
 
 Default stack candidates:
 - `ablative`
 - `winnowing`
 - `quotienting`
+- `representation-independent`
 - `normalizing`
 - `refinement-preserving`
 
@@ -141,6 +166,7 @@ Artifacts:
 - Ablation Ledger
 - Reduction Certificate
 - quotient relation
+- client-observation audit
 - recomposition proof
 
 ## Simplification with strict behavior preservation
@@ -150,17 +176,467 @@ Dominant pressures:
 - bad DRY merges
 - hidden side effects
 - proof weakness
+- unclear equality notion
 
 Default stack candidates:
+- `extensional`
+- `bisimulative`
 - `isomorphic`
 - `clone-classified`
-- `abstraction-laddered`
 - `traceable`
 
 Artifacts:
-- Isomorphism Card
+- Observation Contract
+- Bisimulation Relation or Isomorphism Card
 - duplication map
 - LOC / surface delta
+
+Choose the preservation relation explicitly:
+- `isomorphic` for invertible structural correspondence
+- `bisimulative` for mutually matching transitions
+- `observationally-equivalent` for equality under selected observations
+- `refinement-preserving` when invalid, obsolete, or unrequired behavior may disappear
+
+## Rewrite systems / canonicalization
+
+Dominant pressures:
+- rewrite order changes the result
+- overlapping rules diverge
+- loops do not terminate
+- multiple normal forms survive
+- agent or migration paths conflict
+
+Default stack candidates:
+- `confluent`
+- `terminating`
+- `critical-pair-aware`
+- `congruence-preserving`
+- `normalizing`
+
+Artifacts:
+- Confluence Matrix
+- Critical-Pair Ledger
+- termination measure
+- congruence checks
+- canonical normal form
+
+## Fixed-point / iterative improvement
+
+Dominant pressures:
+- repeated passes that appear productive but do not converge
+- no measurable distance to closure
+- stale or reopened findings
+- loop termination confused with fixed-point stability
+
+Default stack candidates:
+- `contractive`
+- `monotone`
+- `fixed-point`
+- `saturating`
+- `proof-carrying`
+
+Artifacts:
+- Contraction Measure
+- Information-Order Map
+- Fixed-Point Gate
+- saturation stop rule
+- current proof receipts
+
+## Counterexample-guided refinement
+
+Dominant pressures:
+- each failure creates another local patch
+- abstraction too coarse or too broad
+- wound-specific tests accumulate
+- the model does not explain the counterexample family
+
+Default stack candidates:
+- `counterexample-guided`
+- `refinement-driven`
+- `shrinking`
+- `invariant-seeking`
+- `principal`
+
+Artifacts:
+- Minimal Counterexample
+- Counterexample Refinement Ledger
+- refinement chain
+- governing law / invariant
+- principal model candidate
+
+## Protocol / state-machine equivalence
+
+Dominant pressures:
+- final outputs match while intermediate behavior diverges
+- ordering, liveness, or error transitions differ
+- infinite/reactive behavior is judged only by finite examples
+- partial transition coverage
+
+Default stack candidates:
+- `bisimulative`
+- `coinductive`
+- `totalizing`
+- `progress-aware`
+- `confluent`
+
+Artifacts:
+- Bisimulation Relation
+- coinductive invariant
+- transition coverage table
+- liveness/progress checks
+- critical-pair or convergence checks
+
+## Program analysis / whole-input reasoning
+
+Dominant pressures:
+- examples miss reachable bad paths
+- concrete execution is too large to enumerate
+- path conditions are hidden
+- static claims lack sound abstraction
+
+Default stack candidates:
+- `abstract-interpreting`
+- `symbolic`
+- `type-directed`
+- `taint-aware`
+- `sound`
+
+Artifacts:
+- abstract domain / transfer functions
+- path-condition ledger
+- type obligations
+- source-to-sink map
+- soundness claim and limitations
+
+## Verification without a direct oracle
+
+Dominant pressures:
+- exact expected output unavailable
+- tests encode guessed answers
+- one implementation is trusted as truth
+- failures are too large to understand
+
+Default stack candidates:
+- `oracle-aware`
+- `metamorphic`
+- `differential`
+- `property-based`
+- `shrinking`
+
+Artifacts:
+- Oracle Map
+- Metamorphic Relation Suite
+- Differential Result Matrix
+- generators / properties / shrinkers
+- Minimal Counterexample
+
+## Test quality / hardening
+
+Dominant pressures:
+- line coverage without defect sensitivity
+- narrow handpicked examples
+- unreachable state regions
+- no failure containment testing
+
+Default stack candidates:
+- `mutation-resistant`
+- `coverage-guided`
+- `fault-injecting`
+- `replayable`
+- `model-checking`
+
+Artifacts:
+- mutation score and surviving-mutant ledger
+- coverage frontier
+- fault matrix
+- Replay Receipt
+- model-checker counterexample trace
+
+## Concurrency / concurrent-object correctness
+
+Dominant pressures:
+- race-dependent outcomes
+- operations appear out of order
+- transaction correctness confused with object correctness
+- atomicity or real-time order undefined
+
+Default stack candidates:
+- `linearizable`
+- `serializable`
+- `atomic`
+- `commutative`
+- `idempotent`
+
+Artifacts:
+- concurrent history
+- linearization points
+- serialization graph
+- atomicity boundary
+- commutativity/idempotence tests
+
+Use the distinction:
+- `linearizable` for operation histories that must respect real time
+- `serializable` for transaction histories equivalent to a serial order
+
+## Distributed consistency / replication
+
+Dominant pressures:
+- stale reads
+- conflicting replicas
+- partition behavior undefined
+- “eventual consistency” used without convergence
+- authority claimed without agreement
+
+Default stack candidates:
+- `causally-consistent`
+- `eventually-consistent`
+- `quorum-aware`
+- `consensus-backed`
+- `partition-aware`
+- `deduplicating`
+
+Artifacts:
+- happens-before graph
+- convergence and conflict contract
+- quorum matrix
+- consensus authority map
+- partition behavior table
+- deduplication proof
+
+## Recovery / interrupted workflows
+
+Dominant pressures:
+- partial writes
+- resumed work from dirty state
+- retries duplicate effects
+- recovery requires perfect manual reset
+- stale receipts influence continuation
+
+Default stack candidates:
+- `self-stabilizing`
+- `transactional`
+- `idempotent`
+- `rebaselining`
+- `replayable`
+
+Artifacts:
+- recovery invariant
+- convergence proof
+- transaction/rollback boundary
+- Baseline Receipt
+- Replay Receipt
+
+## Streaming / queues / overload
+
+Dominant pressures:
+- unbounded queues
+- producer outruns consumer
+- retries hide overload
+- batch semantics change ordering or failure behavior
+
+Default stack candidates:
+- `backpressure-aware`
+- `streaming`
+- `batching`
+- `bounded`
+- `fault-contained`
+
+Artifacts:
+- demand/capacity contract
+- memory/queue bound
+- chunk or batch semantics
+- failure-containment map
+
+## Algorithm / search selection
+
+Dominant pressures:
+- search may be interrupted
+- no incumbent best-so-far answer
+- heuristics lack guarantees
+- branches are explored after they cannot win
+- “optimal” is claimed without objective or bound
+
+Default stack candidates:
+- `anytime`
+- `admissible`
+- `branch-and-bound`
+- `best-first`
+- `pruning`
+- `approximation-aware`
+
+Artifacts:
+- Incumbent + Remaining-Gap Receipt
+- heuristic proof
+- frontier ordering
+- bounds / pruned branches
+- approximation ratio or quality envelope
+
+## Complexity / tractability analysis
+
+Dominant pressures:
+- total input size hides the governing parameter
+- preprocessing can collapse the hard core
+- one expensive step is mistaken for poor sequence cost
+- output size dominates runtime
+
+Default stack candidates:
+- `parameterized`
+- `kernelizing`
+- `amortized`
+- `output-sensitive`
+- `worst-case-aware`
+- `asymptotic`
+
+Artifacts:
+- parameter map
+- kernel instance and equivalence proof
+- potential/accounting argument
+- complexity bound
+- measured crossover
+
+## Performance / dataflow optimization
+
+Dominant pressures:
+- full recomputation
+- unnecessary materialization
+- poor locality
+- critical path ignored
+- optimization changes semantics
+
+Default stack candidates:
+- `incremental`
+- `demand-driven`
+- `locality-aware`
+- `fusion-oriented`
+- `work-efficient`
+- `span-efficient`
+- `zero-copy`
+
+Artifacts:
+- invalidation graph
+- demand map
+- locality / working-set evidence
+- fused pipeline
+- work/span analysis
+- ownership/lifetime proof
+
+## Security / authority design
+
+Dominant pressures:
+- ambient authority
+- partial policy mediation
+- privilege concentration
+- unintended information flow
+- hidden side channels
+- untrusted code escape
+
+Default stack candidates:
+- `least-authority`
+- `capability-secure`
+- `complete-mediation`
+- `privilege-separated`
+- `noninterfering`
+- `sandboxed`
+
+Artifacts:
+- authority/capability matrix
+- mediation coverage map
+- privilege boundary map
+- Information-Flow Matrix
+- sandbox policy and escape tests
+
+## Cryptographic / low-level security
+
+Dominant pressures:
+- secret-dependent timing or memory behavior
+- unsafe memory boundary
+- parser/tool surface larger than necessary
+- untracked untrusted influence
+
+Default stack candidates:
+- `constant-time`
+- `side-channel-aware`
+- `memory-safe`
+- `taint-aware`
+- `attack-surface-minimizing`
+- `fail-closed`
+
+Artifacts:
+- timing/branch audit
+- side-channel inventory
+- unsafe-code / memory-safety audit
+- source-to-sink flow map
+- attack-surface delta
+
+## API / module abstraction
+
+Dominant pressures:
+- clients depend on hidden representation
+- implementations satisfy signatures but violate laws
+- effects are ambient
+- special cases prevent general reuse
+- extensions alter old behavior
+
+Default stack candidates:
+- `representation-independent`
+- `lawful`
+- `effect-explicit`
+- `parametric`
+- `principal`
+- `conservative-extending`
+
+Artifacts:
+- client-observation audit
+- Law Suite
+- Effect Signature and Handler Map
+- Parametricity Matrix
+- Principal Solution
+- conservative-extension certificate
+
+## Data / schema decomposition
+
+Dominant pressures:
+- decomposition loses information
+- constraints require reconstructing the whole
+- references break during lifecycle changes
+- migrations silently invent defaults
+- lineage disappears
+
+Default stack candidates:
+- `lossless`
+- `dependency-preserving`
+- `referential-integrity-preserving`
+- `schema-evolution-aware`
+- `lineage-preserving`
+
+Artifacts:
+- round-trip/losslessness proof
+- dependency-preservation matrix
+- reference lifecycle audit
+- schema evolution matrix
+- lineage graph
+
+## Event / ledger architecture
+
+Dominant pressures:
+- destructive history rewrite
+- derived state mistaken for authority
+- replay cannot reproduce state
+- supersession is implicit
+
+Default stack candidates:
+- `append-only`
+- `event-sourced`
+- `replayable`
+- `monotone`
+- `reconciling`
+
+Artifacts:
+- append/supersession contract
+- event schema and reducer
+- replay proof
+- information-order map
+- reconciliation ledger
 
 ## Knowledge extraction / session archaeology
 
@@ -220,7 +696,7 @@ Default stack candidates:
 
 Artifacts:
 - Nomothetic Receipt
-- rule, governing scope, non-governing cases, authority, and supersession condition
+- rule, scope, non-governing cases, authority, and supersession condition
 - persona when requested: `Nomothete`
 
 ## Systems thinking / intervention design
@@ -346,25 +822,6 @@ Artifacts:
 - total interpreter
 - preservation proof
 
-## Security review
-
-Dominant pressures:
-- permissive failure
-- hidden attack surfaces
-- unsafe defaults
-- unproved mitigations
-
-Default stack candidates:
-- `fail-closed`
-- `adversarial`
-- `hazard-seeking`
-- `traceable`
-
-Artifacts:
-- threat/hazard ledger
-- mitigation proof
-- fail-closed decision
-
 ## Research memo / market scan
 
 Dominant pressures:
@@ -391,17 +848,20 @@ Dominant pressures:
 - hidden assumptions
 - missing tradeoffs
 - false certainty
+- search that never produces a valid incumbent
 
 Default stack candidates:
 - `ill-posed`
 - `calibrated`
 - `parsimonious`
 - `tractabilizing`
+- `anytime`
 - `traceable`
 
 Artifacts:
 - governing question
 - option table
+- incumbent + remaining gap
 - dominant move
 
 ## Naming / policy wording / contracts
@@ -413,6 +873,7 @@ Dominant pressures:
 - overloaded terminology
 - weak doctrine grammar
 - mode/persona confusion
+- formal term used without its actual guarantee
 
 Default stack candidates:
 - `precise`
@@ -424,5 +885,6 @@ Default stack candidates:
 Notes:
 - `precise`, `scoped`, `obligation-preserving`, and `operator-aligned` are task-local descriptive labels.
 - Use them only if they produce an actual gain in the doctrine block.
-- Prefer mode adjectives/gerunds (`adjudicative`, `nomothetic`, `emulative`) and reserve persona nouns (`Arbiter`, `Nomothete`) for explicit persona requests.
+- Prefer mode adjectives/gerunds and reserve persona nouns for explicit persona requests.
+- Preserve formal distinctions such as `confluent` vs `deterministic`, `principal` vs `optimal`, and `linearizable` vs `serializable`.
 - Replace generic defaults with sharper domain terms whenever the task supports them.


### PR DESCRIPTION
## Summary

- add a dedicated `computer_science_doctrine.md` catalog covering rewrite systems, semantics and equivalence, program analysis, test oracles, concurrency and distributed systems, algorithms, performance, security, and schema evolution
- expand the main doctrine word bank with formal operators such as `confluent`, `contractive`, `principal`, `bisimulative`, `counterexample-guided`, `metamorphic`, `linearizable`, `anytime`, `hygienic`, and `proof-carrying`
- teach the doctrine compiler the associated artifacts, proof burdens, lighter fallbacks, and formal distinctions
- extend task-pressure routing so `$logophile` can select these operators from concrete engineering prompts
- add positive, negative, and distinction probes that prevent misuse of terms such as `deterministic` vs `confluent`, `principal` vs `optimal`, and `serializable` vs `linearizable`
- expand the precision lexicon with guarded mappings from generic engineering language to exact computer-science terminology

## Why

The doctrine bank has become useful enough that breadth now matters, but formal terms must retain their actual guarantees. This change makes the discovery surface broad while preserving the runtime rule: select the smallest non-overlapping doctrine stack that the available evidence can support.

## Notable doctrine families

- rewrite and convergence: confluence, termination, critical pairs, contraction, monotonicity
- semantics and abstraction: principal solutions, parametricity, extensionality, bisimulation, conservative extension
- analysis and verification: abstract interpretation, symbolic reasoning, CEGAR, shrinking, metamorphic and differential testing
- concurrency and distribution: linearizability, serializability, causal/eventual consistency, quorums, self-stabilization, backpressure
- algorithms and systems: anytime search, admissibility, branch-and-bound, parameterization, amortization, incremental and demand-driven execution
- security and data: hygiene, least authority, noninterference, constant time, losslessness, dependency preservation, schema evolution, lineage

## Validation

- diff is scoped to six `$logophile` reference files
- Markdown code fences were checked for balance in the generated references
- doctrine probes now exercise the new operators and their near-miss distinctions
- no operational skill authority or implicit invocation policy changed
