### PR TITLE
Clarify review-policy verifier ownership

### DIFF
--- a/codex/skills/actuating/references/review-policy.md
+++ b/codex/skills/actuating/references/review-policy.md
@@ -161,6 +161,13 @@ observed preservation and progress obligations, actuation events, and SHIP-v1
 receipt that produced the next artifact. The edge preserves the suffix length;
 it never adds an attempt ID.
 
+The policy checker validates this chain algebra and the presence, identity, and
+joins of its cited fields; it does not open RF-v2, resolution, actuation, or
+SHIP artifacts and rediscover their semantics. `$goal-actuating` must verify
+those exact referenced artifacts, prove that the repair contains no unrelated
+mutation, and bind those verifier commands into the GoalContract before the
+carry receives credit.
+
 For a selected request, `request_fingerprint` equals `instruction_digest`: the SHA-256 of the exact
 persisted UTF-8 bytes at `instructions_ref`. The pre-bound policy row and
 GoalContract digest bind those bytes to policy version, artifact identity,


### PR DESCRIPTION
## Summary

- State that the Ledger policy checker validates carry-chain algebra, cited-field identity, and joins.
- Keep semantic verification of RF-v2, resolution, actuation, and SHIP artifacts with $goal-actuating.
- Require the GoalContract to bind the exact verifier commands and unrelated-mutation proof before carry credit.

## Verification

- uv run codex/skills/.system/skill-creator/scripts/quick_validate.py codex/skills/actuating
- git diff --check
- confirmed the Ledger checker opens instruction and contract references while treating cited carry artifacts as reference identities

## Learning disposition

Duplicate-skip: the existing owner-versus-executable-hosting learning already covers this boundary.