### PR TITLE
Align Universalist activation doctrine

### DIFF
--- a/codex/skills/universalist/README.md
+++ b/codex/skills/universalist/README.md
@@ -18,9 +18,11 @@ chmod +x scripts/*.sh scripts/*.py
 
 ## Use
 
-Ask for `$universalist` when code smells indicate a structural refactor rather than an ordinary fix.
+`$universalist` is implicitly invoked whenever implementation, refactoring, review, migration, or resolution considers a code boundary. Boundary consideration itself is the activation signal, including ordinary feature work and PR/review resolution.
 
-The skill decides whether the problem needs:
+Activation is broad; escalation is proportional. The boundary pass may preserve an already exact seam and return to ordinary delivery. Stronger constructions are justified only when the pass finds drift, invalid states, hidden composition, lossy projection, uncertified context, or another structural liability.
+
+The skill decides whether the boundary should remain ordinary or needs:
 
 - product/coproduct/refined type/pullback/exponential/free construction;
 - canonical boundary artifact;
@@ -30,7 +32,7 @@ The skill decides whether the problem needs:
 - observation/generation vocabulary;
 - explicit first-order IR.
 
-Use `$universalist` for the full workflow. Detailed Kan extension/lift, Freyd/AFT, Yoneda/Coyoneda, codensity, categorical-data, and defunctionalization mechanics now live inside `references/mechanics/` and `scripts/emit_mechanics_report.sh`.
+Use `$universalist` for the full boundary workflow. Detailed Kan extension/lift, Freyd/AFT, Yoneda/Coyoneda, codensity, categorical-data, and defunctionalization mechanics now live inside `references/mechanics/` and `scripts/emit_mechanics_report.sh`; load them only after the boundary pass justifies escalation.
 
 ## Ledger-addressed plans
 

--- a/codex/skills/universalist/package.json
+++ b/codex/skills/universalist/package.json
@@ -1,6 +1,6 @@
 {
   "name": "universalist",
-  "version": "16.0.1",
+  "version": "16.0.2",
   "description": "Boundary-triggered Universal Architecture workflow for implementation, resolution, effective substrates, and typed composition.",
   "private": true,
   "unified_mechanics": true,

--- a/codex/skills/universalist/references/boundary-redesign-trigger.md
+++ b/codex/skills/universalist/references/boundary-redesign-trigger.md
@@ -1,8 +1,10 @@
 # Boundary Redesign Trigger
 
-Use `$universalist` when the delivery recipe cannot satisfy the counterexample contract without a boundary or representation change.
+`$universalist` is already active whenever delivery work considers a code boundary. Boundary consideration itself is the activation signal. Activation is broad; escalation is proportional.
 
-Trigger signs:
+This reference decides when the boundary pass must escalate from preservation or ordinary repair to boundary redesign: the delivery recipe cannot satisfy the counterexample contract without a boundary or representation change.
+
+Escalation signs:
 
 - same route family repeatedly falsified in lab;
 - selected boundary keeps needing predicates;
@@ -10,4 +12,6 @@ Trigger signs:
 - one owner absorbs unrelated counterexample families;
 - proof obligations reveal an implicit algebra/protocol.
 
-Return a boundary decision suitable for DPR-v1.
+If none of these signs is present, record the boundary disposition, law, and falsifier, then continue the ordinary delivery path without inventing a stronger construction.
+
+Return any redesign decision in a form suitable for DPR-v1.

--- a/codex/skills/universalist/references/cybernetic-boundary-trigger.md
+++ b/codex/skills/universalist/references/cybernetic-boundary-trigger.md
@@ -1,8 +1,10 @@
 # Cybernetic Boundary Trigger
 
-Use `$universalist` when `$cybernetic` finds that repeated behavior is caused by the wrong shape of truth.
+`$universalist` remains active whenever `$cybernetic` work considers a code boundary. Boundary consideration itself is the activation signal. Activation is broad; escalation is proportional.
 
-## Trigger from cybernetic
+This handoff decides whether the boundary pass should escalate into boundary redesign because repeated behavior is caused by the wrong shape of truth; it does not decide whether Universalist runs.
+
+## Escalation from cybernetic
 
 ```yaml
 cybernetic_context:
@@ -12,7 +14,7 @@ cybernetic_context:
   pattern: "missing boundary artifact | duplicated projection | wrong shape of truth | protocol artifact missing | public contract driving internals"
 ```
 
-## Use universalist for
+## Escalate Universalist for
 
 - missing boundary artifact;
 - duplicated projection;
@@ -20,12 +22,12 @@ cybernetic_context:
 - protocol/state-machine artifact missing;
 - public contract driving internals without a canonical seam.
 
-## Do not use universalist for
+## Do not escalate Universalist merely for
 
 - primarily bad incentives;
 - delayed feedback;
 - metric/proxy gaming;
-- local-vs-whole optimization without boundary artifact;
+- local-vs-whole optimization without a boundary artifact;
 - chaotic stabilization.
 
-Those may need `$cybernetic`, `$negative-ledger`, `$reduce`, or process/rule redesign instead.
+Those concerns may keep `$cybernetic`, `$negative-ledger`, `$reduce`, or process/rule redesign as the primary intervention owner. When they also consider a code boundary, still record the Universalist boundary disposition, law, and falsifier without forcing a redesign.

--- a/codex/skills/universalist/references/minimum-behavioral-kernel.md
+++ b/codex/skills/universalist/references/minimum-behavioral-kernel.md
@@ -1,8 +1,10 @@
 # Minimum Behavioral Kernel
 
-Use `$universalist` when realization design requires a representation, boundary, protocol, context, or syntax/semantics pivot.
+`$universalist` is already active whenever realization design considers a code boundary. Boundary consideration itself is the activation signal. Activation is broad; escalation is proportional.
 
-The output must be a kernel-faithful design record:
+Escalate to a kernel-faithful design record when realization requires a representation, protocol, context, or syntax/semantics pivot rather than preservation or an ordinary boundary repair.
+
+The escalated output must record:
 
 ```text
 canonical boundary
@@ -14,4 +16,4 @@ law witness
 falsifier
 ```
 
-Do not produce another local guard candidate.
+When this escalation condition holds, do not produce another local guard candidate. When it does not hold, keep the compact boundary receipt and continue the ordinary implementation or resolution workflow.

--- a/codex/skills/universalist/references/review-governor-boundary-inventory.md
+++ b/codex/skills/universalist/references/review-governor-boundary-inventory.md
@@ -1,8 +1,10 @@
 # Review Governor Boundary Inventory
 
-Use `$universalist` when the same coarse owner keeps absorbing semantic branches.
+`$universalist` is already active whenever review or resolution considers a code boundary. Boundary consideration itself is the activation signal. Activation is broad; escalation is proportional.
 
-Trigger when:
+Expand the compact boundary receipt into this inventory when the same coarse owner keeps absorbing semantic branches.
+
+Escalation signs:
 
 - same cluster recurs;
 - validation/replay/evidence branches accumulate;
@@ -21,4 +23,4 @@ boundary_inventory:
   decision: universalist | reduce | normal-form | distill | blocked
 ```
 
-If missing boundary artifact is yes or unknown after recurrence, ordinary owner mutation is blocked and any mutation permit must be denied.
+If no escalation sign is present, preserve the compact disposition and continue normal review resolution. If `missing_boundary_artifact` is `yes` or remains `unknown` after recurrence, ordinary owner mutation is blocked and any mutation permit must be denied.

--- a/codex/skills/universalist/references/universalist-overview.md
+++ b/codex/skills/universalist/references/universalist-overview.md
@@ -1,6 +1,8 @@
 # Universalist overview
 
-Universalist is an inner lens for codebase refactors where the shape of truth should change.
+Universalist is an inner lens invoked whenever implementation, refactoring, review, migration, or resolution considers a code boundary. Boundary consideration itself is the activation signal. Activation is broad; escalation is proportional.
+
+The boundary pass may preserve an already exact seam and return to ordinary delivery. It escalates only when changing the shape of truth would reduce drift, invalid states, hidden composition, lossy projection, uncertified context, or another structural liability.
 
 Default discipline:
 

--- a/codex/skills/universalist/scripts/check_universalist.sh
+++ b/codex/skills/universalist/scripts/check_universalist.sh
@@ -62,6 +62,64 @@ if 'allow_implicit_invocation: true' not in Path('agents/openai.yaml').read_text
     raise SystemExit('agents/openai.yaml must allow implicit invocation')
 print(f'description length ok: {len(desc)} chars')
 print('boundary discovery metadata ok')
+activation_surfaces = {
+    'README.md': (
+        'Boundary consideration itself is the activation signal',
+        'Activation is broad; escalation is proportional',
+        'The boundary pass may preserve an already exact seam',
+    ),
+    'references/universalist-overview.md': (
+        'Boundary consideration itself is the activation signal',
+        'Activation is broad; escalation is proportional',
+        'The boundary pass may preserve an already exact seam',
+    ),
+    'references/boundary-redesign-trigger.md': (
+        'already active whenever delivery work considers a code boundary',
+        'Boundary consideration itself is the activation signal',
+        'Activation is broad; escalation is proportional',
+    ),
+    'references/minimum-behavioral-kernel.md': (
+        'already active whenever realization design considers a code boundary',
+        'Boundary consideration itself is the activation signal',
+        'Activation is broad; escalation is proportional',
+    ),
+    'references/cybernetic-boundary-trigger.md': (
+        'remains active whenever `$cybernetic` work considers a code boundary',
+        'Boundary consideration itself is the activation signal',
+        'it does not decide whether Universalist runs',
+    ),
+    'references/review-governor-boundary-inventory.md': (
+        'already active whenever review or resolution considers a code boundary',
+        'Boundary consideration itself is the activation signal',
+        'Activation is broad; escalation is proportional',
+    ),
+    'references/cost-model-and-false-positives.md': (
+        'Run the Universalist boundary pass whenever implementation or resolution considers a code boundary',
+        'Activation does not require a refactor',
+        'Preserving an already exact boundary is a valid Universalist result',
+    ),
+    'references/discovery-signals.md': (
+        'Boundary consideration is itself a discovery signal',
+        'record it as preserved and continue without adding abstraction',
+    ),
+}
+for path, required_phrases in activation_surfaces.items():
+    surface = Path(path).read_text()
+    for phrase in required_phrases:
+        if phrase not in surface:
+            raise SystemExit(f'{path} activation doctrine missing: {phrase}')
+forbidden_activation_phrases = {
+    'README.md': 'structural refactor rather than an ordinary fix',
+    'references/universalist-overview.md': 'refactors where the shape of truth should change',
+    'references/boundary-redesign-trigger.md': 'Use `$universalist` when the delivery recipe',
+    'references/minimum-behavioral-kernel.md': 'Use `$universalist` when realization design',
+    'references/cybernetic-boundary-trigger.md': '## Do not use universalist for',
+    'references/review-governor-boundary-inventory.md': 'Use `$universalist` when the same coarse owner',
+}
+for path, phrase in forbidden_activation_phrases.items():
+    if phrase in Path(path).read_text():
+        raise SystemExit(f'{path} retains selective activation doctrine: {phrase}')
+print(f'boundary activation doctrine aligned: {len(activation_surfaces)} surfaces')
 required = [
     'name: universalist', 'Track A0', 'Domain Algebra Discovery', 'Algebra before architecture', 'carriers', 'operations', 'observations', 'laws', 'non-laws', 'Track D', 'Track E', 'Track F', 'Universal architecture',
     'canonical boundary artifact', 'one signal, one seam', 'Freyd/AFT', 'free builder',


### PR DESCRIPTION
## What changed

- makes the README and overview state the same policy as `SKILL.md` and `codex/AGENTS.md`: boundary consideration always activates `$universalist`
- reframes boundary redesign, minimum-kernel, cybernetic, and review-governor references as **escalation** gates rather than activation gates
- preserves proportional escalation: an exact boundary may be recorded as preserved without adding categorical machinery
- extends `check_universalist.sh` to require the aligned doctrine across eight documentation/reference surfaces and reject the superseded selective phrases
- bumps the package patch version to `16.0.2`

## Why

The package simultaneously carried mandatory boundary activation in its frontmatter/global guidance and selective activation language in several references. That made routing depend on which surface an agent read. This change keeps the intentionally active policy while making activation and escalation distinct and consistent.

## Validation

- `bash -n` passed for the updated `check_universalist.sh`
- the embedded Python contract block compiled successfully
- targeted activation-doctrine assertions passed for all eight guarded surfaces
- `package.json` parsed successfully
- every uploaded blob SHA matched the locally validated file content

The full repository-wide `check_universalist.sh` was not executed in this environment because the GitHub connector exposes repository contents but no local authenticated checkout; the draft PR is left for repository CI or local execution of `./codex/skills/universalist/scripts/check_universalist.sh`.