### PR TITLE
Align Ledger review and storage doctrine

### DIFF
--- a/codex/skills/actuating/SKILL.md
+++ b/codex/skills/actuating/SKILL.md
@@ -59,7 +59,7 @@ The live objects are:
    `actuation-kernel-state/v1`.
 5. `closure-decision/v1`, projected by the kernel from that live fold.
 
-`actuation-review-policy/v1`, `review-resolution/v1`, RF-v2, EF-v1, CAS
+`actuation-review-policy/v2`, `review-resolution/v1`, RF-v2, EF-v1, CAS
 receipts, and SHIP-v1 remain owner-specific evidence. Bind their current
 identities into the GoalContract and discharge their predicates through exact
 verifier commands; do not copy their policy logic into the kernel.
@@ -202,14 +202,24 @@ outstanding obligations.
 `$actuating` owns review selection, exact lens contract and instruction
 digests, standard and auxiliary roles, invalidation, repeated-review
 accounting, and closeout credit. Compile those decisions into
-`actuation-review-policy/v1` before the first run; read
+`actuation-review-policy/v2` before the first run; read
 [review-policy.md](references/review-policy.md).
 
-Require at least five consecutive, distinct, current standard clean attempts.
-Bind every registered auxiliary lens and have `$goal-actuating` launch all
-auxiliary requests concurrently with the first standard attempt. Auxiliary
-clean results discharge only their own request; auxiliary findings enter
-RF-v2; no auxiliary attempt contributes to the standard clean suffix.
+Require a chain ending in at least five consecutive, distinct standard clean
+attempts and a clean standard attempt on the current tuple. Bind every
+registered auxiliary lens and have `$goal-actuating` launch all auxiliary
+requests concurrently with the first standard attempt. Auxiliary clean results
+discharge only their own current request; auxiliary findings enter RF-v2; no
+auxiliary attempt or tuple transition contributes to the standard clean suffix.
+Preserve prior standard credit across a changed CAS tuple only through a
+policy-bound `auxiliary-remediation` carry that cites the accepted finding,
+resolution, correctness observations, actuation events, and SHIP receipt while
+keeping each attempt bound to its original request and tuple. Any standard
+finding, contract drift, base change, or unrelated mutation resets the chain.
+
+Require Ledger 0.7.0 or newer before executing a v2 preflight. Ledger retains
+v1 validation for historical same-tuple snapshots, but new campaigns never
+downgrade to v1 to avoid the chain law.
 
 Treat the policy as executable syntax owned by `$actuating`. Before CAS
 execution, require a passing policy validation decision:
@@ -262,6 +272,8 @@ For a review edit:
   project the exact CAS command into a review obligation;
 - launch the first standard request and all auxiliary requests as one
   concurrent wave against the same artifact;
+- after an auxiliary-driven repair, invalidate every current request and
+  preserve the standard suffix only by appending a certified non-credit carry;
 - bind the current resolution, publication epoch, and evidence identities into
   the GoalContract digest;
 - pass the correctness-refinement preflight and project both preservation

--- a/codex/skills/actuating/references/live-semantics.yaml
+++ b/codex/skills/actuating/references/live-semantics.yaml
@@ -46,9 +46,9 @@ live_semantics:
     closure-decision/v1:
       owner: ledger-actuation
       purpose: Project continuation or terminal outcomes from the live folded state.
-    actuation-review-policy/v1:
+    actuation-review-policy/v2:
       owner: actuating
-      purpose: Bind lens selection, exact instructions, request identity, lane accounting, invalidation, and closeout credit before review execution.
+      purpose: Bind lens selection, exact instructions, request identity, tuple-honest standard attempt history, certified auxiliary-remediation carries, lane accounting, invalidation, and closeout credit before review execution.
     review-resolution/v1:
       owner: actuating
       purpose: Turn classified equivalence classes into owner-boundary correctness refinements and strategies before review mutation.
@@ -114,6 +114,8 @@ live_semantics:
       statement: Review-derived mutation requires fresh classified evidence, a passing pure ledger validate review-fold decision, one owner-boundary correctness refinement per accepted equivalence class, passing Actuating correctness-refinement preflight, and observed preservation and progress obligations; validation grants no authority.
     - id: review-policy-owner
       statement: Actuating binds review semantics before execution and projects only opaque request identity into CAS transport; CAS tuple and verdict facts never select a lens or grant closeout credit.
+    - id: auxiliary-remediation-carry
+      statement: A changed CAS tuple preserves prior standard clean credit only through an Actuating-owned auxiliary-remediation carry; the edge adds no credit, every retained attempt keeps its original tuple, current auxiliary evidence is rerun, and closeout ends standard-clean on the current tuple.
     - id: closure-is-live
       statement: Close and decide recompute the current repository artifact and reject stale folded state.
 

--- a/codex/skills/actuating/references/review-policy.md
+++ b/codex/skills/actuating/references/review-policy.md
@@ -12,11 +12,13 @@ JSON snapshots of its current state for preflight and closeout checks:
 
 ~~~yaml
 actuation_review_policy:
-  version: actuation-review-policy/v1
+  version: actuation-review-policy/v2
   policy_id:
   run_id:
   goal_contract_digest:
   resolution_digest:
+  review_contract_ref:
+  review_contract_digest:
   artifact:
     repo:
     base_ref:
@@ -56,6 +58,59 @@ actuation_review_policy:
           finding_count:
           record_ref:
       review_fold_refs: []
+  standard_clean_chain:
+    standard_attempts:
+      - artifact:
+          repo:
+          base_ref:
+          base_sha:
+          head_sha:
+          state_fingerprint:
+        goal_contract_digest:
+        resolution_digest:
+        review_contract_digest:
+        request_id:
+        request_fingerprint:
+        contract_id:
+        contract_digest:
+        instruction_digest:
+        attempt:
+          workflow_binding:
+            requestId:
+            requestFingerprint:
+          review_attempt_id:
+          review_thread_id:
+          review_turn_id:
+          base_sha:
+          head_sha:
+          target_fingerprint:
+          context_identity_matches: true | false
+          principal_kind:
+          principal_reduced: true | false
+          fallback_used: true | false
+          principal_source:
+          verdict_status: clean | findings
+          finding_count:
+          record_ref:
+    carry_transitions:
+      - kind: auxiliary-remediation
+        from_attempt_id:
+        to_artifact:
+          repo:
+          base_ref:
+          base_sha:
+          head_sha:
+          state_fingerprint:
+        from_goal_contract_digest:
+        to_goal_contract_digest:
+        resolution_digest:
+        source_auxiliary_request_ids: []
+        review_fold_refs: []
+        correctness_decision_refs: []
+        preservation_observation_refs: []
+        progress_observation_refs: []
+        actuation_event_refs: []
+        ship_ref:
   standard_clean_attempt_ids: []
   invalidation_reasons: []
 ~~~
@@ -70,11 +125,41 @@ ledger validate actuation-review-policy \
 ~~~
 
 It emits `actuation-review-policy-decision/v1`, grants no authority, and
-mutates no storage. `preflight` rejects review evidence and requires every
-request to be pending. `closeout` checks registry/request bijection, exact
-referenced contract and instruction bytes, opaque binding and artifact
-identity, source quality, distinct attempts, disjoint lane accounting, and
-terminal request states.
+mutates no storage. New campaigns require Ledger 0.7.0 or newer and emit
+`actuation-review-policy/v2`. The validator retains v1 compatibility with its
+original same-tuple suffix law; a v1 snapshot cannot carry credit across a
+tuple change. `preflight` requires every current request to be pending but may
+accept a v2 chain carried from the immediately preceding artifact. `closeout`
+checks registry/request bijection, exact referenced contract and instruction
+bytes, opaque binding and artifact identity, source quality, distinct attempts,
+chain topology, disjoint lane accounting, and terminal request states.
+
+`review_contract_ref` is the exact persisted aggregate manifest for the policy
+semantics that must remain stable across a carry: policy version, required
+standard-clean count, ordered lens registry, every lens role, contract ID, and
+contract digest. Exclude artifact identity, resolution identity, request IDs,
+instruction bytes, and request fingerprints because those are epoch-specific.
+Set `review_contract_digest` to the SHA-256 of the manifest's exact bytes and
+bind its digest verifier into the GoalContract. Every historical standard row
+must carry that same digest; contract or registry drift therefore resets the
+chain instead of masquerading as auxiliary remediation.
+
+`standard_clean_chain.standard_attempts` is the exhaustive ordered projection
+of valid standard terminal facts retained for streak accounting. Preserve each
+fact's original request identity, contract identity, GoalContract and
+resolution digests, and CAS tuple. Include `findings` attempts because they
+break the trailing clean suffix. The rows for the current artifact must equal
+the current standard request's `attempts` exactly; historical rows never move
+into or impersonate the current request.
+
+`carry_transitions` contains only non-credit edges between adjacent standard
+attempt epochs whose tuples differ. A carry must start from a clean standard
+attempt, keep repo/base identity stable, change head and state fingerprint,
+preserve the aggregate review contract and standard contract, and bind the
+auxiliary request IDs, RF-v2 folds, resolution digest, correctness decisions,
+observed preservation and progress obligations, actuation events, and SHIP-v1
+receipt that produced the next artifact. The edge preserves the suffix length;
+it never adds an attempt ID.
 
 For a selected request, `request_fingerprint` equals `instruction_digest`: the SHA-256 of the exact
 persisted UTF-8 bytes at `instructions_ref`. The pre-bound policy row and
@@ -147,9 +232,9 @@ policy's bound closeout requests.
 Launch every auxiliary request concurrently with the first standard attempt as
 one dispatch wave against the same bound artifact. Do not wait for a standard
 result before starting an auxiliary lane. Run later standard attempts as fresh,
-distinct, ordered attempts until the current clean suffix reaches
-`standard_required_clean_runs`, which must be at least five. Each command
-carries:
+distinct, ordered attempts until the v2 chain's trailing clean suffix reaches
+`standard_required_clean_runs`, which must be at least five, and ends with a
+clean standard attempt on the current tuple. Each command carries:
 
 ~~~bash
 cas review run --cwd <repo> --base <base-ref> \
@@ -192,37 +277,55 @@ pre-0.2.75 binding is `invalid-proof` for closeout.
 ## Lane accounting
 
 ~~~text
-valid auxiliary clean           -> satisfy that auxiliary request; standard count unchanged
-valid auxiliary findings        -> require RF-v2 fold; accepted artifact changes invalidate current requests
-invalid clean                    -> no credit; rerun the exact current request
-invalid findings                 -> candidate-pressure until owner-boundary validation and a valid rerun
-selected-pending                 -> blocks closeout
-valid standard clean             -> append one distinct ordered attempt ID
-standard findings or code change -> reset the current standard clean suffix
+valid auxiliary clean                -> satisfy that current auxiliary request; standard count unchanged
+valid auxiliary findings             -> require RF-v2 fold and resolution; current requests become stale after repair
+certified auxiliary-remediation carry -> preserve the standard suffix; add no credit; rerun the full current wave
+invalid clean                         -> no credit; rerun the exact current request
+invalid findings                      -> candidate-pressure until owner-boundary validation and a valid rerun
+selected-pending                      -> blocks closeout
+valid standard clean                  -> append one distinct ordered standard attempt ID
+valid standard findings               -> append the finding fact and reset the trailing standard clean suffix
+unrelated or uncertified tuple change -> reset the chain
 ~~~
 
-Only distinct, current, ordered standard attempts contribute to
-`standard_clean_attempt_ids`. Auxiliary attempts never contribute: auxiliary
-clean results only discharge their execution obligation, while auxiliary
-findings enter RF-v2. The policy artifact, not CAS history or lock state,
-determines whether the required clean suffix and every auxiliary request are
-satisfied.
+Only distinct, ordered standard `clean` facts contribute to
+`standard_clean_attempt_ids`. They may retain their original earlier tuples
+only when every intervening tuple transition is a valid carry. Auxiliary
+attempts and carry transitions never contribute: auxiliary clean results only
+discharge their execution obligation, while auxiliary findings enter RF-v2.
+The policy artifact, not CAS history or lock state, determines whether the
+required clean suffix and every current auxiliary request are satisfied.
 
 The closeout checker requires `standard_clean_attempt_ids` to equal the exact
-trailing required clean suffix; it rejects duplicate attempt identity,
-cross-lane credit, stale artifact bindings, open auxiliary states, and any
+trailing required suffix derived from `standard_clean_chain`. It rejects
+duplicate attempt identity, cross-lane credit, missing or extraneous carry
+edges, standard findings inside that suffix, contract drift, a chain that does
+not end clean on the current tuple, open current auxiliary states, and any
 invalidation reason.
 
 ## Invalidation
 
-Invalidate affected review requests when any bound artifact identity,
-contract byte, instruction byte, contract ID, policy selection, resolution
-digest, or publication epoch changes. Recover timeouts through the same CAS
-handle; do not turn recovery into another independent attempt.
+Invalidate every current request when any bound artifact identity, instruction
+byte, resolution digest, or publication epoch changes. No auxiliary result from
+the preceding artifact survives as closeout evidence; relaunch the full
+concurrent wave against the new artifact. Recover timeouts through the same CAS
+handle and do not turn recovery into another independent attempt.
 
-Any accepted artifact change invalidates the standard suffix and every
-auxiliary request. Relaunch the full concurrent wave against the new artifact;
-no auxiliary result from the preceding artifact survives as closeout evidence.
+Reset `standard_clean_chain` when the review-contract manifest changes, a
+standard attempt reports findings, the base identity changes, the artifact
+change contains any unclassified or unrelated mutation, or the transition
+lacks any required auxiliary-resolution, correctness, actuation, or SHIP
+evidence. A caller-authored reason or boolean exemption cannot preserve credit.
+
+The sole artifact-change exception is a v2 `auxiliary-remediation` carry. At the
+next artifact's preflight, retain the prior exhaustive standard history and its
+exact clean projection, append one dangling carry from the last clean standard
+attempt to the new current artifact, and keep every new current request pending.
+At closeout, append the new tuple's exhaustive standard attempts, require the
+carry to connect to the first new row, recompute the trailing clean projection,
+and require at least one clean standard attempt plus all auxiliary evidence on
+the current tuple. Multiple auxiliary repairs may compose only as a chain of
+individually certified carries separated by standard attempts.
 
 Adding a lens, renaming a lens, changing a contract, or changing the required
 clean count must require zero CAS schema or implementation changes.

--- a/codex/skills/actuating/references/review-resolution.md
+++ b/codex/skills/actuating/references/review-resolution.md
@@ -29,7 +29,7 @@ review_resolution:
   review_profile:
     policy_ref:
     policy_digest:
-    review_contract_fingerprint:
+    review_contract_fingerprint: # equals the v2 aggregate review-contract manifest digest
     selected_lenses: [standard, footgun-finder, invariant-ace, complexity-mitigator, fresh-eyes]
     standard_required_clean_runs: 5
     standard_clean_attempt_ids: []
@@ -212,8 +212,11 @@ count grants no authority.
 
 Finding semantics and source-to-producer lineage remain cumulative across a
 replacement SHIP. The new receipt resets publication-local fold/batch and CAS
-credit, not admitted liabilities; the next repair resolution must strictly
-extend the retained finding set and preserve every retained source backend.
+current-request credit, not admitted liabilities. Standard clean credit may
+cross that publication boundary only through the owning policy's certified
+`auxiliary-remediation` carry; no auxiliary result survives. The next repair
+resolution must strictly extend the retained finding set and preserve every
+retained source backend.
 
 The resolved re-fold after the last repair preserves exactly the admitted
 finding set and every admitted source reference, and uses another fresh fold
@@ -221,8 +224,11 @@ plus a producer batch that carries material evidence. A newly observed material
 finding keeps the resolution pending and requires another admitted
 continuation. Only after the retained PR is revalidated against the
 admission-bound published artifact may `$ship` update that PR to the resolved
-local head. All earlier policy credit attached to CAS attempts belongs to the
-preceding publication epoch and resets to zero.
+local head. Earlier current-request and auxiliary credit belongs to the
+preceding publication epoch and resets to zero. Earlier standard attempts keep
+their original epoch and tuple; they contribute to the new trailing suffix only
+when the v2 policy binds the intervening auxiliary-remediation carry and later
+ends clean on the current tuple.
 
 ## Abstraction audit
 
@@ -260,7 +266,7 @@ constructs.
 
 The resolution digest is the canonical digest of the artifact binding, source
 finding set, change surfaces, review profile, decisions, and semantic balance.
-The owning `actuation-review-policy/v1` request binds that digest before CAS
+The owning `actuation-review-policy/v2` request binds that digest before CAS
 execution.
 
 ## Review contract
@@ -274,5 +280,8 @@ returns only the opaque request binding and transport facts.
 A post-run label cannot create auxiliary evidence. Credit requires an exact
 join among the pre-bound policy request, its actuation event, the returned CAS
 binding and tuple, and any RF-v2 fold. A new finding or code change updates the
-resolution, changes its digest, invalidates affected requests, and resets the
-current standard clean suffix.
+resolution, changes its digest, and invalidates affected current requests. A
+standard finding or unrelated change resets the standard chain. An
+auxiliary-only repair may preserve its existing clean projection solely through
+the v2 carry that binds this resolution's class, witnesses, actuation evidence,
+and publication receipt.

--- a/codex/skills/goal-actuating/SKILL.md
+++ b/codex/skills/goal-actuating/SKILL.md
@@ -89,7 +89,7 @@ operation.
 For review work, preserve this ownership order:
 
 ~~~text
-actuation-review-policy/v1
+actuation-review-policy/v2
 -> pre-bound exact lens request, contract digest, and instruction digest
 -> passing policy preflight decision
 -> GoalContract digest and review verifier obligations
@@ -113,7 +113,7 @@ recovery, pass `--timeout-ms 1800000` explicitly:
 First require `cas_rer_opaque_request_binding_v1=true`,
 `cas_review_history_v2=true`, and
 `cas_review_scoped_instructions_v1=true` from `cas capabilities` for
-closure-grade work.
+closure-grade work. Require Ledger 0.7.0 or newer before validating a v2 policy.
 
 ~~~bash
 cas review run --cwd <repo> --base <base-ref> \
@@ -149,11 +149,24 @@ lanes behind the standard streak. Auxiliary results may introduce findings or
 discharge their own request, but their attempt identities never enter
 `standard_clean_attempt_ids`.
 
+For an initial v2 preflight, require an empty `standard_clean_chain`. After an
+auxiliary-only repair and SHIP update, allow the next preflight to retain the
+prior ordered standard history and clean projection only when it appends one
+`auxiliary-remediation` carry from the last clean standard attempt to the new
+artifact. Bind the prior auxiliary request IDs and folds, current resolution
+digest, correctness decisions, observed preservation and progress obligations,
+actuation event refs, and SHIP-v1 receipt. Keep every new current request
+`selected-pending`. The carry is a transition, not a review attempt, and never
+increments the clean count.
+
 After exhaustive current CAS history has been joined into the policy snapshot,
 execute the same checker with `--phase closeout`. The validation decision checks the
 stable policy algebra; `$goal-actuating` still proves that the concurrent wave
 was dispatched from the pre-bound requests and that the supplied history is
-exhaustive.
+exhaustive across every standard request epoch retained in the chain. Append
+current standard terminal facts in their actual order, including findings;
+require the current request attempts to equal the chain's current-tuple rows,
+and require the chain to end with a clean standard attempt on the current tuple.
 
 After `$review-fold`, require each accepted equivalence class to have exactly
 one `correctness_refinement` at the classified owner boundary. Before preparing
@@ -184,12 +197,17 @@ The current resolution may select at most one owner node. Project that node's
 ID, owner, paths, and proof requirements into the operation and obligations.
 Refresh sources and open a new generation after any repair or publication
 change; do not relabel a closed generation. Relaunch the first standard attempt
-and every auxiliary request concurrently for the new artifact.
+and every auxiliary request concurrently for the new artifact. Reset the chain
+unless the entire change is the certified auxiliary remediation represented by
+the carry; standard findings, contract or registry drift, base movement, and
+unrelated edits always reset it.
 
 For publication-bearing closeout, bind the accepted SHIP-v1, resolution digest,
 publication tuple, actuation review policy, and selected request identities into
 the next GoalContract. `$ship` alone updates the retained PR. A final published
-change invalidates earlier request and tuple bindings.
+change always invalidates earlier current-request and auxiliary evidence. It
+preserves earlier standard convergence credit only through the v2 carry while
+leaving every retained attempt bound to its original request and tuple.
 
 ## Lifecycle handoff
 

--- a/codex/skills/hylo/SKILL.md
+++ b/codex/skills/hylo/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: hylo
-description: "Compile real Codex sessions and repo-local Ledger evidence into portable replay campaigns, run blind repeated attempts in reconstructed or generated environments, grade outcomes with evidence-bound rubrics, append attempts and grades to `.ledger/hylo/events.jsonl`, and derive comparable progress/frontier views. Use for `$hylo`, self-replay, experience-driven evaluation, session-derived training environments, replay-and-grade loops, repeated agent or skill improvement on real historical requests, or tracking whether responses improve across controlled reruns."
+description: "Compile real Codex sessions and repo-local Ledger evidence into portable replay campaigns, run blind repeated attempts in reconstructed or generated environments, grade outcomes with evidence-bound rubrics, append attempts and grades through the native Hylo Ledger source, and derive comparable progress/frontier views. Use for `$hylo`, self-replay, experience-driven evaluation, session-derived training environments, replay-and-grade loops, repeated agent or skill improvement on real historical requests, or tracking whether responses improve across controlled reruns."
 ---
 
 # Hylo
@@ -79,7 +79,9 @@ report that the native source must be upgraded. Never route Hylo grades through
 `learnings`, `negative-ledger`, `actuation`, `synesthesia`, or `universalist`
 merely to obtain append semantics.
 
-The native Hylo source is the exclusive mutation owner for:
+The native Hylo source is the exclusive mutation owner for operational replay
+evidence. Hylo semantics depend on Ledger's event-store contract, not a storage
+format. The current persistent adapter retains this path for compatibility:
 
 ```text
 <repo>/.ledger/hylo/events.jsonl
@@ -383,6 +385,6 @@ Hylo:
 - No publication unless committed target bytes equal the promoted target snapshot.
 - No staging unrelated paths; do not force-add locally excluded Hylo Ledger artifacts.
 - No raw capabilities, secrets, private reasoning, or unredacted sensitive data in campaign artifacts or events.
-- No hand-editing `.ledger/hylo/events.jsonl`.
+- No hand-editing the current `.ledger/hylo/events.jsonl` adapter.
 - No fallback store writer when the native Hylo source is unavailable.
 - No infinite self-improvement claim: report the observed campaign boundary and stop rule.

--- a/codex/skills/hylo/references/contracts.md
+++ b/codex/skills/hylo/references/contracts.md
@@ -13,16 +13,17 @@ An adapter in any language may interpret those files if it preserves request
 visibility, hidden references, environment and effect boundaries, split
 membership, oracles, and fingerprints.
 
-The native Ledger source owns operational evidence:
+The native Ledger source owns operational evidence through Ledger's event-store
+contract. The current persistent adapter resolves the logical store to:
 
 ```text
 <repo>/.ledger/hylo/events.jsonl
 <repo>/.ledger/hylo/events.jsonl.lock
 ```
 
-Only `ledger --source hylo append` may mutate the event store. The lock sidecar
-is coordination state and must be Git-ignored. A custom `--path` must remain
-inside the addressed repository.
+Only `ledger --source hylo append` may mutate the logical event store. Under the
+current JSONL adapter, the lock sidecar is coordination state and must be
+Git-ignored. A custom `--path` must remain inside the addressed repository.
 
 ## Identifiers and fingerprints
 

--- a/codex/skills/ledger/SKILL.md
+++ b/codex/skills/ledger/SKILL.md
@@ -72,19 +72,24 @@ Canonical source APIs:
 - `ledger --source learnings`
 - `ledger` for negative evidence
 - `ledger --source synesthesia` when present
+- `ledger --source actuation`
+- `ledger --source hylo`
 
-Current persistent-adapter locations, retained for path compatibility and
-explicit migration:
+Current source-memory persistent-adapter locations, retained for path
+compatibility and explicit migration:
 
 - `.ledger/learnings/events.jsonl`
 - `.ledger/negative-ledger/events.jsonl`
 - `.ledger/synesthesia/events.jsonl` when present
 
-Operational, non-memory store:
+Operational, non-memory stores:
 
-- `.ledger/actuation/events.jsonl`, owned exclusively by
-  `ledger --source actuation`; do not harvest it into memory or route its writes
-  through source-memory coordination.
+- `.ledger/actuation/events.jsonl` is the current actuation persistent adapter,
+  owned exclusively by `ledger --source actuation`; do not harvest it into
+  memory or route its writes through source-memory coordination.
+- `.ledger/hylo/events.jsonl` is the current Hylo persistent adapter, owned
+  exclusively by `ledger --source hylo`; do not harvest it into memory or
+  route its writes through source-memory coordination.
 
 Operational, non-memory artifacts:
 
@@ -160,6 +165,9 @@ to source-specific skills and native source APIs:
 - `$memory-source-notes` / `memory-note` for immutable admission snapshots.
 - `$actuating` / `ledger --source actuation` for the operational actuation
   event chain; this is not a memory-admission source.
+- `$hylo` / `ledger --source hylo` for operational replay-campaign evidence;
+  the current compatibility adapter is `.ledger/hylo/events.jsonl`, and this is
+  not a memory-admission source.
 - `$universalist` owns plan contents and updates;
   `ledger --source universalist` owns plan identity, atomic creation, and
   address resolution.

--- a/codex/skills/ledger/references/source-store-layout.md
+++ b/codex/skills/ledger/references/source-store-layout.md
@@ -6,19 +6,28 @@ Canonical repo-local sources are addressed through their native APIs:
 ledger --source learnings
 ledger
 ledger --source synesthesia
+ledger --source actuation
+ledger --source hylo
 ```
 
-The current persistent adapter resolves those sources under:
+Current source-memory persistent-adapter locations:
 
 ```text
 .ledger/learnings/events.jsonl
 .ledger/negative-ledger/events.jsonl
 ```
 
-Optional adapter location:
+Optional source-memory adapter location:
 
 ```text
 .ledger/synesthesia/events.jsonl
+```
+
+Operational, non-memory adapter locations:
+
+```text
+.ledger/actuation/events.jsonl
+.ledger/hylo/events.jsonl
 ```
 
 Legacy stores:


### PR DESCRIPTION
## What changed

- align Actuating and goal-actuating doctrine with `actuation-review-policy/v2`
- preserve standard clean credit only through certified auxiliary-remediation carries
- describe Hylo evidence through the native Ledger source and shared event-store contract
- identify `.ledger/hylo/events.jsonl` as the current persistent adapter rather than semantic truth
- add Hylo and actuation to the Ledger source-layout doctrine

## Why

The operator skills must match Ledger 0.7.0's proof-credit and storage boundaries before that CLI is released.

## Validation

- `quick_validate.py` passed for `actuating`, `goal-actuating`, `hylo`, and `ledger`
- `live-semantics.yaml` parsed successfully
- `git diff --check` passed
