### PR TITLE
Harden actuating review-repair continuation

### DIFF
--- a/codex/skills/actuating/SKILL.md
+++ b/codex/skills/actuating/SKILL.md
@@ -135,9 +135,33 @@ selected step's `review_admission`. That immutable receipt seals the full
 required current SHIP receipt, and its canonical digest. Preserve the receipt
 unchanged on completion and cite `review-admission:<admission_digest>` in EF-v1
 `review_refs`; `step-admission/v1` binds its digest, so the two receipts form one
-admission relation rather than parallel authorities. A later resolution cannot relabel an admitted edit. When
-admitting a step after prior work, also pass every referenced EF-v1 with
-`--evidence`. A dangling reference cannot authorize continuation.
+admission relation rather than parallel authorities. A later resolution cannot
+relabel an admitted edit. When admitting a step after prior work, also pass
+every referenced EF-v1 with `--evidence`. A dangling reference cannot authorize
+continuation.
+
+Before every review-repair admission, refresh the live review sources against
+the current local artifact, re-fold them, and rebuild the pending resolution.
+Do not admit solely from the source batch or resolution that authorized the
+preceding edit.
+
+When the latest completed review edit is `ready-for-closure` but the retained
+PR still publishes the preceding SHIP artifact, the gate may derive an optional
+`publication_continuation` inside the next `review-admission/v1`. Its
+`same-publication-continuation/v1` receipt binds the unchanged SHIP epoch and
+published artifact, the adjacent predecessor's admission digest, and the
+canonical content digest of that predecessor's EF-v1. Eligibility requires a
+pending next node, a strict cumulative increase in material findings,
+cumulative review source references with stable producer backends, fold
+identities absent from admitted repair history, and new producer source batches
+that support every introduced finding. Material semantic identities are
+injective: cloning an admitted finding under a new ID is not growth. This
+derivation may repeat for successive adjacent repairs while the same live PR
+and SHIP remain current. It is never a caller-authored run object, authority
+token, or use counter.
+
+Reject reserved derived-receipt keys elsewhere in caller-supplied run,
+resolution, or SHIP inputs instead of copying them into a new receipt.
 
 After the action:
 
@@ -153,8 +177,10 @@ direct edit may remain uncommitted and must exactly match the initial-to-live
 path delta. Every iterative edit advances through a descendant commit whose
 exact diff equals that step's changed paths. A non-edit preserves the complete
 artifact binding. EF-v1 independently reports the same paths and shows the
-verifier in its passed-command evidence. Only a prior step whose verdict is
-`continue` may admit a following step.
+verifier in its passed-command evidence. A following step requires either the
+prior step's generic `continue` verdict or a gate-validated lifecycle or
+publication transition. Publication-bearing review edits cannot use generic
+`continue` to bypass the publication laws.
 
 A step may finish or block. It cannot complete the parent goal; only
 `closure-decision/v1` owns goal completion.
@@ -171,6 +197,20 @@ Declared run source references must exactly equal the RF-v2 source identities;
 triage supplies those folds directly with repeatable `--review-fold` inputs and
 cannot complete from a source name alone.
 
+Refresh live review input before each review-repair admission. Every successor
+resolution preserves prior finding semantics and source-to-producer lineage,
+strictly grows the cumulative finding set, and supports each introduced finding
+with fresh admitted fold and producer-batch identities. A replacement SHIP
+starts a new publication and CAS epoch, but it does not erase cumulative
+finding or source history. The final resolved re-fold preserves exactly the
+admitted findings and all admitted sources, and supports every material finding
+with another fresh fold and producer batch; it cannot rewrite the admission
+history. A newly observed material finding keeps the resolution pending and
+requires another admitted continuation. An abandoned terminal refold grants no
+state or authority; freshness is measured against admitted repair history.
+After a publication-bearing repair, `clean` cannot erase admitted liabilities;
+the terminal status must be `resolved` against that exact history.
+
 `review-resolution/v1` then consumes each RF-v2 equivalence class through
 exactly one decision, groups repair work by owner boundary, and selects:
 
@@ -185,7 +225,21 @@ suggested repair never grants mutation.
 CAS closure accepts only producer-observed standard review attempts. Specialized
 routing in RF-v2 remains classification metadata; caller-supplied lens labels
 never grant review credit. Standard closure requires three distinct ordered
-clean attempts after the latest artifact, review contract, or resolution change.
+clean attempts after the latest artifact, review contract, resolution, or
+publication change. The final repair reship therefore resets CAS credit to
+zero; only three fresh standard attempts against the republished resolved head
+count.
+
+For publication-bound CAS, validate the live PR before listing records, observe
+its `updatedAt` watermark again after the list, and recheck it before closure.
+Current-binding records at or before the latest watermark are superseded and
+grant no credit; their findings still require RF-v2 classification. A later PR
+metadata update conservatively resets the clean suffix, so closure waits for
+three attempts created strictly after the stable final observation.
+Treat every watermark observation as monotone: a regression blocks closure and
+never lowers the boundary. Require CAS record IDs and same-run producer attempt
+IDs to be unique across the whole exhaustive snapshot, including superseded
+publication epochs.
 
 ## Semantic accounting
 
@@ -260,9 +314,11 @@ the workflow result.
 ## Stop rules
 
 Stop when authority or artifact binding is stale, a selected step is missing,
-the prior action lacks current evidence, review resolution is missing, the
-standard review contract is invalid, the clean CAS suffix is short, semantic balance is
-open, verification regresses, or a public effect would bypass `$ship`.
+the prior action lacks current evidence, live review input was not refreshed,
+same-publication findings or sources regress, review resolution is missing, the
+standard review contract is invalid, the clean CAS suffix is short, semantic
+balance is open, verification regresses, or a public effect would bypass
+`$ship`.
 
 Use these stable verdicts:
 

--- a/codex/skills/actuating/references/closure.md
+++ b/codex/skills/actuating/references/closure.md
@@ -137,6 +137,20 @@ new binding and resets prior credit. When `review.ship_receipt` exists, the
 binding's `resolutionDigest` is derived from the resolution's verified
 self-digest and the canonical digest of that complete SHIP-v1 snapshot.
 
+Publication-bound closure also observes the live PR's `updatedAt` as a
+conservative watermark before and after the exhaustive CAS list and once more
+before closure. A current-binding record whose `createdAt` is not strictly later
+than the latest observation is treated as superseded: it grants no clean credit,
+while any findings still require current RF-v2 classification. If the watermark
+advances during closure, the credited basis is discarded. This deliberately
+means a later PR metadata update resets the clean suffix and requires three
+newer attempts.
+
+Watermark observations must be monotone; a regression blocks closure instead
+of lowering the boundary. CAS record identities and same-run producer attempt
+identities are unique across the full exhaustive snapshot, including superseded
+and current publication epochs.
+
 ## Outcomes
 
 ~~~yaml
@@ -178,18 +192,80 @@ binding before deriving any review admission. The admission records publication
 intent by snapshotting that complete SHIP receipt. After an edit and EF-v1, a current
 resolved refold must observe that exact admitted node; closure then returns
 `ready-to-ship` before CAS. `$ship` updates the PR and replaces
-`review.ship_receipt` before another edit or final CAS. Final review-closeout
-consumes only the current embedded receipt; a duplicate external SHIP input is
-invalid. CAS produced before that replacement belongs to the prior publication
-epoch and grants no credit afterward. The replacement must report `updated` /
-`update-existing`, retain an
+`review.ship_receipt` before final CAS. An unresolved review may instead admit
+another adjacent edit against the same publication only through the derived
+continuation receipt described below.
+
+Final review-closeout consumes only the current embedded receipt; a duplicate
+external SHIP input is invalid. CAS produced before that replacement belongs to
+the prior publication epoch and grants no credit afterward. The replacement
+must report `updated` / `update-existing`, retain an
 existing PR, and use the exact PR URL captured by the prior admission; creating
 a second PR cannot continue the review epoch.
 
-A prior review edit ending `ready-for-closure` admits a following selected step
-only when the canonical digest of its SHIP snapshot differs from the newly
-embedded receipt;
-prior EF-v1 and live validation of that fresh receipt remain mandatory.
+Before every repair admission, refresh the live review sources against the
+current local artifact and construct fresh RF-v2 folds that include a new
+producer batch and a pending resolution.
+If the retained PR and SHIP still publish the original artifact, the gate may
+derive this optional field inside the next `review-admission/v1`:
+
+~~~yaml
+publication_continuation:
+  version: same-publication-continuation/v1
+  publication_epoch: <canonical digest of the unchanged SHIP-v1>
+  published_artifact: <artifact still published by that SHIP-v1>
+  predecessor:
+    step_id: <adjacent completed review edit>
+    evidence_fold_ref: <that edit's EF-v1>
+    evidence_fold_digest: <canonical digest of that exact EF-v1 content>
+    review_admission_digest: <that edit's admission digest>
+~~~
+
+The field is gate output, not caller input or a fourth control object. The
+adjacent predecessor must be a completed `ready-for-closure` review edit under
+the same SHIP. The pending resolution must strictly extend the prior material
+finding set, preserve every prior review source reference, use
+fold IDs disjoint from every admitted fold in that publication epoch, include
+new producer source-batch identities that support every introduced finding,
+preserve each retained source's producer backend, and select the next edit. The
+live PR must still match the bound published artifact. Each succeeding edge is
+derived anew and may repeat under those same laws; no authority reference or
+use counter can grant or limit it.
+
+Reserved derived-receipt keys are invalid anywhere in a caller-supplied run,
+resolution, or SHIP input except at the gate-emitted nested receipt locations.
+
+Material finding semantics are injective across IDs. A clone of an admitted
+`claim`, `observed_fact`, `validity`, `liability`, `intent_relation`,
+`quotient_key`, `owner_boundary`, `law_family`, and `falsifier` under a new ID
+is a duplicate, not strict growth, and cannot derive continuation. Boundary
+whitespace, whitespace-run changes, and canonically equivalent Unicode do not
+create a distinct semantic identity.
+
+After the final repair, the resolved re-fold must preserve exactly the findings
+and all source references admitted during the epoch while using fold IDs
+disjoint from the admission history and another new producer batch that carries
+material evidence. A newly observed material finding keeps the resolution
+pending and requires another admitted continuation. Before `ready-to-ship`, the
+retained PR must still match the admission-bound published artifact. Then
+`$ship` republishes the exact resolved local head to that PR once. That
+publication change resets CAS credit to zero, so final closure requires three
+fresh ordered standard attempts against the new receipt; no pre-reship attempt
+counts.
+
+Once a publication-bearing repair has been admitted, a later `clean` resolution
+cannot erase that history. Terminal review must remain `resolved` and account
+for the exact admitted material finding set.
+
+Replacing SHIP starts a new publication and CAS epoch but does not erase the
+cumulative admitted finding set, source references, or source-to-producer
+lineage. The first repair admission after reship must strictly extend that
+history with current evidence.
+
+A prior review edit ending `ready-for-closure` otherwise admits a following
+selected step only when the canonical digest of its SHIP snapshot differs from
+the newly embedded receipt. Prior EF-v1 and live validation of that fresh
+receipt remain mandatory.
 
 SHIP-v1 is an immutable pre-review publication handoff. Its exact
 `actuation_binding` contains only `actuation_run_id` and `state_fingerprint`;

--- a/codex/skills/actuating/references/decision-contract.yaml
+++ b/codex/skills/actuating/references/decision-contract.yaml
@@ -39,7 +39,7 @@ skill_decision_contract:
       aliases: [remediation-plan]
       terminal: "yes"
     - route_id: ACT-REVIEW-CLOSEOUT
-      description: Resolve findings, execute the current selected node, and acquire closure-grade review evidence.
+      description: Refresh live review sources, resolve cumulative findings, execute the current selected node, and acquire closure-grade review evidence.
       aliases: [review-closeout]
       terminal: "no"
     - route_id: ACT-CLOSURE
@@ -60,16 +60,16 @@ skill_decision_contract:
       expected_routes: [ACT-RUN, ACT-SHIP-HANDOFF, ACT-REVIEW-CLOSEOUT, ACT-CLOSURE, ACT-BLOCK]
       prohibited_routes: []
       required_artifacts: [actuation-run/v1, immutable invocation profile, current source and artifact binding, step-admission/v1 before every action, implementation-checkpoint/v1 before bare review-closeout]
-      success_signals: [scope source remains distinct from execution authority, bare invocation orders implement then ship then review-closeout then final closure in one continuous run, valid ship returns a recomputable implementation checkpoint with goal continuation and implementation complete, proved review edit returns to ship before CAS, republishing updates the same retained PR URL, explicit implement stops after implementation]
-      failure_signals: [plan grants mutation by itself, invocation profile is relabeled, bare invocation skips or reorders a phase, a fresh review run discards implementation provenance, terminal action lacks step admission, review edit enters CAS before republishing, repair shipping creates a second PR, ship handoff terminates bare invocation, SHIP receipt is relabeled with the review epoch, explicit implement publishes or enters review-closeout, unsupported controller is simulated]
+      success_signals: [scope source remains distinct from execution authority, bare invocation orders implement then ship then review-closeout then final closure in one continuous run, valid ship returns a recomputable implementation checkpoint with goal continuation and implementation complete, unresolved adjacent repairs use a gate-derived same-publication continuation, the resolved repair head returns to ship before CAS, republishing updates the same retained PR URL and resets CAS credit to zero, explicit implement stops after implementation]
+      failure_signals: [plan grants mutation by itself, invocation profile is relabeled, bare invocation skips or reorders a phase, a fresh review run discards implementation provenance, terminal action lacks step admission, caller-authored continuation authority or a use counter grants mutation, pre-reship CAS receives closure credit, repair shipping creates a second PR, ship handoff terminates bare invocation, SHIP receipt is relabeled with the review epoch, explicit implement publishes or enters review-closeout, unsupported controller is simulated]
       rationale: Execution authority belongs to the run, while invocation syntax selects the ordered lifecycle boundary.
     - clause_id: ACT-REVIEW-001
       trigger_refs: [ACT-REVIEW]
       expected_routes: [ACT-TRIAGE, ACT-REMEDIATION, ACT-REVIEW-CLOSEOUT, ACT-BLOCK]
       prohibited_routes: []
-      required_artifacts: [current review source, review-fold classification before review resolution, prior SHIP-v1 in review.ship_receipt when publication was requested, gate-derived step-admission/v1 and review-admission/v1 before review mutation]
-      success_signals: [unqualified review selects triage, clean closeout creates no synthetic action, publication-bearing closeout validates SHIP before admission, generic admission binds the specialized review digest, admission snapshots the full resolution observer facts and optional prior SHIP, explicit closeout is required for review-derived mutation, completed review edits preserve both receipts]
-      failure_signals: [raw finding becomes a patch, publication-bearing review mutation precedes SHIP, no-code mode selects a work node, review-required run is relabeled implement, final resolution retrospectively relabels mutation admission]
+      required_artifacts: [current live review source batch before every repair admission, review-fold classification before review resolution, prior SHIP-v1 in review.ship_receipt when publication was requested, gate-derived step-admission/v1 and review-admission/v1 before review mutation, predecessor EF-v1 for same-publication continuation]
+      success_signals: [unqualified review selects triage, clean closeout creates no synthetic action, publication-bearing closeout validates SHIP before admission, generic admission binds the specialized review digest, admission snapshots the full resolution observer facts and optional prior SHIP, continuation preserves cumulative finding semantics and source producer lineage across SHIP epochs with fresh fold and batch identities supporting introduced findings, terminal resolution exactly matches admitted findings, explicit closeout is required for review-derived mutation, completed review edits preserve both receipts]
+      failure_signals: [raw finding becomes a patch, stale review source authorizes a repair, findings regress or are relabeled across a continuation or replacement SHIP, an admitted finding is cloned under a new ID to forge growth, a source changes producer backend, a fold identity is replayed within the current publication epoch or an introduced finding relies only on stale producer batches, terminal resolution adds an unadmitted material finding, clean erases admitted publication repair history, publication-bearing review mutation precedes SHIP, no-code mode selects a work node, review-required run is relabeled implement, final resolution retrospectively relabels mutation admission]
       rationale: Review evidence is not mutation authority.
     - clause_id: ACT-RESOLUTION-001
       trigger_refs: [ACT-RESOLVE]
@@ -84,8 +84,8 @@ skill_decision_contract:
       expected_routes: [ACT-CLOSURE, ACT-SHIP-HANDOFF, ACT-BLOCK]
       prohibited_routes: []
       required_artifacts: [closure-decision/v1, current evidence folds, actual CAS records when review is required]
-      success_signals: [goal and implementation outcomes are separate, three standard attempts are derived from distinct records]
-      failure_signals: [opaque proof reference, scalar clean count, replayed completion decision, proof-patch precedes closure]
+      success_signals: [goal and implementation outcomes are separate, three standard attempts are derived from distinct records created after the stable post-list PR updatedAt watermark, final repair reship or later PR metadata change resets prior CAS credit to zero]
+      failure_signals: [opaque proof reference, scalar clean count, prepublication or pre-watermark CAS attempt receives final credit, PR watermark advances without resetting credited basis, a PR watermark observation regresses, duplicate CAS record or producer attempt identity crosses publication epochs, replayed completion decision, proof-patch precedes closure]
       rationale: Completion must be a live join over current evidence.
   instrumentation:
     decision_receipt: required

--- a/codex/skills/actuating/references/live-semantics.yaml
+++ b/codex/skills/actuating/references/live-semantics.yaml
@@ -108,6 +108,14 @@ live_semantics:
       statement: Review-derived mutation requires classified findings and a current resolution.
     - id: review-admission-before-mutation
       statement: A review edit embeds the gate-derived review-admission receipt with the full resolution observer facts and optional prior SHIP snapshot before mutation and preserves it thereafter.
+    - id: live-review-source-before-admission
+      statement: Every review repair admission follows a live source refresh and a newly folded producer batch for the current local artifact.
+    - id: same-publication-continuation-derived
+      statement: An adjacent review repair under an unchanged SHIP is admitted only by the gate-derived continuation receipt with injective stable finding semantics and source producer lineage, fresh fold and batch identities supporting every introduced finding, and predecessor evidence-content binding.
+    - id: review-history-survives-reship
+      statement: A replacement SHIP resets publication-local proof credit but every later repair admission preserves cumulative finding and source history while strictly extending the finding set.
+    - id: terminal-resolution-exact
+      statement: After a publication-bearing repair clean cannot erase history; a resolved refold matches exactly the admitted material finding set, preserves source producer lineage, and supports every finding with fresh review input while a new finding remains pending.
     - id: review-mode-profile-alignment
       statement: Review-required execution uses review-closeout and cannot be relabeled as implement.
     - id: observable-index-before-mutation
@@ -119,7 +127,11 @@ live_semantics:
     - id: public-effects-owned-by-ship
       statement: Only ship may perform PR or public tracker effects.
     - id: ship-precedes-review-closeout
-      statement: Publication-bearing review-closeout validates an embedded immutable SHIP-v1 before admission and every repair publication updates that same retained PR URL.
+      statement: Publication-bearing review-closeout validates an embedded immutable SHIP-v1 before admission; adjacent same-publication repairs remain local until resolution and the final repair publication updates that same retained PR URL.
+    - id: repair-reship-resets-cas
+      statement: Republishing the resolved repair head resets CAS credit to zero and final closure requires three fresh ordered standard attempts.
+    - id: pr-publication-watermark-before-cas
+      statement: Publication-bound CAS credit uses monotone pre-list observations and a stable post-list live PR updatedAt watermark; a regressing observation blocks closure, records at or before the greatest observation are superseded, duplicate record and producer attempt identities are invalid across epochs, and a later PR metadata update resets the clean suffix while findings remain classification obligations.
     - id: closure-is-live
       statement: Completion is recomputed from current repository state and joined evidence.
     - id: resolved-node-history
@@ -138,6 +150,8 @@ live_semantics:
       - duplicate recursive coordinator
       - proof and closure dependency cycle
       - one-patch-per-comment escalation artifacts
+      - caller-authored publication-continuation authority
+      - single-use same-publication exception
       - runtime-history documentation
 
   closure_flow:
@@ -151,7 +165,10 @@ live_semantics:
     review_closeout:
       requires_when: publication-requested
       receipt: pre-review-SHIP-v1
-      after_edit: [current-resolved-refold, ship, review-closeout]
+      before_repair_admission: [refresh-live-review-sources, review-fold, review-resolution]
+      after_edit:
+        unresolved: [evidence-fold, refresh-live-review-sources, review-fold, review-resolution, gate-derived-continuation]
+        resolved: [evidence-fold, current-resolved-refold, ship, reset-cas-credit, review-closeout]
       then: final-closure
     final_closure: closure-decision/v1
     terminal_view: final-proof-patch

--- a/codex/skills/actuating/references/review-resolution.md
+++ b/codex/skills/actuating/references/review-resolution.md
@@ -100,6 +100,37 @@ the quotient is wrong, correct the RF-v2 classification first.
 Record rejected alternatives and a falsifier for every material decision.
 Judgment owns the strategy; comment count does not.
 
+## Live refresh and publication continuation
+
+Refresh the live review source before every repair admission and construct new
+RF-v2 folds for the current local artifact. A source name alone or only the
+batch that authorized the preceding edit is stale input, even while the PR
+intentionally continues to publish the preceding SHIP artifact.
+
+For an adjacent same-publication repair, the pending resolution must preserve
+all prior same-epoch finding IDs and source references, add at least one new
+material finding, use fold IDs disjoint from every fold already admitted in the
+epoch, include at least one new producer source-batch identity, and select the
+current node. Every introduced finding must come from a new producer batch. The
+gate derives `same-publication-continuation/v1` inside
+`review-admission/v1`; callers do not supply a top-level continuation object,
+authority reference, or use count. The derivation may repeat for successive
+adjacent edits while the same SHIP and live PR remain valid.
+
+Finding semantics and source-to-producer lineage remain cumulative across a
+replacement SHIP. The new receipt resets publication-local fold/batch and CAS
+credit, not admitted liabilities; the next repair resolution must strictly
+extend the retained finding set and preserve every retained source backend.
+
+The resolved re-fold after the last repair preserves exactly the admitted
+finding set and every admitted source reference, and uses another fresh fold
+plus a producer batch that carries material evidence. A newly observed material
+finding keeps the resolution pending and requires another admitted
+continuation. Only after the retained PR is revalidated against the
+admission-bound published artifact may `$ship` update that PR to the resolved
+local head. All earlier CAS credit belongs to the preceding publication epoch
+and resets to zero.
+
 ## Abstraction audit
 
 Audit every abstraction participating in the touched invariant or transition,

--- a/codex/skills/actuating/tests/test_actuating_gate.py
+++ b/codex/skills/actuating/tests/test_actuating_gate.py
@@ -252,6 +252,7 @@ class GateTests(unittest.TestCase):
                 "headRepository": {"nameWithOwner": "example/repo"},
                 "isDraft": False,
                 "state": "OPEN",
+                "updatedAt": "unix-ns:0",
             },
         }
 
@@ -366,19 +367,25 @@ class GateTests(unittest.TestCase):
         (self.repo / "file.txt").write_text("changed\n", encoding="utf-8")
         return self.finish_step(run, ["file.txt"])
 
-    def admit_step(self, run: dict) -> None:
+    def admit_step(
+        self,
+        run: dict,
+        resolution: dict | None = None,
+        evidence_values: list[dict] | None = None,
+    ) -> None:
         step = run["execution"]["steps"][-1]
-        resolution = None
         if (
-            step.get("phase") == "review-closeout"
+            resolution is None
+            and step.get("phase") == "review-closeout"
             and step.get("effect") == "edit"
         ):
             resolution = self.material_resolution(run, node_id=step["step_id"])
-        evidence_values = [
-            self.evidence_for_step(run, index)
-            for index, candidate in enumerate(run["execution"]["steps"])
-            if candidate.get("status") == "completed"
-        ]
+        if evidence_values is None:
+            evidence_values = [
+                self.evidence_for_step(run, index)
+                for index, candidate in enumerate(run["execution"]["steps"])
+                if candidate.get("status") == "completed"
+            ]
         errors, derived = validate_run(
             run,
             self.repo,
@@ -535,8 +542,8 @@ class GateTests(unittest.TestCase):
             {
                 "finding_id": finding_id,
                 "source_ref": f"local:{finding_id}",
-                "claim": "the gate misses an inverse",
-                "observed_fact": "a counterexample closes",
+                "claim": f"the gate misses inverse {finding_id}",
+                "observed_fact": f"counterexample {finding_id} closes",
                 "suggested_repair": "enforce the owner law",
                 "validity": "valid",
                 "liability": "invariant-gap",
@@ -700,6 +707,7 @@ class GateTests(unittest.TestCase):
             observations["changed_paths"],
             observations["hunk_ids"],
             admission["ship_receipt"],
+            admission.get("publication_continuation"),
         )
 
     def cas_review_fold(self, run: dict, record: dict) -> dict:
@@ -831,6 +839,113 @@ class GateTests(unittest.TestCase):
             "pr_url": prior_url,
         }
         return value
+
+    def append_review_edit(self, run: dict, step_id: str) -> None:
+        run["execution"]["kind"] = "iterative"
+        run["execution"]["selected_step_id"] = step_id
+        run["execution"]["steps"].append(
+            {
+                "step_id": step_id,
+                "run_id": run["run_id"],
+                "phase": "review-closeout",
+                "selected_by": "lead",
+                "owner_boundary": "actuating",
+                "effect": "edit",
+                "paths": ["file.txt"],
+                "verifier": ["test"],
+                "changed_paths": [],
+                "status": "selected",
+                "state_before": copy.deepcopy(run["artifact"]),
+                "parent_completion_claimed": False,
+                "performed_public_effects": [],
+            }
+        )
+
+    def cumulative_material_resolution(
+        self,
+        run: dict,
+        finding_ids: list[str],
+        node_id: str,
+        *,
+        fold_id: str,
+        source_batch_id: str,
+        source_ref: str = "local:audit-1",
+        status: str = "pending",
+    ) -> dict:
+        resolution = self.resolution(run)
+        self.bind_resolution_findings(run, resolution, finding_ids)
+        fold = resolution["review_folds"][0]
+        fold["fold_id"] = fold_id
+        fold["source"]["source_batch_id"] = source_batch_id
+        fold["source"]["source_ref"] = source_ref
+        decision = self.decision(run, finding_ids=finding_ids)
+        selected_step = next(
+            step
+            for step in run["execution"]["steps"]
+            if step["step_id"] == node_id
+        )
+        decision["owner_boundary"] = selected_step["owner_boundary"]
+        decision["selected_work_node"] = {
+            "node_id": node_id,
+            "run_id": run["run_id"],
+            "owner_boundary": selected_step["owner_boundary"],
+            "paths": selected_step["paths"],
+            "verifier": selected_step["verifier"],
+        }
+        resolution["decisions"] = [decision]
+        resolution["outcome"]["status"] = status
+        resolution["outcome"]["semantic_balance"]["covered_liabilities"] = [
+            "invariant-gap"
+        ]
+        resolution["outcome"]["resolution_digest"] = canonical_digest(
+            resolution_digest_payload(resolution)
+        )
+        return resolution
+
+    def validate_with_live_pr(
+        self,
+        run: dict,
+        resolution: dict,
+        evidence: list[dict],
+        published_pr: dict,
+    ) -> tuple[list[str], dict]:
+        self.live_pr_override = published_pr
+        try:
+            return validate_run(run, self.repo, resolution, evidence)
+        finally:
+            self.live_pr_override = None
+
+    def same_publication_candidate(
+        self,
+    ) -> tuple[dict, dict, list[dict], dict]:
+        run = self.run_value(review=True, selected=True)
+        run["review"]["publication_requested"] = True
+        ship_receipt = self.ship_record(run)
+        run["review"]["ship_receipt"] = ship_receipt
+        published_pr = self.pr_metadata(
+            self.repo,
+            ship_receipt["ship_record"]["action"]["pr_url"],
+        )
+        first_resolution = self.cumulative_material_resolution(
+            run,
+            ["finding-1"],
+            "step-1",
+            fold_id="rf-1",
+            source_batch_id="audit-1",
+        )
+        self.admit_step(run, first_resolution, [])
+        (self.repo / "file.txt").write_text("first repair\n", encoding="utf-8")
+        run = self.finish_step(run, ["file.txt"])
+        evidence = [self.evidence_for_step(run, 0)]
+        self.append_review_edit(run, "step-2")
+        resolution = self.cumulative_material_resolution(
+            run,
+            ["finding-1", "finding-2"],
+            "step-2",
+            fold_id="rf-2",
+            source_batch_id="audit-2",
+        )
+        return run, resolution, evidence, published_pr
 
     def decision(
         self,
@@ -1119,6 +1234,9 @@ class GateTests(unittest.TestCase):
         run = self.commit_step(self.complete_step(self.bare_run_value(selected=True)))
         initial_ship = self.ship_record(run)
         run = self.transition_bare_run_to_review(run, initial_ship)
+        published_pr = self.pr_metadata(
+            self.repo, initial_ship["ship_record"]["action"]["pr_url"]
+        )
         run["execution"]["kind"] = "iterative"
         run["execution"]["selected_step_id"] = "step-2"
         run["execution"]["steps"].append(
@@ -1142,20 +1260,27 @@ class GateTests(unittest.TestCase):
         (self.repo / "file.txt").write_text("review repair\n", encoding="utf-8")
         run = self.finish_step(run, ["file.txt"])
 
-        resolution = self.material_resolution(
+        resolution = self.cumulative_material_resolution(
             run,
-            node_id="step-2",
+            ["finding-1"],
+            "step-2",
+            fold_id="rf-terminal",
+            source_batch_id="audit-terminal",
             status="resolved",
         )
         evidence = [self.evidence_for_step(run, index) for index in (0, 1)]
-        handoff, code = decide(
-            run,
-            resolution,
-            evidence,
-            [],
-            None,
-            self.repo,
-        )
+        self.live_pr_override = published_pr
+        try:
+            handoff, code = decide(
+                run,
+                resolution,
+                evidence,
+                [],
+                None,
+                self.repo,
+            )
+        finally:
+            self.live_pr_override = None
         self.assertEqual(code, 0, handoff)
         self.assertEqual(handoff["closure_decision"]["verdict"], "ready-to-ship")
 
@@ -1218,6 +1343,43 @@ class GateTests(unittest.TestCase):
             errors, _ = validate_run(tampered, self.repo)
             with self.subTest(field=field):
                 self.assertIn("blocked-step-admission", errors)
+
+    def test_non_review_step_rejects_specialized_review_admission(self) -> None:
+        for status in ("selected", "completed"):
+            with self.subTest(status=status):
+                run = self.run_value(selected=True)
+                if status == "completed":
+                    run = self.complete_step(run)
+                step = run["execution"]["steps"][0]
+                step["review_admission"] = {
+                    "admission_digest": "sha256:" + "1" * 64,
+                    "ship_receipt": None,
+                }
+                if status == "completed":
+                    step["step_admission"] = expected_step_admission(
+                        run, step, 0, step["review_admission"]
+                    )
+
+                errors, derived = validate_run(run, self.repo)
+                self.assertIn("blocked-unexpected-input", errors)
+                self.assertIsNone(derived["review_admission"])
+                self.assertIsNone(derived["step_admission"])
+
+    def test_blocked_review_step_rejects_malformed_preserved_admission(
+        self,
+    ) -> None:
+        run = self.run_value(review=True, selected=True)
+        resolution = self.material_resolution(run)
+        self.admit_step(run, resolution)
+        step = run["execution"]["steps"][0]
+        step["status"] = "blocked"
+        step["review_admission"]["admission_digest"] = "sha256:malformed"
+        run["execution"]["selected_step_id"] = None
+
+        errors, _ = validate_run(run, self.repo, resolution)
+
+        self.assertIn("blocked-resolution-binding", errors)
+        self.assertIn("blocked-step-admission", errors)
 
     def test_review_and_resolve_are_not_executable_effects(self) -> None:
         for effect in ("review", "resolve"):
@@ -1469,8 +1631,84 @@ class GateTests(unittest.TestCase):
         run["execution"]["steps"][0]["review_admission"] = admission
         run = self.complete_step(run)
 
-        current = self.material_resolution(run, status="resolved")
         evidence = self.evidence(run)
+        reused_terminal = self.material_resolution(run, status="resolved")
+        resolution_errors, _ = validate_resolution(
+            run, reused_terminal, self.repo, [evidence]
+        )
+        self.assertIn("blocked-resolution-history", resolution_errors)
+
+        detached_run = copy.deepcopy(run)
+        detached_run["review"]["source_refs"] = [
+            "local:audit-1",
+            "local:audit-2",
+        ]
+        detached_terminal = self.cumulative_material_resolution(
+            detached_run,
+            ["finding-1"],
+            "step-1",
+            fold_id="rf-terminal-old-batch",
+            source_batch_id="audit-1",
+            status="resolved",
+        )
+        clean_refresh = self.review_fold(detached_run)
+        clean_refresh["fold_id"] = "rf-terminal-clean-refresh"
+        clean_refresh["source"]["source_batch_id"] = "audit-terminal-clean"
+        clean_refresh["source"]["source_ref"] = "local:audit-2"
+        detached_terminal["review_folds"].append(clean_refresh)
+        detached_terminal["outcome"]["resolution_digest"] = canonical_digest(
+            resolution_digest_payload(detached_terminal)
+        )
+        self.live_pr_override = historical_pr
+        try:
+            resolution_errors, _ = validate_resolution(
+                detached_run, detached_terminal, self.repo, [evidence]
+            )
+        finally:
+            self.live_pr_override = None
+        self.assertIn("blocked-resolution-history", resolution_errors)
+        self.assertNotIn("blocked-review-fold-source", resolution_errors)
+
+        current = self.cumulative_material_resolution(
+            run,
+            ["finding-1"],
+            "step-1",
+            fold_id="rf-terminal",
+            source_batch_id="audit-terminal",
+            status="resolved",
+        )
+
+        moved, code = decide(
+            run,
+            current,
+            [evidence],
+            [],
+            None,
+            self.repo,
+        )
+        self.assertEqual(code, 2)
+        self.assertIn(
+            "blocked-ship-live-pr-mismatch",
+            moved["closure_decision"]["reasons"],
+        )
+
+        closed_pr = copy.deepcopy(historical_pr)
+        closed_pr["pull_request"]["state"] = "CLOSED"
+        self.live_pr_override = closed_pr
+        closed, code = decide(
+            run,
+            current,
+            [evidence],
+            [],
+            None,
+            self.repo,
+        )
+        self.live_pr_override = None
+        self.assertEqual(code, 2)
+        self.assertIn(
+            "blocked-ship-live-pr-mismatch",
+            closed["closure_decision"]["reasons"],
+        )
 
         forged_history = copy.deepcopy(run)
         forged_admission = copy.deepcopy(
@@ -1525,9 +1763,13 @@ class GateTests(unittest.TestCase):
         )
         self.assertEqual(handback["closure_decision"]["review_basis"], [])
 
-        resolution_errors, pre_ship_derived = validate_resolution(
-            run, current, self.repo
-        )
+        self.live_pr_override = historical_pr
+        try:
+            resolution_errors, pre_ship_derived = validate_resolution(
+                run, current, self.repo, [evidence]
+            )
+        finally:
+            self.live_pr_override = None
         self.assertEqual(resolution_errors, [])
         pre_ship_snapshot = self.review_records(run, current)[0]
         cas_problems, _ = cas_errors(
@@ -1558,6 +1800,21 @@ class GateTests(unittest.TestCase):
         fresh_ship = self.updated_ship_record(run, prior_ship)
         self.assertNotEqual(canonical_digest(fresh_ship), canonical_digest(prior_ship))
         run["review"]["ship_receipt"] = fresh_ship
+        erased_history = self.resolution(run)
+        erased, code = decide(
+            run,
+            erased_history,
+            [evidence],
+            self.review_records(run, erased_history),
+            None,
+            self.repo,
+        )
+        self.assertEqual(code, 2)
+        self.assertIn(
+            "blocked-resolution-history", erased["closure_decision"]["reasons"]
+        )
+        self.assertEqual(erased["closure_decision"]["review_basis"], [])
+
         resolution_errors, post_ship_derived = validate_resolution(
             run, current, self.repo
         )
@@ -1592,11 +1849,27 @@ class GateTests(unittest.TestCase):
                 "performed_public_effects": [],
             }
         )
-        next_pending = self.material_resolution(
+        next_pending = self.cumulative_material_resolution(
             next_run,
-            finding_id="finding-2",
-            node_id="step-2",
+            ["finding-1", "finding-2"],
+            "step-2",
+            fold_id="rf-2",
+            source_batch_id="audit-2",
         )
+        dropped_history = self.cumulative_material_resolution(
+            next_run,
+            ["finding-2"],
+            "step-2",
+            fold_id="rf-dropped-history",
+            source_batch_id="audit-dropped-history",
+        )
+        errors, _ = validate_run(
+            next_run,
+            self.repo,
+            dropped_history,
+            [self.evidence(run)],
+        )
+        self.assertIn("blocked-resolution-history", errors)
         errors, derived = validate_run(
             next_run,
             self.repo,
@@ -1609,16 +1882,1271 @@ class GateTests(unittest.TestCase):
             fresh_ship,
         )
 
+        early_records = self.review_records(run, current)
+        self.live_pr_override = historical_pr
+        stale_publication, code = decide(
+            run,
+            current,
+            [evidence],
+            early_records,
+            None,
+            self.repo,
+        )
+        self.live_pr_override = None
+        self.assertEqual(code, 2)
+        self.assertIn(
+            "blocked-ship-live-pr-mismatch",
+            stale_publication["closure_decision"]["reasons"],
+        )
+        self.assertEqual(stale_publication["closure_decision"]["review_basis"], [])
+
+        caught_up_pr = self.pr_metadata(
+            self.repo, fresh_ship["ship_record"]["action"]["pr_url"]
+        )
+        caught_up_pr["pull_request"]["updatedAt"] = "unix-ns:10"
+        self.live_pr_override = caught_up_pr
+        replayed, code = decide(
+            run,
+            current,
+            [evidence],
+            early_records,
+            None,
+            self.repo,
+        )
+        self.assertEqual(code, 2)
+        self.assertIn(
+            "blocked-cas-clean-streak",
+            replayed["closure_decision"]["reasons"],
+        )
+        self.assertEqual(replayed["closure_decision"]["review_basis"], [])
+
+        new_rows = [
+            self.cas_record(run, current, "standard", ordinal)
+            for ordinal in (11, 12, 13)
+        ]
+        fresh_records = self.cas_snapshot(
+            [*early_records[0]["records"], *new_rows]
+        )
+
+        watermark_attempt_replay = copy.deepcopy(fresh_records)
+        replay_rows = watermark_attempt_replay[0]["records"]
+        replay_rows[0]["attempt"]["attemptId"] = replay_rows[-2]["attempt"][
+            "attemptId"
+        ]
+        self.live_cas_snapshot = watermark_attempt_replay[0]
+        replayed_attempt, code = decide(
+            run,
+            current,
+            [evidence],
+            watermark_attempt_replay,
+            None,
+            self.repo,
+        )
+        self.live_cas_snapshot = fresh_records[0]
+        self.assertEqual(code, 2)
+        self.assertIn(
+            "blocked-cas-unit-duplicate",
+            replayed_attempt["closure_decision"]["reasons"],
+        )
+
+        stable_pr = copy.deepcopy(caught_up_pr)
+        advanced_pr = copy.deepcopy(caught_up_pr)
+        advanced_pr["pull_request"]["updatedAt"] = "unix-ns:20"
+        starting_calls = self.live_pr_mock.call_count
+
+        def advance_after_cas(*_args: object) -> dict:
+            calls = self.live_pr_mock.call_count - starting_calls
+            return advanced_pr if calls >= 4 else stable_pr
+
+        self.live_pr_mock.side_effect = advance_after_cas
+        try:
+            advanced, code = decide(
+                run,
+                current,
+                [evidence],
+                fresh_records,
+                None,
+                self.repo,
+            )
+        finally:
+            self.live_pr_mock.side_effect = self.pr_metadata
+        self.assertEqual(code, 2)
+        self.assertIn(
+            "blocked-cas-publication-watermark",
+            advanced["closure_decision"]["reasons"],
+        )
+        self.assertEqual(advanced["closure_decision"]["review_basis"], [])
+
+        regressed_pr = copy.deepcopy(caught_up_pr)
+        regressed_pr["pull_request"]["updatedAt"] = "unix-ns:20"
+        for high_observation_count in (1, 2):
+            with self.subTest(
+                high_observation_count=high_observation_count
+            ):
+                starting_calls = self.live_pr_mock.call_count
+
+                def regress_watermark(*_args: object) -> dict:
+                    calls = self.live_pr_mock.call_count - starting_calls
+                    return (
+                        regressed_pr
+                        if calls <= high_observation_count
+                        else caught_up_pr
+                    )
+
+                self.live_pr_mock.side_effect = regress_watermark
+                try:
+                    regressed, code = decide(
+                        run,
+                        current,
+                        [evidence],
+                        fresh_records,
+                        None,
+                        self.repo,
+                    )
+                finally:
+                    self.live_pr_mock.side_effect = self.pr_metadata
+                self.assertEqual(code, 2)
+                self.assertIn(
+                    "blocked-cas-publication-watermark",
+                    regressed["closure_decision"]["reasons"],
+                )
+                self.assertEqual(
+                    regressed["closure_decision"]["review_basis"], []
+                )
+
         final, code = decide(
             run,
             current,
             [evidence],
-            self.review_records(run, current),
+            fresh_records,
+            None,
+            self.repo,
+        )
+        self.live_pr_override = None
+        self.assertEqual(code, 0, final)
+        self.assertEqual(final["closure_decision"]["verdict"], "complete")
+
+    def test_same_publication_continuation_is_gate_derived(self) -> None:
+        run, resolution, evidence, published_pr = self.same_publication_candidate()
+        errors, derived = self.validate_with_live_pr(
+            run, resolution, evidence, published_pr
+        )
+
+        self.assertEqual(errors, [])
+        admission = derived["review_admission"]
+        continuation = admission["publication_continuation"]
+        prior = run["execution"]["steps"][0]
+        self.assertEqual(
+            continuation["publication_epoch"],
+            canonical_digest(run["review"]["ship_receipt"]),
+        )
+        self.assertEqual(continuation["published_artifact"], prior["state_before"])
+        self.assertEqual(continuation["predecessor"]["step_id"], "step-1")
+        self.assertEqual(
+            continuation["predecessor"]["review_admission_digest"],
+            prior["review_admission"]["admission_digest"],
+        )
+        self.assertNotIn("authority_ref", json.dumps(continuation))
+        self.assertNotIn("publication_continuation", run["review"])
+
+    def test_caller_cannot_smuggle_derived_control_receipts(self) -> None:
+        review_admission = {
+            "version": "review-admission/v1",
+            "authority_ref": "caller:allow",
+        }
+        publication_continuation = {
+            "version": "same-publication-continuation/v1",
+            "authority_ref": "caller:allow",
+        }
+        cases = {
+            "run-review-admission": lambda run: run.update(
+                review_admission=copy.deepcopy(review_admission)
+            ),
+            "run-continuation": lambda run: run.update(
+                publication_continuation=copy.deepcopy(
+                    publication_continuation
+                )
+            ),
+            "execution-review-admission": lambda run: run["execution"].update(
+                review_admission=copy.deepcopy(review_admission)
+            ),
+            "execution-continuation": lambda run: run["execution"].update(
+                publication_continuation=copy.deepcopy(
+                    publication_continuation
+                )
+            ),
+            "source-continuation": lambda run: run["source"].update(
+                publication_continuation=copy.deepcopy(
+                    publication_continuation
+                )
+            ),
+            "authority-continuation": lambda run: run["authority"].update(
+                publication_continuation=copy.deepcopy(
+                    publication_continuation
+                )
+            ),
+            "review-review-admission": lambda run: run["review"].update(
+                review_admission=copy.deepcopy(review_admission)
+            ),
+            "step-continuation": lambda run: run["execution"]["steps"][0].update(
+                publication_continuation=copy.deepcopy(
+                    publication_continuation
+                )
+            ),
+        }
+        for label, inject in cases.items():
+            with self.subTest(label=label):
+                run = self.run_value(selected=True)
+                inject(run)
+
+                errors, derived = validate_run(run, self.repo)
+
+                self.assertIn("blocked-unexpected-input", errors)
+                self.assertIsNone(derived["review_admission"])
+                self.assertIsNone(derived["step_admission"])
+
+    def test_resolution_cannot_smuggle_derived_control_receipts(self) -> None:
+        cases = {
+            key: {key: {"authority_ref": "caller:allow"}}
+            for key in (
+                "review_admission",
+                "publication_continuation",
+                "unpublished_repair_chain",
+            )
+        }
+        cases["nested-run-shaped"] = {
+            "execution": {
+                "steps": [
+                    {
+                        "review_admission": {
+                            "authority_ref": "caller:allow"
+                        }
+                    }
+                ]
+            }
+        }
+        for label, injection in cases.items():
+            with self.subTest(label=label):
+                run = self.run_value(review=True, selected=True)
+                resolution = self.material_resolution(run)
+                resolution.update(copy.deepcopy(injection))
+
+                errors, derived = validate_run(
+                    run, self.repo, resolution
+                )
+
+                self.assertIn("blocked-unexpected-input", errors)
+                self.assertIsNone(derived["review_admission"])
+                self.assertIsNone(derived["step_admission"])
+
+    def test_ship_cannot_smuggle_derived_control_receipts(self) -> None:
+        run = self.commit_step(
+            self.complete_step(self.bare_run_value(selected=True))
+        )
+        ship = self.ship_record(run)
+        ship["ship_record"]["publication_continuation"] = {
+            "authority_ref": "caller:allow"
+        }
+
+        decision, code = decide(
+            run,
+            None,
+            [self.evidence(run)],
+            [],
+            ship,
+            self.repo,
+        )
+
+        self.assertEqual(code, 2)
+        self.assertIn(
+            "blocked-unexpected-input",
+            decision["closure_decision"]["reasons"],
+        )
+        self.assertIsNone(
+            decision["closure_decision"]["implementation_checkpoint"]
+        )
+
+        nested_ship = self.ship_record(run)
+        nested_ship["ship_record"]["execution"] = {
+            "steps": [
+                {
+                    "review_admission": {
+                        "authority_ref": "caller:allow"
+                    }
+                }
+            ]
+        }
+        decision, code = decide(
+            run,
+            None,
+            [self.evidence(run)],
+            [],
+            nested_ship,
+            self.repo,
+        )
+        self.assertEqual(code, 2)
+        self.assertIn(
+            "blocked-unexpected-input",
+            decision["closure_decision"]["reasons"],
+        )
+
+    def test_same_publication_requires_every_introduced_finding_on_fresh_batch(
+        self,
+    ) -> None:
+        run, _, evidence, published_pr = self.same_publication_candidate()
+        resolution = self.cumulative_material_resolution(
+            run,
+            ["finding-1", "finding-2", "finding-3"],
+            "step-2",
+            fold_id="rf-current",
+            source_batch_id="audit-2",
+        )
+        stale_fold = self.review_fold(
+            run, ["finding-1", "finding-3"]
+        )
+        stale_fold["fold_id"] = "rf-carried-stale"
+        stale_fold["source"]["source_batch_id"] = "audit-1"
+        fresh_fold = self.review_fold(run, ["finding-2"])
+        fresh_fold["fold_id"] = "rf-current-fresh"
+        fresh_fold["source"]["source_batch_id"] = "audit-2"
+        fresh_fold["source"]["source_ref"] = "local:audit-fresh"
+        run["review"]["source_refs"] = [
+            "local:audit-1",
+            "local:audit-fresh",
+        ]
+        resolution["review_folds"] = [stale_fold, fresh_fold]
+        resolution["outcome"]["resolution_digest"] = canonical_digest(
+            resolution_digest_payload(resolution)
+        )
+
+        errors, derived = self.validate_with_live_pr(
+            run, resolution, evidence, published_pr
+        )
+
+        self.assertIn("blocked-publication-continuation", errors)
+        self.assertNotIn("blocked-review-fold-source", errors)
+        self.assertIsNone(derived["review_admission"])
+
+    def test_same_publication_preserves_finding_identity(self) -> None:
+        run, candidate, evidence, published_pr = (
+            self.same_publication_candidate()
+        )
+        resolution = copy.deepcopy(candidate)
+        finding = next(
+            value
+            for value in resolution["review_folds"][0]["findings"]
+            if value["finding_id"] == "finding-1"
+        )
+        finding["claim"] = "a relabeled claim must not reuse the finding id"
+        resolution["outcome"]["resolution_digest"] = canonical_digest(
+            resolution_digest_payload(resolution)
+        )
+
+        errors, derived = self.validate_with_live_pr(
+            run, resolution, evidence, published_pr
+        )
+
+        self.assertIn("blocked-publication-continuation", errors)
+        self.assertIsNone(derived["review_admission"])
+
+        cloned = copy.deepcopy(candidate)
+        admitted = next(
+            value
+            for value in cloned["review_folds"][0]["findings"]
+            if value["finding_id"] == "finding-1"
+        )
+        introduced = next(
+            value
+            for value in cloned["review_folds"][0]["findings"]
+            if value["finding_id"] == "finding-2"
+        )
+        for field in (
+            "claim",
+            "observed_fact",
+            "validity",
+            "liability",
+            "intent_relation",
+            "quotient_key",
+            "owner_boundary",
+            "law_family",
+            "falsifier",
+        ):
+            introduced[field] = copy.deepcopy(admitted[field])
+        cloned["outcome"]["resolution_digest"] = canonical_digest(
+            resolution_digest_payload(cloned)
+        )
+        errors, derived = self.validate_with_live_pr(
+            run, cloned, evidence, published_pr
+        )
+        self.assertIn("blocked-publication-continuation", errors)
+        self.assertIsNone(derived["review_admission"])
+
+        whitespace_clone = copy.deepcopy(candidate)
+        admitted = next(
+            value
+            for value in whitespace_clone["review_folds"][0]["findings"]
+            if value["finding_id"] == "finding-1"
+        )
+        introduced = next(
+            value
+            for value in whitespace_clone["review_folds"][0]["findings"]
+            if value["finding_id"] == "finding-2"
+        )
+        for field in (
+            "claim",
+            "observed_fact",
+            "validity",
+            "liability",
+            "intent_relation",
+            "quotient_key",
+            "owner_boundary",
+            "law_family",
+            "falsifier",
+        ):
+            introduced[field] = copy.deepcopy(admitted[field])
+        introduced["claim"] = admitted["claim"].replace(
+            " ", " \t\n ", 1
+        )
+        whitespace_clone["outcome"]["resolution_digest"] = canonical_digest(
+            resolution_digest_payload(whitespace_clone)
+        )
+        errors, derived = self.validate_with_live_pr(
+            run, whitespace_clone, evidence, published_pr
+        )
+        self.assertIn("blocked-publication-continuation", errors)
+        self.assertNotIn("blocked-review-fold-invalid", errors)
+        self.assertIsNone(derived["review_admission"])
+
+        resolution = copy.deepcopy(candidate)
+        nonmaterial = copy.deepcopy(resolution["review_folds"][0]["findings"][0])
+        nonmaterial.update(
+            {
+                "finding_id": "rejected-duplicate-observation",
+                "source_ref": "local:rejected-duplicate-observation",
+                "novelty": "duplicate",
+                "disposition": "reject",
+            }
+        )
+        resolution["review_folds"][0]["findings"].append(nonmaterial)
+        resolution["review_folds"][0]["compression"]["equivalence_classes"][0][
+            "finding_ids"
+        ] = ["finding-1", "finding-2", "rejected-duplicate-observation"]
+        resolution["review_folds"][0]["routing_obligations"][0][
+            "finding_ids"
+        ] = ["finding-1", "finding-2", "rejected-duplicate-observation"]
+        resolution["outcome"]["resolution_digest"] = canonical_digest(
+            resolution_digest_payload(resolution)
+        )
+        errors, derived = self.validate_with_live_pr(
+            run, resolution, evidence, published_pr
+        )
+        self.assertEqual(errors, [])
+        self.assertIsNotNone(derived["review_admission"])
+
+        resolution = copy.deepcopy(candidate)
+        retained = next(
+            value
+            for value in resolution["review_folds"][0]["findings"]
+            if value["finding_id"] == "finding-1"
+        )
+        retained["novelty"] = "same-class"
+        resolution["outcome"]["resolution_digest"] = canonical_digest(
+            resolution_digest_payload(resolution)
+        )
+        errors, derived = self.validate_with_live_pr(
+            run, resolution, evidence, published_pr
+        )
+        self.assertEqual(errors, [])
+        self.assertIsNotNone(derived["review_admission"])
+
+    def test_same_publication_requires_canonical_freshness_identities(self) -> None:
+        run, candidate, evidence, published_pr = (
+            self.same_publication_candidate()
+        )
+        for target in ("fold", "batch"):
+            with self.subTest(target=target):
+                resolution = copy.deepcopy(candidate)
+                if target == "fold":
+                    resolution["review_folds"][0]["fold_id"] = "   "
+                else:
+                    resolution["review_folds"][0]["source"][
+                        "source_batch_id"
+                    ] = "   "
+                resolution["outcome"]["resolution_digest"] = (
+                    canonical_digest(resolution_digest_payload(resolution))
+                )
+
+                errors, derived = self.validate_with_live_pr(
+                    run, resolution, evidence, published_pr
+                )
+
+                self.assertIn("blocked-publication-continuation", errors)
+                self.assertIsNone(derived["review_admission"])
+
+        for target in ("fold", "batch"):
+            with self.subTest(initial=target):
+                initial_run = self.run_value(review=True, selected=True)
+                initial_resolution = self.material_resolution(initial_run)
+                if target == "fold":
+                    initial_resolution["review_folds"][0]["fold_id"] = "rf-1 "
+                else:
+                    initial_resolution["review_folds"][0]["source"][
+                        "source_batch_id"
+                    ] = "audit-1 "
+                initial_resolution["outcome"]["resolution_digest"] = (
+                    canonical_digest(
+                        resolution_digest_payload(initial_resolution)
+                    )
+                )
+                errors, derived = validate_run(
+                    initial_run, self.repo, initial_resolution
+                )
+                self.assertIn("blocked-review-fold-binding", errors)
+                self.assertIsNone(derived["review_admission"])
+
+    def test_same_publication_rejects_noncanonical_predecessor_identities(
+        self,
+    ) -> None:
+        base_run, resolution, _, published_pr = (
+            self.same_publication_candidate()
+        )
+        for target in ("fold", "batch"):
+            with self.subTest(target=target):
+                run = copy.deepcopy(base_run)
+                prior = run["execution"]["steps"][0]
+                prior_resolution = prior["review_admission"][
+                    "review_resolution"
+                ]
+                if target == "fold":
+                    prior_resolution["review_folds"][0]["fold_id"] = "   "
+                else:
+                    prior_resolution["review_folds"][0]["source"][
+                        "source_batch_id"
+                    ] = "   "
+                prior_resolution["outcome"]["resolution_digest"] = (
+                    canonical_digest(
+                        resolution_digest_payload(prior_resolution)
+                    )
+                )
+                prior["review_admission"] = self.redigest_admission(
+                    prior["review_admission"]
+                )
+                prior["step_admission"] = expected_step_admission(
+                    run, prior, 0, prior["review_admission"]
+                )
+                evidence = [self.evidence_for_step(run, 0)]
+
+                errors, derived = self.validate_with_live_pr(
+                    run, resolution, evidence, published_pr
+                )
+
+                self.assertIn("blocked-publication-continuation", errors)
+                self.assertIsNone(derived["review_admission"])
+
+    def test_terminal_history_requires_every_finding_on_fresh_batch(self) -> None:
+        run, resolution, evidence, published_pr = (
+            self.same_publication_candidate()
+        )
+        errors, derived = self.validate_with_live_pr(
+            run, resolution, evidence, published_pr
+        )
+        self.assertEqual(errors, [])
+        step = run["execution"]["steps"][-1]
+        step["review_admission"] = derived["review_admission"]
+        step["step_admission"] = derived["step_admission"]
+        (self.repo / "file.txt").write_text(
+            "second repair\n", encoding="utf-8"
+        )
+        run = self.finish_step(run, ["file.txt"])
+        terminal = self.cumulative_material_resolution(
+            run,
+            ["finding-1", "finding-2"],
+            "step-2",
+            fold_id="rf-terminal",
+            source_batch_id="audit-terminal",
+            status="resolved",
+        )
+        stale_fold = self.review_fold(run, ["finding-1"])
+        stale_fold["fold_id"] = "rf-terminal-carried"
+        stale_fold["source"]["source_batch_id"] = "audit-2"
+        fresh_fold = self.review_fold(run, ["finding-2"])
+        fresh_fold["fold_id"] = "rf-terminal-fresh"
+        fresh_fold["source"]["source_batch_id"] = "audit-terminal"
+        fresh_fold["source"]["source_ref"] = "local:audit-terminal"
+        run["review"]["source_refs"] = [
+            "local:audit-1",
+            "local:audit-terminal",
+        ]
+        terminal["review_folds"] = [stale_fold, fresh_fold]
+        terminal["outcome"]["resolution_digest"] = canonical_digest(
+            resolution_digest_payload(terminal)
+        )
+        evidence = [
+            self.evidence_for_step(run, index)
+            for index in range(len(run["execution"]["steps"]))
+        ]
+
+        self.live_pr_override = published_pr
+        try:
+            resolution_errors, _ = validate_resolution(
+                run, terminal, self.repo, evidence
+            )
+        finally:
+            self.live_pr_override = None
+
+        self.assertIn("blocked-resolution-history", resolution_errors)
+        self.assertNotIn("blocked-review-fold-source", resolution_errors)
+
+        relabeled_backend = self.cumulative_material_resolution(
+            run,
+            ["finding-1", "finding-2"],
+            "step-2",
+            fold_id="rf-terminal-backend",
+            source_batch_id="audit-terminal-backend",
+            status="resolved",
+        )
+        relabeled_backend["review_folds"][0]["source"]["backend"] = "other"
+        relabeled_backend["outcome"]["resolution_digest"] = canonical_digest(
+            resolution_digest_payload(relabeled_backend)
+        )
+        self.live_pr_override = published_pr
+        try:
+            backend_errors, _ = validate_resolution(
+                run, relabeled_backend, self.repo, evidence
+            )
+        finally:
+            self.live_pr_override = None
+        self.assertIn("blocked-resolution-history", backend_errors)
+
+        changed_identity = copy.deepcopy(terminal)
+        changed_identity["review_folds"][0]["findings"][0]["observed_fact"] = (
+            "a different fact cannot reuse the admitted finding id"
+        )
+        changed_identity["outcome"]["resolution_digest"] = canonical_digest(
+            resolution_digest_payload(changed_identity)
+        )
+        self.live_pr_override = published_pr
+        try:
+            resolution_errors, _ = validate_resolution(
+                run, changed_identity, self.repo, evidence
+            )
+        finally:
+            self.live_pr_override = None
+        self.assertIn("blocked-resolution-history", resolution_errors)
+
+    def test_same_publication_continuation_survives_completed_replay(self) -> None:
+        run, resolution, evidence, published_pr = self.same_publication_candidate()
+        errors, derived = self.validate_with_live_pr(
+            run, resolution, evidence, published_pr
+        )
+        self.assertEqual(errors, [])
+        step = run["execution"]["steps"][-1]
+        step["review_admission"] = derived["review_admission"]
+        step["step_admission"] = derived["step_admission"]
+        (self.repo / "file.txt").write_text("second repair\n", encoding="utf-8")
+        run = self.finish_step(run, ["file.txt"])
+        terminal = self.cumulative_material_resolution(
+            run,
+            ["finding-1", "finding-2"],
+            "step-2",
+            fold_id="rf-terminal",
+            source_batch_id="audit-terminal",
+            status="resolved",
+        )
+        evidence = [
+            self.evidence_for_step(run, index)
+            for index in range(len(run["execution"]["steps"]))
+        ]
+
+        stale_terminal = copy.deepcopy(terminal)
+        stale_terminal["decisions"][0]["selected_work_node"]["node_id"] = "step-1"
+        stale_terminal["outcome"]["resolution_digest"] = canonical_digest(
+            resolution_digest_payload(stale_terminal)
+        )
+        self.live_pr_override = published_pr
+        try:
+            resolution_errors, _ = validate_resolution(
+                run, stale_terminal, self.repo, evidence
+            )
+        finally:
+            self.live_pr_override = None
+        self.assertIn("blocked-resolution-history", resolution_errors)
+
+        relabeled_terminal = self.cumulative_material_resolution(
+            run,
+            ["finding-1", "finding-2", "finding-3"],
+            "step-2",
+            fold_id="rf-terminal-relabeled",
+            source_batch_id="audit-terminal-relabeled",
+            status="resolved",
+        )
+        self.live_pr_override = published_pr
+        try:
+            resolution_errors, _ = validate_resolution(
+                run, relabeled_terminal, self.repo, evidence
+            )
+        finally:
+            self.live_pr_override = None
+        self.assertIn("blocked-resolution-history", resolution_errors)
+
+        self.live_pr_override = published_pr
+        try:
+            handoff, code = decide(
+                run,
+                terminal,
+                evidence,
+                [],
+                None,
+                self.repo,
+            )
+        finally:
+            self.live_pr_override = None
+        self.assertEqual(code, 0, handoff)
+        self.assertEqual(handoff["closure_decision"]["verdict"], "ready-to-ship")
+
+    def test_same_publication_continuation_requires_cumulative_fresh_review(self) -> None:
+        run, resolution, evidence, published_pr = self.same_publication_candidate()
+        errors, _ = self.validate_with_live_pr(
+            run, resolution, evidence, published_pr
+        )
+        self.assertEqual(errors, [])
+
+        dropped = self.cumulative_material_resolution(
+            run,
+            ["finding-2"],
+            "step-2",
+            fold_id="rf-3",
+            source_batch_id="audit-3",
+        )
+        errors, _ = self.validate_with_live_pr(
+            run, dropped, evidence, published_pr
+        )
+        self.assertIn("blocked-publication-continuation", errors)
+
+        reused = self.cumulative_material_resolution(
+            run,
+            ["finding-1", "finding-2"],
+            "step-2",
+            fold_id="rf-1",
+            source_batch_id="audit-1",
+        )
+        errors, _ = self.validate_with_live_pr(
+            run, reused, evidence, published_pr
+        )
+        self.assertIn("blocked-publication-continuation", errors)
+
+        detached_run = copy.deepcopy(run)
+        detached_run["review"]["source_refs"] = [
+            "local:audit-1",
+            "local:audit-2",
+        ]
+        detached_novelty = self.cumulative_material_resolution(
+            detached_run,
+            ["finding-1", "finding-2"],
+            "step-2",
+            fold_id="rf-3",
+            source_batch_id="audit-1",
+        )
+        clean_refresh = self.review_fold(detached_run)
+        clean_refresh["fold_id"] = "rf-4"
+        clean_refresh["source"]["source_batch_id"] = "audit-4"
+        clean_refresh["source"]["source_ref"] = "local:audit-2"
+        detached_novelty["review_folds"].append(clean_refresh)
+        detached_novelty["outcome"]["resolution_digest"] = canonical_digest(
+            resolution_digest_payload(detached_novelty)
+        )
+        errors, _ = self.validate_with_live_pr(
+            detached_run, detached_novelty, evidence, published_pr
+        )
+        self.assertIn("blocked-publication-continuation", errors)
+        self.assertNotIn("blocked-review-fold-source", errors)
+
+        switched_backend = copy.deepcopy(resolution)
+        switched_backend["review_folds"][0]["source"]["backend"] = "other"
+        switched_backend["outcome"]["resolution_digest"] = canonical_digest(
+            resolution_digest_payload(switched_backend)
+        )
+        errors, _ = self.validate_with_live_pr(
+            run, switched_backend, evidence, published_pr
+        )
+        self.assertIn("blocked-publication-continuation", errors)
+
+        alias_run = copy.deepcopy(run)
+        alias_run["review"]["source_refs"] = [
+            "local:audit-1",
+            "local:audit-alias",
+        ]
+        alias_resolution = self.cumulative_material_resolution(
+            alias_run,
+            ["finding-1", "finding-2"],
+            "step-2",
+            fold_id="rf-alias",
+            source_batch_id="audit-1",
+            source_ref="local:audit-alias",
+        )
+        clean_original = self.review_fold(alias_run)
+        clean_original["fold_id"] = "rf-original-clean"
+        clean_original["source"]["source_batch_id"] = "audit-1"
+        alias_resolution["review_folds"].insert(0, clean_original)
+        alias_resolution["outcome"]["resolution_digest"] = canonical_digest(
+            resolution_digest_payload(alias_resolution)
+        )
+        errors, _ = self.validate_with_live_pr(
+            alias_run, alias_resolution, evidence, published_pr
+        )
+        self.assertIn("blocked-publication-continuation", errors)
+
+        dropped_source_run = copy.deepcopy(run)
+        dropped_source_run["review"]["source_refs"] = ["local:audit-2"]
+        dropped_source = self.cumulative_material_resolution(
+            dropped_source_run,
+            ["finding-1", "finding-2"],
+            "step-2",
+            fold_id="rf-3",
+            source_batch_id="audit-3",
+            source_ref="local:audit-2",
+        )
+        errors, _ = self.validate_with_live_pr(
+            dropped_source_run, dropped_source, evidence, published_pr
+        )
+        self.assertIn("blocked-publication-continuation", errors)
+
+        prior_continue = copy.deepcopy(run)
+        prior_continue["execution"]["steps"][0]["verdict"] = "continue"
+        errors, _ = self.validate_with_live_pr(
+            prior_continue, resolution, evidence, published_pr
+        )
+        self.assertIn("blocked-step-continuation", errors)
+
+    def test_same_publication_continuation_binds_evidence_and_live_pr(self) -> None:
+        run, resolution, evidence, published_pr = self.same_publication_candidate()
+
+        forged_root = copy.deepcopy(run)
+        first = forged_root["execution"]["steps"][0]
+        prior_admission = first["review_admission"]
+        prior_admission["publication_continuation"] = {
+            "version": "same-publication-continuation/v1",
+            "publication_epoch": canonical_digest(
+                forged_root["review"]["ship_receipt"]
+            ),
+            "published_artifact": copy.deepcopy(first["state_before"]),
+            "predecessor": {
+                "step_id": "caller-root",
+                "evidence_fold_ref": first["evidence_fold_ref"],
+                "evidence_fold_digest": canonical_digest(
+                    evidence[0]["evidence_fold"]
+                ),
+                "review_admission_digest": prior_admission["admission_digest"],
+            },
+        }
+        first["review_admission"] = self.redigest_admission(prior_admission)
+        first["step_admission"] = expected_step_admission(
+            forged_root, first, 0, first["review_admission"]
+        )
+        errors, _ = self.validate_with_live_pr(
+            forged_root, resolution, evidence, published_pr
+        )
+        self.assertIn("blocked-publication-continuation", errors)
+
+        errors, derived = self.validate_with_live_pr(
+            run, resolution, evidence, published_pr
+        )
+        self.assertEqual(errors, [])
+        step = run["execution"]["steps"][-1]
+        step["review_admission"] = derived["review_admission"]
+        step["step_admission"] = derived["step_admission"]
+
+        changed_evidence = copy.deepcopy(evidence)
+        changed_evidence[0]["evidence_fold"]["evidence"]["observed"] = [
+            "different valid evidence under the same ID"
+        ]
+        errors, _ = self.validate_with_live_pr(
+            run, resolution, changed_evidence, published_pr
+        )
+        self.assertIn("blocked-publication-continuation", errors)
+
+        errors, _ = validate_run(run, self.repo, resolution, evidence)
+        self.assertIn("blocked-ship-live-pr-mismatch", errors)
+
+        for key in ("unpublished_repair_chain", "publication_continuation"):
+            caller_authored = copy.deepcopy(run)
+            caller_authored["review"][key] = {"authority_ref": "caller:allow"}
+            errors, _ = self.validate_with_live_pr(
+                caller_authored, resolution, evidence, published_pr
+            )
+            self.assertIn("blocked-unexpected-input", errors)
+
+    def test_same_publication_continuation_admits_third_edge(self) -> None:
+        run, resolution, evidence, published_pr = self.same_publication_candidate()
+        errors, derived = self.validate_with_live_pr(
+            run, resolution, evidence, published_pr
+        )
+        self.assertEqual(errors, [])
+        second = run["execution"]["steps"][-1]
+        second["review_admission"] = derived["review_admission"]
+        second["step_admission"] = derived["step_admission"]
+        (self.repo / "file.txt").write_text("second repair\n", encoding="utf-8")
+        run = self.finish_step(run, ["file.txt"])
+        evidence = [self.evidence_for_step(run, index) for index in range(2)]
+
+        self.append_review_edit(run, "step-3")
+        third_resolution = self.cumulative_material_resolution(
+            run,
+            ["finding-1", "finding-2", "finding-3"],
+            "step-3",
+            fold_id="rf-3",
+            source_batch_id="audit-3",
+        )
+        errors, derived = self.validate_with_live_pr(
+            run, third_resolution, evidence, published_pr
+        )
+        self.assertEqual(errors, [])
+        third = run["execution"]["steps"][-1]
+        third["review_admission"] = derived["review_admission"]
+        third["step_admission"] = derived["step_admission"]
+        (self.repo / "file.txt").write_text("third repair\n", encoding="utf-8")
+        run = self.finish_step(run, ["file.txt"])
+        terminal = self.cumulative_material_resolution(
+            run,
+            ["finding-1", "finding-2", "finding-3"],
+            "step-3",
+            fold_id="rf-terminal",
+            source_batch_id="audit-terminal",
+            status="resolved",
+        )
+        evidence = [
+            self.evidence_for_step(run, index)
+            for index in range(len(run["execution"]["steps"]))
+        ]
+        self.live_pr_override = published_pr
+        try:
+            handoff, code = decide(
+                run,
+                terminal,
+                evidence,
+                [],
+                None,
+                self.repo,
+            )
+        finally:
+            self.live_pr_override = None
+        self.assertEqual(code, 0, handoff)
+        self.assertEqual(handoff["closure_decision"]["verdict"], "ready-to-ship")
+
+    def test_same_publication_reship_resets_cas_credit(self) -> None:
+        run, resolution, evidence, published_pr = self.same_publication_candidate()
+        old_run = copy.deepcopy(run)
+        old_run["artifact"] = copy.deepcopy(
+            old_run["execution"]["steps"][0]["state_before"]
+        )
+        old_resolution = copy.deepcopy(
+            old_run["execution"]["steps"][0]["review_admission"][
+                "review_resolution"
+            ]
+        )
+        old_record = self.cas_record(old_run, old_resolution, "standard", 0)
+        old_record["tuple"]["targetFingerprint"] = (
+            "target=native;head=published-old;base=accepted"
+        )
+        errors, derived = self.validate_with_live_pr(
+            run, resolution, evidence, published_pr
+        )
+        self.assertEqual(errors, [])
+        step = run["execution"]["steps"][-1]
+        step["review_admission"] = derived["review_admission"]
+        step["step_admission"] = derived["step_admission"]
+        (self.repo / "file.txt").write_text("second repair\n", encoding="utf-8")
+        run = self.finish_step(run, ["file.txt"])
+        terminal = self.cumulative_material_resolution(
+            run,
+            ["finding-1", "finding-2"],
+            "step-2",
+            fold_id="rf-terminal",
+            source_batch_id="audit-terminal",
+            status="resolved",
+        )
+        evidence = [self.evidence_for_step(run, index) for index in range(2)]
+
+        self.live_pr_override = published_pr
+        try:
+            errors, pre_ship = validate_resolution(
+                run, terminal, self.repo, evidence
+            )
+        finally:
+            self.live_pr_override = None
+        self.assertEqual(errors, [])
+        pre_ship_snapshot = self.review_records(run, terminal)[0]
+
+        prior_ship = run["review"]["ship_receipt"]
+        run["review"]["ship_receipt"] = self.updated_ship_record(run, prior_ship)
+        errors, post_ship = validate_resolution(
+            run, terminal, self.repo, evidence
+        )
+        self.assertEqual(errors, [])
+        self.assertNotEqual(
+            pre_ship["resolution_digest"], post_ship["resolution_digest"]
+        )
+        cas_problems, basis = cas_errors(
+            pre_ship_snapshot, run, terminal, post_ship
+        )
+        self.assertIn("blocked-cas-clean-streak", cas_problems)
+        self.assertEqual(basis, [])
+
+        current_records = [
+            self.cas_record(run, terminal, "standard", ordinal)
+            for ordinal in (1, 2, 3)
+        ]
+        mixed_snapshot = self.cas_snapshot([old_record, *current_records])[0]
+        cas_problems, basis = cas_errors(
+            mixed_snapshot, run, terminal, post_ship
+        )
+        self.assertEqual(cas_problems, [])
+        self.assertEqual(
+            set(basis), {record["recordId"] for record in current_records}
+        )
+
+        old_finding = copy.deepcopy(old_record)
+        old_finding["recordId"] = "rer_standard_old_finding"
+        old_finding["attempt"]["attemptId"] = "attempt-standard-old-finding"
+        old_finding["attempt"]["reviewThreadId"] = "thread-standard-old-finding"
+        old_finding["attempt"]["reviewTurnId"] = "turn-standard-old-finding"
+        old_finding["verdict"] = {
+            "tupleVerdictExists": True,
+            "status": "findings",
+            "clean": False,
+            "findingCount": 1,
+            "findings": [{"findingId": "old-finding-1"}],
+        }
+        finding_snapshot = self.cas_snapshot(
+            [old_finding, *current_records]
+        )[0]
+        cas_problems, _ = cas_errors(
+            finding_snapshot, run, terminal, post_ship
+        )
+        self.assertIn("blocked-cas-findings-unresolved", cas_problems)
+        classified_terminal = copy.deepcopy(terminal)
+        classified_terminal["review_folds"].append(
+            self.cas_review_fold(run, old_finding)
+        )
+        cas_problems, basis = cas_errors(
+            finding_snapshot, run, classified_terminal, post_ship
+        )
+        self.assertEqual(cas_problems, [])
+        self.assertEqual(
+            set(basis), {record["recordId"] for record in current_records}
+        )
+
+        two_records = self.cas_snapshot(
+            [
+                self.cas_record(run, terminal, "standard", ordinal)
+                for ordinal in (1, 2)
+            ]
+        )
+        blocked, code = decide(
+            run, terminal, evidence, two_records, None, self.repo
+        )
+        self.assertEqual(code, 2)
+        self.assertIn(
+            "blocked-cas-clean-streak", blocked["closure_decision"]["reasons"]
+        )
+
+        final, code = decide(
+            run,
+            terminal,
+            evidence,
+            self.review_records(run, terminal),
             None,
             self.repo,
         )
         self.assertEqual(code, 0, final)
         self.assertEqual(final["closure_decision"]["verdict"], "complete")
+        self.assertEqual(len(final["closure_decision"]["review_basis"]), 3)
+
+    def test_reship_starts_a_new_same_publication_epoch(self) -> None:
+        run, resolution, evidence, published_pr = self.same_publication_candidate()
+        errors, derived = self.validate_with_live_pr(
+            run, resolution, evidence, published_pr
+        )
+        self.assertEqual(errors, [])
+        second = run["execution"]["steps"][-1]
+        second["review_admission"] = derived["review_admission"]
+        second["step_admission"] = derived["step_admission"]
+        first_epoch = derived["review_admission"]["publication_continuation"][
+            "publication_epoch"
+        ]
+        (self.repo / "file.txt").write_text("second repair\n", encoding="utf-8")
+        run = self.finish_step(run, ["file.txt"])
+        evidence = [self.evidence_for_step(run, index) for index in range(2)]
+
+        prior_ship = run["review"]["ship_receipt"]
+        run["review"]["ship_receipt"] = self.updated_ship_record(run, prior_ship)
+        second_published_pr = self.pr_metadata(
+            self.repo,
+            run["review"]["ship_receipt"]["ship_record"]["action"]["pr_url"],
+        )
+        self.append_review_edit(run, "step-3")
+        third_resolution = self.cumulative_material_resolution(
+            run,
+            ["finding-1", "finding-2", "finding-3"],
+            "step-3",
+            fold_id="rf-epoch-2-1",
+            source_batch_id="audit-epoch-2-1",
+        )
+        errors, derived = validate_run(
+            run, self.repo, third_resolution, evidence
+        )
+        self.assertEqual(errors, [])
+        self.assertNotIn("publication_continuation", derived["review_admission"])
+        third = run["execution"]["steps"][-1]
+        third["review_admission"] = derived["review_admission"]
+        third["step_admission"] = derived["step_admission"]
+        (self.repo / "file.txt").write_text("third repair\n", encoding="utf-8")
+        run = self.finish_step(run, ["file.txt"])
+        evidence = [self.evidence_for_step(run, index) for index in range(3)]
+
+        single_terminal = self.cumulative_material_resolution(
+            run,
+            ["finding-1", "finding-2", "finding-3"],
+            "step-3",
+            fold_id="rf-epoch-2-terminal-1",
+            source_batch_id="audit-epoch-2-terminal-1",
+            status="resolved",
+        )
+        self.live_pr_override = second_published_pr
+        try:
+            handoff, code = decide(
+                run, single_terminal, evidence, [], None, self.repo
+            )
+        finally:
+            self.live_pr_override = None
+        self.assertEqual(code, 0, handoff)
+        self.assertEqual(handoff["closure_decision"]["verdict"], "ready-to-ship")
+
+        self.append_review_edit(run, "step-4")
+        fourth_resolution = self.cumulative_material_resolution(
+            run,
+            ["finding-1", "finding-2", "finding-3", "finding-4"],
+            "step-4",
+            fold_id="rf-epoch-2-2",
+            source_batch_id="audit-epoch-2-2",
+        )
+        errors, derived = self.validate_with_live_pr(
+            run, fourth_resolution, evidence, second_published_pr
+        )
+        self.assertEqual(errors, [])
+        continuation = derived["review_admission"]["publication_continuation"]
+        self.assertNotEqual(continuation["publication_epoch"], first_epoch)
+        self.assertEqual(
+            continuation["publication_epoch"],
+            canonical_digest(run["review"]["ship_receipt"]),
+        )
+        fourth = run["execution"]["steps"][-1]
+        fourth["review_admission"] = derived["review_admission"]
+        fourth["step_admission"] = derived["step_admission"]
+        (self.repo / "file.txt").write_text("fourth repair\n", encoding="utf-8")
+        run = self.finish_step(run, ["file.txt"])
+        terminal = self.cumulative_material_resolution(
+            run,
+            ["finding-1", "finding-2", "finding-3", "finding-4"],
+            "step-4",
+            fold_id="rf-epoch-2-terminal",
+            source_batch_id="audit-epoch-2-terminal",
+            status="resolved",
+        )
+        evidence = [self.evidence_for_step(run, index) for index in range(4)]
+        self.live_pr_override = second_published_pr
+        try:
+            handoff, code = decide(
+                run, terminal, evidence, [], None, self.repo
+            )
+        finally:
+            self.live_pr_override = None
+        self.assertEqual(code, 0, handoff)
+        self.assertEqual(handoff["closure_decision"]["verdict"], "ready-to-ship")
+
+    def test_reship_continuation_rechecks_cumulative_freshness(self) -> None:
+        run, resolution, evidence, published_pr = (
+            self.same_publication_candidate()
+        )
+        errors, derived = self.validate_with_live_pr(
+            run, resolution, evidence, published_pr
+        )
+        self.assertEqual(errors, [])
+        second = run["execution"]["steps"][-1]
+        second["review_admission"] = derived["review_admission"]
+        second["step_admission"] = derived["step_admission"]
+        (self.repo / "file.txt").write_text(
+            "second repair\n", encoding="utf-8"
+        )
+        run = self.finish_step(run, ["file.txt"])
+        evidence = [self.evidence_for_step(run, index) for index in range(2)]
+        prior_ship = run["review"]["ship_receipt"]
+        run["review"]["ship_receipt"] = self.updated_ship_record(
+            run, prior_ship
+        )
+        self.append_review_edit(run, "step-3")
+
+        split = self.cumulative_material_resolution(
+            run,
+            ["finding-1", "finding-2", "finding-3", "finding-4"],
+            "step-3",
+            fold_id="rf-reship-current",
+            source_batch_id="audit-reship-current",
+        )
+        stale_fold = self.review_fold(
+            run, ["finding-1", "finding-2", "finding-4"]
+        )
+        stale_fold["fold_id"] = "rf-reship-carried"
+        stale_fold["source"]["source_batch_id"] = "audit-2"
+        fresh_fold = self.review_fold(run, ["finding-3"])
+        fresh_fold["fold_id"] = "rf-reship-fresh"
+        fresh_fold["source"]["source_batch_id"] = "audit-reship-current"
+        fresh_fold["source"]["source_ref"] = "local:audit-reship-fresh"
+        run["review"]["source_refs"] = [
+            "local:audit-1",
+            "local:audit-reship-fresh",
+        ]
+        split["review_folds"] = [stale_fold, fresh_fold]
+        split["outcome"]["resolution_digest"] = canonical_digest(
+            resolution_digest_payload(split)
+        )
+        errors, derived = validate_run(run, self.repo, split, evidence)
+        self.assertIn("blocked-resolution-history", errors)
+        self.assertNotIn("blocked-review-fold-source", errors)
+        self.assertIsNone(derived["review_admission"])
+
+        relabeled = self.cumulative_material_resolution(
+            run,
+            ["finding-1", "finding-2", "finding-3"],
+            "step-3",
+            fold_id="rf-reship-relabeled",
+            source_batch_id="audit-reship-relabeled",
+        )
+        relabeled_finding = next(
+            value
+            for value in relabeled["review_folds"][0]["findings"]
+            if value["finding_id"] == "finding-1"
+        )
+        relabeled_finding["observed_fact"] = (
+            "a different fact cannot reuse a prior finding id"
+        )
+        relabeled["outcome"]["resolution_digest"] = canonical_digest(
+            resolution_digest_payload(relabeled)
+        )
+        errors, derived = validate_run(run, self.repo, relabeled, evidence)
+        self.assertIn("blocked-resolution-history", errors)
+        self.assertIsNone(derived["review_admission"])
+
+        whitespace = self.cumulative_material_resolution(
+            run,
+            ["finding-1", "finding-2", "finding-3"],
+            "step-3",
+            fold_id="   ",
+            source_batch_id="audit-reship-whitespace",
+        )
+        errors, derived = validate_run(run, self.repo, whitespace, evidence)
+        self.assertIn("blocked-resolution-history", errors)
+        self.assertIsNone(derived["review_admission"])
 
     def test_resolution_rejects_local_growth(self) -> None:
         run = self.complete_step(self.run_value(review=True, selected=True))
@@ -2736,12 +4264,66 @@ class GateTests(unittest.TestCase):
         self.assertEqual(resolution_errors, [])
         current = self.review_records(run, resolution)[0]["records"]
 
+        base_snapshot = self.cas_snapshot(current)[0]
+        cross_epoch_duplicate = copy.deepcopy(current[0])
+        cross_epoch_duplicate["workflowBinding"]["resolutionDigest"] = (
+            "sha256:superseded"
+        )
+        duplicate_snapshot = copy.deepcopy(base_snapshot)
+        duplicate_snapshot["records"] = [cross_epoch_duplicate, *current]
+        errors, basis = cas_errors(
+            duplicate_snapshot, run, resolution, derived
+        )
+        self.assertIn("blocked-cas-unit-duplicate", errors)
+        self.assertEqual(basis, [row["recordId"] for row in current])
+
         old_clean = self.cas_record(run, resolution, "standard", 0)
         old_clean["workflowBinding"]["resolutionDigest"] = "sha256:superseded"
         snapshot = self.cas_snapshot([old_clean, *current])[0]
         errors, basis = cas_errors(snapshot, run, resolution, derived)
         self.assertEqual(errors, [])
         self.assertNotIn(old_clean["recordId"], basis)
+
+        replayed_attempt = copy.deepcopy(old_clean)
+        replayed_attempt["recordId"] = "rer_superseded_replayed_attempt"
+        replayed_attempt["attempt"]["attemptId"] = current[1]["attempt"][
+            "attemptId"
+        ]
+        snapshot = self.cas_snapshot([replayed_attempt, *current])[0]
+        errors, _ = cas_errors(snapshot, run, resolution, derived)
+        self.assertIn("blocked-cas-unit-duplicate", errors)
+
+        malformed_cases = [
+            {
+                "status": "clean",
+                "clean": True,
+                "findingCount": 0,
+                "findings": ["hidden-nonobject"],
+            },
+            {
+                "status": "findings",
+                "clean": False,
+                "findingCount": 1,
+                "findings": [
+                    {"title": "visible object"},
+                    "hidden-nonobject",
+                ],
+            },
+        ]
+        for index, malformed_verdict in enumerate(malformed_cases, start=1):
+            with self.subTest(malformed_superseded=index):
+                malformed = copy.deepcopy(old_clean)
+                malformed["recordId"] = f"rer_superseded_malformed_{index}"
+                malformed["attempt"]["attemptId"] = (
+                    f"attempt-superseded-malformed-{index}"
+                )
+                malformed["verdict"] = {
+                    "tupleVerdictExists": True,
+                    **malformed_verdict,
+                }
+                snapshot = self.cas_snapshot([malformed, *current])[0]
+                errors, _ = cas_errors(snapshot, run, resolution, derived)
+                self.assertIn("blocked-cas-unit-unnormalized", errors)
 
         old_finding = copy.deepcopy(old_clean)
         old_finding["recordId"] = "rer_superseded_finding"

--- a/codex/skills/actuating/tests/test_live_semantics.py
+++ b/codex/skills/actuating/tests/test_live_semantics.py
@@ -105,11 +105,27 @@ class LiveSemanticsTests(unittest.TestCase):
             {
                 "requires_when": "publication-requested",
                 "receipt": "pre-review-SHIP-v1",
-                "after_edit": [
-                    "current-resolved-refold",
-                    "ship",
-                    "review-closeout",
+                "before_repair_admission": [
+                    "refresh-live-review-sources",
+                    "review-fold",
+                    "review-resolution",
                 ],
+                "after_edit": {
+                    "unresolved": [
+                        "evidence-fold",
+                        "refresh-live-review-sources",
+                        "review-fold",
+                        "review-resolution",
+                        "gate-derived-continuation",
+                    ],
+                    "resolved": [
+                        "evidence-fold",
+                        "current-resolved-refold",
+                        "ship",
+                        "reset-cas-credit",
+                        "review-closeout",
+                    ],
+                },
                 "then": "final-closure",
             },
         )
@@ -164,11 +180,46 @@ class LiveSemanticsTests(unittest.TestCase):
         self.assertIn("review_admission", closure)
         self.assertIn("review-admission:<admission_digest>", closure)
         self.assertIn("review.ship_receipt", closure)
+        self.assertIn("same-publication-continuation/v1", closure)
+        self.assertIn("evidence_fold_digest", closure)
+        self.assertIn("resets CAS credit to zero", closure)
+        self.assertNotIn("unpublished_repair_chain", closure)
         self.assertIn("blocked-index-observer-flags", closure)
         self.assertIn("actuation_binding:", ship)
         self.assertNotIn("review_contract_fingerprint", ship)
         self.assertIn("Never add or relabel", ship)
         self.assertIn("review.ship_receipt", ship)
+
+    def test_review_repair_continuation_is_derived_and_refresh_bound(self) -> None:
+        invariants = {
+            row["id"]: row["statement"] for row in SEMANTICS["invariants"]
+        }
+        self.assertIn("live-review-source-before-admission", invariants)
+        self.assertIn("same-publication-continuation-derived", invariants)
+        self.assertIn("review-history-survives-reship", invariants)
+        self.assertIn("terminal-resolution-exact", invariants)
+        self.assertIn("repair-reship-resets-cas", invariants)
+        self.assertIn("pr-publication-watermark-before-cas", invariants)
+        self.assertIn(
+            "gate-derived continuation receipt",
+            invariants["same-publication-continuation-derived"],
+        )
+        self.assertIn(
+            "three fresh ordered standard attempts",
+            invariants["repair-reship-resets-cas"],
+        )
+        self.assertIn(
+            "records at or before the greatest observation are superseded",
+            invariants["pr-publication-watermark-before-cas"],
+        )
+        self.assertIn(
+            "a regressing observation blocks closure",
+            invariants["pr-publication-watermark-before-cas"],
+        )
+        self.assertIn(
+            "strictly extending the finding set",
+            invariants["review-history-survives-reship"],
+        )
 
     def test_retired_protocol_is_absent_from_live_surfaces(self) -> None:
         paths = [

--- a/codex/skills/actuating/tools/actuating_gate.py
+++ b/codex/skills/actuating/tools/actuating_gate.py
@@ -13,6 +13,7 @@ from pathlib import Path
 import subprocess
 import sys
 from typing import Any
+import unicodedata
 
 import yaml
 
@@ -200,7 +201,7 @@ def live_pr_metadata(repo: Path, pr_url: str) -> dict[str, Any]:
         "view",
         pr_url,
         "--json",
-        "url,baseRefName,baseRefOid,headRefName,headRefOid,headRepository,isDraft,state",
+        "url,baseRefName,baseRefOid,headRefName,headRefOid,headRepository,isDraft,state,updatedAt",
     )
     return {"repository": repository, "pull_request": pull_request}
 
@@ -733,6 +734,7 @@ def expected_review_admission(
     changed_paths: list[str],
     hunk_ids: list[str],
     ship_receipt: dict[str, Any] | None = None,
+    publication_continuation: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     payload = {
         "version": "review-admission/v1",
@@ -744,7 +746,372 @@ def expected_review_admission(
         },
         "ship_receipt": copy.deepcopy(ship_receipt),
     }
+    if publication_continuation is not None:
+        payload["publication_continuation"] = copy.deepcopy(
+            publication_continuation
+        )
     return {**payload, "admission_digest": canonical_digest(payload)}
+
+
+def resolution_fold_ids(resolution: dict[str, Any]) -> list[str]:
+    identities: list[str] = []
+    for value in object_list(resolution.get("review_folds")):
+        try:
+            fold = unwrap(value, "review_fold")
+        except ValueError:
+            identities.append("")
+            continue
+        identities.append(text(fold.get("fold_id")))
+    return identities
+
+
+def canonical_review_identity(value: Any) -> bool:
+    return (
+        isinstance(value, str)
+        and bool(value)
+        and value == value.strip()
+    )
+
+
+def canonical_semantic_text(value: str) -> str:
+    return " ".join(unicodedata.normalize("NFC", value).split())
+
+
+def resolution_finding_identities(
+    resolution: dict[str, Any],
+) -> dict[str, str] | None:
+    identity_fields = (
+        "claim",
+        "observed_fact",
+        "validity",
+        "liability",
+        "intent_relation",
+        "quotient_key",
+        "owner_boundary",
+        "law_family",
+        "falsifier",
+    )
+    identities: dict[str, str] = {}
+    for value in object_list(resolution.get("review_folds")):
+        try:
+            fold = unwrap(value, "review_fold")
+        except ValueError:
+            return None
+        for finding in object_list(fold.get("findings")):
+            if finding.get("disposition") != "resolution-input":
+                continue
+            finding_id = finding.get("finding_id")
+            if not canonical_review_identity(finding_id):
+                return None
+            if any(
+                not isinstance(finding.get(key), str)
+                for key in identity_fields
+            ):
+                return None
+            if finding_id in identities:
+                return None
+            projection = {
+                key: canonical_semantic_text(finding[key])
+                for key in identity_fields
+            }
+            digest = canonical_digest(projection)
+            identities[finding_id] = digest
+    finding_ids = resolution.get("finding_ids")
+    if (
+        not has_exact_string_list(finding_ids)
+        or any(not canonical_review_identity(value) for value in finding_ids)
+        or set(finding_ids) != set(identities)
+        or len(identities) != len(set(identities.values()))
+    ):
+        return None
+    return identities
+
+
+def resolution_source_batches(
+    resolution: dict[str, Any],
+) -> list[tuple[str, str]]:
+    identities: list[tuple[str, str]] = []
+    for value in object_list(resolution.get("review_folds")):
+        try:
+            fold = unwrap(value, "review_fold")
+        except ValueError:
+            identities.append(("", ""))
+            continue
+        source = fold.get("source") if isinstance(fold.get("source"), dict) else {}
+        identities.append(
+            (text(source.get("backend")), text(source.get("source_batch_id")))
+        )
+    return identities
+
+
+def resolution_source_backends(
+    resolution: dict[str, Any],
+) -> dict[str, str] | None:
+    backends: dict[str, str] = {}
+    for value in object_list(resolution.get("review_folds")):
+        try:
+            fold = unwrap(value, "review_fold")
+        except ValueError:
+            return None
+        source = fold.get("source") if isinstance(fold.get("source"), dict) else {}
+        source_ref = text(source.get("source_ref"))
+        backend = text(source.get("backend"))
+        if (
+            not canonical_review_identity(source_ref)
+            or not canonical_review_identity(backend)
+            or source_ref in backends
+        ):
+            return None
+        backends[source_ref] = backend
+    return backends
+
+
+def resolution_findings_from_new_batches(
+    resolution: dict[str, Any],
+    prior_batches: set[tuple[str, str]],
+) -> set[str]:
+    findings: set[str] = set()
+    for value in object_list(resolution.get("review_folds")):
+        try:
+            fold = unwrap(value, "review_fold")
+        except ValueError:
+            continue
+        source = fold.get("source") if isinstance(fold.get("source"), dict) else {}
+        batch = (text(source.get("backend")), text(source.get("source_batch_id")))
+        if batch not in prior_batches:
+            findings.update(
+                text(finding.get("finding_id"))
+                for finding in object_list(fold.get("findings"))
+                if text(finding.get("finding_id"))
+            )
+    return findings
+
+
+def evidence_fold_digest(
+    evidence_values: list[dict[str, Any]], evidence_ref: str
+) -> str | None:
+    matches: list[dict[str, Any]] = []
+    for value in evidence_values:
+        try:
+            evidence = normalize_evidence(value)
+        except ValueError:
+            continue
+        if text(evidence.get("evidence_id")) == evidence_ref:
+            matches.append(evidence)
+    return canonical_digest(matches[0]) if len(matches) == 1 else None
+
+
+def publication_continuation_shape_errors(value: Any) -> list[str]:
+    if not isinstance(value, dict) or set(value) != {
+        "version",
+        "publication_epoch",
+        "published_artifact",
+        "predecessor",
+    }:
+        return ["blocked-publication-continuation"]
+    published = value.get("published_artifact")
+    predecessor = value.get("predecessor")
+    digests = [value.get("publication_epoch")]
+    if isinstance(predecessor, dict):
+        digests.extend(
+            [
+                predecessor.get("evidence_fold_digest"),
+                predecessor.get("review_admission_digest"),
+            ]
+        )
+    if (
+        value.get("version") != "same-publication-continuation/v1"
+        or not isinstance(published, dict)
+        or set(published)
+        != {"repo", "base_sha", "branch", "head_sha", "state_fingerprint"}
+        or any(not text(published.get(key)) for key in published)
+        or not isinstance(predecessor, dict)
+        or set(predecessor)
+        != {
+            "step_id",
+            "evidence_fold_ref",
+            "evidence_fold_digest",
+            "review_admission_digest",
+        }
+        or not text(predecessor.get("step_id"))
+        or not text(predecessor.get("evidence_fold_ref"))
+        or any(
+            not isinstance(digest, str)
+            or len(digest) != 71
+            or not digest.startswith("sha256:")
+            for digest in digests
+        )
+    ):
+        return ["blocked-publication-continuation"]
+    return []
+
+
+def expected_publication_continuation(
+    prior_steps: list[dict[str, Any]],
+    next_step: dict[str, Any],
+    resolution: dict[str, Any],
+    review_source_refs: list[str],
+    ship_receipt: dict[str, Any] | None,
+    evidence_values: list[dict[str, Any]],
+) -> tuple[list[str], dict[str, Any] | None]:
+    if not prior_steps:
+        return [], None
+    prior = prior_steps[-1]
+    prior_admission = prior.get("review_admission")
+    prior_ship = (
+        prior_admission.get("ship_receipt")
+        if isinstance(prior_admission, dict)
+        else None
+    )
+    eligible_edge = bool(
+        prior.get("status") == "completed"
+        and prior.get("verdict") == "ready-for-closure"
+        and prior.get("phase") == "review-closeout"
+        and prior.get("effect") == "edit"
+        and next_step.get("phase") == "review-closeout"
+        and next_step.get("effect") == "edit"
+        and isinstance(prior_admission, dict)
+        and isinstance(prior_ship, dict)
+        and isinstance(ship_receipt, dict)
+        and canonical_digest(prior_ship) == canonical_digest(ship_receipt)
+    )
+    if not eligible_edge:
+        return [], None
+
+    errors: list[str] = []
+    if review_admission_errors(prior_admission, prior):
+        errors.append("blocked-publication-continuation")
+    prior_resolution = prior_admission.get("review_resolution")
+    prior_observations = prior_admission.get("observations")
+    if not isinstance(prior_resolution, dict) or not isinstance(
+        prior_observations, dict
+    ):
+        return ["blocked-publication-continuation"], None
+    outcome = resolution.get("outcome")
+    if not isinstance(outcome, dict) or outcome.get("status") != "pending":
+        errors.append("blocked-publication-continuation")
+
+    prior_findings = string_list(prior_resolution.get("finding_ids"))
+    current_findings = string_list(resolution.get("finding_ids"))
+    prior_finding_identities = resolution_finding_identities(prior_resolution)
+    current_finding_identities = resolution_finding_identities(resolution)
+    if (
+        not has_exact_string_list(prior_resolution.get("finding_ids"))
+        or not has_exact_string_list(resolution.get("finding_ids"))
+        or not set(prior_findings) < set(current_findings)
+        or prior_finding_identities is None
+        or current_finding_identities is None
+        or any(
+            current_finding_identities.get(finding_id) != digest
+            for finding_id, digest in prior_finding_identities.items()
+        )
+    ):
+        errors.append("blocked-publication-continuation")
+
+    prior_sources = string_list(prior_observations.get("review_source_refs"))
+    prior_source_backends = resolution_source_backends(prior_resolution)
+    current_source_backends = resolution_source_backends(resolution)
+    if (
+        not has_exact_string_list(prior_observations.get("review_source_refs"))
+        or not has_exact_string_list(review_source_refs)
+        or not set(prior_sources).issubset(review_source_refs)
+        or prior_source_backends is None
+        or current_source_backends is None
+        or any(
+            current_source_backends.get(source_ref) != backend
+            for source_ref, backend in (prior_source_backends or {}).items()
+        )
+    ):
+        errors.append("blocked-publication-continuation")
+
+    publication_epoch = canonical_digest(ship_receipt)
+    epoch_fold_ids: set[str] = set()
+    epoch_batches: set[tuple[str, str]] = set()
+    for candidate in prior_steps:
+        admission = candidate.get("review_admission")
+        candidate_ship = (
+            admission.get("ship_receipt") if isinstance(admission, dict) else None
+        )
+        candidate_resolution = (
+            admission.get("review_resolution")
+            if isinstance(admission, dict)
+            else None
+        )
+        if (
+            not isinstance(candidate_ship, dict)
+            or canonical_digest(candidate_ship) != publication_epoch
+            or not isinstance(candidate_resolution, dict)
+        ):
+            continue
+        epoch_fold_ids.update(resolution_fold_ids(candidate_resolution))
+        epoch_batches.update(resolution_source_batches(candidate_resolution))
+
+    current_fold_ids = resolution_fold_ids(resolution)
+    current_batches = resolution_source_batches(resolution)
+    introduced_findings = set(current_findings) - set(prior_findings)
+    findings_from_fresh_batches = resolution_findings_from_new_batches(
+        resolution, epoch_batches
+    )
+    if (
+        not current_fold_ids
+        or any(
+            not canonical_review_identity(fold_id)
+            for fold_id in current_fold_ids
+        )
+        or any(
+            not canonical_review_identity(fold_id)
+            for fold_id in epoch_fold_ids
+        )
+        or not set(current_fold_ids).isdisjoint(epoch_fold_ids)
+        or not current_batches
+        or any(
+            not canonical_review_identity(backend)
+            or not canonical_review_identity(batch)
+            for backend, batch in current_batches
+        )
+        or any(
+            not canonical_review_identity(backend)
+            or not canonical_review_identity(batch)
+            for backend, batch in epoch_batches
+        )
+        or not (set(current_batches) - epoch_batches)
+        or not introduced_findings
+        or not introduced_findings.issubset(findings_from_fresh_batches)
+    ):
+        errors.append("blocked-publication-continuation")
+
+    evidence_ref = text(prior.get("evidence_fold_ref"))
+    evidence_digest = evidence_fold_digest(evidence_values, evidence_ref)
+    if not evidence_ref or evidence_digest is None:
+        errors.append("blocked-publication-continuation")
+
+    prior_continuation = prior_admission.get("publication_continuation")
+    if prior_continuation is not None:
+        if publication_continuation_shape_errors(prior_continuation):
+            errors.append("blocked-publication-continuation")
+            published_artifact = None
+        else:
+            published_artifact = prior_continuation.get("published_artifact")
+    else:
+        published_artifact = prior.get("state_before")
+    if not isinstance(published_artifact, dict):
+        errors.append("blocked-publication-continuation")
+        return sorted(set(errors)), None
+
+    continuation = {
+        "version": "same-publication-continuation/v1",
+        "publication_epoch": publication_epoch,
+        "published_artifact": copy.deepcopy(published_artifact),
+        "predecessor": {
+            "step_id": prior.get("step_id"),
+            "evidence_fold_ref": evidence_ref,
+            "evidence_fold_digest": evidence_digest,
+            "review_admission_digest": prior_admission.get("admission_digest"),
+        },
+    }
+    if publication_continuation_shape_errors(continuation):
+        errors.append("blocked-publication-continuation")
+    return sorted(set(errors)), continuation
 
 
 def review_admission_errors(value: Any, step: dict[str, Any]) -> list[str]:
@@ -762,6 +1129,7 @@ def review_admission_errors(value: Any, step: dict[str, Any]) -> list[str]:
     )
     hunk_ids = observations.get("hunk_ids") if isinstance(observations, dict) else None
     ship_receipt = value.get("ship_receipt")
+    publication_continuation = value.get("publication_continuation")
     if (
         not isinstance(review_resolution, dict)
         or not isinstance(observations, dict)
@@ -774,16 +1142,31 @@ def review_admission_errors(value: Any, step: dict[str, Any]) -> list[str]:
         or (ship_receipt is not None and not isinstance(ship_receipt, dict))
     ):
         return ["blocked-resolution-binding"]
+    if publication_continuation is not None:
+        if publication_continuation_shape_errors(publication_continuation):
+            return ["blocked-resolution-binding"]
+        if (
+            not isinstance(ship_receipt, dict)
+            or publication_continuation.get("publication_epoch")
+            != canonical_digest(ship_receipt)
+        ):
+            return ["blocked-resolution-binding"]
     expected = expected_review_admission(
         review_resolution,
         review_source_refs,
         changed_paths,
         hunk_ids,
         ship_receipt,
+        publication_continuation,
+    )
+    historical_artifact = (
+        publication_continuation.get("published_artifact")
+        if isinstance(publication_continuation, dict)
+        else step.get("state_before")
     )
     historical_run = {
         "run_id": step.get("run_id"),
-        "artifact": step.get("state_before"),
+        "artifact": historical_artifact,
     }
     try:
         resolution_problems, _ = _resolution_contract_errors(
@@ -979,6 +1362,55 @@ def path_allowed_root(path: str, repo: Path | None = None) -> bool:
     return True
 
 
+def has_misplaced_derived_control(
+    value: Any,
+    path: tuple[str | int, ...] = (),
+    *,
+    allow_step_receipts: bool = True,
+) -> bool:
+    if isinstance(value, list):
+        return any(
+            has_misplaced_derived_control(
+                item,
+                (*path, index),
+                allow_step_receipts=allow_step_receipts,
+            )
+            for index, item in enumerate(value)
+        )
+    if not isinstance(value, dict):
+        return False
+    for key, child in value.items():
+        child_path = (*path, key)
+        step_receipt = bool(
+            allow_step_receipts
+            and key == "review_admission"
+            and len(path) == 3
+            and path[:2] == ("execution", "steps")
+            and isinstance(path[2], int)
+        )
+        nested_continuation = bool(
+            allow_step_receipts
+            and key == "publication_continuation"
+            and len(path) == 4
+            and path[:2] == ("execution", "steps")
+            and isinstance(path[2], int)
+            and path[3] == "review_admission"
+        )
+        if key == "unpublished_repair_chain" or (
+            key == "review_admission" and not step_receipt
+        ) or (
+            key == "publication_continuation" and not nested_continuation
+        ):
+            return True
+        if has_misplaced_derived_control(
+            child,
+            child_path,
+            allow_step_receipts=allow_step_receipts,
+        ):
+            return True
+    return False
+
+
 def validate_run(
     run: dict[str, Any],
     repo: Path,
@@ -989,6 +1421,8 @@ def validate_run(
 ) -> tuple[list[str], dict[str, Any]]:
     repo = git_root(repo)
     errors: list[str] = []
+    publication_watermark: int | None = None
+    evidence_values = evidence_values or []
     semantics = load_semantics()
     modes = set((semantics.get("modes") or {}).keys())
     execution_kinds = set(semantics.get("execution_kinds") or [])
@@ -996,6 +1430,13 @@ def validate_run(
 
     if run.get("version") != "actuation-run/v1":
         errors.append("blocked-run-version")
+    if has_misplaced_derived_control(run):
+        errors.append("blocked-unexpected-input")
+    if resolution is not None and has_misplaced_derived_control(
+        resolution,
+        allow_step_receipts=False,
+    ):
+        errors.append("blocked-unexpected-input")
     run_id = text(run.get("run_id"))
     if not run_id:
         errors.append("blocked-run-id-missing")
@@ -1155,15 +1596,23 @@ def validate_run(
     completed_steps: list[dict[str, Any]] = []
     review_admission_candidate: dict[str, Any] | None = None
     step_admission_candidate: dict[str, Any] | None = None
+    selected_publication_continuation: dict[str, Any] | None = None
+    active_publication_artifact: dict[str, Any] | None = None
     seen_review_phase = False
     for index, step in enumerate(steps):
         if index > 0:
             prior = steps[index - 1]
             prior_admission = prior.get("review_admission")
-            current_ship = (
-                review_value.get("ship_receipt")
-                if isinstance(review_value, dict)
-                else None
+            step_admission_value = step.get("review_admission")
+            step_ship = (
+                step_admission_value.get("ship_receipt")
+                if step.get("status") == "completed"
+                and isinstance(step_admission_value, dict)
+                else (
+                    review_value.get("ship_receipt")
+                    if isinstance(review_value, dict)
+                    else None
+                )
             )
             fresh_ship_continuation = bool(
                 prior.get("verdict") == "ready-for-closure"
@@ -1171,13 +1620,160 @@ def validate_run(
                 and review_value.get("publication_requested") is True
                 and isinstance(prior_admission, dict)
                 and isinstance(prior_admission.get("ship_receipt"), dict)
-                and isinstance(current_ship, dict)
-                and canonical_digest(current_ship)
+                and isinstance(step_ship, dict)
+                and canonical_digest(step_ship)
                 != canonical_digest(prior_admission["ship_receipt"])
                 and not ship_epoch_continuity_errors(
-                    prior_admission["ship_receipt"], current_ship
+                    prior_admission["ship_receipt"], step_ship
                 )
             )
+            edge_resolution = (
+                resolution
+                if step.get("status") == "selected"
+                else (
+                    step_admission_value.get("review_resolution")
+                    if isinstance(step_admission_value, dict)
+                    else None
+                )
+            )
+            step_observations = (
+                step_admission_value.get("observations")
+                if isinstance(step_admission_value, dict)
+                and isinstance(step_admission_value.get("observations"), dict)
+                else {}
+            )
+            edge_source_refs = (
+                string_list(review_value.get("source_refs"))
+                if step.get("status") == "selected"
+                and isinstance(review_value, dict)
+                else string_list(step_observations.get("review_source_refs"))
+            )
+            if fresh_ship_continuation and isinstance(edge_resolution, dict):
+                prior_resolution = prior_admission.get("review_resolution")
+                prior_observations = prior_admission.get("observations")
+                prior_findings = (
+                    string_list(prior_resolution.get("finding_ids"))
+                    if isinstance(prior_resolution, dict)
+                    else []
+                )
+                current_findings = string_list(edge_resolution.get("finding_ids"))
+                prior_finding_identities = (
+                    resolution_finding_identities(prior_resolution)
+                    if isinstance(prior_resolution, dict)
+                    else None
+                )
+                current_finding_identities = resolution_finding_identities(
+                    edge_resolution
+                )
+                prior_sources = (
+                    string_list(prior_observations.get("review_source_refs"))
+                    if isinstance(prior_observations, dict)
+                    else []
+                )
+                prior_source_backends = (
+                    resolution_source_backends(prior_resolution)
+                    if isinstance(prior_resolution, dict)
+                    else None
+                )
+                current_source_backends = resolution_source_backends(
+                    edge_resolution
+                )
+                prior_fold_ids = (
+                    set(resolution_fold_ids(prior_resolution))
+                    if isinstance(prior_resolution, dict)
+                    else set()
+                )
+                prior_batches = (
+                    set(resolution_source_batches(prior_resolution))
+                    if isinstance(prior_resolution, dict)
+                    else set()
+                )
+                current_fold_ids = set(resolution_fold_ids(edge_resolution))
+                current_batches = set(resolution_source_batches(edge_resolution))
+                introduced_findings = set(current_findings) - set(prior_findings)
+                fresh_batch_findings = resolution_findings_from_new_batches(
+                    edge_resolution, prior_batches
+                )
+                if (
+                    not isinstance(prior_resolution, dict)
+                    or not isinstance(prior_observations, dict)
+                    or not set(prior_findings) < set(current_findings)
+                    or prior_finding_identities is None
+                    or current_finding_identities is None
+                    or any(
+                        current_finding_identities.get(finding_id) != digest
+                        for finding_id, digest in prior_finding_identities.items()
+                    )
+                    or not set(prior_sources).issubset(edge_source_refs)
+                    or prior_source_backends is None
+                    or current_source_backends is None
+                    or any(
+                        current_source_backends.get(source_ref) != backend
+                        for source_ref, backend in (
+                            prior_source_backends or {}
+                        ).items()
+                    )
+                    or not current_fold_ids
+                    or any(
+                        not canonical_review_identity(fold_id)
+                        for fold_id in current_fold_ids
+                    )
+                    or any(
+                        not canonical_review_identity(fold_id)
+                        for fold_id in prior_fold_ids
+                    )
+                    or not current_fold_ids.isdisjoint(prior_fold_ids)
+                    or any(
+                        not canonical_review_identity(backend)
+                        or not canonical_review_identity(batch)
+                        for backend, batch in current_batches
+                    )
+                    or any(
+                        not canonical_review_identity(backend)
+                        or not canonical_review_identity(batch)
+                        for backend, batch in prior_batches
+                    )
+                    or not (current_batches - prior_batches)
+                    or not introduced_findings
+                    or not introduced_findings.issubset(fresh_batch_findings)
+                ):
+                    errors.append("blocked-resolution-history")
+                    fresh_ship_continuation = False
+            continuation_errors: list[str] = []
+            expected_continuation: dict[str, Any] | None = None
+            if isinstance(edge_resolution, dict):
+                continuation_errors, expected_continuation = (
+                    expected_publication_continuation(
+                        steps[:index],
+                        step,
+                        edge_resolution,
+                        edge_source_refs,
+                        step_ship if isinstance(step_ship, dict) else None,
+                        evidence_values,
+                    )
+                )
+                errors.extend(continuation_errors)
+            stored_continuation = (
+                step_admission_value.get("publication_continuation")
+                if isinstance(step_admission_value, dict)
+                else None
+            )
+            same_publication_continuation = bool(
+                expected_continuation is not None
+                and not continuation_errors
+                and (
+                    step.get("status") == "selected"
+                    or stored_continuation == expected_continuation
+                )
+            )
+            if stored_continuation is not None and (
+                expected_continuation is None
+                or stored_continuation != expected_continuation
+            ):
+                errors.append("blocked-publication-continuation")
+            if same_publication_continuation:
+                if step.get("status") == "selected":
+                    selected_publication_continuation = expected_continuation
             phase_transition = bool(
                 prior.get("status") == "completed"
                 and prior.get("verdict") == "ready-for-closure"
@@ -1187,9 +1783,19 @@ def validate_run(
                 and lifecycle_phase == "review-closeout"
                 and not implementation_checkpoint_errors(run)
             )
-            if prior.get("status") != "completed" or not (
+            generic_continuation = bool(
                 prior.get("verdict") == "continue"
+                and not (
+                    prior.get("phase") == "review-closeout"
+                    and prior.get("effect") == "edit"
+                    and isinstance(prior_admission, dict)
+                    and isinstance(prior_admission.get("ship_receipt"), dict)
+                )
+            )
+            if prior.get("status") != "completed" or not (
+                generic_continuation
                 or fresh_ship_continuation
+                or same_publication_continuation
                 or phase_transition
             ):
                 errors.append("blocked-step-continuation")
@@ -1224,6 +1830,16 @@ def validate_run(
             errors.append("blocked-step-effect")
         review_admission = step.get("review_admission")
         step_admission = step.get("step_admission")
+        if review_admission is not None and not (
+            step_phase == "review-closeout" and effect == "edit"
+        ):
+            errors.append("blocked-unexpected-input")
+        if (
+            index == 0
+            and isinstance(review_admission, dict)
+            and review_admission.get("publication_continuation") is not None
+        ):
+            errors.append("blocked-publication-continuation")
         step_paths_raw = step.get("paths")
         changed_paths_raw = step.get("changed_paths")
         step_paths = string_list(step_paths_raw)
@@ -1384,7 +2000,40 @@ def validate_run(
                 "invalid-proof",
             }:
                 errors.append("blocked-step-verdict")
+            if (
+                step_phase == "review-closeout"
+                and effect == "edit"
+                and isinstance(review_admission, dict)
+                and isinstance(review_admission.get("ship_receipt"), dict)
+                and text(step.get("verdict")) != "ready-for-closure"
+            ):
+                errors.append("blocked-step-verdict")
         elif status == "blocked":
+            if (
+                step_phase == "review-closeout"
+                and effect == "edit"
+                and (review_admission is None) is not (step_admission is None)
+            ):
+                errors.append("blocked-step-admission")
+            if review_admission is not None:
+                if step_phase == "review-closeout" and effect == "edit":
+                    errors.extend(
+                        review_admission_errors(review_admission, step)
+                    )
+            if step_admission is not None:
+                errors.extend(
+                    step_admission_errors(
+                        step_admission,
+                        run,
+                        step,
+                        index,
+                        (
+                            review_admission
+                            if isinstance(review_admission, dict)
+                            else None
+                        ),
+                    )
+                )
             previous_after = before
         else:
             errors.append("blocked-step-status")
@@ -1406,6 +2055,37 @@ def validate_run(
             errors.append("blocked-step-change-mismatch")
     if not steps and current and initial != current:
         errors.append("blocked-run-initial-artifact")
+
+    run_ship = (
+        review_value.get("ship_receipt")
+        if isinstance(review_value, dict)
+        else None
+    )
+    latest_published_edit = next(
+        (
+            completed
+            for completed in reversed(completed_steps)
+            if completed.get("phase") == "review-closeout"
+            and completed.get("effect") == "edit"
+            and isinstance(completed.get("review_admission"), dict)
+            and isinstance(
+                completed["review_admission"].get("ship_receipt"), dict
+            )
+        ),
+        None,
+    )
+    if isinstance(latest_published_edit, dict) and isinstance(run_ship, dict):
+        latest_admission = latest_published_edit["review_admission"]
+        if canonical_digest(latest_admission["ship_receipt"]) == canonical_digest(
+            run_ship
+        ):
+            continuation = latest_admission.get("publication_continuation")
+            active_publication_artifact = (
+                continuation.get("published_artifact")
+                if isinstance(continuation, dict)
+                and not publication_continuation_shape_errors(continuation)
+                else latest_published_edit.get("state_before")
+            )
 
     review = review_value
     if not isinstance(review, dict):
@@ -1443,9 +2123,19 @@ def validate_run(
     ):
         if not isinstance(ship_receipt, dict):
             errors.append("blocked-ship-missing")
-        elif selected:
+        else:
+            ship_run = (
+                {
+                    "run_id": run_id,
+                    "artifact": copy.deepcopy(active_publication_artifact),
+                }
+                if isinstance(active_publication_artifact, dict)
+                else run
+            )
             try:
-                ship_problems, _ = ship_errors(ship_receipt, run)
+                ship_problems, _, publication_watermark = (
+                    ship_observation_errors(ship_receipt, ship_run)
+                )
             except ValueError:
                 ship_problems = ["blocked-ship-binding"]
             errors.extend(ship_problems)
@@ -1486,7 +2176,7 @@ def validate_run(
             errors.append("blocked-review-resolution-missing")
         else:
             resolution_errors, resolution_derived = validate_resolution(
-                run, resolution, repo
+                run, resolution, repo, evidence_values
             )
             errors.extend(resolution_errors)
             selected_step = selected[0]
@@ -1498,6 +2188,7 @@ def validate_run(
                     string_list(resolution_derived.get("live_changed_paths")),
                     string_list(resolution_derived.get("live_hunk_ids")),
                     ship_receipt if isinstance(ship_receipt, dict) else None,
+                    selected_publication_continuation,
                 )
                 review_admission_candidate = expected_admission
                 if admission is not None and admission != expected_admission:
@@ -1553,6 +2244,7 @@ def validate_run(
         "step_admission": step_admission_candidate if not errors else None,
         "has_blocked_step": any(step.get("status") == "blocked" for step in steps),
         "live_changed_paths": sorted(live_paths),
+        "publication_watermark": publication_watermark,
     }
     return sorted(set(errors)), derived
 
@@ -1600,10 +2292,20 @@ def validate_review_folds(
             errors.append("blocked-review-fold-version")
         fold_id = text(fold.get("fold_id"))
         fold_ids.append(fold_id)
-        if not fold_id or text(fold.get("goal_id")) != text(run.get("run_id")):
+        if not canonical_review_identity(fold_id) or text(
+            fold.get("goal_id")
+        ) != text(run.get("run_id")):
             errors.append("blocked-review-fold-binding")
         source = fold.get("source") if isinstance(fold.get("source"), dict) else {}
-        fold_source_refs.append(text(source.get("source_ref")))
+        source_ref = text(source.get("source_ref"))
+        backend = text(source.get("backend"))
+        source_batch_id = text(source.get("source_batch_id"))
+        fold_source_refs.append(source_ref)
+        if any(
+            not canonical_review_identity(value)
+            for value in (source_ref, backend, source_batch_id)
+        ):
+            errors.append("blocked-review-fold-binding")
         source_artifact = (
             source.get("artifact") if isinstance(source.get("artifact"), dict) else {}
         )
@@ -1626,7 +2328,7 @@ def validate_review_folds(
         for finding in findings:
             finding_id = text(finding.get("finding_id"))
             finding_ids.append(finding_id)
-            if not finding_id:
+            if not canonical_review_identity(finding_id):
                 errors.append("blocked-review-fold-finding")
             authority = finding.get("mutation_authority")
             if not isinstance(authority, dict) or authority.get("allowed") is not False:
@@ -2083,12 +2785,14 @@ def validate_resolution(
     run: dict[str, Any],
     resolution: dict[str, Any],
     repo: Path,
+    evidence_values: list[dict[str, Any]] | None = None,
 ) -> tuple[list[str], dict[str, Any]]:
     repo = git_root(repo)
     errors, run_derived = validate_run(
         run,
         repo,
         resolution,
+        evidence_values,
         admission_check=False,
     )
     contract_errors, contract_derived = _resolution_contract_errors(
@@ -2097,8 +2801,24 @@ def validate_resolution(
     )
     errors.extend(contract_errors)
     outcome = resolution.get("outcome")
+    completed_steps = run_derived.get("completed_steps", [])
+    publication_admission_steps = [
+        step
+        for step in completed_steps
+        if step.get("phase") == "review-closeout"
+        and step.get("effect") == "edit"
+        and isinstance(step.get("review_admission"), dict)
+        and isinstance(step["review_admission"].get("ship_receipt"), dict)
+    ]
+    if (
+        publication_admission_steps
+        and not run_derived.get("selected_step_id")
+        and (
+        not isinstance(outcome, dict) or outcome.get("status") != "resolved"
+        )
+    ):
+        errors.append("blocked-resolution-history")
     if isinstance(outcome, dict) and outcome.get("status") == "resolved":
-        completed_steps = run_derived.get("completed_steps", [])
         for binding in contract_derived.get("selected_work_bindings", []):
             matches = [
                 step
@@ -2114,6 +2834,146 @@ def validate_resolution(
             ]
             if len(matches) != 1:
                 errors.append("blocked-resolution-node-unexecuted")
+        latest_review_step = next(
+            (
+                step
+                for step in reversed(completed_steps)
+                if step.get("phase") == "review-closeout"
+                and step.get("effect") == "edit"
+                and isinstance(step.get("review_admission"), dict)
+                and isinstance(step["review_admission"].get("ship_receipt"), dict)
+            ),
+            None,
+        )
+        latest_review_admission = (
+            latest_review_step.get("review_admission")
+            if isinstance(latest_review_step, dict)
+            else None
+        )
+        publication_epoch = (
+            canonical_digest(latest_review_admission["ship_receipt"])
+            if isinstance(latest_review_admission, dict)
+            else ""
+        )
+        epoch_admission_steps = [
+            step
+            for step in completed_steps
+            if step.get("phase") == "review-closeout"
+            and step.get("effect") == "edit"
+            and isinstance(step.get("review_admission"), dict)
+            and isinstance(step["review_admission"].get("ship_receipt"), dict)
+            and canonical_digest(step["review_admission"]["ship_receipt"])
+            == publication_epoch
+        ]
+        if epoch_admission_steps:
+            admitted_findings: set[str] = set()
+            admitted_sources: set[str] = set()
+            admitted_fold_ids: set[str] = set()
+            admitted_batches: set[tuple[str, str]] = set()
+            admitted_finding_identities: dict[str, str] = {}
+            admitted_identity_conflict = False
+            admitted_source_backends: dict[str, str] = {}
+            admitted_backend_conflict = False
+            for step in epoch_admission_steps:
+                admission = step.get("review_admission")
+                admitted_resolution = (
+                    admission.get("review_resolution")
+                    if isinstance(admission, dict)
+                    else None
+                )
+                observations = (
+                    admission.get("observations")
+                    if isinstance(admission, dict)
+                    and isinstance(admission.get("observations"), dict)
+                    else {}
+                )
+                if (
+                    not isinstance(admitted_resolution, dict)
+                ):
+                    continue
+                admitted_findings.update(
+                    string_list(admitted_resolution.get("finding_ids"))
+                )
+                admitted_sources.update(
+                    string_list(observations.get("review_source_refs"))
+                )
+                admitted_fold_ids.update(resolution_fold_ids(admitted_resolution))
+                admitted_batches.update(
+                    resolution_source_batches(admitted_resolution)
+                )
+                identities = resolution_finding_identities(admitted_resolution)
+                if identities is None:
+                    admitted_identity_conflict = True
+                else:
+                    for finding_id, digest in identities.items():
+                        previous = admitted_finding_identities.get(finding_id)
+                        if previous is not None and previous != digest:
+                            admitted_identity_conflict = True
+                        admitted_finding_identities[finding_id] = digest
+                source_backends = resolution_source_backends(admitted_resolution)
+                if source_backends is None:
+                    admitted_backend_conflict = True
+                else:
+                    for source_ref, backend in source_backends.items():
+                        previous = admitted_source_backends.get(source_ref)
+                        if previous is not None and previous != backend:
+                            admitted_backend_conflict = True
+                        admitted_source_backends[source_ref] = backend
+            final_findings = set(string_list(resolution.get("finding_ids")))
+            final_finding_identities = resolution_finding_identities(resolution)
+            final_source_backends = resolution_source_backends(resolution)
+            review = run.get("review") if isinstance(run.get("review"), dict) else {}
+            final_sources = set(string_list(review.get("source_refs")))
+            final_fold_ids = set(resolution_fold_ids(resolution))
+            final_batches = set(resolution_source_batches(resolution))
+            final_findings_from_fresh_batches = (
+                resolution_findings_from_new_batches(
+                    resolution, admitted_batches
+                )
+            )
+            final_selected_nodes = {
+                text(binding.get("node_id"))
+                for binding in contract_derived.get("selected_work_bindings", [])
+            }
+            if (
+                admitted_findings != final_findings
+                or admitted_identity_conflict
+                or final_finding_identities is None
+                or final_finding_identities != admitted_finding_identities
+                or admitted_backend_conflict
+                or final_source_backends is None
+                or any(
+                    final_source_backends.get(source_ref) != backend
+                    for source_ref, backend in admitted_source_backends.items()
+                )
+                or not admitted_sources.issubset(final_sources)
+                or not final_fold_ids
+                or any(
+                    not canonical_review_identity(fold_id)
+                    for fold_id in final_fold_ids
+                )
+                or any(
+                    not canonical_review_identity(fold_id)
+                    for fold_id in admitted_fold_ids
+                )
+                or not final_fold_ids.isdisjoint(admitted_fold_ids)
+                or any(
+                    not canonical_review_identity(backend)
+                    or not canonical_review_identity(batch)
+                    for backend, batch in final_batches
+                )
+                or any(
+                    not canonical_review_identity(backend)
+                    or not canonical_review_identity(batch)
+                    for backend, batch in admitted_batches
+                )
+                or not (final_batches - admitted_batches)
+                or not final_findings
+                or not final_findings.issubset(final_findings_from_fresh_batches)
+                or text(latest_review_step.get("step_id"))
+                not in final_selected_nodes
+            ):
+                errors.append("blocked-resolution-history")
     return sorted(set(errors)), {**run_derived, **contract_derived}
 
 
@@ -2159,7 +3019,8 @@ def cas_errors(
         text(row.get("recordId")): row.get("proofCreditEligible")
         for row in ref_rows
     }
-    snapshot_ids = {text(row.get("recordId")) for row in normalized}
+    normalized_ids = [text(row.get("recordId")) for row in normalized]
+    snapshot_ids = set(normalized_ids)
     if (
         referenced_ids != snapshot_ids
         or "" in referenced_ids
@@ -2167,12 +3028,47 @@ def cas_errors(
         or any(type(value) is not bool for value in ref_credit.values())
     ):
         errors.append("blocked-cas-evidence-set-incomplete")
-    expected_artifact = (
-        run.get("artifact") if isinstance(run.get("artifact"), dict) else {}
-    )
+    if len(normalized_ids) != len(snapshot_ids):
+        errors.append("blocked-cas-unit-duplicate")
+    same_run_attempt_ids: list[str] = []
+    for record in normalized:
+        binding = (
+            record.get("workflowBinding")
+            if isinstance(record.get("workflowBinding"), dict)
+            else {}
+        )
+        if binding.get("actuationRunId") != run.get("run_id"):
+            continue
+        attempt = (
+            record.get("attempt")
+            if isinstance(record.get("attempt"), dict)
+            else {}
+        )
+        attempt_id = text(attempt.get("attemptId"))
+        if not attempt_id:
+            errors.append("blocked-cas-attempt-identity")
+        else:
+            same_run_attempt_ids.append(attempt_id)
+    if len(same_run_attempt_ids) != len(set(same_run_attempt_ids)):
+        errors.append("blocked-cas-unit-duplicate")
+    artifact_value = run.get("artifact")
+    if not isinstance(artifact_value, dict) or any(
+        not text(artifact_value.get(key))
+        for key in ("repo", "base_sha", "branch", "head_sha", "state_fingerprint")
+    ):
+        return sorted(set([*errors, "blocked-cas-unit-stale"])), []
+    expected_artifact = artifact_value
     expected_lenses = derived["selected_lenses"]
     expected_contract = derived["review_contract_fingerprint"]
     expected_resolution = derived["resolution_digest"]
+    review = run.get("review") if isinstance(run.get("review"), dict) else {}
+    publication_bound = bool(
+        review.get("publication_requested") is True
+        and isinstance(review.get("ship_receipt"), dict)
+    )
+    publication_watermark = derived.get("publication_watermark")
+    if publication_bound and type(publication_watermark) is not int:
+        errors.append("blocked-cas-publication-watermark")
     contracts = load_semantics().get("lens_contracts") or {}
     allowed_lanes = set(expected_lenses)
     folds_by_batch: dict[str, list[dict[str, Any]]] = {}
@@ -2232,28 +3128,13 @@ def cas_errors(
             reject("blocked-cas-unit-id")
         if created_at is None:
             reject("blocked-cas-attempt-identity")
-        if tuple_value.get("repoRealpath") != expected_artifact.get("repo"):
-            reject("blocked-cas-unit-stale")
-        for field, artifact_key in (
-            ("baseSha", "base_sha"),
-            ("headSha", "head_sha"),
-        ):
-            if tuple_value.get(field) != expected_artifact.get(artifact_key):
-                reject("blocked-cas-unit-stale")
-        native_target_fingerprint = text(tuple_value.get("targetFingerprint"))
-        if not native_target_fingerprint:
-            reject("blocked-cas-unit-stale")
-        else:
-            native_target_fingerprints.add(native_target_fingerprint)
-        if tuple_value.get("tupleCurrentAtRecordTime") is not True:
-            reject("blocked-cas-unit-stale")
         if not isinstance(binding, dict):
             reject("blocked-cas-workflow-unbound")
             continue
         if binding.get("actuationRunId") != run.get("run_id"):
             reject("blocked-cas-workflow-unbound")
             continue
-        current_epoch = all(
+        workflow_epoch = all(
             (
                 binding.get("reviewContractFingerprint") == expected_contract,
                 binding.get("resolutionDigest") == expected_resolution,
@@ -2261,9 +3142,33 @@ def cas_errors(
                 == expected_artifact.get("state_fingerprint"),
             )
         )
+        after_publication_watermark = bool(
+            not publication_bound
+            or (
+                type(publication_watermark) is int
+                and created_at is not None
+                and created_at > publication_watermark
+            )
+        )
+        current_epoch = workflow_epoch and after_publication_watermark
         if not current_epoch:
-            if verdict.get("status") == "findings":
-                producer_findings = object_list(verdict.get("findings"))
+            superseded_status = text(verdict.get("status"))
+            producer_findings_raw = verdict.get("findings")
+            producer_findings = object_list(producer_findings_raw)
+            finding_count = verdict.get("findingCount")
+            if (
+                verdict.get("tupleVerdictExists") is not True
+                or superseded_status not in {"clean", "findings"}
+                or not has_exact_object_list(producer_findings_raw)
+                or type(finding_count) is not int
+                or finding_count != len(producer_findings)
+                or verdict.get("clean") is not (superseded_status == "clean")
+                or (superseded_status == "clean" and finding_count != 0)
+                or (superseded_status == "findings" and finding_count <= 0)
+            ):
+                reject("blocked-cas-unit-unnormalized")
+                continue
+            if superseded_status == "findings":
                 expected_source_refs = [
                     text(finding.get("findingId")) or f"{record_id}#{index}"
                     for index, finding in enumerate(producer_findings, start=1)
@@ -2295,6 +3200,21 @@ def cas_errors(
                 if not classified:
                     reject("blocked-cas-findings-unresolved")
             continue
+        if tuple_value.get("repoRealpath") != expected_artifact.get("repo"):
+            reject("blocked-cas-unit-stale")
+        for field, artifact_key in (
+            ("baseSha", "base_sha"),
+            ("headSha", "head_sha"),
+        ):
+            if tuple_value.get(field) != expected_artifact.get(artifact_key):
+                reject("blocked-cas-unit-stale")
+        native_target_fingerprint = text(tuple_value.get("targetFingerprint"))
+        if not native_target_fingerprint:
+            reject("blocked-cas-unit-stale")
+        else:
+            native_target_fingerprints.add(native_target_fingerprint)
+        if tuple_value.get("tupleCurrentAtRecordTime") is not True:
+            reject("blocked-cas-unit-stale")
         lenses = binding.get("selectedLenses")
         if (
             not isinstance(lenses, list)
@@ -2324,7 +3244,7 @@ def cas_errors(
         if (
             verdict.get("tupleVerdictExists") is not True
             or status not in {"clean", "findings"}
-            or not isinstance(findings, list)
+            or not has_exact_object_list(findings)
             or type(finding_count) is not int
             or finding_count != len(findings)
             or verdict.get("clean") is not (status == "clean")
@@ -2487,6 +3407,23 @@ def evidence_errors(
             admission_ref = f"review-admission:{text(admission.get('admission_digest'))}"
             if admission_ref not in string_list(evidence.get("review_refs")):
                 errors.append("blocked-evidence-fold-mismatch")
+            continuation = admission.get("publication_continuation")
+            predecessor = (
+                continuation.get("predecessor")
+                if isinstance(continuation, dict)
+                and isinstance(continuation.get("predecessor"), dict)
+                else None
+            )
+            if isinstance(predecessor, dict):
+                predecessor_item = by_id.get(
+                    text(predecessor.get("evidence_fold_ref"))
+                )
+                if (
+                    predecessor_item is None
+                    or canonical_digest(predecessor_item)
+                    != predecessor.get("evidence_fold_digest")
+                ):
+                    errors.append("blocked-evidence-fold-mismatch")
         if (
             not string_list(commands.get("passed"))
             or commands.get("failed") != []
@@ -2535,6 +3472,11 @@ def static_ship_errors(
     run: dict[str, Any],
 ) -> tuple[list[str], list[str]]:
     errors: list[str] = []
+    if has_misplaced_derived_control(
+        ship_value,
+        allow_step_receipts=False,
+    ):
+        errors.append("blocked-unexpected-input")
     record = unwrap(ship_value, "ship_record")
     if record.get("record_version") != "SHIP-v1":
         errors.append("blocked-ship-version")
@@ -2649,12 +3591,21 @@ def ship_errors(
     ship_value: dict[str, Any],
     run: dict[str, Any],
 ) -> tuple[list[str], list[str]]:
+    errors, basis, _ = ship_observation_errors(ship_value, run)
+    return errors, basis
+
+
+def ship_observation_errors(
+    ship_value: dict[str, Any],
+    run: dict[str, Any],
+) -> tuple[list[str], list[str], int | None]:
     errors, static_basis = static_ship_errors(ship_value, run)
     record = unwrap(ship_value, "ship_record")
     artifact = run.get("artifact") if isinstance(run.get("artifact"), dict) else {}
     base_branch = text(record.get("base_branch"))
     pr_url = static_basis[0] if static_basis else ""
     live_pr_valid = False
+    publication_watermark: int | None = None
     if pr_url:
         try:
             metadata = live_pr_metadata(Path(text(artifact.get("repo"))), pr_url)
@@ -2685,13 +3636,17 @@ def ship_errors(
                     pull_request.get("headRefOid") != artifact.get("head_sha"),
                     pull_request.get("state") != "OPEN",
                     pull_request.get("isDraft") is not False,
+                    cas_time_key(pull_request.get("updatedAt")) is None,
                 )
             ):
                 errors.append("blocked-ship-live-pr-mismatch")
             else:
                 live_pr_valid = True
+                publication_watermark = cas_time_key(
+                    pull_request.get("updatedAt")
+                )
     basis = [pr_url] if live_pr_valid else []
-    return sorted(set(errors)), basis
+    return sorted(set(errors)), basis, publication_watermark
 
 
 def decide(
@@ -2704,8 +3659,14 @@ def decide(
     review_fold_values: list[dict[str, Any]] | None = None,
 ) -> tuple[dict[str, Any], int]:
     repo = git_root(repo)
-    run_errors, run_derived = validate_run(run, repo, resolution)
+    run_errors, run_derived = validate_run(
+        run, repo, resolution, evidence_values
+    )
     errors = list(run_errors)
+    publication_watermarks: list[int] = []
+    initial_publication_watermark = run_derived.get("publication_watermark")
+    if type(initial_publication_watermark) is int:
+        publication_watermarks.append(initial_publication_watermark)
     mode = text(run.get("mode"))
     lifecycle = run.get("lifecycle") if isinstance(run.get("lifecycle"), dict) else {}
     invocation_profile = text(lifecycle.get("invocation_profile"))
@@ -2721,7 +3682,8 @@ def decide(
         (
             step
             for step in reversed(completed_steps)
-            if step.get("effect") == "edit"
+            if step.get("phase") == "review-closeout"
+            and step.get("effect") == "edit"
             and isinstance(step.get("review_admission"), dict)
             and isinstance(step["review_admission"].get("ship_receipt"), dict)
         ),
@@ -2768,12 +3730,26 @@ def decide(
             errors.append("blocked-review-resolution-missing")
         else:
             resolution_errors, resolution_derived = validate_resolution(
-                run, resolution, repo
+                run, resolution, repo, evidence_values
             )
             errors.extend(resolution_errors)
             resolution_digest = resolution_derived.get("resolution_digest")
+            if type(resolution_derived.get("publication_watermark")) is int:
+                publication_watermarks.append(
+                    resolution_derived["publication_watermark"]
+                )
     elif resolution is not None:
         errors.append("blocked-unexpected-input")
+
+    if any(
+        current < previous
+        for previous, current in zip(
+            publication_watermarks,
+            publication_watermarks[1:],
+            strict=False,
+        )
+    ):
+        errors.append("blocked-cas-publication-watermark")
 
     if run_derived.get("selected_step_id"):
         errors.append("blocked-step-open")
@@ -2809,7 +3785,13 @@ def decide(
                 errors.append("blocked-artifact-uncommitted")
 
     cas_ids: list[str] = []
-    if review_required and not needs_reship and resolution is not None:
+    cas_publication_watermark: int | None = None
+    if (
+        review_required
+        and not needs_reship
+        and resolution is not None
+        and not errors
+    ):
         artifact = run.get("artifact") if isinstance(run.get("artifact"), dict) else {}
         try:
             live_snapshot = live_cas_list(
@@ -2829,10 +3811,36 @@ def decide(
                 and canonical_digest(cas_values[0]) != canonical_digest(live_snapshot)
             ):
                 errors.append("blocked-cas-evidence-set-incomplete")
-            cas_problems, cas_ids = cas_errors(
-                live_snapshot, run, resolution, resolution_derived
-            )
-            errors.extend(cas_problems)
+            if publication_requested and isinstance(embedded_ship, dict):
+                ship_problems, _, observed_watermark = ship_observation_errors(
+                    embedded_ship, run
+                )
+                errors.extend(ship_problems)
+                if not ship_problems and type(observed_watermark) is int:
+                    prior_watermark = (
+                        max(publication_watermarks)
+                        if publication_watermarks
+                        else None
+                    )
+                    if (
+                        type(prior_watermark) is int
+                        and observed_watermark < prior_watermark
+                    ):
+                        errors.append("blocked-cas-publication-watermark")
+                    else:
+                        publication_watermarks.append(observed_watermark)
+                        cas_publication_watermark = max(
+                            publication_watermarks
+                        )
+                        resolution_derived = {
+                            **resolution_derived,
+                            "publication_watermark": cas_publication_watermark,
+                        }
+            if not errors:
+                cas_problems, cas_ids = cas_errors(
+                    live_snapshot, run, resolution, resolution_derived
+                )
+                errors.extend(cas_problems)
     elif cas_values:
         errors.append("blocked-unexpected-input")
     outcome = (
@@ -2910,7 +3918,17 @@ def decide(
                 goal_outcome = "continue"
                 next_owner = "ship"
         else:
-            ship_problems, ship_basis = ship_errors(effective_ship, run)
+            ship_problems, ship_basis, final_publication_watermark = (
+                ship_observation_errors(effective_ship, run)
+            )
+            if (
+                cas_ids
+                and type(cas_publication_watermark) is int
+                and final_publication_watermark != cas_publication_watermark
+            ):
+                ship_problems.append("blocked-cas-publication-watermark")
+            if ship_problems:
+                cas_ids = []
             errors.extend(ship_problems)
             if ship_problems:
                 verdict = "blocked"
@@ -2987,6 +4005,7 @@ def parser() -> argparse.ArgumentParser:
     resolution = sub.add_parser("validate-resolution")
     resolution.add_argument("--run", required=True)
     resolution.add_argument("--resolution", required=True)
+    resolution.add_argument("--evidence", action="append", default=[])
     resolution.add_argument("--repo", required=True)
     close = sub.add_parser("decide")
     close.add_argument("--run", required=True)
@@ -3020,7 +4039,10 @@ def main(argv: list[str] | None = None) -> int:
         if args.command == "validate-resolution":
             if resolution is None:
                 raise ValueError("resolution is required")
-            errors, derived = validate_resolution(run, resolution, repo)
+            resolution_evidence = [load_data(path) for path in args.evidence]
+            errors, derived = validate_resolution(
+                run, resolution, repo, resolution_evidence
+            )
             return emit(args.command, errors, derived)
         evidence = [load_data(path) for path in args.evidence]
         review_folds = [load_data(path) for path in args.review_fold]


### PR DESCRIPTION
## Summary

- replace caller-authored, single-use review-repair continuation with a repeatable gate-derived receipt inside `review-admission/v1`
- preserve cumulative material findings and source lineage across replacement SHIP epochs, then require an exact fresh terminal resolution
- harden publication-bound CAS closure against regressing PR watermarks, cross-epoch record or producer-attempt replay, malformed superseded findings, and reserved-receipt smuggling
- align the `$actuating` doctrine, live semantics, gate implementation, and focused regression coverage

## Proof

- `uv run --with pyyaml python -m unittest codex.skills.actuating.tests.test_actuating_gate`: pass (146 tests)
- `uv run --with pyyaml python -m unittest codex.skills.actuating.tests.test_live_semantics`: pass (13 tests)
- `uv run codex/skills/spec-pipeline/tools/quick_validate.py codex/skills/actuating`: pass (5 tests)
- `uvx ruff check codex/skills/actuating/tools/actuating_gate.py codex/skills/actuating/tests/test_actuating_gate.py codex/skills/actuating/tests/test_live_semantics.py`: pass
- `git diff --check`: pass
- independent final kernel/doctrine audit: clean

## Scope

- branch: `fix/actuating-unpublished-repair-chain`
- head: `7119b489ba01a45582495d9aae7e6a9826a707fb`
- base: `main`

## Risk and follow-up

- the gate is intentionally stricter: malformed or control-looking inputs that were previously ignored now fail closed
- no implementation task, blocker, or deferred follow-up remains

## Readiness

- PR mode: ready
- Reason: the branch is complete, fully validated, rebased onto current `main`, and independently audited
- Caveats: none
