### PR TITLE
Harden $ship PR publication semantics

### DIFF
--- a/codex/skills/ship/SKILL.md
+++ b/codex/skills/ship/SKILL.md
@@ -7,7 +7,7 @@ description: "Finalize validated work into a proof-backed pull request without m
 
 ## Purpose
 
-Finalize deliverables after validation and publish a concise proof trail in a pull request.
+Finalize deliverables after validation and publish a concise, non-destructive proof trail in a pull request.
 
 `$ship` opens, updates, or promotes a PR. It does not merge.
 
@@ -22,7 +22,7 @@ Draft PR is an exception, not the default.
 
 Use `$ship` when the user asks to:
 
-- ship/finalize current branch;
+- ship/finalize the current branch;
 - open a PR;
 - update an existing PR body with proof;
 - publish validation proof before handoff;
@@ -34,7 +34,7 @@ Do not use `$ship` when:
 - implementation is not done and the user did not ask for early visibility;
 - validation is failing and the user did not explicitly accept a caveated draft;
 - the user wants merge/landing; use `$land`;
-- the user only wants readiness proof; use `$proof-patch`;
+- the user wants only a local readiness report and no public PR effect; report readiness and stop. Use `$proof-patch` only when a current complete actuation closure decision exists;
 - the current branch has unrelated or unstaged work that cannot be scoped.
 
 ## Inputs
@@ -44,11 +44,15 @@ Before acting, establish:
 ```yaml
 ship_input:
   source: direct | actuation
+  repository: owner/name
+  title:
   branch:
   base_branch:
+  base_sha:
   head_sha:
   existing_pr:
     exists: yes | no | unknown
+    number:
     url:
     state: open | closed | merged | unknown
     draft: yes | no | unknown
@@ -73,20 +77,22 @@ ship_input:
   repo_policy_pr_mode: ready | draft | unknown
 ```
 
-If key state is unknown, inspect the repository and PR state before creating or updating a PR.
+If key state is unknown, inspect the repository and live PR state before creating or updating a PR.
 
-For `source: actuation`, require a current Zig-derived `closure-decision/v1` with
-`verdict: ready-to-ship`. That verdict may come from initial implementation or
-from a proved review-closeout repair that must be republished before more
-review. Each SHIP-v1 is immutable for its publication epoch: preserve the kernel run ID
-and state fingerprint in the exact two-field `actuation_binding`.
-Never add or relabel it with review-closeout state. Actuation input cannot use the early
-draft path because draft publication has no valid closure re-entry. A direct
-ship input does not require this object.
+For `source: actuation`, require a current kernel-derived `closure-decision/v1`
+with `verdict: ready-to-ship`. That verdict may come from initial implementation
+or from a proved review-closeout repair that must be republished before more
+review. Each SHIP-v1 is immutable for its publication epoch: preserve the kernel
+run ID and state fingerprint in the exact two-field `actuation_binding`. Never
+add or relabel it with review-closeout state. Actuation input cannot use the
+early-draft path because draft publication has no valid closure re-entry. If
+repository policy requires a draft for an actuation input, block with an
+incompatible-policy reason rather than publishing an invalid lifecycle state. A
+direct ship input does not require the actuation object.
 
-## PR Readiness Policy
+## PR readiness policy
 
-Default PR mode is `ready`.
+Default final PR state is `ready`.
 
 Use `draft` only when at least one is true:
 
@@ -95,120 +101,180 @@ Use `draft` only when at least one is true:
 - one or more in-scope tasks are blocked, deferred, or open;
 - PR is intentionally being opened for early visibility before readiness;
 - required review context is missing and the user asks to publish anyway;
-- repo policy explicitly requires draft PRs for this branch/workflow.
+- repository policy explicitly requires draft PRs for this branch/workflow and `source: direct`.
 
 The ordered post-ship review-closeout phase is a goal continuation, not an
 incomplete implementation task or a draft warrant.
 
 If the branch is fully validated and no blockers remain, do not create a draft PR by default.
 
+## PR decision
+
+Keep the GitHub operation separate from the desired final state, then project it
+to the existing `pr_readiness.mode` field for SHIP-v1 compatibility.
+
 ```yaml
-pr_readiness:
-  mode: ready | draft | update-existing | promote-draft | blocked
+pr_decision:
+  operation: create | update | update-and-promote | blocked
+  final_state: ready | draft | preserve
+  compatibility_mode: ready | draft | update-existing | promote-draft | blocked
   reason: "..."
   draft_allowed_reason: "none | explicit-user | incomplete-validation | blocked-tasks | early-visibility | missing-context | repo-policy"
 ```
 
+Projection:
+
+| Condition | operation | final_state | compatibility_mode |
+|---|---|---|---|
+| No open PR; fully ready | `create` | `ready` | `ready` |
+| No open PR; warranted draft | `create` | `draft` | `draft` |
+| Open PR; preserve current draft/ready state | `update` | `preserve` | `update-existing` |
+| Open draft; fully ready | `update-and-promote` | `ready` | `promote-draft` |
+| Invalid, ambiguous, or unauthorized state | `blocked` | `preserve` | `blocked` |
+
 ## Existing PR policy
 
-If an open PR already exists for the branch:
+Before mutation, query live PRs for the exact repository, base branch, and head
+branch. Require at most one matching open PR.
 
-```text
-update-existing
+- Prefer the matching open PR over creating another PR.
+- If a matching open draft is fully validated with no blockers, update its proof body and then promote it unless the user or repository policy explicitly says to preserve draft.
+- If a matching open draft still has blockers, preserve draft and update the proof/blocker state.
+- If a matching open ready PR is now caveated or blocked, preserve ready state; do not silently convert it to draft.
+- A merged PR, a closed unmerged PR, multiple matching open PRs, or a PR with the wrong repository/base/head tuple blocks shipping. Report the exact mismatch instead of guessing, reopening, or creating a duplicate.
+
+## Managed PR body
+
+`$ship` owns only the marker-bounded proof block:
+
+```md
+<!-- ship-proof:start -->
+...
+<!-- ship-proof:end -->
 ```
 
-is preferred over creating a new PR.
+For a new PR, the body may consist only of this block. For an existing PR:
 
-If the existing PR is draft and the branch is fully validated with no blockers:
-
-```text
-promote-draft
-```
-
-is the default unless the user or repo policy explicitly says to preserve draft.
-
-If the existing PR is draft and blockers remain, preserve draft and update the body with the current proof/blocker state.
-
-If the existing PR is ready and validation is now caveated or blocked, do not silently convert it to draft. Report the blocker and ask for explicit direction if a state change is needed.
+1. Read the current body before editing.
+2. Replace exactly one complete managed block, or append a new block when neither marker exists.
+3. Preserve all text outside the managed block byte-for-byte.
+4. Block when only one marker exists, multiple managed blocks exist, or the marker structure is otherwise ambiguous.
+5. Never replace the entire existing body with a newly generated proof body unless the existing body is empty.
 
 ## Command policy
 
 Use GitHub CLI where applicable.
 
-Ready PR:
+Ready PR creation:
 
 ```bash
 gh pr create --title "<title>" --body-file <body-file> --base <base> --head <branch>
 ```
 
-Draft PR only when `pr_readiness.mode: draft`:
+Draft PR creation only when `pr_decision.final_state: draft`:
 
 ```bash
 gh pr create --draft --title "<title>" --body-file <body-file> --base <base> --head <branch>
 ```
 
-Promote existing draft only when `pr_readiness.mode: promote-draft`:
+Existing PR update:
 
 ```bash
+gh pr view <pr> --json body --jq .body > <current-body-file>
+# Replace or append only the managed proof block into <merged-body-file>.
+gh pr edit <pr> --body-file <merged-body-file>
+```
+
+Existing draft promotion must update proof first:
+
+```bash
+gh pr edit <pr> --body-file <merged-body-file>
 gh pr ready <pr>
 ```
 
-Update existing PR body:
+After every create, update, or promotion, read back live state:
 
 ```bash
-gh pr edit <pr> --body-file <body-file>
+gh pr view <pr> \
+  --json number,url,state,isDraft,baseRefName,baseRefOid,headRefName,headRefOid,body
 ```
 
-Do not pass `--draft` unless the readiness record says `mode: draft`.
+Do not pass `--draft` unless the decision has a non-`none`
+`draft_allowed_reason`. Do not report `created`, `updated`, or `promoted` until
+the readback postconditions pass.
+
+## Publication postconditions
+
+The live readback must prove:
+
+- PR state is open;
+- repository and URL identify the intended PR;
+- `baseRefName` and `baseRefOid` match `base_branch` and `base_sha`;
+- `headRefName` and `headRefOid` match `branch` and `head_sha`;
+- `isDraft` matches `final_state`, or matches the preflight value when `final_state: preserve`;
+- the body contains exactly one managed block whose contents match the generated proof block;
+- an update-and-promote operation completed the body update before the draft-to-ready transition.
+
+If a command succeeds but readback fails, do not emit a successful action result.
+Report the completed side effect, the failed postcondition, and the exact repair
+or retry step. Re-read live state before retrying; never assume the earlier
+preflight remains current.
 
 ## Workflow
 
-1. Confirm current branch, base branch, head SHA, and repository remote.
-2. Inspect worktree status.
-3. Confirm recent validation signal exists for the current change set; if not, run or request validation.
-4. For actuation input, validate the current implementation or review-repair
-   closure decision and preserve its run and target binding.
-5. Determine PR mode using the readiness policy.
-6. Summarize proof: commands/signals and outcomes.
-7. Build PR body with proof, scope, risks, and remaining follow-ups.
-8. Open/update/promote PR according to `pr_readiness.mode`.
-9. Emit SHIP-v1 for closure recomputation and report PR state. For the ordered
-   actuation lifecycle, hand the complete immutable receipt back as both the
-   implementation checkpoint's first publication receipt and
-   `review.ship_receipt` before the same run enters review-closeout. The
-   checkpoint copy never changes; `review.ship_receipt` tracks the current
-   publication epoch. A proved review edit
-   returns here before CAS; update the existing PR at the exact URL retained in
-   the prior admission, replace the stale receipt with that fresh SHIP-v1, then
-   resume the next admitted edit or final CAS closeout. Creating another PR is
-   invalid for this handback.
+1. Confirm repository, current branch, base branch and SHA, head SHA, and remote.
+2. Inspect worktree status and ensure the intended head is committed and available on the remote branch.
+3. Inspect live PRs for the exact repository/base/head tuple and reject ambiguous or mismatched state.
+4. Confirm recent validation exists for the current change set; if not, run or request validation.
+5. For actuation input, validate the current implementation or review-repair closure decision and preserve its run and target binding.
+6. Determine `pr_decision`, including operation, final state, and compatibility mode.
+7. Build the managed proof block with proof, scope, risks, follow-ups, readiness, and caveats.
+8. Create or merge the managed block into the PR body without overwriting human-authored text.
+9. Execute the ordered operation: create; update; or update, then promote.
+10. Read back live PR metadata and body and require every publication postcondition.
+11. Emit SHIP-v1 for closure recomputation and report PR state. For the ordered actuation lifecycle, hand the complete immutable receipt back as both the implementation checkpoint's first publication receipt and `review.ship_receipt` before the same run enters review-closeout. The checkpoint copy never changes; `review.ship_receipt` tracks the current publication epoch. A proved review edit returns here before CAS; update the existing PR at the exact URL retained in the prior admission, replace the stale receipt with that fresh SHIP-v1, then resume the next admitted edit or final CAS closeout. Creating another PR is invalid for this handback.
 
 ## PR body contract
 
-Keep proof concise and scoped.
+Keep proof concise, scoped, and free of credentials, tokens, private paths, or
+sensitive command arguments.
 
-Include:
+Include this managed block:
 
 ```md
+<!-- ship-proof:start -->
 ## Summary
-- ...
+- What changed and why.
 
 ## Proof
-- `<command>`: pass/fail/blocked
-- `<command>`: pass/fail/blocked
+- `<command>`: pass/fail/blocked/not-run
+- `<command>`: pass/fail/blocked/not-run
 
 ## Scope
+- repository:
 - branch:
 - head:
 - base:
+- base SHA:
+
+## Risks
+- None identified, or concise residual risks.
+
+## Follow-ups
+- None, or explicitly deferred work.
 
 ## Readiness
-- PR mode: ready | draft | update-existing | promote-draft | blocked
+- Operation: create | update | update-and-promote | blocked
+- Final state: ready | draft | preserve
+- SHIP-v1 compatibility mode: ready | draft | update-existing | promote-draft | blocked
 - Reason:
 - Caveats:
+<!-- ship-proof:end -->
 ```
 
-Do not overclaim validation. If a category was missing or not run, say so.
+Do not overclaim validation. If a category was missing or not run, say so. Use
+`None` only after checking the relevant section; do not omit risks or follow-ups
+merely because they are empty.
 
 ## Ship record
 
@@ -244,6 +310,12 @@ ship_record:
     state_fingerprint: "..."
 ```
 
+`pr_readiness.mode` is the compatibility projection of `pr_decision`; do not use
+it as the sole description of both operation and final state. `action.command`
+may contain the ordered mutation and readback commands. A successful
+`action.result` means the live publication postconditions passed, not merely
+that the mutation command exited zero.
+
 `actuation_binding` is required for actuation ready/update/promote records and
 omitted for direct records. Its exact two-field pre-review shape must match the
 input ready-to-ship closure decision. Missing, extra, relabeled, or mismatched
@@ -252,19 +324,23 @@ resolution or CAS values. Publication-bearing review-closeout embeds this
 complete first receipt unchanged in the implementation checkpoint and copies it
 to `review.ship_receipt`; a later repair handback updates that same PR URL,
 creates a new SHIP-v1, and replaces only the current review field.
-After publication, closure must query live PR metadata and match the repository,
-base ref and SHA, head ref and SHA, URL, open state, and ready status; copied
-SHIP fields are not authoritative for those facts.
+
+After publication, closure must independently query live PR metadata and match
+the repository, base ref and SHA, head ref and SHA, URL, open state, and ready
+status; copied SHIP fields are not authoritative for those facts.
 
 ## Guardrails
 
 - Never ship without a validation signal or an explicitly reported validation limitation.
 - Never create a draft PR by default after full validation.
 - Never pass `--draft` without a `draft_allowed_reason`.
-- Never create a duplicate PR when an open branch PR exists.
+- Never create a duplicate PR when an open exact-tuple PR exists.
+- Never overwrite human-authored PR body content outside the managed proof block.
+- Never promote a draft before updating its current proof block.
+- Never claim publication success without a matching live readback.
 - Never merge or land.
 - Never stage or commit unrelated work.
-- If PR creation/update is blocked by auth, remote, permissions, or missing branch push, state the exact blocker and next command.
+- If PR creation/update is blocked by auth, remote, permissions, missing branch push, malformed body markers, or mismatched live state, state the exact blocker and next command.
 
 ## Output
 
@@ -275,8 +351,10 @@ Ship Bottom Line:
 - branch:
 - head:
 - validation:
-- PR mode:
+- operation:
+- final PR state:
 - PR:
+- readback:
 - proof:
 - blocker / next step:
 ```

--- a/codex/skills/ship/SKILL.md
+++ b/codex/skills/ship/SKILL.md
@@ -180,7 +180,7 @@ gh pr create --draft --title "<title>" --body-file <body-file> --base <base> --h
 Existing PR update:
 
 ```bash
-gh pr view <pr> --json body --jq .body > <current-body-file>
+gh pr view <pr> --json body | jq -j .body > <current-body-file>
 # Replace or append only the managed proof block into <merged-body-file>.
 gh pr edit <pr> --body-file <merged-body-file>
 ```

--- a/codex/skills/ship/references/pr-body-proof.md
+++ b/codex/skills/ship/references/pr-body-proof.md
@@ -1,18 +1,46 @@
 # PR Body Proof
 
-Include:
+`$ship` owns only one marker-bounded block:
 
 ```md
+<!-- ship-proof:start -->
 ## Summary
+- What changed and why.
 
 ## Proof
+- `<command>`: pass/fail/blocked/not-run
 
 ## Scope
+- repository:
+- branch:
+- head:
+- base:
+- base SHA:
+
+## Risks
+- None identified, or concise residual risks.
+
+## Follow-ups
+- None, or explicitly deferred work.
 
 ## Readiness
-- PR mode:
+- Operation: create | update | update-and-promote | blocked
+- Final state: ready | draft | preserve
+- SHIP-v1 compatibility mode: ready | draft | update-existing | promote-draft | blocked
 - Reason:
 - Caveats:
+<!-- ship-proof:end -->
 ```
 
+For an existing PR, read the current body and replace exactly one complete
+managed block. Append the block when neither marker exists. Preserve everything
+outside the block byte-for-byte. Block instead of editing when markers are
+unbalanced, duplicated, or ambiguous.
+
+For `update-and-promote`, update the managed block before marking the PR ready.
+After every mutation, read back the PR and require exactly one matching managed
+block plus the expected repository, base, head, open state, and draft state.
+
 Do not claim all checks pass if a validation category was missing or not run.
+Do not include credentials, tokens, private paths, or sensitive command
+arguments in proof text.

--- a/codex/skills/ship/references/pr-readiness-policy.md
+++ b/codex/skills/ship/references/pr-readiness-policy.md
@@ -1,16 +1,40 @@
 # PR Readiness Policy
 
-Default PR mode is `ready`.
+Decide the GitHub operation separately from the desired final PR state.
+
+```yaml
+pr_decision:
+  operation: create | update | update-and-promote | blocked
+  final_state: ready | draft | preserve
+  compatibility_mode: ready | draft | update-existing | promote-draft | blocked
+  reason:
+  draft_allowed_reason:
+```
+
+Default final state is `ready`.
 
 Use `draft` only when:
 
 - user explicitly requests draft;
-- validation is incomplete/blocked/failing/caveated;
-- in-scope tasks remain blocked/deferred/open;
+- validation is incomplete, blocked, failing, or caveated;
+- in-scope tasks remain blocked, deferred, or open;
 - early visibility is explicitly intended;
-- required context is missing and user asks to publish anyway;
-- repo policy requires draft.
+- required context is missing and the user asks to publish anyway;
+- repository policy requires draft and the source is direct.
 
-If work is complete and validation passes, create a ready PR by default.
+Actuation input cannot publish a draft. A repository policy that requires draft
+therefore blocks actuation shipping until the policy or lifecycle is resolved.
 
-Do not pass `--draft` unless `pr_readiness.mode: draft`.
+Compatibility projection:
+
+| Condition | operation | final_state | compatibility_mode |
+|---|---|---|---|
+| No open PR; fully ready | `create` | `ready` | `ready` |
+| No open PR; warranted draft | `create` | `draft` | `draft` |
+| Open PR; preserve current state | `update` | `preserve` | `update-existing` |
+| Open draft; fully ready | `update-and-promote` | `ready` | `promote-draft` |
+| Invalid or ambiguous state | `blocked` | `preserve` | `blocked` |
+
+If work is complete and validation passes, create or promote to a ready PR by
+default. Do not pass `--draft` unless `final_state: draft` and
+`draft_allowed_reason` is not `none`.

--- a/codex/skills/ship/references/ship-record.md
+++ b/codex/skills/ship/references/ship-record.md
@@ -30,15 +30,37 @@ ship_record:
     state_fingerprint:
 ```
 
+`pr_readiness.mode` is a compatibility projection from the internal two-axis
+`pr_decision`:
+
+```yaml
+pr_decision:
+  operation: create | update | update-and-promote | blocked
+  final_state: ready | draft | preserve
+  compatibility_mode: ready | draft | update-existing | promote-draft | blocked
+```
+
+- `create` + `ready` -> `ready`;
+- `create` + `draft` -> `draft`;
+- `update` + `preserve` -> `update-existing`;
+- `update-and-promote` + `ready` -> `promote-draft`;
+- invalid or ambiguous state -> `blocked`.
+
+`action.command` may record an ordered sequence: body update, optional promotion,
+and live readback. `created`, `updated`, or `promoted` is valid only after the
+live PR matches the intended repository, base ref and SHA, head ref and SHA,
+open/draft state, and managed proof block. A successful mutation command with a
+failed readback must report `blocked` plus the observed partial side effect.
+
 `actuation_binding` is required when `source=actuation` and the readiness mode
 is ready, update-existing, or promote-draft. It is omitted for direct shipping.
-The exact two-field binding is copied from the current Zig implementation or
-review-repair `closure-decision/v1`: kernel run ID and state fingerprint are preserved.
-It must not be reconstructed from PR text, extended with review fields, or
-relabeled with later review-closeout evidence. SHIP-v1 is immutable evidence for
-one publication epoch. The ordered actuation lifecycle binds that receipt into
-the GoalContract digest of a new review generation under the same goal ID. A
-proved review edit closes another `ready-to-ship` generation and produces a
-fresh SHIP-v1 for the retained PR. That replacement reports `updated` /
-`update-existing`, retains
-`existing_pr.exists: true`, and uses the exact prior receipt's PR URL.
+The exact two-field binding is copied from the current implementation or
+review-repair `closure-decision/v1`: kernel run ID and state fingerprint are
+preserved. It must not be reconstructed from PR text, extended with review
+fields, or relabeled with later review-closeout evidence. SHIP-v1 is immutable
+evidence for one publication epoch. The ordered actuation lifecycle binds that
+receipt into the GoalContract digest of a new review generation under the same
+goal ID. A proved review edit closes another `ready-to-ship` generation and
+produces a fresh SHIP-v1 for the retained PR. That replacement reports
+`updated` / `update-existing`, retains `existing_pr.exists: true`, and uses the
+exact prior receipt's PR URL.

--- a/codex/skills/ship/tests/test_contract.py
+++ b/codex/skills/ship/tests/test_contract.py
@@ -1,4 +1,6 @@
+import json
 from pathlib import Path
+import subprocess
 import unittest
 
 
@@ -26,6 +28,29 @@ class ShipContractTests(unittest.TestCase):
             self.assertIn("Preserve", text)
         self.assertIn("Never overwrite human-authored PR body content", SKILL)
         self.assertIn("unbalanced, duplicated, or ambiguous", BODY)
+
+    def test_body_acquisition_preserves_exact_bytes(self) -> None:
+        body = (
+            "Human-authored café context\n"
+            "<!-- ship-proof:start -->\nmanaged\n<!-- ship-proof:end -->\n"
+            "Human-authored suffix without a terminal newline"
+        )
+        payload = json.dumps({"body": body}, ensure_ascii=False).encode("utf-8")
+
+        result = subprocess.run(
+            ["jq", "-j", ".body"],
+            input=payload,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=True,
+        )
+
+        self.assertEqual(body.encode("utf-8"), result.stdout)
+        self.assertIn(
+            "gh pr view <pr> --json body | jq -j .body > <current-body-file>",
+            SKILL,
+        )
+        self.assertNotIn("gh pr view <pr> --json body --jq .body", SKILL)
 
     def test_promotion_updates_proof_before_ready_transition(self) -> None:
         section = SKILL.split("Existing draft promotion must update proof first:", 1)[1]

--- a/codex/skills/ship/tests/test_contract.py
+++ b/codex/skills/ship/tests/test_contract.py
@@ -1,0 +1,60 @@
+from pathlib import Path
+import unittest
+
+
+SKILL_DIR = Path(__file__).resolve().parents[1]
+SKILL = (SKILL_DIR / "SKILL.md").read_text(encoding="utf-8")
+READINESS = (SKILL_DIR / "references" / "pr-readiness-policy.md").read_text(
+    encoding="utf-8"
+)
+BODY = (SKILL_DIR / "references" / "pr-body-proof.md").read_text(encoding="utf-8")
+RECORD = (SKILL_DIR / "references" / "ship-record.md").read_text(encoding="utf-8")
+
+
+class ShipContractTests(unittest.TestCase):
+    def test_decision_separates_operation_from_final_state(self) -> None:
+        for text in (SKILL, READINESS, RECORD):
+            self.assertIn("operation: create | update | update-and-promote | blocked", text)
+            self.assertIn("final_state: ready | draft | preserve", text)
+        self.assertIn("compatibility_mode", SKILL)
+        self.assertIn("update-and-promote` + `ready` -> `promote-draft`", RECORD)
+
+    def test_existing_body_updates_are_marker_scoped(self) -> None:
+        for text in (SKILL, BODY):
+            self.assertIn("<!-- ship-proof:start -->", text)
+            self.assertIn("<!-- ship-proof:end -->", text)
+            self.assertIn("Preserve", text)
+        self.assertIn("Never overwrite human-authored PR body content", SKILL)
+        self.assertIn("unbalanced, duplicated, or ambiguous", BODY)
+
+    def test_promotion_updates_proof_before_ready_transition(self) -> None:
+        section = SKILL.split("Existing draft promotion must update proof first:", 1)[1]
+        section = section.split("After every create, update, or promotion", 1)[0]
+        edit = section.index("gh pr edit <pr> --body-file <merged-body-file>")
+        ready = section.index("gh pr ready <pr>")
+        self.assertLess(edit, ready)
+        self.assertIn("Never promote a draft before updating", SKILL)
+
+    def test_publication_requires_live_readback(self) -> None:
+        for field in (
+            "number,url,state,isDraft,baseRefName,baseRefOid,headRefName,headRefOid,body",
+            "headRefOid",
+            "baseRefOid",
+            "exactly one managed block",
+        ):
+            self.assertIn(field, SKILL)
+        self.assertIn("failed readback must report `blocked`", RECORD)
+
+    def test_body_contract_surfaces_risks_and_followups(self) -> None:
+        for text in (SKILL, BODY):
+            self.assertIn("## Risks", text)
+            self.assertIn("## Follow-ups", text)
+            self.assertIn("not-run", text)
+
+    def test_actuation_draft_conflict_blocks(self) -> None:
+        self.assertIn("Actuation input cannot publish a draft", READINESS)
+        self.assertIn("incompatible-policy", SKILL)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- ship-proof:start -->
## Summary
- Separate the GitHub operation (`create`, `update`, or `update-and-promote`) from the desired final PR state while preserving the existing `SHIP-v1` compatibility modes.
- Make existing PR-description updates marker-scoped so `$ship` preserves human-authored text outside its managed proof block.
- Require proof refresh before draft promotion and live PR readback before reporting `created`, `updated`, or `promoted`.
- Clarify ambiguous existing-PR states, actuation draft-policy conflicts, direct readiness-only routing, redaction, risks, and follow-ups.
- Use a no-terminator JSON projection for PR-body acquisition and prove exact UTF-8 byte preservation with a no-final-newline regression.

## Why
`$ship` had grown from a PR-opening helper into a publication protocol, but its instructions still conflated action with final state, allowed whole-body replacement, promoted drafts without requiring a fresh proof-body update, and treated mutation-command success as sufficient evidence of the resulting PR state.

## Impact
- Existing `SHIP-v1` consumers retain the same readiness-mode enum.
- Human-authored PR context is protected from generated-body replacement and acquisition-time newline drift.
- Publication claims are bound to the intended base/head tuple, draft state, and managed proof block through live readback.
- Actuation inputs fail closed when repository policy requires a draft lifecycle that actuation cannot legally re-enter.

## Proof
- `uv run python -m unittest discover -s codex/skills/ship/tests -p 'test_*.py' -v`: pass, 7 tests.
- `uv run --with pyyaml -- python codex/skills/.system/skill-creator/scripts/quick_validate.py codex/skills/ship`: pass.
- `bash codex/skills/tune/scripts/validate-changed-skills --base origin/main`: pass, 1 changed skill validated.
- `git diff --check origin/main...HEAD`: pass.
- Hosted checks: not run; GitHub reports no checks and `main` has no required status checks.

## Scope
- repository: `tkersey/dotfiles`
- branch: `agent/harden-ship-pr-publication`
- head: `0438b04c45dd1982aaada3078b2615edad3e48b7`
- base: `main`
- base SHA: `8a1f2f8240696daf8e13374ff82365672848e6a3`

## Risks
- Marker-scoped body merging remains a documented protocol; this change does not add a standalone merge helper.
- The focused suite proves the local publication contract and exact-byte projection, but it does not execute GitHub mutations end-to-end.

## Follow-ups
- Consider a later `SHIP-v2` with a machine-validated postcondition object rather than continuing to encode ordered publication evidence in `action.command`.

## Readiness
- Operation: update-and-promote
- Final state: ready
- SHIP-v1 compatibility mode: promote-draft
- Reason: the exact-byte blocker is repaired; 7 contract tests and the repository skill validator pass; the PR has no review or required-check blocker.
- Caveats: GitHub reports no hosted checks, so readiness relies on the recorded local proof and branch-protection state.
<!-- ship-proof:end -->
