### PR TITLE
universalist: generalize pullback and pushout mechanics

### DIFF
--- a/codex/agents/universalist-categorical-architect.toml
+++ b/codex/agents/universalist-categorical-architect.toml
@@ -8,16 +8,18 @@ developer_instructions = """
 Role: Select the smallest canonical categorical architecture that closes the assigned obligation.
 
 Focus on:
-- products, coproducts, refinements, pullbacks, quotients, free/cofree objects;
+- products, coproducts, refinements, equalizers/coequalizers, pullbacks, pushouts, quotients, free/cofree objects;
+- pullback agreement objects, pushout integration, pushout complements, double-pushout graph/model rewriting, and adhesive-category assumptions;
 - adjunctions, Kan extensions/lifts, Yoneda/Coyoneda, density/codensity;
 - sheafification, schema/data-exchange, abstract domains, relations, coalgebras, effects;
 - categories, monoidal categories, Freyd/premonoidal categories, colored operads, PROPs/properads, traced structures, and resource-sensitive composition;
 - easy-world/category pivots when the ordinary executable world is opaque;
 - effective presentation and one executable law/falsifier;
-- choose the weakest composition geometry that makes legal assembly, sequencing, symmetry, feedback, and resources explicit.
+- choose the weakest composition geometry that makes legal assembly, agreement, gluing, sequencing, symmetry, feedback, and resources explicit.
+
+For pullbacks and pushouts, require the actual shared target or overlap maps, square commutativity, factorization, and an engineering approximation of uniqueness. Reject plain pairs mislabeled as pullbacks and plain merges mislabeled as pushouts. For DPO rewrites, require a preserved interface and pushout-complement obstruction analysis.
 
 Compare nearby alternatives. Return obstruction rather than decorative category theory.
 
 Do not spawn subagents. Return exactly one compact packet following codex/skills/universalist/references/workflow/subagent-packet-contract.md. Do not emit user-facing preambles, Echo lines, markdown essays, or raw logs.
-
 """

--- a/codex/agents/universalist-proof-auditor.toml
+++ b/codex/agents/universalist-proof-auditor.toml
@@ -12,6 +12,9 @@ Check:
 - category-theoretic claims versus engineering analogy;
 - syntax/semantics soundness and adequacy;
 - effect/state/interaction totality;
+- pullback claims: real shared target, agreement equation, factorization, uniqueness approximation, mismatch rejection;
+- pushout claims: real overlap object and maps, exact identifications, non-overlap/provenance preservation, factorization, uniqueness approximation, false-merge counterexample;
+- double-pushout claims: preserved interface, pushout-complement existence, dangling/identification conditions, rewrite provenance, adhesive assumptions where composition is claimed;
 - operadic substitution and port-typing laws;
 - Freyd pure-embedding, centrality, evaluation-order, and observational-commutativity claims;
 - observation family and equivalence claims;
@@ -19,8 +22,7 @@ Check:
 - resource feasibility;
 - strongest counterexample, missing law, and obstruction.
 
-Do not propose broad rewrites. Return pass, narrow, revise, or obstruct with minimum proof obligations.
+Do not accept square commutativity alone as a pullback/pushout proof. Require a credible factorization path and a canonical-construction argument approximating uniqueness. Do not propose broad rewrites. Return pass, narrow, revise, or obstruct with minimum proof obligations.
 
 Do not spawn subagents. Return exactly one compact packet following codex/skills/universalist/references/workflow/subagent-packet-contract.md. Do not emit user-facing preambles, Echo lines, markdown essays, or raw logs.
-
 """

--- a/codex/skills/universalist/README.md
+++ b/codex/skills/universalist/README.md
@@ -2,7 +2,7 @@
 
 Single drop-in Universal Architecture workflow for domain algebra, law discovery, structural refactoring, and universal-construction-driven software synthesis. This version folds the former `kan` skill into `universalist` as an internal mechanics layer, so `$universalist` is the only top-level skill needed for this doctrine.
 
-It keeps the Universalist intent: **one signal, one seam, one smallest honest construction**. It now folds Algebra-Driven Design into Track A0 so local worlds are discovered through carriers, operations, observations, laws, non-laws, interpreters, and property tests before escalation. It adds Track D for universal architecture boundaries: free syntax, coherent observations, transported semantics, lifted implementations, Freyd/AFT-style free-builder diagnostics, obstruction reports, behavioral coalgebras, effect signatures with handlers, Freyd/premonoidal effect boundaries, operadic component grammars, explicit IR, and law tests.
+It keeps the Universalist intent: **one signal, one seam, one smallest honest construction**. It now folds Algebra-Driven Design into Track A0 so local worlds are discovered through carriers, operations, observations, laws, non-laws, interpreters, and property tests before escalation. It adds Track D for universal architecture boundaries: free syntax, coherent observations, pullback witnesses, pushout integration, transported semantics, lifted implementations, Freyd/AFT-style free-builder diagnostics, obstruction reports, behavioral coalgebras, effect signatures with handlers, Freyd/premonoidal effect boundaries, operadic component grammars, explicit IR, and law tests.
 
 ## Install
 
@@ -24,7 +24,7 @@ Activation is broad; escalation is proportional. The boundary pass may preserve 
 
 The skill decides whether the boundary should remain ordinary or needs:
 
-- product/coproduct/refined type/pullback/exponential/free construction;
+- product/coproduct/refined type/pullback/pushout/exponential/free construction;
 - canonical boundary artifact;
 - lifted implementation or obstruction report;
 - behavioral coalgebra for stateful/protocol behavior;
@@ -32,7 +32,7 @@ The skill decides whether the boundary should remain ordinary or needs:
 - observation/generation vocabulary;
 - explicit first-order IR.
 
-Use `$universalist` for the full boundary workflow. Detailed Kan extension/lift, Freyd/AFT, Yoneda/Coyoneda, codensity, categorical-data, and defunctionalization mechanics now live inside `references/mechanics/` and `scripts/emit_mechanics_report.sh`; load them only after the boundary pass justifies escalation.
+Use `$universalist` for the full boundary workflow. Detailed Kan extension/lift, Freyd/AFT, pullback/pushout, Yoneda/Coyoneda, codensity, categorical-data, graph-rewrite, and defunctionalization mechanics now live inside `references/mechanics/` and `scripts/emit_mechanics_report.sh`; load them only after the boundary pass justifies escalation.
 
 ## Ledger-addressed plans
 
@@ -51,7 +51,6 @@ the run. Use `ledger latest --source universalist` only as a recovery lookup,
 then verify the plan's task metadata before resuming it. Existing flat
 `.ledger/universalist-plan-*.md` files remain readable legacy addresses and
 are not rewritten.
-
 
 ## Track A0 — Domain Algebra Discovery
 
@@ -83,7 +82,7 @@ Ordinary code lives inside boundaries. Universal artifacts live at boundaries.
 
 ## Worlds and boundaries practice
 
-This version makes worlds and boundaries the first Track D step. Before selecting Kan, Freyd/AFT, Yoneda/Coyoneda, defunctionalization, effects, or coalgebras, the skill asks for worlds, objects, transformations, invariants, observations, primitives, composition rules, boundary kind, what is preserved/forgotten/generated/observed, and the law that would catch drift.
+This version makes worlds and boundaries the first Track D step. Before selecting Kan, Freyd/AFT, pullback/pushout, Yoneda/Coyoneda, defunctionalization, effects, or coalgebras, the skill asks for worlds, objects, transformations, invariants, observations, primitives, composition rules, boundary kind, what is preserved/forgotten/generated/observed, and the law that would catch drift.
 
 The rule is:
 
@@ -129,7 +128,6 @@ Useful commands:
 ./scripts/emit_context_publication_boundary.sh published-context agnostic
 ```
 
-
 ## Possibility Sheafification
 
 Track G treats the codebase as a usage site. Local uses are sections; shared fields, tests, traces, and observations are overlaps. A correct architecture-level abstraction behaves like a sheaf: compatible local meanings glue uniquely to one global meaning. Use this track to replace inexact abstractions with canonical artifacts and produce a Sheafification Certificate.
@@ -145,8 +143,6 @@ Useful commands:
 ./scripts/emit_category_pivot.sh abstract-domain agnostic
 ./scripts/emit_syntax_semantics_certificate.sh ToolOperation typescript
 ```
-
-
 
 ## Composition geometry: Freyd categories and operads
 
@@ -170,7 +166,31 @@ The former `freyd` mechanics name was ambiguous. Use:
 ./scripts/emit_mechanics_report.sh operad typescript
 ```
 
-A bare `freyd` mechanics request now fails with a disambiguation message rather than silently selecting the wrong construction.
+A bare `freyd` mechanics request fails with a disambiguation message rather than silently selecting the wrong construction.
+
+## Pullbacks, pushouts, and graph rewriting
+
+The mechanics layer now treats these as general software constructions rather than only a context-reconciliation analogy:
+
+```text
+pullback        canonical witness that two values agree through a shared projection
+pushout         canonical integration that glues two sources along explicit overlap
+double pushout  graph/model rewrite with delete-preserve-add structure
+```
+
+Use pullbacks for typed joins, authorization contexts, wire/domain compatibility, synchronized views, and evidence attached to required claims. Use pushouts for schema/data integration, modular API or language extension, canonical models, and overlap-based reconciliation. Use double-pushout mechanics when a graph/model rewrite may fail because the preserved interface or pushout complement is invalid.
+
+The distinctive proof obligation is not merely a commuting square. Require factorization through the canonical witness/integrated artifact and approximate uniqueness with opaque constructors, canonical IDs, normalization, and removal of competing public paths.
+
+Useful commands:
+
+```bash
+./scripts/emit_mechanics_report.sh pullback typescript
+./scripts/emit_mechanics_report.sh pushout agnostic
+./scripts/emit_mechanics_report.sh pullback-pushout agnostic
+./scripts/emit_mechanics_report.sh double-pushout agnostic
+bash ./scripts/check_pullback_pushout_mechanics.sh
+```
 
 ## Unified mechanics layer
 
@@ -186,7 +206,7 @@ Use the unified workflow:
 
 ```text
 $universalist identifies the signal, seam, worlds, boundary, artifact, witness, law, falsifier, and certificate.
-Mechanics references elaborate Kan/Yoneda/Coyoneda/Freyd/codensity/CQL/sheafification only when needed.
+Mechanics references elaborate Kan/Yoneda/Coyoneda/Freyd/pullback/pushout/codensity/CQL/sheafification only when needed.
 ```
 
 Useful mechanics commands:
@@ -194,6 +214,9 @@ Useful mechanics commands:
 ```bash
 ./scripts/emit_mechanics_report.sh index
 ./scripts/emit_mechanics_report.sh kan-lift typescript
+./scripts/emit_mechanics_report.sh pullback typescript
+./scripts/emit_mechanics_report.sh pushout agnostic
+./scripts/emit_mechanics_report.sh double-pushout agnostic
 ./scripts/emit_mechanics_report.sh codensity-presentation agnostic
 ./scripts/emit_mechanics_report.sh cql-context agnostic
 ./scripts/emit_mechanics_report.sh sheafification typescript
@@ -202,8 +225,6 @@ Useful mechanics commands:
 ```
 
 You can safely remove `codex/skills/kan`; this package is self-contained.
-
-
 
 ## Effective universal substrate and custom-agent workflow
 

--- a/codex/skills/universalist/references/artifact-selection-by-unknown-location.md
+++ b/codex/skills/universalist/references/artifact-selection-by-unknown-location.md
@@ -7,7 +7,9 @@ Choose the artifact by asking where the unknown lives.
 | Independent data | Product | record/object | construct and project consistently |
 | Exclusive state | Coproduct | ADT/sealed union | exhaustive handling, invalid shapes rejected |
 | Stable predicate | Refined type / equalizer | checked constructor/wrapper | valid accepted, invalid rejected |
-| Shared projection agreement | Pullback | witness pair/join object | mismatches rejected, projections preserved |
+| Shared projection agreement | Pullback | witness pair/join object | mismatches rejected, projections preserved, compatible alternatives factor through it |
+| Integrated output from explicit overlap | Pushout | canonical merged schema/model/module | source injections agree on overlap; compatible consumers factor through it |
+| Delete-preserve-add graph/model rewrite | Pushout complement + double pushout | rewrite rule and trace | dangling/identification failures rejected; preserved interface unchanged |
 | Supplied behavior | Exponential | strategy/function seam | parity with old branch fixtures |
 | Syntax from generators | Free construction / initial algebra | AST/IR plus interpreters | interpreter agrees with old evaluator |
 | Ongoing behavior over time | Behavioral coalgebra | state transition + observation | traces satisfy observations |
@@ -23,5 +25,7 @@ Choose the artifact by asking where the unknown lives.
 | Generated payloads lose provenance | Coyoneda-style path vocabulary | payload + path + lowering | lowering equals direct interpretation |
 | Query/projection sprawl | Yoneda-style observation vocabulary | `Observation` + `runObservation` | representation change preserves observations |
 | Callbacks cross boundary | Defunctionalized IR | constructors + `apply` | encoded case equals old callback behavior |
+
+Use pullback only when there is a real shared target/observation and an agreement equation. Use pushout only when there is a real overlap object and explicit maps into both sources. A plain pair is not automatically a pullback; a plain merge is not automatically a pushout.
 
 If the unknown location is unclear, do not escalate. First pick a smaller seam and a concrete witness.

--- a/codex/skills/universalist/references/boundary-law-catalogue.md
+++ b/codex/skills/universalist/references/boundary-law-catalogue.md
@@ -7,6 +7,9 @@ These are practical proof signals, not formal proofs. Use one positive law and o
 | Embedding | `new(embed(old)) == old(old)` | embedded old case changes behavior |
 | Projection | `observe(project(internal)) == expectedPublicBehavior` | internal candidate cannot produce public observation |
 | Forgetful | `forget(combineRich(a,b)) == combineRaw(forget(a),forget(b))` | forgetting after combination disagrees with combining forgotten values |
+| Pullback agreement | `f(projectA(p)) == g(projectB(p))`; every compatible pair factors through the canonical witness | mismatched pair admitted, projections lost, or two distinct public mediators preserve the same views |
+| Pushout gluing | `injectA(includeA(o)) == injectB(includeB(o))`; every compatible pair of consumers factors through the integrated artifact | false identification, silent conflict collapse, lost non-overlap data, or noncanonical duplicate integration paths |
+| Double-pushout rewrite | preserved interface survives; delete/add squares commute; rewrite runs only when pushout complement exists | dangling edge, forbidden identification, deleted shared structure, or silently guessed complement |
 | Interpreter | `interpret(translate(syntax)) == oldBehavior(syntax)` | translated syntax changes behavior |
 | Serializer | `decode(encode(internal))` preserves public invariants | encoded form loses required evidence |
 | Migration | `oldReport(old) == oldReport(restrict(migrate(old)))` | migrated data breaks old report |
@@ -19,3 +22,5 @@ These are practical proof signals, not formal proofs. Use one positive law and o
 | Defunctionalization | `apply(encodedCase,x) == oldFunction(x)` | constructor payload omits captured behavior |
 | Free builder | `project(free(required(case)))` satisfies required behavior | projection loses evidence required by behavior |
 | Residual obligation | missing obligation fails; satisfying obligations passes | accepted implementation lacks required obligation |
+
+For pullbacks and pushouts, do not stop at square commutativity. The distinctive universal obligation is factorization through the selected artifact, with uniqueness approximated by an opaque canonical constructor, quotient/normal form, and no competing public construction path.

--- a/codex/skills/universalist/references/canonical-boundary-artifacts.md
+++ b/codex/skills/universalist/references/canonical-boundary-artifacts.md
@@ -1,5 +1,107 @@
 # Canonical Boundary Artifacts
 
+Use this catalogue after naming the worlds, boundary kind, unknown location, witness slice, law, and falsifier. Select the smallest artifact that makes the seam exact. A category-theory label is justified only when it changes code shape or proof obligations.
+
+## Pullback witness / compatibility object
+
+Use when two source values, models, requests, configurations, or evidence objects must agree through a shared projection.
+
+Code shape:
+
+```text
+data CompatiblePair A B C = ...
+makeCompatible : A -> B -> Result (CompatiblePair A B C)
+projectA : CompatiblePair A B C -> A
+projectB : CompatiblePair A B C -> B
+```
+
+Required data:
+
+```text
+f : A -> C
+g : B -> C
+```
+
+Proof signals:
+
+- `f(projectA(p)) == g(projectB(p))`;
+- mismatches are rejected at construction;
+- both original values remain recoverable;
+- every alternate compatible representation factors through the canonical constructor/API;
+- no public bypass can create an unchecked pair.
+
+Typical uses:
+
+- typed relational joins;
+- request/principal tenant agreement;
+- wire/domain compatibility witnesses;
+- evidence attached to the exact required claim;
+- synchronized model/view or configuration/deployment pairs.
+
+## Pushout integration artifact
+
+Use when two source worlds must be glued along an explicit common overlap.
+
+Code shape:
+
+```text
+data Overlap = ...
+data Integrated = ...
+integrate : SourceA -> SourceB -> OverlapEvidence -> Result Integrated
+```
+
+Required data:
+
+```text
+i : Overlap -> SourceA
+j : Overlap -> SourceB
+injectA : SourceA -> Integrated
+injectB : SourceB -> Integrated
+```
+
+Proof signals:
+
+- `injectA(i(o)) == injectB(j(o))`;
+- only the declared overlap is identified;
+- non-overlap structure survives;
+- conflict is surfaced or resolved by named policy;
+- provenance survives from both sources;
+- every compatible downstream consumer factors through the integrated artifact;
+- canonical IDs/normal forms approximate uniqueness.
+
+Typical uses:
+
+- schema and data integration;
+- modular API/language extension over a common core;
+- canonical enterprise/context models;
+- version/model reconciliation;
+- graph and architecture integration.
+
+Do not call an arbitrary merge a pushout. Without an overlap object and maps into both sources, the semantics are not specified.
+
+## Double-pushout rewrite
+
+Use when a graph/model transformation has explicit delete-preserve-add structure.
+
+```text
+Rule: L <- K -> R
+Match: L -> G
+Result: G <- D -> H
+```
+
+`K` is the preserved interface. First compute a pushout complement `D` to remove `L-K`; then push out `K -> R` and `K -> D` to add `R-K`.
+
+Proof signals:
+
+- preserved interface remains unchanged;
+- deleted structure is absent;
+- added structure is present;
+- dangling and forbidden-identification conditions are rejected;
+- failed pushout complement becomes an obstruction report;
+- rewrite traces retain provenance.
+
+Use for typed graph rewriting, AST/IR graph transformations, model-driven engineering, dependency-graph refactors, and architecture evolution. Prefer adhesive or adhesive-like categories when local rewrites must compose predictably.
+
 ## Free syntax
 
 Use when syntax, execution, logging, explanation, or validation are tangled together.
@@ -97,7 +199,6 @@ Use when public behavior determines internals but no exact/free lifted implement
 Code shape:
 
 ```text
-data RequiredBehavior = ...
 data Obstruction
   = MissingEvidence(...)
   | MissingCapability(...)
@@ -141,7 +242,7 @@ Code shape:
 data State = ...
 data Input = ...
 data Observation = ...
-step : State × Input -> State
+step : State x Input -> State
 observe : State -> ObservationResult
 ```
 
@@ -167,8 +268,7 @@ Proof signals:
 
 - test and production handlers agree on declared observations;
 - every operation has a handler case;
-- handler omits operation -> failing test or exhaustive-match failure.
-
+- omitted operations fail through exhaustive matching or tests.
 
 ## Freyd effect boundary
 
@@ -180,7 +280,7 @@ Code shape:
 Pure C
 Effectful K
 embedPure J : C -> K
-sequence : K(A,B) × K(B,C) -> K(A,C)
+sequence : K(A,B) x K(B,C) -> K(A,C)
 centrality / commutativity witnesses
 ```
 
@@ -188,7 +288,7 @@ Proof signals:
 
 - `J` preserves identity and composition;
 - pure operations commute with effect context;
-- reordered effectful operations agree observationally only when certified;
+- reordered effects agree observationally only when certified;
 - at least one noncommuting pair demonstrates why sequencing matters.
 
 ## Operadic composition grammar
@@ -200,7 +300,7 @@ Code shape:
 ```text
 data Color / PortType
 data Operation(inputs, output)
-substitute : Operation × [Operation] -> Operation
+substitute : Operation x [Operation] -> Operation
 interpret : Operation -> SemanticComponent
 ```
 
@@ -208,7 +308,7 @@ Proof signals:
 
 - ports/colors type-check;
 - identity and substitution laws hold;
-- `interpret(substitute(...))` equals composition of interpreted components;
+- interpretation preserves substitution;
 - forbidden wiring and unjustified permutations are rejected.
 
 ## Explicit IR
@@ -227,7 +327,6 @@ Proof signal:
 ```text
 applyBoundaryCase(encode(oldCallback), input) == oldCallback(input)
 ```
-
 
 ## Dense probe presentation / semantic compression
 

--- a/codex/skills/universalist/references/mechanics/README.md
+++ b/codex/skills/universalist/references/mechanics/README.md
@@ -23,6 +23,7 @@ Kan extensions and lifts
 Freyd/AFT boundary diagnostics
 Freyd categories / premonoidal effect geometry
 Operads and typed composition grammars
+Pullbacks, pushouts, and double-pushout graph rewriting
 Yoneda/Coyoneda representation
 codensity and dense-dual presentations
 defunctionalization
@@ -30,5 +31,7 @@ categorical data / CQL context compilation
 pushout reconciliation
 possibility sheafification mechanics
 ```
+
+Use `pullback` when two source values or structures must agree through a shared observation. Use `pushout` when two sources must be glued along an explicit overlap. Use `double-pushout` for graph/model rewrites with delete-preserve-add structure and a potentially failing pushout complement.
 
 The old `$kan` handoff is removed. Use `$universalist`; then read the relevant mechanics reference lazily.

--- a/codex/skills/universalist/references/mechanics/pullbacks-and-pushouts.md
+++ b/codex/skills/universalist/references/mechanics/pullbacks-and-pushouts.md
@@ -1,0 +1,498 @@
+# Pullbacks and Pushouts
+
+Pullbacks and pushouts are universal constructions for **agreement** and **gluing**.
+
+```text
+Pullback: select or construct the most general object whose two views agree.
+Pushout:  construct the most general object obtained by gluing two objects along an explicit overlap.
+```
+
+Use this mechanics reference only after Universalist has named the worlds, maps, observations, witness slice, and falsifier. A pullback or pushout is justified only when its universal property changes code shape, proof obligations, or ownership.
+
+## 1. Formal shapes
+
+### Pullback
+
+Given:
+
+```text
+f : A -> C
+g : B -> C
+```
+
+a pullback is an object `P` with projections:
+
+```text
+pA : P -> A
+pB : P -> B
+```
+
+such that:
+
+```text
+f . pA = g . pB
+```
+
+and universal among all such agreement objects: for every `X` with maps `xA : X -> A` and `xB : X -> B` satisfying `f . xA = g . xB`, there is a unique `u : X -> P` with:
+
+```text
+pA . u = xA
+pB . u = xB
+```
+
+Diagram:
+
+```text
+        pB
+    P ------> B
+    |         |
+ pA |         | g
+    v         v
+    A ------> C
+        f
+```
+
+Software reading:
+
+> `P` is the canonical witness object containing an `A`-side value and a `B`-side value that agree under their shared projection to `C`.
+
+In `Set`:
+
+```text
+P = { (a,b) in A x B | f(a) = g(b) }
+```
+
+### Pushout
+
+Given:
+
+```text
+i : O -> A
+j : O -> B
+```
+
+a pushout is an object `Q` with injections:
+
+```text
+qA : A -> Q
+qB : B -> Q
+```
+
+such that:
+
+```text
+qA . i = qB . j
+```
+
+and universal among all compatible gluings: for every `X` with maps `xA : A -> X` and `xB : B -> X` satisfying `xA . i = xB . j`, there is a unique `u : Q -> X` with:
+
+```text
+u . qA = xA
+u . qB = xB
+```
+
+Diagram:
+
+```text
+        i
+    O ------> A
+    |         |
+  j |         | qA
+    v         v
+    B ------> Q
+        qB
+```
+
+Software reading:
+
+> `Q` is the canonical integrated object obtained by keeping everything from `A` and `B` while identifying exactly the overlap specified by `O`.
+
+In `Set`, construct it as the disjoint union `A + B` quotiented by the least equivalence relation identifying `i(o)` with `j(o)` for every `o in O`.
+
+## 2. The core distinction
+
+```text
+Pullback = compatibility by shared observation.
+Pushout  = integration by shared presentation.
+```
+
+Use a pullback when the unknown is an **input/witness that must satisfy two projections simultaneously**.
+
+Use a pushout when the unknown is an **integrated output formed by gluing two sources along a declared interface or overlap**.
+
+A useful mnemonic:
+
+```text
+Pull back requirements from a common target.
+Push out sources through a common overlap.
+```
+
+## 3. Decision table
+
+| Pressure | Construction | Software artifact | First law |
+| --- | --- | --- | --- |
+| Two values must agree on a shared key/view | Pullback | validated pair, dependent join, witness object | shared projections are equal |
+| Two APIs/configurations must be jointly satisfiable | Pullback | compatibility context | any compatible candidate factors through it |
+| Two source worlds must be integrated along known overlap | Pushout | canonical merged schema/model/context | injections agree on overlap |
+| Two modules/extensions share a core contract | Pushout | combined extension | every compatible consumer factors through combined artifact |
+| Two independent values need no agreement | Product | record/pair | projections only |
+| Two alternatives remain disjoint | Coproduct | sum/variant | case analysis only |
+| Two maps from one object must be equalized | Equalizer | refined subset | selected values make maps equal |
+| Two representations must be identified | Coequalizer | quotient/normal form | parallel representations become equal |
+
+## 4. Proven software uses of pullbacks
+
+### 4.1 Relational joins and dependent records
+
+A pullback in `Set` is an equijoin:
+
+```text
+Orders.customer_id -> CustomerId <- Customers.id
+```
+
+The pullback contains exactly `(order, customer)` pairs whose keys agree.
+
+Use this reading for:
+
+- typed joins;
+- foreign-key witnesses;
+- attaching evidence to the exact claim/source it belongs to;
+- pairing an API request with the authenticated principal for the same tenant;
+- combining configuration and runtime state that refer to the same deployment.
+
+The law is stronger than “both values exist”: they must agree through the specified maps.
+
+### 4.2 API and authorization contexts
+
+Suppose:
+
+```text
+requestTenant : Request -> TenantId
+principalTenant : Principal -> TenantId
+```
+
+The pullback is the type of authorized request contexts whose request and principal name the same tenant.
+
+```text
+AuthorizedContext = Request x_TenantId Principal
+```
+
+This makes tenant agreement a constructor invariant rather than a repeated runtime branch.
+
+Falsifier: a request/principal pair with differing tenant IDs can be constructed or reaches the handler.
+
+### 4.3 Refinements and dependent compatibility
+
+Use a pullback when a new value must retain evidence that two representations describe the same semantic object:
+
+```text
+ParsedConfig -> ConfigIdentity <- DeployedConfig
+```
+
+The pullback carries both representations plus their agreement witness.
+
+This is useful for:
+
+- validated boundary decoders;
+- wire/domain parity objects;
+- synchronized model/view pairs;
+- migration witnesses;
+- version compatibility contexts.
+
+### 4.4 Synchronous products of state machines
+
+Given stateful systems that expose a shared synchronization label, a pullback-like construction selects pairs of transitions that agree on the shared event. Use cautiously: concurrency, time, fairness, and partiality may require richer categories than plain `Set`.
+
+### 4.5 Exact Context relevance
+
+A pullback expresses **joint relevance**:
+
+```text
+Evidence -> Claim <- ClaimsRequiredByTask
+```
+
+The pullback selects evidence that actually supports or contradicts a required claim, not merely data that is textually similar to a task.
+
+## 5. Proven software uses of pushouts
+
+### 5.1 Schema and data integration
+
+Pushouts are a standard model for integrating schemas or instances with explicit overlap:
+
+```text
+SchemaA <- SharedSchema -> SchemaB
+```
+
+The overlap says which entities, attributes, paths, or equations truly correspond. The pushout produces an integrated target schema.
+
+Use for:
+
+- database integration;
+- enterprise canonical models;
+- CQL/functorial data migration;
+- versioned schema evolution;
+- context reconciliation;
+- ontology or model integration.
+
+The pushout does not discover overlap. Entity resolution, vocabulary alignment, and identity policy remain domain work.
+
+### 5.2 API and module composition
+
+Two modules may extend a shared core interface:
+
+```text
+PaymentsCore -> CardPayments
+PaymentsCore -> BankTransfers
+```
+
+A pushout-shaped artifact combines the extensions while identifying the common core exactly once.
+
+Use only when:
+
+- the overlap contract is explicit;
+- extension names and behaviors are compatible;
+- conflicting definitions are rejected or resolved by named policy;
+- downstream interpreters factor through the combined module.
+
+Falsifier: the combined API contains two incompatible meanings for the same core operation, or identifies operations that only share a name.
+
+### 5.3 Syntax and language extension
+
+Pushouts can combine language fragments or signatures that share a base syntax. This is useful for modular DSLs, effect signatures, type systems, and compiler IR extensions.
+
+The practical artifact is usually:
+
+```text
+BaseSyntax -> ExtensionA
+BaseSyntax -> ExtensionB
+CombinedSyntax
+```
+
+The universal law says any interpreter that consistently interprets both extensions and agrees on the base factors through `CombinedSyntax`.
+
+### 5.4 Graph and model rewriting
+
+Pushouts are foundational in algebraic graph transformation.
+
+For a double-pushout rewrite rule:
+
+```text
+L <- K -> R
+```
+
+and a match `L -> G`:
+
+1. compute a pushout complement to remove `L - K` from host graph `G`, producing context `D`;
+2. compute a pushout of `K -> R` and `K -> D` to add `R - K`, producing rewritten graph `H`.
+
+```text
+L <- K -> R
+|    |    |
+v    v    v
+G <- D -> H
+```
+
+Use DPO reasoning for:
+
+- model-driven engineering;
+- AST/IR graph rewrites;
+- architecture graph evolution;
+- refactoring dependency graphs;
+- visual language tooling;
+- rule-based transformations where deletion and preservation must be explicit.
+
+A pushout complement may fail. Typical obstructions include dangling edges, forbidden identifications, or deletion of shared structure. That failure should become an obstruction report, not a guessed rewrite.
+
+### 5.5 Adhesive categories
+
+Adhesive categories provide well-behaved pushouts along monomorphisms and Van Kampen properties, making graph-like rewriting stable under pullback and composition.
+
+Software guidance:
+
+- if local graph/model rewrites must compose predictably, ask whether the modeling category is adhesive or has an adhesive-like fragment;
+- prefer monic interface embeddings for preserved structure;
+- treat failure of a pushout complement as a first-class invalid rewrite;
+- do not assume arbitrary object categories have graph-like pushout behavior.
+
+Common categories of typed graphs, many presheaf categories, and related model categories support adhesive rewriting patterns.
+
+### 5.6 Multi-source context reconciliation
+
+The existing Universalist Pushout Reconciliation pattern is one application:
+
+```text
+ContextA <- OverlapContext -> ContextB
+```
+
+The integrated context should preserve non-overlap facts, retain provenance from both sources, and expose conflict instead of silently collapsing it.
+
+## 6. Effective implementation patterns
+
+### Pullback in application code
+
+Represent the universal object with an opaque constructor:
+
+```text
+class CompatiblePair<A,B> {
+  private constructor(a, b)
+  static create(a, b, projectA, projectB): Result<CompatiblePair<A,B>>
+}
+```
+
+The constructor checks:
+
+```text
+projectA(a) == projectB(b)
+```
+
+Tests:
+
+- matching projections construct successfully;
+- mismatches fail;
+- both projections are preserved;
+- every alternate compatible representation normalizes through the same constructor/API.
+
+### Pushout in application code
+
+For finite sets/graphs/schemas:
+
+1. tag all elements from `A` and `B`;
+2. introduce identifications generated by `O`;
+3. compute the quotient with union-find, canonical IDs, or a congruence closure;
+4. preserve provenance from each equivalence class to original sources;
+5. reject or report conflicts where the target category requires more than identification.
+
+Tests:
+
+- both source injections preserve source data;
+- overlap images have one canonical representative;
+- unrelated elements remain distinct;
+- compatible downstream consumers factor through the canonical integrated artifact;
+- different merge order does not change the canonical result, when the selected category/policy promises this.
+
+## 7. Universal-property laws as software tests
+
+### Pullback certificate
+
+```text
+Agreement:
+  f(pA(p)) == g(pB(p))
+
+Projection preservation:
+  pA(makeCompatible(a,b)) == a
+  pB(makeCompatible(a,b)) == b
+
+Factorization:
+  every alternate X carrying compatible A/B views maps through P
+
+Uniqueness:
+  two mediators preserving both projections are observationally equal
+```
+
+### Pushout certificate
+
+```text
+Overlap agreement:
+  qA(i(o)) == qB(j(o))
+
+Source preservation:
+  qA and qB retain all non-identified source structure
+
+Factorization:
+  every compatible pair A -> X and B -> X induces Q -> X
+
+Uniqueness:
+  two induced maps agreeing on both injections are observationally equal
+```
+
+In ordinary languages, uniqueness is usually approximated through canonical constructors, normalization, property tests, and the absence of alternate public construction paths.
+
+## 8. Pullback versus pushout selection
+
+Ask these questions in order:
+
+```text
+1. Is the unknown a witness/input satisfying two views of one target?
+   -> Pullback.
+
+2. Is the unknown an integrated output gluing two sources along one overlap?
+   -> Pushout.
+
+3. Is there no shared target/overlap?
+   -> Product or coproduct instead.
+
+4. Are two maps from one source being forced equal?
+   -> Equalizer.
+
+5. Are two maps into one target generating identifications?
+   -> Coequalizer.
+
+6. Is the structure a graph rewrite with deletion/preservation/addition?
+   -> Pushout complement + double pushout; check adhesive conditions.
+```
+
+## 9. Common misconceptions and falsifiers
+
+### “Pushout means merge”
+
+False. A pushout is a merge **along specified maps from an overlap**. No overlap map, no justified pushout.
+
+### “Pullback means fetch both things”
+
+False. A pullback enforces equality of shared projections. A product merely pairs values.
+
+### “The universal property resolves business conflict”
+
+False. It gives the least/general object satisfying declared identifications or agreements. It does not choose which identifiers, attributes, policies, or concepts should be identified.
+
+### “Git merge is a pushout”
+
+Only as an analogy unless a precise category, overlap/base object, morphisms, and universal property are modeled. Textual conflict resolution and history semantics usually require additional structure.
+
+### “Pushouts always exist and behave like set union”
+
+False. Existence and behavior depend on the category. Even when they exist, quotienting can collapse more structure than intended.
+
+### “Pullbacks and pushouts preserve every operational property”
+
+False. Latency, security, ordering, resource ownership, transactionality, and effect semantics require separate witnesses or richer categories.
+
+## 10. Composition Certificate fields
+
+When pullback/pushout mechanics are selected, add:
+
+```text
+Construction:
+  pullback / pushout / DPO rewrite
+
+Category/world:
+  Set / types / schemas / graphs / presheaves / other
+
+Span or cospan:
+  maps and their meanings
+
+Agreement/overlap:
+  equality or identity policy
+
+Universal mediator:
+  constructor, adapter, integrated schema, normalizer, interpreter
+
+Effective construction:
+  validation / join / quotient / union-find / graph rewrite
+
+Law:
+  commutative square + factorization + uniqueness approximation
+
+Falsifier:
+  mismatch admitted / false identification / silent conflict / lost provenance /
+  non-unique public construction / failed pushout complement
+```
+
+## 11. Sources and further reading
+
+- Saunders Mac Lane, *Categories for the Working Mathematician* — limits, colimits, pullbacks, pushouts.
+- Stephen Lack and Paweł Sobociński, *Adhesive Categories* — categorical foundations for compositional graph transformation.
+- Hartmut Ehrig et al., *Fundamentals of Algebraic Graph Transformation* — double-pushout rewriting and applications.
+- David Spivak, *Functorial Data Migration* and related categorical database work.
+- Patrick Schultz and Ryan Wisnesky, *Algebraic Data Integration* — CQL, schema/instance colimits, pushout integration.
+- Brendan Fong and David Spivak, *An Invitation to Applied Category Theory* — compositional systems and universal constructions.

--- a/codex/skills/universalist/references/mechanics/pushout-reconciliation.md
+++ b/codex/skills/universalist/references/mechanics/pushout-reconciliation.md
@@ -1,6 +1,8 @@
-# Pushout Reconciliation
+# Pushout Reconciliation Mechanics
 
-Use pushout-style reconciliation when two or more contexts overlap and must be merged with explicit identity/overlap semantics.
+Read `pullbacks-and-pushouts.md` first for the formal universal property, implementation patterns, DPO rewriting, and selection criteria.
+
+Use this specialization when two or more contexts or schemas overlap and must be integrated with explicit identity, conflict, and provenance semantics.
 
 ```text
 ContextA <- OverlapContext -> ContextB
@@ -11,17 +13,42 @@ ContextA <- OverlapContext -> ContextB
 
 ## Recover
 
-- source contexts;
+- source contexts or schemas;
 - overlap schema;
 - overlap instance / identity correspondences;
+- maps from overlap into each source;
+- attributes and relations safe to identify;
+- attributes and relations that must remain distinct;
 - conflict policy;
 - target integrated context schema;
-- provenance survival policy.
+- provenance survival policy;
+- canonical public integration path.
+
+## Universal law
+
+With `i : O -> A`, `j : O -> B`, `qA : A -> Q`, and `qB : B -> Q`:
+
+```text
+qA . i = qB . j
+```
+
+Every compatible pair of consumers from `A` and `B` that agrees on `O` should factor through `Q`. Approximate uniqueness with one canonical integration function/view and normalized identifiers.
 
 ## Laws
 
 - overlap identities are explicit;
+- only declared overlap is identified;
 - non-overlap facts are preserved;
 - conflicts are reported or resolved by named policy;
 - provenance from each source survives;
-- integrated context satisfies target constraints.
+- integrated context satisfies target constraints;
+- competing merge paths are removed or shown observationally equivalent.
+
+## Falsifiers
+
+- false identity;
+- silent conflict collapse;
+- lost provenance;
+- source-order-dependent result where order independence was promised;
+- integrated constraints are inconsistent;
+- a downstream consumer bypasses the canonical integrated representation.

--- a/codex/skills/universalist/references/pushout-reconciliation.md
+++ b/codex/skills/universalist/references/pushout-reconciliation.md
@@ -1,21 +1,26 @@
 # Pushout Reconciliation
 
-Use Pushout Reconciliation when multiple systems, teams, agents, or stores have overlapping context that must be merged with explicit overlap semantics.
+Pushout Reconciliation is the context/schema integration specialization of the general mechanics in `references/mechanics/pullbacks-and-pushouts.md`.
+
+Use it when multiple systems, teams, stores, models, or contexts have an **explicit overlap** that must be glued with preserved provenance and visible conflict.
 
 ```text
 Context A  <-  Overlap Context  ->  Context B
-     \                              /
-      \                            /
-       ---- Integrated Context ----
+     |                               |
+     v                               v
+              Integrated Context
 ```
 
 ## Use when
 
 - two source worlds overlap;
 - entity identity must be explicit;
+- the overlap maps can be named;
 - conflicting overlap must be surfaced;
 - provenance from each side must survive;
-- merging by string similarity would be unsafe.
+- merging by field name or string similarity would be unsafe.
+
+Do not call an arbitrary merge a pushout. If there is no overlap object and no maps from it into both sources, use ordinary integration language until those semantics are modeled.
 
 ## Artifacts
 
@@ -27,12 +32,57 @@ SourceContextB
 IntegratedContext
 ConflictReport
 ProvenanceManifest
+CanonicalIdPolicy
 ```
+
+## Universal-property witness
+
+Let:
+
+```text
+i : Overlap -> ContextA
+j : Overlap -> ContextB
+qA : ContextA -> IntegratedContext
+qB : ContextB -> IntegratedContext
+```
+
+Require:
+
+```text
+qA . i = qB . j
+```
+
+Then test the software approximation of factorization:
+
+> Every downstream consumer that handles both contexts and agrees on the overlap must consume the canonical integrated context, rather than implement a competing merge path.
+
+Approximate uniqueness with:
+
+- one canonical integration function or materialized view;
+- canonical IDs / normalized representatives;
+- no public bypass merge;
+- property tests showing source-order independence when promised by the policy.
 
 ## Laws
 
 - overlap identities are explicit;
+- only declared overlap structure is identified;
 - non-overlap facts are preserved;
 - overlap conflicts are reported or resolved by named policy;
 - provenance from both sides survives integration;
-- integrated context satisfies target constraints.
+- the integrated context satisfies target constraints;
+- compatible downstream consumers factor through the integrated representation.
+
+## Falsifiers
+
+- false merge caused by name similarity;
+- two source concepts identified despite different semantics;
+- one source silently dominates another without policy;
+- non-overlap data disappears;
+- provenance is lost;
+- two public merge functions yield observably different integrated contexts;
+- no target object can satisfy the declared overlap constraints.
+
+## Operational note
+
+Pushout semantics do not replace transactions, authorization, distributed convergence, temporal ordering, or conflict-resolution policy. Operational stores own mutation; the pushout-shaped integration belongs at a verified publication, migration, reconciliation, or model-transformation boundary.

--- a/codex/skills/universalist/references/sources.md
+++ b/codex/skills/universalist/references/sources.md
@@ -1,18 +1,21 @@
 # Sources and claim boundaries
 
-Use sources only to support mathematical/programming claims. Architecture recommendations are engineering interpretations unless the repo explicitly models the relevant category/functor/law.
+Use sources only to support mathematical/programming claims. Architecture recommendations are engineering interpretations unless the repo explicitly models the relevant category, maps, universal property, and law.
 
 Stable references:
 
-- Mac Lane, *Categories for the Working Mathematician*: adjunctions, products/coproducts, limits/colimits, Yoneda, Kan extensions.
-- Riehl, *Category Theory in Context*: modern presentation of universal properties, adjunctions, limits, Kan extensions.
+- Mac Lane, *Categories for the Working Mathematician*: adjunctions, products/coproducts, limits/colimits, pullbacks, pushouts, Yoneda, Kan extensions.
+- Riehl, *Category Theory in Context*: modern presentation of universal properties, limits/colimits, pullbacks/pushouts, adjunctions, and Kan extensions.
+- Lack and Sobociński, “Adhesive Categories”: well-behaved pushouts along monomorphisms, Van Kampen squares, and foundations for compositional graph rewriting.
+- Ehrig et al., *Fundamentals of Algebraic Graph Transformation*: pushout complements, double-pushout rewriting, gluing conditions, typed graph and model transformation.
+- Spivak/Wisnesky functorial data migration work: schemas as categories and Sigma/Delta/Pi migration.
+- Schultz and Wisnesky, “Algebraic Data Integration”: CQL, schema/instance colimits, pushout integration, constraints, and provenance-aware migration.
+- Fong and Spivak, *An Invitation to Applied Category Theory* / *Seven Sketches in Compositionality*: universal constructions, compositional systems, wiring diagrams, and applied categorical modeling.
 - Reynolds, “Definitional Interpreters for Higher-Order Programming Languages”: origin context for defunctionalization.
 - Danvy and Nielsen, “Defunctionalization at Work”: higher-order to first-order transformation.
-- Spivak/Wisnesky functorial data migration work: schemas as categories and Sigma/Delta/Pi migration.
 - Power and Robinson, “Premonoidal Categories and Notions of Computation”: ordered effectful composition and central morphisms.
 - Power and Thielecke, “Closed Freyd- and kappa-categories”: Freyd-category semantics for call-by-value.
 - Spivak, “The Operad of Wiring Diagrams”: typed hierarchical system assembly.
-- Fong and Spivak, *Seven Sketches in Compositionality*: practical operadic and wiring-diagram composition.
 
 Mark every nontrivial claim as one of:
 
@@ -20,6 +23,16 @@ Mark every nontrivial claim as one of:
 - programming;
 - architecture inference;
 - repo observation.
+
+For pullback/pushout claims, distinguish:
+
+```text
+formal universal property
+software approximation of factorization/uniqueness
+engineering analogy only
+```
+
+Do not call a join a pullback without a shared target and agreement equation. Do not call a merge a pushout without an explicit overlap object and maps into both sources. Do not call a textual or version-control rewrite a double-pushout rewrite unless the host category, rule span, match, pushout complement, and rewrite laws are modeled.
 
 ## Codex workflow sources
 

--- a/codex/skills/universalist/references/structures-and-laws.md
+++ b/codex/skills/universalist/references/structures-and-laws.md
@@ -14,7 +14,54 @@ Use when repeated predicates should be centralized. Laws: valid accepted, invali
 
 ## Pullback
 
-Use when two values must agree on a shared projection. Laws: mismatch rejected; projections preserved.
+Use when two values, models, contexts, or interfaces must agree through maps to a shared target.
+
+```text
+f : A -> C
+g : B -> C
+P = A x_C B
+```
+
+Practical laws:
+
+- `f(projectA(p)) == g(projectB(p))`;
+- mismatches are rejected at construction;
+- both projections are preserved;
+- every compatible alternate pair factors through the canonical witness object;
+- uniqueness is approximated by one opaque constructor/normal form and no unchecked bypass.
+
+Typical software forms: equijoins, authorization contexts, wire/domain compatibility witnesses, synchronized configuration/state, and evidence joined to required claims.
+
+## Pushout
+
+Use when two source worlds must be glued along an explicit overlap.
+
+```text
+i : O -> A
+j : O -> B
+Q = A +_O B
+```
+
+Practical laws:
+
+- `injectA(i(o)) == injectB(j(o))`;
+- only declared overlap is identified;
+- non-overlap structure and provenance survive;
+- conflict is surfaced or resolved by named policy;
+- every compatible pair of downstream consumers factors through the integrated artifact;
+- uniqueness is approximated by canonical IDs/quotients and one public integration path.
+
+Typical software forms: schema/data integration, modular API or language extension, canonical models, and overlap-based context reconciliation.
+
+## Pushout complement / double-pushout rewrite
+
+Use for graph/model transformations with delete-preserve-add structure:
+
+```text
+L <- K -> R
+```
+
+The pushout complement removes `L-K` from a matched host while preserving `K`; a second pushout adds `R-K`. Laws: preserved interface unchanged, deletions/additions exact, dangling and forbidden-identification cases rejected, failed complement reported as obstruction. Prefer adhesive or adhesive-like categories when local rewrites must compose predictably.
 
 ## Exponential
 
@@ -26,8 +73,7 @@ Use when syntax should be separated from execution. Laws: interpreters agree on 
 
 ## Canonical boundary artifact
 
-Use when a boundary requires free syntax, coherent observations, transported semantics, lifted implementations, explicit IR, or residual obligations. Laws depend on the artifact: preservation, coherence, projection, lowering, or interpreter equivalence.
-
+Use when a boundary requires free syntax, coherent observations, transported semantics, lifted implementations, pullback witnesses, pushout integration, explicit IR, or residual obligations. Laws depend on the artifact: preservation, coherence, agreement, factorization, projection, lowering, or interpreter equivalence.
 
 ## Freyd / premonoidal category
 

--- a/codex/skills/universalist/scripts/check_pullback_pushout_mechanics.sh
+++ b/codex/skills/universalist/scripts/check_pullback_pushout_mechanics.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+root="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$root"
+
+required=(
+  references/mechanics/pullbacks-and-pushouts.md
+  references/mechanics/pushout-reconciliation.md
+  references/pushout-reconciliation.md
+  templates/mechanics/pullback-pushout-report.md
+  scripts/emit_pullback_pushout_report.sh
+)
+
+for f in "${required[@]}"; do
+  test -f "$f" || { echo "missing $f" >&2; exit 1; }
+done
+
+for token in \
+  'every compatible pair factors' \
+  'pushout complement' \
+  'double-pushout' \
+  'Adhesive categories' \
+  'A plain pair is not automatically a pullback' \
+  'a plain merge is not automatically a pushout'
+do
+  grep -R -F "$token" references scripts templates >/dev/null || {
+    echo "missing pullback/pushout doctrine token: $token" >&2
+    exit 1
+  }
+done
+
+bash scripts/emit_pullback_pushout_report.sh pullback typescript >/dev/null
+bash scripts/emit_pullback_pushout_report.sh pushout agnostic >/dev/null
+bash scripts/emit_pullback_pushout_report.sh dpo agnostic >/dev/null
+bash scripts/emit_pullback_pushout_report.sh compare agnostic >/dev/null
+
+./scripts/emit_mechanics_report.sh pullback typescript >/dev/null
+./scripts/emit_mechanics_report.sh pushout agnostic >/dev/null
+./scripts/emit_mechanics_report.sh pullback-pushout agnostic >/dev/null
+./scripts/emit_mechanics_report.sh double-pushout agnostic >/dev/null
+
+./scripts/emit_boundary_law_catalogue.sh pullback >/dev/null
+./scripts/emit_boundary_law_catalogue.sh pushout >/dev/null
+./scripts/emit_boundary_law_catalogue.sh double-pushout >/dev/null
+
+echo "check_pullback_pushout_mechanics: ok"

--- a/codex/skills/universalist/scripts/check_universal_architecture_upgrade.sh
+++ b/codex/skills/universalist/scripts/check_universal_architecture_upgrade.sh
@@ -1,3 +1,5 @@
 #!/usr/bin/env bash
 set -euo pipefail
-exec "$(cd "$(dirname "$0")" && pwd)/check_universalist.sh" "$@"
+dir="$(cd "$(dirname "$0")" && pwd)"
+"$dir/check_universalist.sh" "$@"
+bash "$dir/check_pullback_pushout_mechanics.sh"

--- a/codex/skills/universalist/scripts/check_universalist_replacement.sh
+++ b/codex/skills/universalist/scripts/check_universalist_replacement.sh
@@ -1,3 +1,5 @@
 #!/usr/bin/env bash
 set -euo pipefail
-exec "$(cd "$(dirname "$0")" && pwd)/check_universalist.sh" "$@"
+dir="$(cd "$(dirname "$0")" && pwd)"
+"$dir/check_universalist.sh" "$@"
+bash "$dir/check_pullback_pushout_mechanics.sh"

--- a/codex/skills/universalist/scripts/emit_boundary_law_catalogue.sh
+++ b/codex/skills/universalist/scripts/emit_boundary_law_catalogue.sh
@@ -5,6 +5,9 @@ case "$kind" in
   embedding) echo 'Embedding law: new(embed(old)) == old(old)' ;;
   projection) echo 'Projection law: observe(project(internal)) == expectedPublicBehavior' ;;
   forgetful) echo 'Forgetful law: forget(combineRich(a,b)) == combineRaw(forget(a),forget(b))' ;;
+  pullback) echo 'Pullback law: f(projectA(p)) == g(projectB(p)); every compatible pair factors uniquely through the canonical witness' ;;
+  pushout) echo 'Pushout law: injectA(includeA(o)) == injectB(includeB(o)); every compatible pair of consumers factors uniquely through the integrated artifact' ;;
+  double-pushout|dpo) echo 'Double-pushout law: preserved interface survives; delete/add squares commute; rewrite is rejected when the pushout complement does not exist' ;;
   interpreter) echo 'Interpreter law: interpret(translate(syntax)) == oldBehavior(syntax)' ;;
   serializer) echo 'Serializer law: decode(encode(internal)) preserves public invariants' ;;
   migration) echo 'Migration law: oldReport(old) == oldReport(restrict(migrate(old)))' ;;
@@ -19,6 +22,9 @@ case "$kind" in
 Embedding: new(embed(old)) == old(old)
 Projection: observe(project(internal)) == expectedPublicBehavior
 Forgetful: forget(combineRich(a,b)) == combineRaw(forget(a),forget(b))
+Pullback: shared projections agree; every compatible pair factors through the canonical witness
+Pushout: source injections agree on overlap; every compatible consumer pair factors through the integrated artifact
+Double pushout: preserved interface survives and missing pushout complement blocks the rewrite
 Interpreter: interpret(translate(syntax)) == oldBehavior(syntax)
 Serializer: decode(encode(internal)) preserves public invariants
 Migration: oldReport(old) == oldReport(restrict(migrate(old)))

--- a/codex/skills/universalist/scripts/emit_composition_certificate.sh
+++ b/codex/skills/universalist/scripts/emit_composition_certificate.sh
@@ -26,7 +26,7 @@ Target world:
 ## Boundary
 
 - name:
-- kind: embedding / projection / forgetful / interpreter / compiler / serializer / view / handler / observer / migration / adapter
+- kind: embedding / projection / forgetful / interpreter / compiler / serializer / view / handler / observer / migration / pullback agreement / pushout integration / graph rewrite / adapter
 - function or module:
 - preserved:
 - forgotten:
@@ -35,13 +35,27 @@ Target world:
 
 ## Unknown
 
-- location: after boundary / behind boundary / inside syntax / behavior / effects / observation / generation / callback
+- location: after boundary / behind boundary / compatible witness / integrated output / inside syntax / behavior / effects / observation / generation / callback
 
 ## Canonical artifact
 
 - artifact:
 - why this artifact:
 - nearby alternative rejected:
+
+## Pullback / pushout square, when applicable
+
+- construction: none / pullback / pushout / pushout-complement + double-pushout
+- category/world: Set / types / schemas / graphs / presheaves / other
+- span or cospan maps:
+- shared target or overlap:
+- agreement / identity policy:
+- commutative-square law:
+- factorization witness:
+- uniqueness approximation / canonical normal form:
+- effective construction: validator / join / quotient / union-find / graph rewrite
+- pushout-complement or existence obstruction:
+- provenance and conflict policy:
 
 ## Composition grammar
 
@@ -80,6 +94,7 @@ Target world:
 ## Law witness
 
 - positive law test:
+- factorization / uniqueness approximation:
 - falsifier / negative witness:
 
 ## Status

--- a/codex/skills/universalist/scripts/emit_mechanics_report.sh
+++ b/codex/skills/universalist/scripts/emit_mechanics_report.sh
@@ -17,6 +17,10 @@ Available mechanics topics:
 - freyd-category
 - operad
 - composition-geometry
+- pullback
+- pushout
+- pullback-pushout
+- double-pushout
 - yoneda
 - defunctionalization
 - codensity-presentation
@@ -34,6 +38,9 @@ Available mechanics topics:
 - property-tests
 
 Examples:
+  ./scripts/emit_mechanics_report.sh pullback typescript
+  ./scripts/emit_mechanics_report.sh pushout agnostic
+  ./scripts/emit_mechanics_report.sh double-pushout agnostic
   ./scripts/emit_mechanics_report.sh kan-lift typescript
   ./scripts/emit_mechanics_report.sh codensity-presentation agnostic
   ./scripts/emit_mechanics_report.sh cql-context agnostic
@@ -51,6 +58,14 @@ OUT
     ./scripts/emit_operadic_architecture.sh component-wiring "$language" ;;
   composition-geometry|geometry)
     cat references/composition-geometry.md ;;
+  pullback|pullbacks)
+    bash ./scripts/emit_pullback_pushout_report.sh pullback "$language" ;;
+  pushout|pushouts)
+    bash ./scripts/emit_pullback_pushout_report.sh pushout "$language" ;;
+  pullback-pushout|pullbacks-pushouts|limit-colimit-square)
+    bash ./scripts/emit_pullback_pushout_report.sh compare "$language" ;;
+  double-pushout|dpo|graph-rewrite)
+    bash ./scripts/emit_pullback_pushout_report.sh dpo "$language" ;;
   freyd)
     echo "Ambiguous mechanics topic: freyd" >&2
     echo "Use 'freyd-aft' for the adjoint-functor/free-builder diagnostic or 'freyd-category' for effectful call-by-value composition." >&2
@@ -65,7 +80,7 @@ OUT
     ./scripts/emit_context_compilation_report.sh report "$language" ;;
   cql|cql-context)
     ./scripts/emit_cql_context_report.sh context-publication "$language" ;;
-  pushout|pushout-reconciliation)
+  pushout-reconciliation)
     ./scripts/emit_pushout_reconciliation_plan.sh context-merge "$language" ;;
   verified-context|verified-context-publication)
     ./scripts/emit_verified_context_publication_plan.sh publication-boundary "$language" ;;

--- a/codex/skills/universalist/scripts/emit_pullback_pushout_report.sh
+++ b/codex/skills/universalist/scripts/emit_pullback_pushout_report.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+set -euo pipefail
+mode="${1:-compare}"
+language="${2:-agnostic}"
+
+case "$mode" in
+  pullback)
+    cat <<OUT
+# Pullback Report (${language})
+
+## Software seam
+- witness object / compatible pair:
+- shared target/observation C:
+
+## Diagram
+- f : A -> C:
+- g : B -> C:
+- P with pA : P -> A and pB : P -> B:
+
+## Agreement
+- equation f.pA = g.pB:
+- mismatch behavior:
+
+## Effective implementation
+- opaque constructor / validated join / dependent pair:
+- public bypass prevention:
+
+## Universal law
+- every compatible A/B candidate factors through P:
+- uniqueness approximation / normalization:
+
+## Tests
+- matching pair accepted:
+- mismatch rejected:
+- projections preserved:
+- falsifier:
+OUT
+    ;;
+  pushout)
+    cat <<OUT
+# Pushout Report (${language})
+
+## Software seam
+- source A:
+- source B:
+- explicit overlap O:
+
+## Diagram
+- i : O -> A:
+- j : O -> B:
+- Q with qA : A -> Q and qB : B -> Q:
+
+## Overlap policy
+- identities safe to identify:
+- structures that must remain distinct:
+- named conflict policy:
+
+## Effective implementation
+- tagged coproduct:
+- quotient / union-find / canonical IDs:
+- provenance survival:
+
+## Universal law
+- qA.i = qB.j:
+- every compatible A/B consumer factors through Q:
+- uniqueness approximation / canonical normalization:
+
+## Tests
+- non-overlap preserved:
+- overlap identified exactly once:
+- false merge rejected:
+- conflict surfaced:
+- falsifier:
+OUT
+    ;;
+  dpo|double-pushout|graph-rewrite)
+    cat <<OUT
+# Double-Pushout Rewrite Report (${language})
+
+## Rule
+- L <- K -> R:
+- preserved interface K:
+- match L -> G:
+
+## Pushout complement
+- deletions L-K:
+- dangling-edge check:
+- identification check:
+- obstruction report if complement does not exist:
+
+## Pushout
+- additions R-K:
+- result H:
+- provenance / rewrite trace:
+
+## Tests
+- preserved interface unchanged:
+- deleted structure absent:
+- added structure present:
+- forbidden dangling rewrite rejected:
+- local rewrite composes under selected adhesive assumptions:
+OUT
+    ;;
+  compare|selector)
+    cat <<OUT
+# Pullback / Pushout Selector (${language})
+
+## Governing question
+
+1. Is the unknown a witness/input whose A and B views must agree in C?
+   -> Pullback.
+
+2. Is the unknown an integrated output gluing A and B along explicit O?
+   -> Pushout.
+
+3. Is the task a graph/model rewrite with delete-preserve-add structure?
+   -> Pushout complement + double pushout.
+
+4. No agreement target or overlap?
+   -> Product/coproduct or ordinary adapter instead.
+
+## Candidate diagram
+- worlds:
+- maps:
+- agreement or overlap:
+- selected category:
+- existence assumptions:
+
+## Proof obligations
+- commutative square:
+- factorization:
+- uniqueness approximation:
+- operational constraints:
+- falsifier:
+OUT
+    ;;
+  *)
+    echo "Unknown mode: $mode" >&2
+    echo "Use pullback, pushout, dpo, or compare." >&2
+    exit 2
+    ;;
+esac

--- a/codex/skills/universalist/templates/composition-certificate.md
+++ b/codex/skills/universalist/templates/composition-certificate.md
@@ -38,6 +38,20 @@ Artifact:
 Why this artifact:
 Nearby alternative rejected:
 
+## Pullback / pushout square, when applicable
+
+Construction: none / pullback / pushout / pushout-complement + double-pushout
+Category/world: Set / types / schemas / graphs / presheaves / other
+Span or cospan maps:
+Shared target or overlap:
+Agreement / identity policy:
+Commutative-square law:
+Factorization witness:
+Uniqueness approximation / canonical normal form:
+Effective construction: validator / join / quotient / union-find / graph rewrite
+Pushout-complement or existence obstruction:
+Provenance and conflict policy:
+
 ## Composition grammar
 
 Geometry: category / monoidal / Freyd-premonoidal / operad / PROP-properad / traced-coalgebraic / resource-sensitive

--- a/codex/skills/universalist/templates/mechanics/pullback-pushout-report.md
+++ b/codex/skills/universalist/templates/mechanics/pullback-pushout-report.md
@@ -1,0 +1,75 @@
+# Pullback / Pushout Mechanics Report
+
+## Problem frame
+
+- Software seam:
+- Current worlds/categories:
+- Why ordinary product/coproduct/merge/join is insufficient:
+- Witness slice:
+
+## Construction selection
+
+- Selected: pullback / pushout / double-pushout rewrite / none
+- Category/world: Set / types / schemas / graphs / presheaves / other
+- Nearby alternatives rejected:
+
+## Pullback data
+
+- `f : A -> C`:
+- `g : B -> C`:
+- Candidate `P`:
+- `pA : P -> A`:
+- `pB : P -> B`:
+- Agreement equation `f . pA = g . pB`:
+- Effective constructor / join / validator:
+
+## Pushout data
+
+- `i : O -> A`:
+- `j : O -> B`:
+- Candidate `Q`:
+- `qA : A -> Q`:
+- `qB : B -> Q`:
+- Overlap equation `qA . i = qB . j`:
+- Identity / conflict policy:
+- Effective quotient / canonical-ID / union-find construction:
+
+## Double-pushout rewrite data
+
+- Rule `L <- K -> R`:
+- Match `L -> G`:
+- Preserved interface `K`:
+- Pushout-complement conditions:
+- Deletion/dangling/identification obstructions:
+- Result `H`:
+
+## Universal-property witness
+
+- Commutative square:
+- Factorization candidate:
+- Uniqueness approximation:
+- Canonical public constructor / mediator:
+- Bypass prevention:
+
+## Operational constraints
+
+- Provenance:
+- Ordering/effects:
+- Transactions/concurrency:
+- Security/authorization:
+- Resource costs:
+- Category-specific existence assumptions:
+
+## Law tests
+
+- agreement / overlap law:
+- projection / injection preservation:
+- factorization:
+- uniqueness / normalization:
+- falsifier:
+
+## Disposition
+
+- implement / preserve / obstructed / ordinary adapter instead
+- first seam:
+- stop point:

--- a/codex/skills/universalist/templates/universalist-plan.md
+++ b/codex/skills/universalist/templates/universalist-plan.md
@@ -6,6 +6,7 @@
 ## Canonical boundary artifact:
 ## Worlds / boundaries inventory:
 ## Boundary kind:
+## Pullback / pushout square:
 ## Composition geometry:
 ## Boundary law:
 ## Freyd/AFT boundary diagnostic:

--- a/codex/skills/universalist/tests/golden/activation.yml
+++ b/codex/skills/universalist/tests/golden/activation.yml
@@ -36,10 +36,18 @@ cases:
     should_use_skill: true
     should_spawn_subagents: false
     expected: ["one seam", "smallest honest construction"]
-
   - prompt: "Our typed service components are wired through arbitrary call graphs; make the legal hierarchical assembly explicit."
     should_use_skill: true
     expected: ["Track D", "colored operad", "ports", "substitution law", "forbidden wiring"]
   - prompt: "Pure planning code and effectful tool calls are mixed, and someone wants to parallelize them."
     should_use_skill: true
     expected: ["Freyd category", "premonoidal", "evaluation order", "central operations", "noncommuting witness"]
+  - prompt: "Construct an authorization context only when the request tenant and principal tenant agree."
+    should_use_skill: true
+    expected: ["pullback", "shared projection", "mismatch rejected", "factorization"]
+  - prompt: "Merge these two schemas along their explicit shared core while preserving provenance and surfacing conflicts."
+    should_use_skill: true
+    expected: ["pushout", "overlap", "provenance", "conflict policy", "factorization"]
+  - prompt: "Rewrite this typed architecture graph by deleting one pattern, preserving its interface, and adding a replacement."
+    should_use_skill: true
+    expected: ["double pushout", "pushout complement", "preserved interface", "obstruction"]

--- a/codex/skills/universalist/tests/golden/output-invariants.yml
+++ b/codex/skills/universalist/tests/golden/output-invariants.yml
@@ -13,7 +13,15 @@ invariants:
   - name: subagents_require_explicit_request
     when: "team mode"
     required: ["explicit request", "root synthesis", "one writer", "independent verifier"]
-
   - name: composition_geometry_requires_law
     when: "operad or Freyd category"
     required: ["Composition geometry", "Semantic interpretation", "Law witness", "Falsifier"]
+  - name: pullback_requires_agreement_and_factorization
+    when: "pullback"
+    required: ["Shared target", "Agreement equation", "Canonical witness", "Factorization", "Mismatch falsifier"]
+  - name: pushout_requires_overlap_and_factorization
+    when: "pushout"
+    required: ["Explicit overlap", "Source injections", "Conflict policy", "Provenance", "Factorization", "False-merge falsifier"]
+  - name: double_pushout_requires_complement_check
+    when: "double pushout or graph rewrite"
+    required: ["Preserved interface", "Pushout complement", "Dangling/identification conditions", "Obstruction report", "Rewrite trace"]


### PR DESCRIPTION
## Summary

Integrates the pullback/pushout research into `$universalist` as general software-architecture mechanics rather than only a context-reconciliation analogy.

### Added

- formal pullback and pushout universal properties with software readings
- practical selector for pullback vs pushout vs product/coproduct/equalizer/coequalizer
- API, authorization, join, schema integration, syntax/module extension, and context-reconciliation patterns
- pushout complements, double-pushout graph/model rewriting, and adhesive-category guidance
- effective constructions: opaque compatible-pair constructors, canonical IDs, quotient/union-find, rewrite obstruction reports
- factorization and uniqueness approximations in certificates and law catalogues
- new mechanics report/template and activation/eval cases
- categorical architect and proof auditor coverage

## Key guardrails

- A plain pair is not automatically a pullback: require a shared target and agreement equation.
- A plain merge is not automatically a pushout: require an explicit overlap object and maps into both sources.
- Square commutativity alone is insufficient: require factorization and a credible uniqueness approximation.
- Pushouts do not invent domain identity or conflict policy.
- Double-pushout rewriting must report missing pushout complements, dangling conditions, or forbidden identifications.

## Validation

- compared branch against `main`; 24 files changed, branch is based directly on current `main`
- syntax-checked and smoke-ran the new pullback/pushout report generator for `pullback`, `pushout`, `dpo`, and `compare`
- added `check_pullback_pushout_mechanics.sh`
- wired replacement/upgrade validation aliases to run the new check after `check_universalist.sh`

The full repository-local `check_universalist.sh` should be run in a checkout before marking the PR ready.