### PR TITLE
Bind $hylo to the executable CRF/HCTP workflow

### DIFF
--- a/.github/workflows/hylo-operator-contract.yml
+++ b/.github/workflows/hylo-operator-contract.yml
@@ -1,4 +1,4 @@
-name: Hylo operator contract
+name: Hylo candidate operator contract
 
 on:
   pull_request:
@@ -21,6 +21,7 @@ jobs:
       - name: Check out dotfiles
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
+          ref: ${{ github.event.pull_request.head.sha }}
           path: dotfiles
           persist-credentials: false
 
@@ -46,6 +47,20 @@ jobs:
           ref: ${{ steps.native-surface.outputs.commit }}
           path: skills-zig
           persist-credentials: false
+
+      - name: Verify and report exact candidate tuple
+        shell: bash
+        run: |
+          set -euo pipefail
+          dotfiles_commit="$(git -C dotfiles rev-parse HEAD)"
+          native_commit="$(git -C skills-zig rev-parse HEAD)"
+          test "$dotfiles_commit" = "${{ github.event.pull_request.head.sha }}"
+          test "$native_commit" = "${{ steps.native-surface.outputs.commit }}"
+          printf 'dotfiles=%s\n' "$dotfiles_commit"
+          printf 'skills-zig=%s\n' "$native_commit"
+          printf '%s\n' \
+            "- dotfiles: \`$dotfiles_commit\`" \
+            "- skills-zig: \`$native_commit\`" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Install Zig
         uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1

--- a/.github/workflows/hylo-operator-contract.yml
+++ b/.github/workflows/hylo-operator-contract.yml
@@ -1,0 +1,86 @@
+name: Hylo operator contract
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/hylo-operator-contract.yml"
+      - "codex/skills/hylo/**"
+      - "codex/skills/cas/**"
+      - "codex/skills/ledger/**"
+      - "codex/skills/retrace/**"
+      - "codex/skills/seq/**"
+
+permissions:
+  contents: read
+
+jobs:
+  operator-contract:
+    runs-on: macos-latest
+    timeout-minutes: 30
+    steps:
+      - name: Check out dotfiles
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          path: dotfiles
+          persist-credentials: false
+
+      - name: Resolve pinned native surface
+        id: native-surface
+        working-directory: dotfiles
+        shell: bash
+        run: |
+          set -euo pipefail
+          lock="codex/skills/hylo/native-surface.lock.json"
+          test "$(jq -r '.schema' "$lock")" = "hylo-native-surface-lock/v1"
+          repository="$(jq -er '.repository' "$lock")"
+          commit="$(jq -er '.commit' "$lock")"
+          test "$repository" = "tkersey/skills-zig"
+          [[ "$commit" =~ ^[0-9a-f]{40}$ ]]
+          printf 'repository=%s\n' "$repository" >> "$GITHUB_OUTPUT"
+          printf 'commit=%s\n' "$commit" >> "$GITHUB_OUTPUT"
+
+      - name: Check out pinned skills-zig
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          repository: ${{ steps.native-surface.outputs.repository }}
+          ref: ${{ steps.native-surface.outputs.commit }}
+          path: skills-zig
+          persist-credentials: false
+
+      - name: Install Zig
+        uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
+        with:
+          version: 0.16.0
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+
+      - name: Build pinned native operator surface
+        working-directory: skills-zig
+        run: >-
+          zig build build-seq build-ledger build-cas
+          -Doptimize=ReleaseFast -j1 --summary all
+
+      - name: Execute pinned native operator recipe
+        working-directory: skills-zig
+        run: >-
+          zig build test-hylo-operator-recipe
+          test-hylo-operator-recipe-executable
+          -j1 --summary all
+
+      - name: Verify documentation contract against pinned manifest
+        working-directory: dotfiles
+        env:
+          HYLO_OPERATOR_SURFACE_MANIFEST: ${{ github.workspace }}/skills-zig/testdata/hctp-v1/operator-recipe/operator-surface-manifest.json
+        run: uv run python codex/skills/hylo/tests/test_operator_recipe_contract.py
+
+      - name: Probe pinned native operator surface
+        working-directory: dotfiles
+        run: |
+          uv run python codex/skills/hylo/scripts/check-operator-surface \
+            --mode operator \
+            --surface-manifest "${GITHUB_WORKSPACE}/skills-zig/testdata/hctp-v1/operator-recipe/operator-surface-manifest.json" \
+            --seq "${GITHUB_WORKSPACE}/skills-zig/zig-out/bin/seq" \
+            --ledger "${GITHUB_WORKSPACE}/skills-zig/zig-out/bin/ledger" \
+            --cas "${GITHUB_WORKSPACE}/skills-zig/zig-out/bin/cas" \
+            --json

--- a/codex/skills/cas/SKILL.md
+++ b/codex/skills/cas/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cas
-description: "Run Zig CAS helpers (`cas`, `cas_account`, `cas_goal`, `cas_smoke_check`, `cas_instance_runner`, `cas_review_session`, `cas_session_inquiry`, `cas_conformance_suite`) for v2 app-server account status, smoke checks, goal lifecycle control, direct thread/turn execution, detached review control, review evidence ledger import/validation, session inquiry replay, and multi-instance fanout. For review evidence, distinguish CAS-RER records, pre-review lane transport, real review attempts, normalized tuple-bound review verdicts, account/resource exhaustion, and tuple concurrency guards."
+description: "Run Zig CAS helpers (`cas`, `cas_account`, `cas_goal`, `cas_smoke_check`, `cas_instance_runner`, `cas_review_session`, `cas_session_inquiry`, `cas_trial`, `cas_conformance_suite`) for v2 app-server account status, smoke checks, goal lifecycle control, direct thread/turn execution, detached review control, HCTP one-claim lane execution, review evidence ledger import/validation, session inquiry replay, and multi-instance fanout. For review evidence, distinguish CAS-RER records, pre-review lane transport, real review attempts, normalized tuple-bound review verdicts, account/resource exhaustion, and tuple concurrency guards."
 ---
 
 # cas (Zig App-Server Control)
@@ -33,6 +33,7 @@ cas smoke_check
 cas instance_runner
 cas review_session
 cas session_inquiry <preflight|run|start|status|wait|interrupt|receipt|cleanup>
+cas trial <preflight|compile-replay|run|status|cleanup|key-info>
 cas conformance
 ```
 
@@ -41,6 +42,145 @@ cas conformance
 `cas conformance` probes app-server helper compatibility and retry-policy scenarios.
 
 `cas session_inquiry` owns safe historical replay lifecycle for `$retrace`; see `references/retrace-session-inquiry.md`.
+
+## HCTP trial execution
+
+Before the first native Ledger command in this workflow, load `$ledger` and
+complete `$ledger ensure` once. Reuse that readiness for every later Ledger
+command.
+
+`cas trial` is an admitted macOS product surface. Probe
+`cas capabilities --json` and require only the exact features needed by the
+route. Private-v2 direct execution requires:
+
+```text
+hylo_trial_runner_v2
+hylo_fd_lane_lease_v1
+hylo_signed_run_receipt_v2
+hylo_private_lane_materialization_fd_v1
+hylo_private_receipt_redaction_v1
+hylo_target_common_projection_opening_v1
+hylo_trial_route_projection_v1
+```
+
+Historical execution additionally requires:
+
+```text
+hylo_internal_historical_replay_v1
+dcp_v2
+rip_v1
+fir_v1
+```
+
+These keys are absent on non-macOS builds. Do not infer historical replay or a
+sealed broker from `hylo_trial_runner_v2`. Legacy `hylo_trial_runner_v1` and
+`hylo_signed_run_receipt_v1` remain compatibility features only.
+
+Run preflight for each frozen lane:
+
+```bash
+cas trial preflight --trial trial.json --lane-id <lane-id> --json
+```
+
+Its route projection uses these exact fields:
+
+```text
+source_profile_kind
+compile_replay_required
+replay_preparation_mode
+source_profile_body_delivery
+execution_route
+required_lineage
+```
+
+For a direct lane, require `source_profile_kind:"direct"`,
+`compile_replay_required:false`, `source_profile_body_delivery:"none"`,
+`replay_preparation_mode:"none"`, `execution_route:"direct"`, and
+`required_lineage:null`. Skip
+`compile-replay`; materialize the visible input, receive the exact lease-bound
+Ledger claim through `--materialization-fd`, and invoke `cas trial run` exactly
+once.
+
+For a historical lane, require `source_profile_kind:"historical_decision"`,
+`compile_replay_required:false`, `replay_preparation_mode:"integrated_run"`,
+`execution_route:"historical_replay"`, and the frozen `required_lineage`.
+For every v2 historical lane, require
+`source_profile_body_delivery:"source_profile_fd"`; the public
+`units[*].source_profile` is only the exact validator-defined safe projection,
+and extra keys or semantic profile material are invalid. Supply the complete
+historical profile directly to `cas trial run --source-profile-fd` from the
+admitted materializer. Before claiming the lane, `cas trial run` privately
+compiles exactly one DCP and RIP and binds their fingerprints into the claim
+and terminal receipt. It then executes one bounded replay; a successful
+terminal receipt must join the resulting FIR lineage, while a failed terminal
+receipt records FIR unavailability. Embedded delivery is legacy v1 or
+standalone diagnostic compatibility, not the v2 execution route.
+
+Every `hylo-trial/v2` lane requires `--materialization-fd`, independently of
+source route. The FD carries `hylo-lane-materialization-claim/v2` from
+`ledger --source hylo lane-materialization`; it binds the public trial,
+registration/start lineage, retained lease, selected treatment commitment, and
+private treatment body without disclosing semantic role. It is distinct from
+the visible-input, lease, source-profile, and signing-seed descriptors.
+
+That private claim also carries the exact
+`hylo-target-common-projection-opening/v1`. CAS accepts no raw
+`target_common_projection` alias: it verifies the whole opening against the
+public trial's target-common-projection commitment, then verifies the nested
+`hylo-target-common-projection/v1` against its public projection fingerprint
+before executor preparation. Neither opening nor projection body appears in
+the public run receipt.
+
+CAS emits `hylo-run-receipt/v2` for v2 trials. Its public materialization
+projection is commitment-only: it may expose the treatment commitment,
+visible-input lineage, permitted historical fingerprints, source-profile
+delivery mode, and non-disclosure booleans. It must not expose semantic role,
+raw target snapshot/materialization identities, target/factor archive paths,
+package-tree fingerprints, or private evidence references. Its FIR carrier is
+exactly `hylo-fir-public-projection/v1`; the full FIR stays private. Legacy
+`hylo-trial/v1` continues to emit `hylo-run-receipt/v1` with its compatible
+full-FIR carrier.
+
+The v2 public materialization projection also carries
+`materialization_claim_fingerprint`. Before reveal, it must exact-join the
+same lane's `hylo-lane-materialization-receipt/v2.claim_fingerprint`. Ledger
+requires one matching v2 receipt per lane and rejects changed, missing,
+duplicate, or version-mixed per-lane safe-receipt sets before appending reveal.
+This join does not apply to the legacy v1 receipt carrier.
+
+Protected lane leases, visible inputs, treatment claims, source profiles, and
+signing seeds use distinct anonymous directional descriptors numbered `>=3`.
+Do not carry their secret bytes in argv, environment variables, regular files,
+normal stdout, the event store, or proof bundles. A started one-claim lane is
+never retried as new work; `status` and recovery may only finish or re-emit
+already-admitted state.
+
+### Diagnostic `compile-replay`
+
+The standalone `cas trial compile-replay` command is historical-only diagnostic
+infrastructure. It rejects direct lanes, case-blind or FD-delivered source
+profiles, and `role_separated` or `sealed` assurance. It grants no execution
+authority, reports `execution_authority:false`, and must not enter the normal
+historical path. `cas trial run` neither consumes its receipt nor its DCP/RIP
+files; run performs authoritative integrated preparation before the one-shot
+claim.
+
+For an allowed open, embedded historical diagnostic, `--output-dir` must name
+a caller-owned canonical private root with no symlink path components and mode
+`0700`. CAS creates the lane DCP and RIP as new `0600` files, rejects conflicts,
+and revalidates modes, ownership, inode shape, and content fingerprints. Normal
+stdout contains only `cas-trial-replay-plan-receipt/v1` metadata and
+fingerprints; it never returns the semantic source profile, DCP, or RIP bodies.
+
+### Sealed broker boundary
+
+Sealed assurance requires an explicitly admitted external broker satisfying the
+published role, protected-FD, checkpoint, recovery, and non-disclosure
+contracts. The repository-owned `hctp-sealed-role-driver` is conformance/test
+infrastructure, not an installed product command or capability. Fail closed
+before secret generation or trial mutation when no admitted broker exists.
+Retain `os_confinement:false`; the macOS route does not claim hostile same-user
+process isolation.
 
 ## Artifact store
 

--- a/codex/skills/hylo/SKILL.md
+++ b/codex/skills/hylo/SKILL.md
@@ -1,160 +1,154 @@
 ---
 name: hylo
-description: "Compile historical Codex sessions into blinded counterfactual replay episodes, govern sealed paired HCTP trials, grade comparable observable outcomes, and fold typed evidence into RUN, OBSERVE, or STOP. Use for `$hylo`, counterfactual replay, causal frontiers, paired baseline/candidate trials, sealed evidence, or evidence-governed improvement."
+description: "Compile historical Codex sessions into governed counterfactual evidence, evaluate an existing owner-applied candidate through blinded paired HCTP trials, and fold observable evidence into RUN, OBSERVE, or STOP. Use for `$hylo`, CRF extraction, counterfactual replay, source-governed direct or historical trials, sealed evidence, paired baseline/candidate evaluation, causal frontiers, or evidence-governed improvement."
 ---
 
 # Hylo
 
 ## Mission
 
-Turn historical execution evidence into controlled counterfactual experiments
-and a reusable causal frontier.
+Coordinate the released CRF/HCTP owners into one custody-safe experiment:
 
 ```text
-historical session
-  -> counterfactual cut + blinded replay episode
-  -> baseline and candidate executions under one frozen contract
-  -> observable traces + frozen grades + paired comparison
-  -> failure signatures + hypotheses + bounded experiments
-  -> RUN | OBSERVE | STOP
+CRF evidence
+  -> governed source selection
+  -> admitted campaign, scenarios, and target bundles
+  -> existing owner-applied candidate
+  -> validated and source-bound paired trial
+  -> route-correct one-claim lanes
+  -> blind grades -> reveal -> observe result -> close -> proof
+  -> causal frontier -> owner-routed action or STOP
 ```
 
-Hylo does not imitate a transcript, recover private reasoning, train model
-weights, or invent a sequence of edits. It freezes the causal prefix before a
-target first influences the session and regenerates everything downstream.
-
-`STOP: no_obvious_next_step` is a successful result when the evidence does not
-justify one intervention.
+Hylo does not recover private reasoning, treat a historical answer as a replay
+baseline, create a candidate, or grant edit, reveal, commit, push, spend, or
+external-effect authority. `STOP: no_obvious_next_step` is a successful result.
 
 ## Current product boundary
 
-The released CRF/HCTP product route is:
-
 ```text
-Seq 0.3.50+     episode compilation and source governance
-Ledger 0.10.3+  artifact validation, trial custody, event folds, causal frontier
-CAS 0.2.80+     one-claim lane execution and run-receipt normalization
+Seq 0.3.52+     CRF extraction, source governance, route admission, materialization
+Ledger 0.10.6+  campaign/trial validation, compilation, lifecycle, folds, proof
+CAS 0.2.81+     route projection, internal historical preparation, one-claim execution
 ```
 
-The `seq hylo-extract`, `ledger --source hylo`, and `cas trial` product
-surfaces are currently admitted on macOS. Stateless `ledger validate hylo-*`
-schema checks remain platform-neutral. Do not invent an unadmitted
-platform-specific isolation route.
+`seq hylo-extract`, `seq hctp-source`, `ledger --source hylo`, and `cas trial`
+are macOS product surfaces. Root `ledger validate hylo-*` artifact validators
+are platform-neutral. The macOS route establishes commitments, role separation,
+one-shot descriptor delivery, public non-disclosure, and exactly-once claims
+while reporting
+`os_confinement:false`; it does not establish hostile same-user isolation.
 
-The supported macOS proof establishes commitments, role separation, one-shot
-descriptor delivery, and public non-disclosure. It records
-`os_confinement:false`; it does not claim hostile same-user isolation.
+Sealed assurance requires a caller-provided admitted broker whose binary and
+contract fingerprints satisfy the native role, FD, checkpoint, recovery, and
+non-disclosure contracts. Native `compile-trial` currently rejects every sealed
+build request as `SealedBrokerUnavailable`; a sealed trial therefore requires a
+separately validator-backed trial and an admitted external broker. The
+repository's `hctp-sealed-role-driver` is conformance infrastructure, not an
+installed product command. Fail closed before secret generation or trial
+mutation when either prerequisite is absent.
 
 ## Ownership
 
 ```text
-$seq / seq hylo-extract
-    owns historical parsing, target activation, the causal cut, redaction,
-    episode construction, target capture, and runner/custody separation
-
-$ledger / ledger --source hylo
-    owns validation, trial registration and lifecycle, immutable campaign
-    events, deterministic folds, proof export, and causal-frontier decisions
-
-$cas / cas trial
-    owns one-claim lane execution, clean workspaces, observable evidence hashes,
-    and hylo-run-receipt/v1 production
-
-runner and grader adapters
-    own model/tool execution and frozen observations; they do not edit targets
-
-target owner workflow
-    owns any authorized edit, staging, commit, or publication
-
-$hylo
-    coordinates those owners without borrowing their authority
+$seq       historical parsing, cut, redaction, source selection, route admission
+$ledger    validation, immutable admission, trial compilation/lifecycle, folds, proof
+$cas       route projection, private historical replay preparation, one-claim run
+adapters   frozen model/tool execution and observable grading
+owner      target changes, staging, commit, push, and publication
+$hylo      coordination only; authority_granted:false
 ```
 
-The historical response is sealed source evidence. It MAY support diagnostic
-failure mining after authorized custody access, but it MUST NOT satisfy a replay
-baseline or act as a golden answer.
+The historical response is sealed diagnostic evidence. It is never the fresh
+baseline or a golden answer.
 
 ## Source-of-truth order
 
-When surfaces disagree, use this order:
+When surfaces disagree, use:
 
 1. installed CLI help and capabilities;
-2. released validators and schemas;
-3. implementation documentation and executable fixtures;
-4. this skill;
-5. proposed specifications or historical campaign prose.
+2. released validators, schemas, and executable fixtures;
+3. implementation documentation;
+4. this skill and its references;
+5. historical or proposed specifications.
 
-Do not invoke a proposed `hylo replay`, `hylo grade`, or `hylo compare` binary.
-Those standalone commands are not the released product surface.
+Do not invent standalone `hylo replay`, `hylo grade`, or `hylo compare`
+commands.
 
-## Bootstrap and capability gate
+## Mode-sensitive capability gate
 
 Before the first native Ledger command, load `$ledger` and complete
-`$ledger ensure` once. Then probe all three released owners:
+`$ledger ensure` once. Probe only the requested operation:
+
+| Operation | Required surface |
+| --- | --- |
+| `validate` (pure artifact validation) | Root `ledger validate hylo-*`; no Seq or CAS requirement |
+| repo-aware `doctor`, report, or frontier | macOS `ledger --source hylo` product surface and selected command |
+| `extract` | pure validation plus Seq `hylo_extract_v1`, `seq hylo-extract` |
+| source selection | Seq `hctp_source_selection_v1`, `hctp_source_route_admission_v1`, `hctp_independence_clusters_v1`, `seq hctp-source` |
+| open/direct trial | Ledger `hylo_trial_v2`, `hylo_private_trial_custody_v1`, `hylo_trial_custody_fd_v1`, `hylo_private_lane_start_custody_fd_v1`, `hylo_lane_materialization_v1`, `hylo_lane_materialization_receipt_v2`, `hylo_lane_leases_v1`, `hylo_signed_attestations_v1`, `hylo_trial_compiler_v1`, `hylo_trial_build_receipt_v2`, `hylo_run_receipt_v2`, `hylo_trial_reveal_v2`, `hylo_reveal_material_fd_v1`; CAS `hylo_trial_runner_v2`, `hylo_fd_lane_lease_v1`, `hylo_signed_run_receipt_v2`, `hylo_private_lane_materialization_fd_v1`, `hylo_private_receipt_redaction_v1`, `hylo_target_common_projection_opening_v1`, `hylo_trial_route_projection_v1` |
+| historical trial | direct requirements plus CAS `hylo_internal_historical_replay_v1`, `dcp_v2`, `rip_v1`, `fir_v1` |
+| case-blind trial | source-selection plus selected direct/historical requirements and Seq `hctp_sealed_case_v1`, `hctp_materializer_v1`, `hctp_source_materialization_v1`, `hctp_source_selection_opening_fd_v1`; historical case-blind additionally requires `hctp_historical_profile_v1` and `hctp_case_blind_source_profile_fd_v1` |
+| sealed trial | Native `compile-trial` is unavailable (`SealedBrokerUnavailable`); require a separately validator-backed trial, the selected trial capabilities, and an explicitly admitted external broker |
+| proof export | Ledger v2 trial/custody requirements plus `hylo_proof_bundle_v1`, `hylo_external_proof_anchor_v1`, and proof commands; no Seq or CAS requirement after close |
+
+`hylo_trial_v1`, `hylo_trial_runner_v1`, and `hylo_signed_run_receipt_v1`
+remain legacy compatibility features. They do not satisfy the private-v2 happy
+path.
+
+Use the installed capabilities shape:
 
 ```bash
 ledger --version
 ledger --source hylo capabilities
-ledger --source hylo --help
-
 seq --version
 seq capabilities --format json
-seq hylo-extract --help
-seq hctp-source --help
-
 cas --version
 cas capabilities --json
-cas trial --help
 ```
 
-For the complete route, require the version floor in **Current product
-boundary** and these capabilities or commands:
+Probe command help only for commands selected by the mode. If a required
+feature or broker is absent, stop before evidence creation or mutation; do not
+emulate it or hand-edit `.ledger/hylo/events.jsonl`.
+
+## Candidate lifecycle
+
+Choose one lifecycle before building a trial:
 
 ```text
-Seq:    hylo_extract_v1, hctp_source_selection_v1, hctp_sealed_case_v1
-Ledger: hylo_trial_v1, hylo_lane_leases_v1, hylo_pair_grade_v1,
-        hylo_trial_reveal_v1, hylo_proof_bundle_v1,
-        hylo_grade_commit_open_v1
-CAS:    trial preflight, compile-replay, run, status, cleanup
+evaluate_existing_candidate
+  owner-applied candidate already exists
+  -> admit before/after identities and bounded change
+  -> freeze and evaluate it in a new trial
+
+derive_next_candidate
+  prior evidence exists
+  -> fold failures, hypotheses, experiments, and frontier
+  -> RUN | OBSERVE | STOP
+  -> owner may apply RUN only under separate authority
+  -> return after a new candidate identity exists
 ```
 
-If a required surface is absent, stop before creating evidence. Do not emulate
-the source with a fallback writer or hand-edit `.ledger/hylo/events.jsonl`.
-
-Read [contracts.md](references/contracts.md) before authoring artifacts or
-trial events. Read
-[grading-and-progression.md](references/grading-and-progression.md) before
-grading, comparing, selecting an experiment, or claiming improvement.
-
-## Modes
-
-Choose one primary mode per invocation:
-
-```text
-extract   compile one historical response into a blinded CRF episode
-trial     register or advance one paired HCTP trial
-measure   grade observable attempts and derive paired evidence
-frontier  compile typed hypotheses, experiments, and RUN | OBSERVE | STOP
-report    inspect progress, trial state, proof state, or limitations
-doctor    validate artifacts, campaign state, or event-chain integrity
-```
-
-A persistent request may repeat a verified mode transition. It does not grant
-target-edit, external-effect, reveal, publication, or spend authority.
+`RUN` selects an eligible experiment. It neither mutates the target nor creates
+the candidate. Report candidate state independently as `absent`,
+`owner_applied`, `frozen_for_trial`, `evaluated`, `promoted`, or `rejected`.
 
 ## Workflow
 
-### 1. Compile the counterfactual episode
+Read [orchestration.md](references/orchestration.md) before executing a trial;
+it owns the complete state machine and protected-FD rules. Read
+[contracts.md](references/contracts.md) before authoring artifacts or event
+intents. Read
+[grading-and-progression.md](references/grading-and-progression.md) before
+grading, comparing, promoting, or selecting an experiment.
 
-Select one historical response and the target whose influence is being
-replaced. Use the canonical trace compiler, not an analytics projection that
-deduplicates messages or drops context.
+### 1. Extract and apply the fidelity gate
+
+Run `seq hylo-extract` with the complete target root. Deliver the seal key only
+through an already-open, unlinked anonymous protected descriptor supplied by
+the admitted custodian; every sensitive FD is distinct and `>=3`.
 
 ```bash
-umask 077
-: >./owner.key
-chmod 600 ./owner.key
-
 seq hylo-extract \
   --root ~/.codex/sessions \
   --session-id <session-id> \
@@ -165,333 +159,383 @@ seq hylo-extract \
   --capture-world \
   --output-root ./runner \
   --sealed-root ./custody \
-  --seal-key-output-fd 3 3>./owner.key
+  --seal-key-output-fd <custodian-key-sink-fd>
 ```
 
-The key sink must be a caller-owned `0600` single-link regular file outside
-the source, target, runner, and custody roots, or an anonymous pipe. Never use
-stdin, stdout, stderr, an environment variable, a named FIFO, or a file inside
-an artifact root.
+Never replace a protected-FD placeholder with regular-file redirection, a
+named FIFO, stdin/stdout/stderr, argv, or an environment variable.
 
-`--target-root` names the complete historical bundle, including referenced
-files, scripts, templates, and assets. Extraction fails closed on target drift,
-root overlap, symlinks, malformed trace data, ambiguous activation, unknown
-state-bearing pre-cut carriers, sensitive target bytes, or answer-before-
-activation ordering.
+Validate the complete extraction graph with Ledger's pure validators. Then
+record the episode fingerprint, cut, target bundle, world availability,
+runtime, fidelity, `replay_eligible`, and limitations. Schema validity alone
+does not admit execution.
 
-The cut MUST precede the earliest structured target influence. Preserve
-ordered and duplicate message occurrences, fixed pre-cut observations, and the
-replaceable target slot. Regenerate post-cut target behavior, workers, tools,
-files, responses, and outcomes.
+### 2. Select and compile the source route
 
-### 2. Keep runner and custody artifacts separate
+Apply this non-upgrading gate:
 
-The runner root receives only causal inputs:
+| CRF evidence | Source profile | Native result |
+| --- | --- | --- |
+| `replay_eligible:true` | genuinely `direct` | direct comparison admission |
+| `replay_eligible:false` | `direct` | `diagnostic_only` source admission; trial compilation, registration, and comparison execution forbidden |
+| `replay_eligible:true` | valid governed `historical_decision` | historical replay admission |
+| `replay_eligible:false` | valid governed `historical_decision` | historical replay admission at the retained reconstruction ceiling |
+| any | absent or invalid `historical_decision` governance | compilation fails; the source remains diagnostic evidence only |
 
-```text
-runner-input.json
-stimulus.json
-baseline-bundle.json
-captured target files
-world.json
-world-availability.json
-runtime.json
-```
+A historical source must never be relabeled `direct`. Historical
+`practice_repair` and `promotion` require authoritative SGG/DCP target-text
+witness governance and the required RIP/FIR lineage.
 
-The private `0700` custody root receives controller/grader evidence:
-
-```text
-episode.json
-cut.json
-redaction.json
-historical-response.sealed.json
-manifest.json
-```
-
-The runner consumes `runner-input.json`, not custody `episode.json`. Never
-copy the sealed response, excluded-future digest material, future outcomes, or
-grader-only references into the runner root.
-
-Treat `world-availability.json` as authoritative for fidelity. Slice 1
-reserves `exact_reconstruction`; it does not claim it. If historical repository
-or runtime bytes are unavailable, retain the explicit limitation and do not
-upgrade a `transcript_only` or `replay_eligible:false` episode by assertion.
-
-Validate the generated graph before trial construction:
-
-```bash
-ledger validate hylo-runner-input --input ./runner/runner-input.json
-ledger validate hylo-stimulus --input ./runner/stimulus.json
-ledger validate hylo-target-bundle --input ./runner/baseline-bundle.json
-ledger validate hylo-world-snapshot --input ./runner/world.json
-ledger validate hylo-world-availability-receipt --input ./runner/world-availability.json
-ledger validate hylo-runtime-contract --input ./runner/runtime.json
-ledger validate hylo-replay-episode --input ./custody/episode.json
-ledger validate hylo-counterfactual-cut-receipt --input ./custody/cut.json
-ledger validate hylo-redaction-receipt --input ./custody/redaction.json
-ledger validate hylo-custody-manifest --input ./custody/manifest.json
-```
-
-These are pure schema/invariant checks. A pass grants no replay, reveal, edit,
-or publication authority.
-
-### 3. Freeze source selection
-
-Use `seq hctp-source` to compile the complete denominator, dependency-aware
-independence clusters, split integrity, sanitized source commitments, and any
-case-blind sealed payloads:
+Compile the source-selection receipt before trial construction. The signing
+seed and any seal key use admitted protected descriptors:
 
 ```bash
 seq hctp-source compile \
-  --manifest source.json --output selection.json \
-  --source-signing-seed-fd <fd>
-seq hctp-source validate --receipt selection.json --trial trial.json
+  --manifest source.json \
+  --output selection.json \
+  --source-signing-seed-fd <source-owner-seed-fd>
 ```
 
-`govern` derives source-governance evidence. `materialize` releases one exact
-registered visible case through a protected FD and emits a lane-scoped signed
-receipt; it must not release the hidden reference. Consult
-`seq hctp-source --help` for sealed-case arguments and descriptor ownership.
+Do not run `hctp-source validate` yet; it requires the completed trial.
 
-### 4. Freeze a paired HCTP trial
+### 3. Admit the parent campaign
 
-Build `hylo-trial/v1` before candidate execution. Freeze:
-
-- campaign, purpose, split, units, independence clusters, pairs, and repeats;
-- opaque arms and balanced A/B-B/A execution order;
-- baseline and candidate target identities and common projection;
-- source-selection and visible/hidden commitments;
-- runtime, tool/effect policy, runner, model, and environment projections;
-- rubric, oracle, judge, producer, trust, and assurance authorities;
-- reveal, stop, publication, and proof policies.
-
-Use `practice_repair` trials to select repairs. Reserve untouched `promotion` units for
-holdout evidence. A null trial is a real control: its two semantic arms have an
-identical common target projection and a declared null intervention witness.
-
-```bash
-ledger --source hylo validate-trial --repo <repo> --trial trial.json
-ledger --source hylo register-trial --repo <repo> --trial trial.json
-```
-
-Registration is atomic over the complete manifest. Trial lifecycle events are
-owned by high-level Hylo commands; low-level `append` must not author them.
-
-### 5. Execute lanes without unblinding
-
-Use `cas trial` for each registered lane:
-
-```bash
-cas trial preflight --trial trial.json --lane-id <lane> --json
-cas trial compile-replay \
-  --trial trial.json --lane-id <lane> --output-dir <compiled-dir> --json
-```
-
-For an admitted run, the controller obtains or commits the lane lease through
-Ledger, delivers the lease and visible input through protected file
-descriptors, and calls `cas trial run` with the exact registration and start
-digests. CAS claims the lane before execution, creates a fresh workspace,
-invokes the executor exactly once, hashes every evidence file, and emits one
-`hylo-run-receipt/v1`.
-
-The executor receives only:
-
-```text
-EXECUTOR --request REQUEST.json --result RESULT.json
-```
-
-It must not receive the lane lease, semantic arm identity, sealed historical
-response, hidden reference, future outcome, grade opening, or pair result.
-
-For `assurance.required_level:sealed`, use the supported broker/driver route
-with `commit-lane-start`; output-style `start-lane` is invalid. Preserve the
-encrypted pending checkpoint and use exact recovery commands after an
-acknowledgement loss. Recovery may finish already-admitted work; it must not
-create changed or additional work.
-
-Public lifecycle primitives include:
-
-```text
-register-trial
-start-lane | commit-lane-start | recover-lane-start
-lane-materialization
-finish-lane | recover-lane-finish
-grade-lane
-grade-pair
-reveal-trial
-trial-result
-close-trial
-inspect
-proof-artifact-set
-export-proof
-verify-proof
-```
-
-Consult `ledger --source hylo --help` for the exact current arguments. Never
-put leases, signing seeds, grade openings, hidden references, or custody keys
-in command-line arguments, environment variables, normal stdout, the event
-store, or proof bundles.
-
-### 6. Grade observable consequences
-
-Grade hard gates before scored dimensions. Use visible messages, tool events,
-file effects, worker events, tests, runtime metadata, signed receipts, and
-human attestations. Never request or persist private chain-of-thought.
-
-Record blind absolute lane grades and blind pair grades against the frozen
-producer and grader authorities. Pre-reveal controller output may contain only
-public metadata, commitments, fingerprints, and opaque acknowledgements. It
-must not disclose plaintext grades, pair winners, or semantic arm labels.
-
-The historical response may be inspected only by an authorized custody/grader
-route and remains diagnostic. The comparison denominator is a fresh compatible
-`replay_baseline` executed before the candidate for the same episode.
-
-### 7. Reveal, compare, and prove
-
-Reveal only after every required lane and grade is terminal and the frozen
-reveal policy is satisfied:
-
-```bash
-ledger --source hylo reveal-trial --repo <repo> --reveal reveal.json
-ledger --source hylo trial-result \
-  --repo <repo> --trial-id <trial-id> --format markdown
-```
-
-After reveal, derive paired dimension deltas, hard-gate changes, dispersion,
-critical violations, observable behavior deltas, and calibration/null-trial
-results. Keep association, comparison-valid delta, supported mechanism, and
-causal claim distinct.
-
-For portable proof, obtain the exact artifact set, have the trusted source
-owner sign that set, then export and verify:
-
-```bash
-ledger --source hylo proof-artifact-set \
-  --repo <repo> --trial-id <trial-id> --output proof-artifacts.json
-
-ledger --source hylo export-proof \
-  --repo <repo> --trial-id <trial-id> --output proof.tar \
-  --sanitization-receipt proof-sanitization.json
-
-ledger --source hylo verify-proof --repo <repo> --input proof.tar
-```
-
-Proof verification establishes the declared closure and anchors. It does not
-grant target-edit, commit, push, or generalized-improvement authority.
-
-### 8. Fold campaign evidence and the causal frontier
-
-The compatible campaign fold remains available for
-`hylo-campaign/v1`, `hylo-scenario/v1`, target snapshots, attempts, grades,
-changes, publications, and progress:
+Construct `campaign.json` and its complete scenarios JSONL. An HCTP campaign
+opts into `hylo-trial/v2` (and MAY also retain `hylo-trial/v1` compatibility),
+`hylo-canonical-json/v1`, its trial policy,
+`source_route_admission:"required"`, proof authority/trust where required, and
+the complete scenario manifest.
 
 ```bash
 ledger --source hylo validate-campaign --campaign campaign.json
-ledger --source hylo snapshot-target \
-  --repo <repo> --revision INDEX --input target-roots.json
-ledger --source hylo append --repo <repo> --json event-intent.json
+ledger --source hylo append --repo <repo> --json campaign-created.json
+ledger --source hylo append --repo <repo> --json baseline-target-bundle-admitted.json
+ledger --source hylo append --repo <repo> --json candidate-target-bundle-admitted.json
+ledger --source hylo append --repo <repo> --json scenario-admitted-001.json
+ledger --source hylo append --repo <repo> --json change-recorded.json
 ledger --source hylo doctor --repo <repo>
-ledger --source hylo progress \
-  --repo <repo> --campaign-id <campaign-id> --format json
 ```
 
-Do not confuse compatibility with authority. A `historical_baseline` event is
-diagnostic only; candidate comparison still requires a compatible prior
-`replay_baseline`.
+Append every remaining `scenario_admitted` intent in the frozen manifest before
+the change intent and doctor pass.
 
-Typed causal events are:
+A trial is additive to an admitted campaign, not a campaign substitute. Do not
+compile or register it until the campaign, every required scenario, and both
+required target identities are admitted. Promotion must cover the complete
+applicable protected set fixed by the campaign.
 
-```text
-failure_signature_recorded
-hypothesis_recorded
-experiment_recorded
-next_step_recorded
-```
+### 4. Bind the existing candidate
 
-Every target-changing experiment must bind observable evidence, one mechanism,
-a bounded intervention, measurable predictions, protected controls, explicit
-falsifiers, a changed content-addressed target, and sufficient reserved
-promotion budget.
+Require the owner-applied candidate, exact before/after bundle and snapshot
+identities, bounded path set, and applied change event. If no concrete candidate
+exists, stop trial construction and use the causal frontier first.
 
-Derive, do not guess, the next step:
+### 5. Compile, validate, source-validate, and register
+
+Use the native compiler and deliver `hylo-trial-custody/v1` to an admitted
+custodian over an unlinked anonymous protected descriptor. The public output is
+commitment-only `hylo-trial/v2`:
 
 ```bash
-ledger --source hylo frontier \
-  --repo <repo> --campaign-id <campaign-id> --format json
+ledger --source hylo compile-trial \
+  --repo <repo> \
+  --request trial-build-request.json \
+  --source-receipt selection.json \
+  --output trial.json \
+  --custody-output-fd <custodian-custody-sink-fd>
 
-ledger --source hylo next-experiment \
-  --repo <repo> --campaign-id <campaign-id>
+ledger --source hylo validate-trial --repo <repo> --trial trial.json
+seq hctp-source validate --receipt selection.json --trial trial.json
+ledger --source hylo register-trial \
+  --repo <repo> \
+  --trial trial.json \
+  --custody-input-fd <custodian-registration-source-fd>
 ```
 
-Interpret the result literally:
+Stop if any command fails. The `hylo-trial-build-receipt/v2` on stdout with
+`custody_material_delivered:true` is the compiler's completion observation. The
+compiler attempts to remove the public trial when private delivery reports
+failure; `TrialOutputRollbackFailed` identifies an uncommitted recovery path.
+Transient file visibility or a partial custody stream is not completion or
+authority. Source
+validation joins the external signed receipt to the public portable
+`artifact:sha256:<64 lowercase hex>` reference, fingerprint, and commitment;
+the reference digest equals the receipt fingerprint. The public trial never
+embeds the full receipt or a caller-local path.
+
+Every public v2 `units[*].source_profile` is the exact native safe projection.
+Exact-key validation rejects semantic extras; a full historical profile body,
+source target text, rationale, rejected routes, and hidden references remain
+outside the public trial and use the admitted private carrier when required.
+
+The custodian retains the exact custody record outside public artifacts and
+re-delivers it through a fresh protected pipe for registration, each new v2
+lane start or caller-retained start commit, each lane materialization, and
+reveal. The public registration event persists only the v2 trial and a
+validated nonsemantic custody-commitment observation. Exact recovery of an
+already-started lane uses the retained lease and does not create changed work.
+
+For private-v2 registration, the earlier validators and command preflight are
+necessary but do not own the append decision. Ledger reacquires exclusive
+store ownership, loads the exact append snapshot, and reruns the full semantic
+trial-against-campaign validation on the custody-backed trial before applying
+or appending `trial_registered`. A stale or mismatched semantic view fails
+without append. The legacy v1 registration path retains its established public
+trial contract.
+
+### 6. Execute each lane by its frozen route
+
+Run `cas trial preflight --trial trial.json --lane-id <lane> --json` and obey
+its exact `source_profile_kind`, `compile_replay_required`,
+`replay_preparation_mode`, `source_profile_body_delivery`, `execution_route`,
+and `required_lineage`. Direct lanes report
+`compile_replay_required:false` and `replay_preparation_mode:"none"`;
+historical lanes report `compile_replay_required:false` and
+`replay_preparation_mode:"integrated_run"`.
 
 ```text
-RUN      exactly one eligible intervention is non-dominated
-OBSERVE  one bounded read-only probe can discriminate among alternatives
-STOP     no eligible intervention, or unresolved alternatives have no bounded probe
+source_profile.kind == "direct"
+  -> materialize visible input
+  -> start or commit the lease
+  -> privately materialize the selected treatment from custody under that lease
+  -> cas trial run once with --materialization-fd and no source-profile FD
+  -> finish or recover the terminal acknowledgement
+
+source_profile.kind == "historical_decision"
+  -> materialize visible input
+  -> privately materialize the source profile through the required v2 FD
+  -> start or commit the lease
+  -> privately materialize the selected treatment from custody under that lease
+  -> cas trial run receives --materialization-fd and --source-profile-fd,
+     then prepares one DCP/RIP internally before claim
+  -> validate FIR/native receipt lineage
+  -> finish or recover the terminal acknowledgement
 ```
 
-Every projection reports `authority_granted:false` and
-`target_mutated:false`. A `RUN` decision selects an experiment; it does not
-authorize or apply the edit.
+For every v2 lane, bind the public start event to `treatment_commitment`, retain
+the exact lease, and supply custody while the new start validates the private
+target treatment under the repository locks:
 
-### 9. Route an authorized repair through the owner
+```bash
+ledger --source hylo start-lane \
+  --repo <repo> \
+  --campaign-id <campaign-id> \
+  --trial-id <trial-id> \
+  --lane-id <lane-id> \
+  --runner-id <runner-id> \
+  --custody-input-fd <custodian-start-source-fd> \
+  --lease-output-fd <runner-lease-sink-fd>
+```
 
-Only practice evidence may motivate a change in the active campaign. Route the
-selected experiment through the target's owner workflow and preserve:
+For a caller-retained start, `commit-lane-start` likewise receives the exact
+custody through `--custody-input-fd` alongside its lease input. Then invoke the
+private treatment bridge:
+
+```bash
+ledger --source hylo lane-materialization \
+  --repo <repo> \
+  --trial-id <trial-id> \
+  --lane-id <lane-id> \
+  --registration-event-digest <registration-digest> \
+  --lane-started-event-digest <start-digest> \
+  --lane-lease-digest <lease-digest> \
+  --custody-input-fd <custodian-lane-source-fd> \
+  --lease-input-fd <retained-lease-source-fd> \
+  --materialization-output-fd <cas-materialization-sink-fd>
+
+cas trial run \
+  --trial trial.json \
+  --lane-id <lane-id> \
+  ... \
+  --materialization-fd <ledger-materialization-source-fd>
+```
+
+Ledger emits only `hylo-lane-materialization-receipt/v2` on stdout; retain that
+safe receipt for reveal. The FD carries the lease-bound claim and selected
+treatment without semantic role. It also carries the exact
+`hylo-target-common-projection-opening/v1`; CAS verifies the committed opening
+and nested projection before execution. CAS emits commitment-only
+`hylo-run-receipt/v2`; raw target, factor, archive, and treatment fields remain
+private. Its only public FIR carrier is the exact
+`hylo-fir-public-projection/v1`; the full FIR remains private. A v1 run receipt
+retains its compatible full-FIR carrier.
+
+For each v2 lane, retain and exact-join the safe receipt's `claim_fingerprint`
+to
+`hylo-run-receipt/v2.materialization.materialization_claim_fingerprint`.
+Reveal admits one matching `hylo-lane-materialization-receipt/v2` per lane;
+changed, missing, duplicate, or version-mixed per-lane safe receipts fail
+before append.
+
+For case-blind input materialization, the custodian projects only the exact
+`hylo-source-selection-opening/v1` from trial custody onto a separate protected
+FD:
+
+```bash
+seq hctp-source materialize \
+  --sealed-case <sealed-case> \
+  --trial trial.json \
+  --lane-id <lane-id> \
+  --seal-key-fd <custodian-seal-key-source-fd> \
+  --visible-output-fd <runner-visible-input-sink-fd> \
+  --source-selection-opening-fd <custodian-source-selection-opening-source-fd> \
+  --signing-seed-fd <materializer-signing-seed-source-fd> \
+  --output <safe-materialization-receipt>
+```
+
+For every v2 historical lane, preflight freezes
+`source_profile_body_delivery:"source_profile_fd"`. Add
+`--source-profile-output-fd <runner-source-profile-sink-fd>` and connect that
+protected source directly to the historical `cas trial run
+--source-profile-fd` input. Embedded historical delivery is legacy v1 or
+standalone diagnostic compatibility, not the v2 execution route.
+
+Direct lanes skip and forbid `compile-replay`. Historical execution also does
+not use the standalone command: CAS performs private replay preparation inside
+`run` before the irreversible claim. The standalone `compile-replay` surface is
+diagnostic-only, rejects direct/case-blind/role-separated/sealed use, grants no
+execution authority, reports `execution_authority:false`, and is not part of
+the trial happy path. `run` does not consume its receipt or DCP/RIP files.
+
+Follow the frozen balanced A/B-B/A lane order exactly; either semantic arm may
+execute first. Never retry a claimed lane as new work. Use native status and
+recovery to re-emit or finish only the exact admitted work.
+
+### 7. Grade, reveal, and prove
+
+Record hard gates before scores, then blind absolute and pair grades under the
+frozen authorities. Pre-reveal public output contains only commitments,
+fingerprints, opaque acknowledgements, and permitted terminal metadata.
+
+When consumed by a v2 trial, `hylo-grade-receipt/v1`,
+`hylo-pair-grade-receipt/v1`, and
+`hylo-grade-presentation-receipt/v1` are closed and exact native shapes:
+unknown keys or undeclared nested fields are invalid. Every consumed public
+evidence, rationale, grade-receipt, pair-grade-receipt, and
+presentation-receipt reference uses exactly
+`artifact:sha256:<64 lowercase hex>` and exact-joins any companion fingerprint.
+V1 trial carriers retain their established compatibility behavior.
+
+Reveal only after every required lane and grade is terminal and policy permits
+it. Supply the exact custody record plus every required safe lane-materialization
+receipt:
+
+```bash
+ledger --source hylo reveal-trial \
+  --repo <repo> \
+  --reveal-material-fd <custodian-reveal-source-fd> \
+  --materialization-receipt lane-001-materialization-receipt.json
+```
+
+Repeat `--materialization-receipt` for every lane.
+
+`--reveal FILE` is legacy v1-only and accepts only
+`hylo-trial-reveal/v1`. A caller-authored `hylo-trial-reveal/v2` file has no
+admitted provenance. V2 reveal requires the validated `hylo-trial-custody/v1`
+record through `--reveal-material-fd`; Ledger derives and validates the v2
+reveal, exact-joins every lane receipt to its run receipt, and only then may
+append `trial_revealed`.
+
+Validated `hylo-trial-reveal/v2` is the first public semantic opening. It opens
+the arm map, treatments, target epoch, intervention witness, and target common
+projection; the full source-selection receipt remains custody-only. Derive
+paired deltas, hard-gate changes, critical regressions, dispersion,
+uncertainty, independence-cluster coverage, null/calibration results, and
+post-reveal diagnostic position/order effects. Observe the derived result, then
+close the trial; proof occurs only after close:
+
+```bash
+ledger --source hylo trial-result --repo <repo> --trial-id <trial-id> --format json
+ledger --source hylo close-trial --repo <repo> --trial-id <trial-id>
+```
+
+Proof export grants no mutation or publication authority. Proof bundles exclude
+`hylo-trial-custody/v1` and private lane claims/materializations and derive
+semantic evidence only from the validated public reveal. Public proof
+sanitization rejects private semantic keys such as `private_reasoning`,
+`historical_response`, and `source_target_text`, while retaining
+schema-declared boolean non-disclosure observations such as
+`hidden_reference:false`.
+
+### 8. Fold the frontier and route owner action
+
+Derive failure signatures, hypotheses, bounded experiments, and the native
+frontier decision:
 
 ```text
-experiment_id
-hypothesis_ids
-before and after bundle fingerprints
-before and after target snapshots
-prediction-contract fingerprint
-authorized paths and semantic change budget
+RUN      owner may apply the selected intervention only under separate authority
+OBSERVE  execute only the bounded read-only probe
+STOP     stop the current campaign scope
 ```
 
-After eligible holdout or challenge evidence is exposed for the candidate,
-reject further target changes in that campaign. A miss means reject the
-candidate or begin a new campaign with untouched cases.
-
-Publication requires explicit authority, the exact evaluated bundle and
-snapshot, the latest complete required repeat cohort, no forbidden critical
-violations, exact changed paths, and equality between the committed target
-projection and the promoted projection. Push authority remains separate.
+A newly applied candidate requires a new evaluation trial. Keep the HCTP
+allocation law separate from the compatibility campaign law: HCTP accepts A/B
+or B/A frozen pairs, while the legacy fold still requires a `replay_baseline`
+attempt to predate its matching `candidate` attempt.
 
 ## Output
 
 ```text
 Hylo:
-- mode / campaign / trial / target bundle
-- episode / cut / world / runtime / fidelity limitations
-- runner-custody separation and blindness status
-- pairs / repeats / terminal lanes / eligible grades
-- hard gates / dimension deltas / behavior deltas / uncertainty
-- active failure signatures / hypotheses / experiments
-- decision: RUN | OBSERVE | STOP
-- Hylo authority_granted: false; report any owner authority separately
+- requested operation, assurance, versions, and capability result
+- campaign ID/head and admission completeness
+- episode/cut, CRF fidelity, replay_eligible, route, and retained limitations
+- source-selection receipt fingerprint/commitment and independence-cluster coverage
+- trial ID/fingerprint, purpose, allocation, pair/repeat/lane counts
+- direct/historical preparation and terminal/recovered lane counts
+- hard gates, grades, pair deltas, position effects, and uncertainty
+- reveal/proof state and scoped claim class
+- active failures, hypotheses, experiments, and frontier decision
+- candidate_state
+- authority_granted_by_hylo:false
+- owner_authority: none | propose | apply | commit | push
 - event-chain or proof identity
 ```
+
+Never print private reasoning, pre-reveal semantic arm mapping, historical
+answer, hidden reference, full source-selection receipt, raw target epoch,
+target common projection, intervention witness, treatment materialization,
+lease material, openings, signing seeds, custody record, or custody keys.
 
 ## Hard rules
 
 - No cut after the first causally relevant target influence.
-- No dropped or deduplicated fixed-prefix message occurrence.
-- No historical answer, future outcome, hidden oracle, or grade opening in runner input.
-- No historical response as a replay baseline or golden answer.
-- No invented world, exact-reconstruction claim, fixture response, or missing observation.
-- No target label change without a target-content change.
-- No trial change after registration; changed contracts require a new trial.
-- No lane execution without registration, lease lineage, and one-claim custody.
-- No trial lifecycle event through low-level `append`.
-- No private reasoning in attempts, grades, portable artifacts, or proofs.
-- No hard-gate failure averaged away by a scalar score.
-- No comparison across episode, world, runtime, tool/effect, oracle, grader, or visibility drift.
+- No dropped or deduplicated fixed-prefix occurrence.
+- No replay-ineligible CRF source relabeled as direct.
+- No source receipt validation before a complete trial exists.
+- No trial compilation or registration before complete campaign admission.
+- No private-v2 registration without the exact custody record on a protected FD.
+- No private-v2 registration append without full semantic revalidation against
+  the exact exclusive append snapshot.
+- No new private-v2 lane start or caller-retained start commit without the
+  exact custody record on `--custody-input-fd`.
+- No private-v2 case materialization without the exact custody-projected
+  `hylo-source-selection-opening/v1` on `--source-selection-opening-fd`.
+- No private-v2 CAS run without the exact lease-bound lane materialization FD.
+- No v2 reveal without one exact per-lane join from
+  `hylo-lane-materialization-receipt/v2.claim_fingerprint` to
+  `hylo-run-receipt/v2.materialization.materialization_claim_fingerprint`.
+- No caller-authored v2 reveal through legacy `--reveal FILE`.
+- No full FIR or source-profile semantic extras on a v2 public trial, run
+  receipt, event, or proof surface.
+- No unknown keys in v2-consumed grade, pair-grade, or presentation receipts;
+  no nonportable public evidence, rationale, or receipt reference.
+- No trial mutation after registration; changed contracts require a new trial.
+- No protected-FD value carried through argv, environment variables,
+  regular-file redirection, named FIFOs, normal stdout, the event store, or
+  proof bundles; native private DCP/RIP files remain governed by their explicit
+  `0700`/`0600` custody contract.
+- No standalone `compile-replay` in an execution path.
+- No custody record or private lane claim included in a public event or proof.
+- No baseline-first requirement imposed on frozen HCTP B/A allocation.
+- No historical answer used as a baseline or golden answer.
+- No claimed lane retried as new execution.
+- No low-level `append` used for trial lifecycle events.
+- No hard-gate failure averaged away.
+- No comparison across source, world, runtime, model, tool/effect, oracle,
+  grader, visibility, or split drift.
 - No repair motivated by exposed holdout or challenge evidence.
-- No intervention without predictions, controls, falsifiers, scope, and budget.
-- No `RUN` decision treated as mutation authority.
-- No publication from cherry-picked repeats or mismatched committed bytes.
-- No unadmitted platform-specific isolation claim or hidden OS-confinement assumption.
+- No `RUN` represented as target mutation or candidate creation.
+- No uninstalled sealed driver represented as product infrastructure.
+- No OS-confinement, generalized-causality, or authority overclaim.
 - No hand-editing `.ledger/hylo/events.jsonl`.
-- No endless edit loop when the derived answer is `STOP`.

--- a/codex/skills/hylo/agents/openai.yaml
+++ b/codex/skills/hylo/agents/openai.yaml
@@ -1,6 +1,6 @@
 interface:
   display_name: "Hylo"
-  short_description: "Compile blinded replays into causal next steps"
-  default_prompt: "Use $hylo to compile a historical Codex session at its counterfactual cut, run a blinded paired baseline/candidate trial, grade observable evidence, and derive RUN, OBSERVE, or STOP without treating the result as edit authority."
+  short_description: "Evaluate source-bound trials and derive causal next steps"
+  default_prompt: "Use $hylo to evaluate an existing owner-applied candidate in a source-bound blinded trial, then derive RUN, OBSERVE, or STOP without treating the result as mutation authority."
 policy:
   allow_implicit_invocation: false

--- a/codex/skills/hylo/native-surface.lock.json
+++ b/codex/skills/hylo/native-surface.lock.json
@@ -1,5 +1,5 @@
 {
   "schema": "hylo-native-surface-lock/v1",
   "repository": "tkersey/skills-zig",
-  "commit": "9bfb9ed47ec634bd1928ab7373f8381a5b52c164"
+  "commit": "ff6a26e0fe39e789db4a2932fb428129411ecebc"
 }

--- a/codex/skills/hylo/native-surface.lock.json
+++ b/codex/skills/hylo/native-surface.lock.json
@@ -1,5 +1,5 @@
 {
   "schema": "hylo-native-surface-lock/v1",
   "repository": "tkersey/skills-zig",
-  "commit": "82b65cd87f951e3b544fa1e1cdc174aec8b5a5b4"
+  "commit": "5bdaa90393084dcca20e5625caffd24a3e74a1a9"
 }

--- a/codex/skills/hylo/native-surface.lock.json
+++ b/codex/skills/hylo/native-surface.lock.json
@@ -1,5 +1,5 @@
 {
   "schema": "hylo-native-surface-lock/v1",
   "repository": "tkersey/skills-zig",
-  "commit": "5bdaa90393084dcca20e5625caffd24a3e74a1a9"
+  "commit": "c2221b5ccb89878657d560e899df3efde40d94b7"
 }

--- a/codex/skills/hylo/native-surface.lock.json
+++ b/codex/skills/hylo/native-surface.lock.json
@@ -1,0 +1,5 @@
+{
+  "schema": "hylo-native-surface-lock/v1",
+  "repository": "tkersey/skills-zig",
+  "commit": "82b65cd87f951e3b544fa1e1cdc174aec8b5a5b4"
+}

--- a/codex/skills/hylo/native-surface.lock.json
+++ b/codex/skills/hylo/native-surface.lock.json
@@ -1,5 +1,5 @@
 {
   "schema": "hylo-native-surface-lock/v1",
   "repository": "tkersey/skills-zig",
-  "commit": "c2221b5ccb89878657d560e899df3efde40d94b7"
+  "commit": "9bfb9ed47ec634bd1928ab7373f8381a5b52c164"
 }

--- a/codex/skills/hylo/references/contracts.md
+++ b/codex/skills/hylo/references/contracts.md
@@ -4,13 +4,26 @@ This reference describes the released Hylo CRF/HCTP boundary used by `$hylo`.
 Installed CLI help, capabilities, validators, and executable schemas remain the
 authority when this document and a binary differ.
 
+## Contents
+
+- [Contract layers](#contract-layers)
+- [Canonical identity](#canonical-identity)
+- [CRF extraction graph](#crf-extraction-graph)
+- [HCTP source governance](#hctp-source-governance)
+- [Campaign–trial relationship](#campaigntrial-relationship)
+- [HCTP trial protocol](#hctp-trial-protocol)
+- [Compatibility campaign fold](#compatibility-campaign-fold)
+- [Typed causal frontier](#typed-causal-frontier)
+- [Native observation commands](#native-observation-commands)
+- [Availability and threat model](#availability-and-threat-model)
+
 ## Contract layers
 
 Hylo currently has four additive layers:
 
 ```text
 CRF episode graph      counterfactual cut, target bundle, world, runtime, custody
-HCTP trial protocol    blinded paired lanes, grades, reveal, proof
+HCTP trial protocol    public trial, private custody, lane claims, grades, reveal, proof
 campaign event fold    compatibility campaigns, attempts, grades, progress
 causal frontier fold   failures, hypotheses, experiments, RUN | OBSERVE | STOP
 ```
@@ -199,8 +212,16 @@ output fingerprints, classes, counts, namespaces, semantic impact, and local
 unredacted availability.
 
 The historical response payload is sealed with XChaCha20-Poly1305. The key is
-delivered only through the declared owner FD and is not persisted in the
+delivered only through the declared custodian FD and is not persisted in the
 runner root, custody manifest, event store, stdout, or proof bundle.
+
+Every secret-bearing descriptor is already-open, unlinked, anonymous,
+directional, distinct, and `>=3`, and is supplied under the admitted
+custodian's custody. The CLI verifies descriptor shape, direction, and
+non-aliasing required by its contract; it does not authenticate the peer
+process or establish hostile same-user isolation. Regular-file redirection, a
+named FIFO, stdin/stdout/stderr, argv, and environment variables are not
+protected secret transport.
 
 ### Pure validators
 
@@ -215,6 +236,7 @@ ledger validate hylo-runtime-contract --input FILE
 ledger validate hylo-counterfactual-cut-receipt --input FILE
 ledger validate hylo-redaction-receipt --input FILE
 ledger validate hylo-custody-manifest --input FILE
+ledger validate hylo-trial --input FILE
 ```
 
 These validators are platform-neutral, read no Hylo store, mutate nothing, and
@@ -226,8 +248,10 @@ grant no authority.
 
 ```text
 compile      derive the complete denominator, independence clusters, split
-             integrity, sanitization, source commitments, and sealed cases
-validate     prove one source-selection receipt matches one trial
+             integrity, sanitization, source commitments, route admissions
+             from supplied replay-episode evidence, and sealed cases
+validate     prove the exact signed source-selection receipt matches one
+             completed trial
 govern       derive source-governance evidence from admitted inputs
 materialize release one registered visible case and source profile by FD,
              then emit a lane-scoped role attestation
@@ -236,10 +260,23 @@ materialize release one registered visible case and source profile by FD,
 ```bash
 seq hctp-source compile \
   --manifest source.json --output selection.json \
-  --source-signing-seed-fd 3
-
-seq hctp-source validate --receipt selection.json --trial trial.json
+  --source-signing-seed-fd <source-owner-seed-fd>
 ```
+
+Compilation precedes campaign admission and trial construction. Validation
+does not: run it only after `trial.json` exists and passes `validate-trial`, and
+before `register-trial`:
+
+```bash
+ledger --source hylo validate-trial --repo REPO --trial trial.json
+seq hctp-source validate --receipt selection.json --trial trial.json
+ledger --source hylo register-trial \
+  --repo REPO \
+  --trial trial.json \
+  --custody-input-fd <custodian-registration-source-fd>
+```
+
+Do not attempt registration after source validation fails.
 
 Case-blind compilation additionally uses a sealed directory and owner-only
 seal-key output FD. Materialization accepts the exact sealed case, registered
@@ -251,22 +288,79 @@ The primary artifacts are:
 
 ```text
 hylo-source-selection-receipt/v1
+hylo-source-route-admission/v1
 hylo-sealed-case/v1
 hylo-case-materializer-contract/v1
 hylo-materialization-receipt/v1
 ```
 
 The source-selection receipt must cover the registered units exactly, preserve
-scenario/split/cluster/source commitments, and reject exact cross-split
-duplicates. The materialization receipt binds one lane, one opaque arm, one
-visible-input fingerprint, the frozen producer, and the controller/materializer
-trust domain without disclosing semantic arm identity or hidden reference.
+scenario/split/cluster/source commitments, carry the compiler-derived route
+admission where required, and reject exact cross-split duplicates. The
+source-owner attestation on the exact receipt covers the admission. Validation
+compares the exact canonical signed-receipt value and its fingerprint, not a
+caller-rebuilt semantic equivalent.
+
+The route admission binds campaign, unit, scenario, episode, CRF fidelity,
+`replay_eligible`, source episode projection, source profile, effective
+reconstruction, limitations, required lineage/FIR, comparison eligibility, and
+one execution route:
+
+```text
+direct + replay_eligible:true             -> direct, comparison eligible
+direct + replay_eligible:false            -> diagnostic_only, ineligible
+historical_decision + valid governance    -> historical_replay,
+                                             capped by retained CRF fidelity
+absent or invalid historical governance   -> compilation failure;
+                                             diagnostic evidence only
+```
+
+Seq derives this admission from the validated CRF episode and source profile;
+the caller must not supply it. A replay-ineligible historical source retains
+the CRF reconstruction ceiling and limitations. It may not be relabeled
+`direct`. Historical `practice_repair` and `promotion` require authoritative
+governance with workflow effects allowed.
+
+The materialization receipt binds one lane, one opaque arm, one visible-input
+fingerprint, the frozen producer, and the controller/materializer trust domain
+without disclosing semantic arm identity, hidden reference, or a private
+historical-profile body.
+
+## Campaign–trial relationship
+
+An HCTP trial is additive to an immutable admitted campaign; it is not a
+campaign substitute. Before trial compilation or registration, the campaign
+fold must contain:
+
+```text
+campaign_created
+every required target_bundle_admitted
+every scenario_admitted in the complete manifest
+the exact owner-applied change and current target identity when evaluating a candidate
+```
+
+The private-v2 route opts into `protocol_profiles:["hylo-trial/v2"]` and MAY
+also retain `"hylo-trial/v1"` for compatibility,
+`canonical_json_profile:"hylo-canonical-json/v1"`, and
+`trial_policy.source_route_admission:"required"`. It also freezes proof
+authority/trust when applicable and the complete scenario manifest.
+
+This opt-in does not rewrite legacy campaign bytes. Existing campaigns without
+HCTP profiles remain valid under the compatibility fold, and legacy profiles
+must not acquire HCTP-only fields where the current validator rejects them.
+
+Registration derives campaign, scenario, target, split, and promotion-coverage
+authority from the event fold. It rejects an unknown campaign, incomplete
+scenario admission, missing target bindings, and a promotion trial that omits
+an applicable protected scenario. Low-level `append` admits ordinary campaign
+events only; high-level trial commands exclusively own HCTP lifecycle events.
 
 ## HCTP trial protocol
 
-### `hylo-trial/v1`
+### `hylo-trial/v2` and `hylo-trial-custody/v1`
 
-A trial freezes the complete paired experiment before execution:
+A trial freezes the complete paired experiment before registration and
+execution:
 
 ```text
 trial and campaign identity
@@ -277,22 +371,126 @@ assurance and trust policy
 allocation and order balancing
 units, scenarios, splits, and independence clusters
 pairs, repeats, lanes, and opaque arms
-source profiles and source-selection receipt
-target arm values and common projection
+source profiles and source-selection receipt commitment
+target treatment, epoch, witness, and common-projection commitments
 execution, model, runtime, tool, and effect projections
 rubric, oracle, judge, and producer authorities
 case, arm, and grade visibility
 reveal and publication policy
 ```
 
-Registration validates and appends the complete manifest atomically:
+The public/private carrier split is normative:
+
+| Carrier | Public `hylo-trial/v2` | Private `hylo-trial-custody/v1` |
+| --- | --- | --- |
+| arms | opaque `arm_id` and `treatment_commitment` | semantic roles, value/materialization identities, nonces, and materialization bodies |
+| target epoch | before/after/change commitments | target fingerprints and change ID openings |
+| factor | intervention-witness and target-common-projection commitments | witness and target-common-projection bodies |
+| source selection | portable `artifact:sha256:<64 lowercase hex>` ref, matching fingerprint, and commitment | exact signed receipt and nonce |
+| unit source profile | exact validator-defined safe projection | full profile body and semantic material |
+| arm map | commitment | semantic mapping and nonce |
+
+Two private sub-openings have distinct consumers. Seq receives only
+`hylo-source-selection-opening/v1` from `custody.source_selection` through
+`--source-selection-opening-fd` when materializing a v2 case. CAS receives
+`hylo-target-common-projection-opening/v1` inside the lease-bound treatment
+claim and validates it before execution. Neither consumer receives the whole
+custody record through those narrower carriers.
+
+Before reveal, the public trial MUST NOT contain `value_fingerprint`,
+`materialization_ref`, or `materialization_fingerprint` in its arms; raw target
+fingerprints or change ID; intervention-witness or target-common-projection
+bodies; the caller's local source-receipt path; or the full source-selection
+receipt. `hylo-trial/v1` retains its exact
+legacy semantics and does not satisfy the private-v2 execution route.
+
+Each v2 `units[*].source_profile` MUST match the native safe projection exactly.
+Unknown or semantic extra keys are invalid; the projection cannot carry a full
+historical profile body, source target text, rationale, rejected routes, or
+hidden references. V1 retains its established source-profile contract.
+
+### Trial compiler
+
+The native compiler maps an admitted campaign, exact source receipt, current
+owner-applied target change, and `hylo-trial-build-request/v1` into public
+commitment-only `hylo-trial/v2` plus private `hylo-trial-custody/v1`:
+
+```bash
+ledger --source hylo compile-trial \
+  --repo REPO \
+  --request trial-build-request.json \
+  --source-receipt selection.json \
+  --output trial.json \
+  --custody-output-fd <custodian-custody-sink-fd>
+```
+
+The build request binds:
+
+```text
+trial ID, campaign ID, and expected campaign head
+purpose, selected units, and exact source-receipt fingerprint
+before/after target bundles and snapshots, applied change, allowed roots
+hypothesis, estimand, execution, grading, assurance, and sealing
+allocation, stop, and calibration policy
+```
+
+The factor verifier fingerprint must equal the running Ledger executable's
+observed fingerprint. The request's `sealing` object may contain only
+`reveal_scope` and the case-materializer reference, fingerprint, and optional
+contract. Case, arm, and grade visibility plus visible/hidden commitment sets
+are derived from the signed source receipt and compiler law; supplying those
+generated fields is a conflict, not an override.
+
+The current compiler admits `practice_repair` and `promotion` target-snapshot
+routes with `balanced_ab_ba` and a positive even fixed pair count. It rejects
+sealed assurance as `SealedBrokerUnavailable`; a future product route may add
+broker admission. It also rejects unsupported non-null proof/publication
+request bodies rather than ignoring them.
+
+It validates campaign, scenario, target, change, and source state before
+generating entropy. It creates opaque IDs, freezes the balanced allocation,
+derives the target common projection and intervention witness, commits every
+private treatment and semantic opening, validates the public/custody join, and
+returns only public commitments in `hylo-trial-build-receipt/v2`.
+
+Public and private sinks cannot be crash-atomic. The compiler links a
+create-new `0600` public trial, delivers private custody material, and attempts
+to remove the public artifact if private delivery reports failure.
+`TrialOutputRollbackFailed` means the path may remain as an uncommitted recovery
+artifact. A partial custody byte stream is not an admitted custody record. The
+compiler emits its build receipt with `custody_material_delivered:true` only
+after both sinks complete. That stdout receipt is the completion observation;
+transient public-file visibility is neither completion nor authority. Custody
+bytes never enter normal stdout or the event store.
+
+### Validation and registration
+
+Use the exact order below after complete campaign admission:
 
 ```bash
 ledger --source hylo validate-trial --repo REPO --trial trial.json
-ledger --source hylo register-trial --repo REPO --trial trial.json
+seq hctp-source validate --receipt selection.json --trial trial.json
+ledger --source hylo register-trial \
+  --repo REPO \
+  --trial trial.json \
+  --custody-input-fd <custodian-registration-source-fd>
 ```
 
-Changing any frozen field requires a new trial identity.
+Registration validates and appends the complete manifest atomically. Changing
+any frozen field requires a new trial identity. For v2, the custodian supplies
+the exact custody record through a fresh protected pipe. The event persists the
+public trial and only a validated nonsemantic custody observation containing
+the custody commitment, `validated:true`, and
+`semantic_material_persisted:false`.
+
+Private-v2 registration has two validation times. The command-level preflight
+validates the public/custody join and the current semantic campaign view, but it
+does not authorize append. After acquiring exclusive store ownership, the
+append owner reloads the exact snapshot and reruns the full semantic
+trial-against-campaign validator on the custody-backed trial before event
+application. Any stale campaign, scenario, source, target, grading, assurance,
+coverage, or policy binding fails before append and leaves the store unchanged.
+Legacy v1 registration retains its established public-trial path.
 
 Purpose constrains factor kind:
 
@@ -309,7 +507,9 @@ reliability_probe     null
 
 Assurance levels are `precommitted`, `receipt_bound`, `role_separated`, and
 `sealed`. Every label must satisfy its declared trust and role contract; the
-label alone is not evidence.
+label alone is not evidence. Sealed execution additionally requires an
+explicitly admitted broker and never infers that product boundary from a test
+driver.
 
 ### Blinding
 
@@ -329,6 +529,10 @@ It must not include:
 semantic arm map
 hidden reference
 historical response plaintext
+full source-selection receipt or sealed-case locator
+raw before/after target fingerprints or change ID
+target common projection or intervention witness body
+treatment opening or materialization body
 plaintext grade or pair winner
 private grade opening
 lease nonce or signing seed
@@ -356,6 +560,7 @@ The public commands are:
 
 ```text
 validate-trial
+compile-trial
 register-trial
 start-lane
 commit-lane-start
@@ -379,6 +584,26 @@ start event commits. `commit-lane-start` accepts a caller-retained lease and is
 the sealed-assurance route. Recovery requires the exact retained lease and
 lineage; it re-emits an existing receipt and does not append changed work.
 
+Private trial custody uses `--custody-output-fd` at compilation,
+`--custody-input-fd` at registration, each new v2 `start-lane` or
+`commit-lane-start`, and lane materialization, and `--reveal-material-fd` at
+reveal. The custodian retains one exact
+`hylo-trial-custody/v1` record outside public artifacts and re-delivers it over
+a fresh protected pipe for each operation. Lane materialization additionally
+receives the exact retained lease through `--lease-input-fd` and writes one
+lease-bound private claim through `--materialization-output-fd`. Each endpoint
+is a distinct unlinked anonymous directional pipe. The CLI verifies descriptor
+shape, direction, and non-aliasing required by its contract; it does not
+authenticate the peer process or establish hostile same-user isolation. No
+endpoint is a regular input or output file.
+
+For case-blind v2 input release, the custodian separately projects the exact
+`hylo-source-selection-opening/v1` value onto
+`--source-selection-opening-fd`. Seq requires the opening, verifies its whole
+commitment against the public trial, and joins its nested signed receipt before
+materializing the visible input or optional historical profile. V1 retains its
+embedded source receipt and rejects this v2-only carrier.
+
 ### CAS lane runner
 
 `cas trial` exposes:
@@ -393,12 +618,89 @@ key-info
 ```
 
 CAS owns the persistent one-claim boundary. `run` claims before executing,
-uses a clean workspace, invokes the declared executor exactly once, hashes
-evidence, and emits `hylo-run-receipt/v1`. An existing claim makes retry a hard
-error; use status/recovery rather than executing again.
+uses a clean workspace, invokes the declared executor exactly once, and hashes
+evidence. A legacy v1 trial emits `hylo-run-receipt/v1`. A private-v2 trial
+requires `--materialization-fd` and emits commitment-only
+`hylo-run-receipt/v2`. An existing claim makes retry a hard error; use
+status/recovery rather than executing again.
+
+For v2, `ledger --source hylo lane-materialization` consumes the exact custody
+record and retained lease and sends `hylo-lane-materialization-claim/v2` only
+over the protected materialization FD. Normal stdout contains only
+`hylo-lane-materialization-receipt/v2`, which binds trial, lane, and claim
+fingerprint, records `delivered_by_fd:true`, and records
+`semantic_role_disclosed:false`. Retain that safe receipt for reveal; never
+persist the private claim. The private claim contains the exact
+`hylo-target-common-projection-opening/v1`; CAS verifies its whole-opening
+commitment and the nested projection fingerprint against the public trial and
+rejects a raw projection alias.
+
+CAS publishes the same claim identity as
+`hylo-run-receipt/v2.materialization.materialization_claim_fingerprint`.
+Before reveal, every lane must satisfy the exact join:
+
+```text
+hylo-lane-materialization-receipt/v2.claim_fingerprint
+  == hylo-run-receipt/v2.materialization.materialization_claim_fingerprint
+```
+
+The reveal fold accepts exactly one v2 materialization receipt for every lane.
+A changed fingerprint, missing lane, duplicate lane, unknown lane, wrong trial,
+non-v2 safe receipt, or mixed version in the per-lane safe-receipt set is
+invalid and must fail before `trial_revealed` appends. Separate private
+materializer evidence, when required, follows its existing contract and cannot
+satisfy or replace this join. The v2 join does not change the legacy v1
+materialization/reveal contract.
+
+`preflight --json` projects the frozen route without granting authority:
+
+```text
+source_profile_kind
+compile_replay_required
+replay_preparation_mode
+source_profile_body_delivery
+execution_route
+required_lineage
+```
+
+Lane preparation branches on the frozen source profile:
+
+```text
+source_profile.kind == "direct"
+  -> compile_replay_required:false
+  -> replay_preparation_mode:"none"
+  -> source_profile_body_delivery:"none"
+  -> run without a source-profile FD
+
+source_profile.kind == "historical_decision"
+  -> compile_replay_required:false
+  -> replay_preparation_mode:"integrated_run"
+  -> source_profile_body_delivery:"source_profile_fd" for every v2 lane
+  -> run validates the profile and prepares one DCP/RIP internally before claim
+  -> claim, executor request, native receipt, and FIR bind those fingerprints
+```
+
+For every v2 historical lane, connect the materializer's protected source
+profile output directly to `cas trial run --source-profile-fd`. Embedded
+historical delivery is legacy v1 or standalone diagnostic compatibility. No
+standalone replay-plan receipt or DCP/RIP file is an execution input.
+
+Direct lanes skip and reject standalone `compile-replay`. Historical execution
+also does not call it: the accountable preparation lives inside `run` before
+the irreversible claim. The standalone command is an open, embedded historical
+diagnostic. It rejects case-blind, `role_separated`, and `sealed` use; its
+receipt records `execution_authority:false`. `run` consumes neither that receipt
+nor its DCP/RIP files. Diagnostic named outputs require a caller-owned
+no-symlink `0700` root and create-new `0600` files, but they are not execution
+inputs.
 
 The executor receives one request path and one result path. It does not receive
-the lane lease or hidden reference.
+the lane lease, semantic arm mapping, historical answer, or hidden reference.
+The public v2 run receipt exposes only the treatment commitment, visible-input
+lineage, permitted historical fingerprints, non-disclosure booleans, and the
+exact `hylo-fir-public-projection/v1`. It MUST NOT expose raw
+target/factor/archive identifiers, treatment material, or the full FIR. The v1
+run-receipt path retains its compatible full-FIR carrier.
 
 ### Grades and reveal
 
@@ -413,10 +715,37 @@ grade commitments and private openings
 critical-policy derivation
 ```
 
+For a v2 trial, the native consumers treat
+`hylo-grade-presentation-receipt/v1`, `hylo-grade-receipt/v1`, and
+`hylo-pair-grade-receipt/v1` as closed and exact shapes. Unknown top-level keys,
+undeclared nested keys, or fields outside the applicable optional branch are
+invalid. Every consumed public `evidence_refs` item, pair-dimension
+`rationale_ref`, `grade_receipt_ref`, `pair_grade_receipt_ref`, and
+`grade_presentation_receipt_ref` must be exactly
+`artifact:sha256:<64 lowercase hex>`. When a carrier also declares a
+fingerprint, the reference digest must equal it. Local paths, bare
+fingerprints, other algorithms, uppercase hex, and malformed lengths are not
+portable evidence. Legacy v1 trial carriers retain their established receipt
+compatibility.
+
 Grade commitments may be public before reveal; plaintext outcomes and openings
 may not. Reveal must match the precommitted semantic arm map and all required
-terminal/grade conditions. A reveal does not retroactively authorize target
-mutation.
+terminal/grade conditions. `--reveal FILE` is the legacy v1 carrier and accepts
+only `hylo-trial-reveal/v1`; a caller-authored `hylo-trial-reveal/v2` file is
+rejected. For v2, the custodian supplies the exact
+`hylo-trial-custody/v1` record through `--reveal-material-fd` plus one exact
+safe `hylo-lane-materialization-receipt/v2` per lane. Ledger validates custody
+provenance, derives `hylo-trial-reveal/v2`, exact-joins each receipt to its
+lane's authenticated run-receipt claim fingerprint, and fails changed,
+missing, duplicate, or version-mixed per-lane safe-receipt sets before append.
+The validated v2 reveal is the first public semantic opening: it opens the arm
+map, treatments, target epoch, intervention witness, and target common
+projection. The full source-selection receipt remains custody-only. A reveal
+does not retroactively authorize target mutation. After reveal, `trial-result`
+reports diagnostic position balance and per-dimension order-effect records.
+`mean_second_minus_first` is non-null only when both baseline-first and
+candidate-first orientations contribute. These observations are noncausal and
+do not alter claim eligibility.
 
 ### Proof bundles
 
@@ -425,6 +754,17 @@ a trusted source owner may sign as
 `hylo-proof-sanitization-receipt/v1`. Export produces a deterministic
 `hylo-proof-bundle/v1`; verification checks internal closure and may bind
 explicit external anchors.
+
+Proof bundles MUST exclude `hylo-trial-custody/v1`, private lane claims,
+treatment materializations, retained leases, and custody keys. V2 proof
+projection derives semantic target, witness, and common-projection evidence
+only from the validated public `hylo-trial-reveal/v2`, never directly from
+private custody. The public-proof sanitizer recursively rejects private
+semantic keys, including `chain_of_thought`, `future_outcome`, `hidden_oracle`,
+`hidden_oracle_text`, `hidden_reasoning`, `historical_response`,
+`private_reasoning`, and `source_target_text`, while allowing schema-declared
+boolean non-disclosure observations such as `hidden_reference:false`. The
+boolean is a public disclosure observation, not hidden-reference content.
 
 Live verification accepts the declared global event range as an immutable
 prefix and validates the current suffix. An offline expected campaign head and
@@ -496,6 +836,11 @@ Historical attempts omit comparable world/replay identity unless genuinely
 known and remain comparison-ineligible. A candidate grade requires an earlier
 compatible replay-baseline attempt for the same scenario. The historical
 response never supplies the comparison denominator.
+
+That chronology belongs only to the compatibility campaign fold. HCTP freezes
+balanced A/B-B/A allocation before execution, permits either semantic arm to
+run first, and joins the two matching frozen lanes after reveal. Do not impose
+baseline-first chronology on an HCTP B/A pair.
 
 ### Target snapshots and changes
 
@@ -614,7 +959,13 @@ leave the store unchanged.
 The released CRF/HCTP product commands are admitted on macOS. Their sealing
 route uses Zig, macOS/POSIX process primitives, cryptographic commitments,
 separate roles, anonymous descriptors, and an encrypted recovery checkpoint.
-It intentionally records `os_confinement:false`.
+Sealed execution also requires a caller-provided admitted broker whose binary
+and contract fingerprints satisfy the native role, FD, checkpoint, recovery,
+and non-disclosure contracts. The repository-owned
+`hctp-sealed-role-driver` is conformance/test infrastructure, not an installed
+product command or capability. Without an admitted broker, fail before secret
+generation or trial mutation. The route intentionally records
+`os_confinement:false`.
 
 Therefore the proof does establish:
 

--- a/codex/skills/hylo/references/grading-and-progression.md
+++ b/codex/skills/hylo/references/grading-and-progression.md
@@ -1,5 +1,26 @@
 # Hylo grading, comparison, and causal progression
 
+## Contents
+
+- [What is being measured](#what-is-being-measured)
+- [Candidate lifecycle](#candidate-lifecycle)
+- [Freeze evaluation before candidate execution](#freeze-evaluation-before-candidate-execution)
+- [Hard gates before scores](#hard-gates-before-scores)
+- [Grader authority](#grader-authority)
+- [Blinding and commitments](#blinding-and-commitments)
+- [Comparable paired evidence](#comparable-paired-evidence)
+- [Repeats, allocation, and order effects](#repeats-allocation-and-order-effects)
+- [Absolute and pair grades](#absolute-and-pair-grades)
+- [Observable behavior delta](#observable-behavior-delta)
+- [Claim vocabulary](#claim-vocabulary)
+- [Failure signatures](#failure-signatures)
+- [Causal hypotheses](#causal-hypotheses)
+- [Experiments](#experiments)
+- [Dominance and next-step selection](#dominance-and-next-step-selection)
+- [Practice, holdout, and challenge discipline](#practice-holdout-and-challenge-discipline)
+- [Promotion and publication](#promotion-and-publication)
+- [Stop rule](#stop-rule)
+
 ## What is being measured
 
 Measure observable consequences, not resemblance to the historical answer:
@@ -14,6 +35,30 @@ operational cost    tokens, latency, retries, and human intervention
 The historical response is sealed diagnostic evidence. It may help identify a
 failure after an authorized custody/grader reveal, but it is not a golden
 answer and never supplies the replay-baseline denominator.
+
+## Candidate lifecycle
+
+Keep evaluation and derivation separate:
+
+```text
+evaluate_existing_candidate
+  owner-applied candidate already exists
+  -> before/after target identities and bounded change are admitted
+  -> freeze baseline and candidate before trial execution
+  -> run, grade, reveal, and fold evidence
+
+derive_next_candidate
+  prior evidence already exists
+  -> failures -> hypotheses -> experiments -> RUN | OBSERVE | STOP
+  -> RUN selects but does not apply an intervention
+  -> owner may apply it only under separate authority
+  -> evaluate the new candidate in a new trial
+```
+
+Report `candidate_state` independently as `absent`, `owner_applied`,
+`frozen_for_trial`, `evaluated`, `promoted`, or `rejected`. Report
+`frontier_decision` independently as `RUN`, `OBSERVE`, `STOP`, or
+`not_computed`. Hylo always reports `authority_granted_by_hylo:false`.
 
 ## Freeze evaluation before candidate execution
 
@@ -92,10 +137,17 @@ uninspectable evidence reference remains a limitation.
 
 ## Blinding and commitments
 
-Before reveal, the controller and runner must not receive:
+Before reveal, public/controller-visible material must not contain:
 
 - semantic arm identities;
 - the historical response or hidden reference;
+- the full source-selection receipt or sealed-case locator;
+- the `hylo-source-selection-opening/v1` or its nonce;
+- raw before/after target fingerprints or change ID;
+- the target common projection, its
+  `hylo-target-common-projection-opening/v1`, or intervention witness body;
+- a treatment opening or materialization body;
+- a full FIR rather than `hylo-fir-public-projection/v1` on a v2 surface;
 - later source-session outcomes;
 - hidden oracle values;
 - plaintext absolute grades;
@@ -104,11 +156,24 @@ Before reveal, the controller and runner must not receive:
 - target-specific repair hints derived from sealed evidence.
 
 Public pre-reveal output may contain commitments, fingerprints, producer
-metadata, terminal state, and opaque acknowledgements.
+metadata, terminal state, and opaque acknowledgements. A v2 runner privately
+receives only its lease-bound `hylo-lane-materialization-claim/v2`; the claim
+contains the selected treatment without semantic role and never enters the
+event store or proof bundle. CAS returns commitment-only
+`hylo-run-receipt/v2`.
+
+Public proof sanitization rejects private semantic keys such as
+`private_reasoning`, `historical_response`, and `source_target_text`. It may
+retain a schema-declared boolean disclosure observation such as
+`hidden_reference:false`; that value proves non-disclosure and carries no
+hidden-reference content.
 
 For sealed assurance, use distinct role processes and anonymous descriptor
 delivery. Record the truth: the current proof has role and cryptographic
 separation with `os_confinement:false`, not hostile same-user isolation.
+Sealed execution additionally requires a caller-provided admitted broker. The
+repository's `hctp-sealed-role-driver` is conformance infrastructure, not an
+installed product command.
 
 ## Comparable paired evidence
 
@@ -131,14 +196,18 @@ hidden-reference visibility
 The treatment bundle may differ. That planned difference is the intervention.
 
 Every candidate lane requires a compatible replay-baseline lane from the
-frozen pair. In the compatibility campaign fold, the replay-baseline attempt
-must predate the candidate attempt for that scenario. Historical diagnostics
-never satisfy this requirement.
+frozen pair. HCTP follows its frozen balanced A/B-B/A allocation, so either
+semantic arm may execute first. Comparability requires both matching frozen
+lanes, not baseline-first execution.
+
+Only in the compatibility campaign fold must the replay-baseline attempt
+predate the candidate attempt for that scenario. Historical diagnostics never
+satisfy this requirement.
 
 Invalidate or label diagnostic any comparison with unexpected drift. Do not
 repair drift by relabeling a target, world, runtime, grader, or oracle.
 
-## Repeats and pairing
+## Repeats, allocation, and order effects
 
 When deterministic seeds exist, pair them. Otherwise use frozen balanced order
 and mandatory repeats for promotion claims.
@@ -159,11 +228,28 @@ null-trial or calibration result
 The promotion cohort is the latest required complete cohort. A newer failure
 reopens the frontier; older successes cannot be cherry-picked around it.
 
+After reveal, report order effects as diagnostic observations. Include the
+terminal baseline-first and candidate-first pair counts. For each dimension,
+report contributor count and mean second-minus-first only when both
+orientations exist; otherwise report `null`. Order effects are noncausal and
+must not manufacture, invalidate, or strengthen a treatment claim by
+themselves.
+
 ## Absolute and pair grades
 
 An absolute lane grade answers whether one attempt satisfies the frozen rubric
 and hard gates. A pair grade compares two opaque arms under the frozen pair
 contract. Neither may see the semantic arm map before reveal.
+
+For v2 trials, `hylo-grade-presentation-receipt/v1`,
+`hylo-grade-receipt/v1`, and `hylo-pair-grade-receipt/v1` are closed and exact
+native shapes. Reject unknown top-level keys, undeclared nested keys, and fields
+outside their applicable optional branch. Every consumed public
+`evidence_refs` item, pair-dimension `rationale_ref`, `grade_receipt_ref`,
+`pair_grade_receipt_ref`, and `grade_presentation_receipt_ref` is exactly
+`artifact:sha256:<64 lowercase hex>`; a companion fingerprint must equal the
+reference digest. V1 trial carriers retain their established receipt
+compatibility.
 
 Grade commitment/opening flow preserves:
 
@@ -179,6 +265,14 @@ opening equality at reveal
 Treat a missing or mismatched opening, wrong producer, wrong ordered pair,
 unregistered receipt, or changed retry as invalid evidence rather than a
 recoverable score.
+
+V2 reveal also closes the run/materialization evidence join. Each lane must
+provide exactly one `hylo-lane-materialization-receipt/v2` whose
+`claim_fingerprint` equals
+`hylo-run-receipt/v2.materialization.materialization_claim_fingerprint`.
+Changed, missing, duplicate, or version-mixed per-lane safe receipts invalidate
+reveal before append. `--reveal FILE` remains a v1-only carrier; v2 reveal is
+derived from validated custody delivered through `--reveal-material-fd`.
 
 ## Observable behavior delta
 
@@ -214,6 +308,10 @@ incomparable              a required comparison contract changed
 insufficient_evidence     repeat, sample, uncertainty, or fidelity gate unmet
 invalid                   custody, replay, grader, chain, or proof integrity failed
 ```
+
+Classify a `replay_eligible:false` CRF source routed as `direct` as `invalid`,
+not merely low fidelity. A valid historical route may retain the CRF
+reconstruction ceiling and limitations; it does not upgrade them.
 
 State dimension and denominator. “Instruction fidelity improved on 8/10
 holdout units over three blind repeats” is meaningful; “the score improved” is
@@ -338,7 +436,10 @@ Keep these states distinct:
 ```text
 selected    causal frontier emitted RUN
 applied     owner changed the exact bounded target surface
+frozen      owner-applied candidate was bound into an immutable trial
+evaluated   required trial evidence reached a revealed result
 promoted    complete blind cohort passed the frozen gate
+rejected    revealed evidence failed the frozen acceptance gate
 committed   explicit publication authority produced an exact commit
 pushed      separate remote authority published it
 ```

--- a/codex/skills/hylo/references/orchestration.md
+++ b/codex/skills/hylo/references/orchestration.md
@@ -1,0 +1,813 @@
+# Hylo executable orchestration
+
+This reference owns the ordered CRF/HCTP operator state machine. Installed CLI
+help, capabilities, validators, and executable fixtures remain authoritative.
+
+## Contents
+
+- [Execution graph](#execution-graph)
+- [Native operator-recipe binding](#native-operator-recipe-binding)
+- [Phase 0 — Resolve intent and authority](#phase-0--resolve-intent-and-authority)
+- [Phase 1 — Extract and validate CRF evidence](#phase-1--extract-and-validate-crf-evidence)
+- [Phase 2 — Select a source route](#phase-2--select-a-source-route)
+- [Phase 3 — Compile source selection](#phase-3--compile-source-selection)
+- [Phase 4 — Admit the campaign](#phase-4--admit-the-campaign)
+- [Phase 5 — Establish a candidate](#phase-5--establish-a-candidate)
+- [Phase 6 — Compile and register the trial](#phase-6--compile-and-register-the-trial)
+- [Phase 7 — Materialize and execute lanes](#phase-7--materialize-and-execute-lanes)
+- [Phase 8 — Grade, reveal, and prove](#phase-8--grade-reveal-and-prove)
+- [Phase 9 — Fold the causal frontier](#phase-9--fold-the-causal-frontier)
+- [Protected descriptor contract](#protected-descriptor-contract)
+- [Allocation and chronology](#allocation-and-chronology)
+- [Sealed assurance](#sealed-assurance)
+- [Recovery](#recovery)
+
+## Execution graph
+
+```text
+resolve mode and authority
+  -> probe only required capabilities
+  -> extract and validate CRF graph
+  -> apply fidelity gate
+  -> compile governed source selection
+  -> construct and admit campaign, scenarios, target bundles
+  -> require an existing owner-applied candidate
+  -> compile public v2 trial and private custody
+  -> validate trial
+  -> validate exact source receipt against completed trial
+  -> register trial with private custody
+  -> preflight each lane
+  -> materialize each selected treatment under its retained lease
+  -> execute each lane by frozen source route
+  -> blind grade
+  -> reveal and observe the derived result
+  -> close trial
+  -> prove when requested and authorized
+  -> fold causal frontier
+  -> route owner action or stop
+```
+
+Each arrow is fail-closed. Do not skip a predecessor because a later schema
+validator might also detect the omission.
+
+## Native operator-recipe binding
+
+The pinned native `expected-route.json` owns the exact executable recipe step
+order. This table is its documentation projection. Repeated owner commands are
+intentional: they represent distinct immutable transitions or frozen lanes.
+The cross-repository contract requires exact step order and requires every
+command identity below to belong to the pinned native surface manifest.
+
+| Native step | Owner command |
+| --- | --- |
+| `source_compile` | `seq hctp-source compile` |
+| `campaign_validate` | `ledger --source hylo validate-campaign` |
+| `campaign_created` | `ledger --source hylo append` |
+| `target_bundle_admitted` | `ledger --source hylo append` |
+| `scenario_manifest_complete` | `ledger --source hylo append` |
+| `owner_applied_candidate_precondition` | `ledger --source hylo append` |
+| `campaign_doctor` | `ledger --source hylo doctor` |
+| `trial_compile` | `ledger --source hylo compile-trial` |
+| `trial_validate` | `ledger --source hylo validate-trial` |
+| `source_validate` | `seq hctp-source validate` |
+| `trial_register` | `ledger --source hylo register-trial` |
+| `direct_lane_preflight` | `cas trial preflight` |
+| `direct_lane_source_materialize` | `seq hctp-source materialize` |
+| `direct_lane_start` | `ledger --source hylo start-lane` |
+| `direct_lane_recover_start` | `ledger --source hylo recover-lane-start` |
+| `direct_lane_materialization` | `ledger --source hylo lane-materialization` |
+| `direct_lane_run` | `cas trial run` |
+| `direct_lane_finish` | `ledger --source hylo finish-lane` |
+| `direct_lane_recover_finish` | `ledger --source hylo recover-lane-finish` |
+| `direct_lane_grade` | `ledger --source hylo grade-lane` |
+| `historical_lane_preflight` | `cas trial preflight` |
+| `historical_lane_source_materialize` | `seq hctp-source materialize` |
+| `historical_lane_start` | `ledger --source hylo start-lane` |
+| `historical_lane_recover_start` | `ledger --source hylo recover-lane-start` |
+| `historical_lane_materialization` | `ledger --source hylo lane-materialization` |
+| `historical_lane_run` | `cas trial run` |
+| `historical_lane_finish` | `ledger --source hylo finish-lane` |
+| `historical_lane_recover_finish` | `ledger --source hylo recover-lane-finish` |
+| `historical_lane_grade` | `ledger --source hylo grade-lane` |
+| `pair_grade` | `ledger --source hylo grade-pair` |
+| `custody_reveal` | `ledger --source hylo reveal-trial` |
+| `trial_result` | `ledger --source hylo trial-result` |
+| `trial_close` | `ledger --source hylo close-trial` |
+| `proof_artifact_set` | `ledger --source hylo proof-artifact-set` |
+| `proof_export` | `ledger --source hylo export-proof` |
+| `proof_verify` | `ledger --source hylo verify-proof` |
+
+### Native semantic binding
+
+The following JSON is the machine-checked documentation projection of every
+semantic object in the pinned native `expected-route.json`. It is intentionally
+literal: any native change to these route, authority, allocation, custody,
+broker, or candidate-lifecycle laws must update the operator prose and this
+projection together.
+
+```json
+{
+  "trial_boundary": {
+    "public_schema": "hylo-trial/v2",
+    "private_schema": "hylo-trial-custody/v1",
+    "registration_requires_custody_fd": true,
+    "lane_materialization_requires_custody_and_lease_fds": true,
+    "cas_run_requires_lease_input_and_materialization_fds": true
+  },
+  "execution_authorities": {
+    "runner_contract_schema": "cas-hylo-runner/v1",
+    "runtime_rebinding_required": true,
+    "runner": {
+      "producer_id": "cas-trial",
+      "key_id": "runner-key",
+      "binary_binding": "cas_trial_path",
+      "version_binding": "cas_version"
+    },
+    "executor": {
+      "producer_id": "cas-trial-executor",
+      "key_id": "executor-authority-key",
+      "binary_binding": "fixture_executor_path"
+    },
+    "ledger": {
+      "producer_id": "hylo-ledger",
+      "key_id": "executor-authority-key",
+      "binary_binding": "ledger_path"
+    }
+  },
+  "routes": {
+    "direct": {
+      "comparison_eligible": true,
+      "crf_replay_eligible_required": true,
+      "compile_replay_required": false,
+      "source_profile_body_delivery": "none",
+      "replay_preparation_mode": "none",
+      "execution_route": "direct",
+      "required_lineage": null,
+      "compile_replay_owner": null
+    },
+    "historical_decision": {
+      "comparison_eligible": true,
+      "crf_replay_eligible_required": false,
+      "compile_replay_required": false,
+      "source_profile_body_delivery": "source_profile_fd",
+      "case_blind_source_profile_body_delivery": "source_profile_fd",
+      "replay_preparation_mode": "integrated_run",
+      "execution_route": "historical_replay",
+      "required_lineage": "either",
+      "compile_replay_owner": "cas_trial_run"
+    },
+    "diagnostic_only": {
+      "comparison_eligible": false,
+      "compile_replay_required": false,
+      "execution_route": "diagnostic_only",
+      "registration_allowed": false
+    }
+  },
+  "allocation": {
+    "method": "balanced_ab_ba",
+    "semantic_baseline_must_run_first": false,
+    "compatibility_fold_requires_prior_baseline": true
+  },
+  "sealed_product_boundary": {
+    "admitted_broker_required": true,
+    "repository_driver_installed": false,
+    "fail_before": [
+      "secret_generation",
+      "campaign_mutation",
+      "trial_mutation"
+    ],
+    "os_confinement": false
+  },
+  "candidate_lifecycle": {
+    "evaluate_requires_existing_candidate": true,
+    "run_grants_mutation_authority": false,
+    "new_candidate_requires_new_trial": true
+  }
+}
+```
+
+## Phase 0 — Resolve intent and authority
+
+Record:
+
+```text
+operation:
+  validate | extract | evaluate_existing_candidate | derive_next_candidate |
+  report | doctor
+
+assurance:
+  precommitted | receipt_bound | role_separated | sealed
+
+source route:
+  direct | historical_decision | unresolved
+
+owner authority:
+  none | propose | apply | commit | push
+```
+
+Default every authority to `none`. A persistent request is persistence toward
+the outcome, not broader authority.
+
+Probe only the selected mode. Root `ledger validate hylo-*` artifact checks do
+not require the macOS product surfaces. Repo-aware `ledger --source hylo`
+doctor, report, campaign, and trial operations do. Source selection adds Seq;
+execution adds CAS; a historical route adds DCP/RIP/FIR and internal historical
+replay; case-blind adds source sealing, materialization, and protected
+source-selection opening delivery; sealed adds a separately admitted broker.
+Post-close proof export probes only Ledger's v2 trial/custody and proof surfaces;
+it does not require an installed Seq or CAS binary.
+
+## Phase 1 — Extract and validate CRF evidence
+
+Invoke `seq hylo-extract` with the complete target bundle root and an admitted
+custodian's protected seal-key output descriptor. Preserve separate runner and
+`0700` custody roots.
+
+Validate:
+
+```bash
+ledger validate hylo-runner-input --input ./runner/runner-input.json
+ledger validate hylo-stimulus --input ./runner/stimulus.json
+ledger validate hylo-target-bundle --input ./runner/baseline-bundle.json
+ledger validate hylo-world-snapshot --input ./runner/world.json
+ledger validate hylo-world-availability-receipt --input ./runner/world-availability.json
+ledger validate hylo-runtime-contract --input ./runner/runtime.json
+ledger validate hylo-replay-episode --input ./custody/episode.json
+ledger validate hylo-counterfactual-cut-receipt --input ./custody/cut.json
+ledger validate hylo-redaction-receipt --input ./custody/redaction.json
+ledger validate hylo-custody-manifest --input ./custody/manifest.json
+```
+
+Report before routing:
+
+```text
+episode ID and fingerprint
+counterfactual cut and confidence
+target bundle fingerprint
+world availability and runtime fingerprint
+CRF fidelity class
+replay_eligible
+limitations
+runner and custody root identities
+```
+
+A pure validator pass establishes structure and invariants only. It grants no
+execution, reveal, edit, or publication authority.
+
+## Phase 2 — Select a source route
+
+### Source route table
+
+| CRF evidence | Source profile | Native result |
+| --- | --- | --- |
+| `replay_eligible:true` | genuinely `direct` | direct comparison admission |
+| `replay_eligible:false` | `direct` | `diagnostic_only` source admission; trial compilation, registration, and comparison execution forbidden |
+| `replay_eligible:true` | valid governed `historical_decision` | historical replay admission |
+| `replay_eligible:false` | valid governed `historical_decision` | historical replay admission at the retained reconstruction ceiling |
+| any | absent or invalid `historical_decision` governance | compilation fails; the source remains diagnostic evidence only |
+
+For source-profile literals:
+
+```text
+source_profile.kind == "direct"
+source_profile.kind == "historical_decision"
+```
+
+Seq derives `source_route_admission` during source compilation; the caller does
+not supply it. The source-owner attestation on the exact source-selection
+receipt covers that admission. The admission binds campaign, unit, scenario,
+split, source episode projection, source profile, effective reconstruction,
+limitations, and execution route.
+
+A historical source is never upgraded by changing its label. A historical
+route requires SGG-v1, DCP-v2 at a `pre_decision` anchor, a source-target-text
+witness, `retrace_mode:"replay"`, required lineage and FIR version, and an
+honest reconstructability label. Historical `practice_repair` and `promotion`
+require authoritative governance with workflow effects allowed.
+
+## Phase 3 — Compile source selection
+
+Run source compilation before trial construction:
+
+```bash
+seq hctp-source compile \
+  --manifest source.json \
+  --output selection.json \
+  --source-signing-seed-fd <source-owner-seed-fd>
+```
+
+Retain:
+
+```text
+complete denominator and split membership
+independence clusters and duplicate analysis
+source episode and source profile fingerprints
+source route admissions
+visible and hidden commitments
+sealed-case references when case-blind
+source-owner attestation and receipt fingerprint
+```
+
+Do not run `seq hctp-source validate` yet. That command compares the receipt to
+a complete trial and therefore has no valid pre-trial invocation.
+
+## Phase 4 — Admit the campaign
+
+Construct `campaign.json` and the complete scenarios JSONL. The new operator
+route requires:
+
+```text
+protocol_profiles: ["hylo-trial/v2"]
+canonical_json_profile: "hylo-canonical-json/v1"
+trial_policy.source_route_admission: "required"
+complete scenario_manifest
+proof authority and proof trust policy when proof is required
+```
+
+The campaign MAY also include `hylo-trial/v1` for legacy trial compatibility.
+
+### Registration order
+
+```text
+validate campaign
+  -> append campaign_created
+  -> append every required target_bundle_admitted
+  -> append every scenario_admitted in the complete manifest
+  -> append the owner-applied change when evaluating a changed target
+  -> doctor and inspect admission state
+  -> compile trial
+  -> validate trial
+  -> source-validate completed trial
+  -> register trial
+```
+
+Representative commands:
+
+```bash
+ledger --source hylo validate-campaign --campaign campaign.json
+ledger --source hylo append --repo <repo> --json campaign-created.json
+ledger --source hylo append --repo <repo> --json baseline-target-bundle-admitted.json
+ledger --source hylo append --repo <repo> --json candidate-target-bundle-admitted.json
+ledger --source hylo append --repo <repo> --json scenario-admitted-001.json
+ledger --source hylo append --repo <repo> --json change-recorded.json
+ledger --source hylo doctor --repo <repo>
+```
+
+Append every remaining scenario intent in the complete manifest before the
+change intent and final doctor pass.
+
+Use only native `hylo-event-intent/v1` bodies and fingerprints. Low-level
+`append` owns compatibility campaign events; it must not author HCTP trial
+lifecycle events.
+
+The parent campaign fixes promotion coverage. Registration must reject an
+unknown campaign, an unadmitted or partially admitted scenario manifest,
+missing target bindings, and a promotion trial that omits an applicable
+protected unit.
+
+## Phase 5 — Establish a candidate
+
+### Candidate lifecycle
+
+```text
+evaluate existing candidate
+  owner-applied candidate identity exists
+  -> before and after target bundles admitted
+  -> before and after snapshots admitted
+  -> exact bounded change recorded as applied
+  -> candidate can be frozen for a trial
+
+derive next candidate
+  prior evidence folds to RUN | OBSERVE | STOP
+  -> RUN grants no mutation authority
+  -> target owner may apply the bounded intervention if separately authorized
+  -> a new content-addressed candidate identity exists
+  -> begin a new evaluation trial
+```
+
+If the candidate is absent, stop trial construction. Do not create a circular
+trial whose candidate depends on the evidence that the same trial has not yet
+produced.
+
+## Phase 6 — Compile and register the trial
+
+The current compiler accepts `hylo-trial-build-request/v1`, the exact
+`hylo-source-selection-receipt/v1`, a create-new public output path, and an
+admitted custodian's protected custody output descriptor:
+
+```bash
+ledger --source hylo compile-trial \
+  --repo <repo> \
+  --request trial-build-request.json \
+  --source-receipt selection.json \
+  --output trial.json \
+  --custody-output-fd <custodian-custody-sink-fd>
+```
+
+The request binds the current campaign head, purpose, unit IDs, source receipt,
+before/after target bundles and snapshots, applied change, allowed difference
+roots, hypothesis, estimand, execution, grading, assurance, sealing, allocation,
+stop, and calibration policies. The current compiler supports the admitted
+`practice_repair`/`promotion` target-snapshot route, balanced A/B-B/A allocation,
+and a positive even fixed pair count. It rejects unsupported non-null proof or
+publication request bodies rather than ignoring them.
+
+The factor verifier fingerprint must match the observed Ledger executable.
+The sealing request carries only reveal scope and admitted materializer fields;
+case/arm/grade visibility and commitment sets are source/compiler-derived, and
+the compiler rejects a request that tries to supply them.
+
+Compilation validates campaign/scenario/target/change/source state before
+entropy. It generates opaque arm IDs, allocation, arm-map commitment, canonical
+public `hylo-trial/v2`, and private `hylo-trial-custody/v1`.
+
+Within the public trial, every `units[*].source_profile` is the exact native
+safe projection. Exact-key validation rejects semantic extras. A full
+historical profile body, source target text, rationale, rejected routes, and
+hidden references remain private and use the admitted FD carrier when required.
+
+The two sinks cannot be crash-atomic. The compiler links a create-new `0600`
+public trial, delivers private custody, and attempts to remove the public trial
+when delivery reports failure. `TrialOutputRollbackFailed` identifies a path
+that may remain as an uncommitted recovery artifact; a partial custody byte
+stream is not an admitted custody record. The compiler emits
+`hylo-trial-build-receipt/v2` with `custody_material_delivered:true` only after
+both sinks complete. Treat that stdout receipt—not transient file visibility—as
+the commit observation. The receipt grants no authority.
+
+The public v2 trial carries only opaque arm/treatment commitments, committed
+target epoch, committed intervention witness and common projection, and the
+portable `artifact:sha256:<64 lowercase hex>` source-receipt reference,
+matching fingerprint, and commitment. The exact signed source receipt,
+treatment openings and materializations, semantic arm map, target openings,
+witness, and common projection remain in custody.
+
+Then use this exact sequence:
+
+```bash
+ledger --source hylo validate-trial --repo <repo> --trial trial.json
+seq hctp-source validate --receipt selection.json --trial trial.json
+ledger --source hylo register-trial \
+  --repo <repo> \
+  --trial trial.json \
+  --custody-input-fd <custodian-registration-source-fd>
+```
+
+Source validation checks the exact canonical signed-receipt value and its
+fingerprint plus every unit, scenario, split, cluster, visible commitment,
+hidden commitment, source episode projection, source profile, and route
+admission. Never attempt registration after source validation fails. For v2,
+the custodian re-delivers the exact custody record through a fresh protected
+pipe. The registration event persists only the public trial and a validated
+nonsemantic custody-commitment observation. Retain custody for every new v2
+lane start or caller-retained start commit, treatment materialization, and
+reveal; each use receives a fresh protected input pipe.
+
+For private-v2 registration, treat the preceding validation as necessary
+preflight, not append authority. Ledger reacquires exclusive store ownership,
+loads the exact append snapshot, and reruns the full semantic
+trial-against-campaign validation on the custody-backed trial before applying
+or appending `trial_registered`. Any stale binding fails without append. The
+legacy v1 registration route retains its established public-trial behavior.
+
+## Phase 7 — Materialize and execute lanes
+
+### Lane execution
+
+For each lane, run:
+
+```bash
+cas trial preflight --trial trial.json --lane-id <lane> --json
+```
+
+Consume its exact projection:
+
+```text
+source_profile_kind
+compile_replay_required
+replay_preparation_mode
+source_profile_body_delivery
+execution_route
+required_lineage
+```
+
+#### Direct lane
+
+```text
+preflight reports:
+  source_profile_kind:"direct"
+  compile_replay_required:false
+  replay_preparation_mode:"none"
+  source_profile_body_delivery:"none"
+  execution_route:"direct"
+  required_lineage:null
+  -> materialize the exact visible input
+  -> start-lane or commit-lane-start under the frozen assurance route
+  -> materialize the selected treatment from custody under the retained lease
+  -> call cas trial run exactly once with --materialization-fd and without
+     --source-profile-fd
+  -> finish-lane, or recover the exact terminal acknowledgement
+```
+
+`compile-replay` is forbidden for direct lanes.
+
+#### Historical lane
+
+```text
+preflight reports:
+  source_profile_kind:"historical_decision"
+  compile_replay_required:false
+  replay_preparation_mode:"integrated_run"
+  source_profile_body_delivery:"source_profile_fd"
+  execution_route:"historical_replay"
+  required_lineage:<frozen-lineage>
+  -> materialize the exact visible input
+  -> materialize the private profile to the runner FD
+  -> start-lane or commit-lane-start under the frozen assurance route
+  -> materialize the selected treatment from custody under the retained lease
+  -> call cas trial run exactly once with --materialization-fd and the
+     protected --source-profile-fd
+  -> CAS validates the profile and prepares one DCP/RIP internally before claim
+  -> CAS binds preparation fingerprints into claim, executor request, and receipt
+  -> finish-lane after FIR/native lineage validation, or exact recovery
+```
+
+Embedded historical delivery is legacy v1 or standalone diagnostic
+compatibility. It is not the v2 execution route.
+
+#### Private treatment bridge
+
+Every new `hylo-trial/v2` lane start validates its private target treatment
+from custody while the repository observation locks are held:
+
+```bash
+ledger --source hylo start-lane \
+  --repo <repo> \
+  --campaign-id <campaign-id> \
+  --trial-id <trial-id> \
+  --lane-id <lane-id> \
+  --runner-id <runner-id> \
+  --custody-input-fd <custodian-start-source-fd> \
+  --lease-output-fd <runner-lease-sink-fd>
+```
+
+`commit-lane-start` also requires `--custody-input-fd` when it commits a new
+v2 start from a caller-retained lease. Exact already-started recovery uses the
+retained lease and re-emits existing state without rereading custody. After the
+start event, every v2 lane uses the same lease-bound treatment bridge:
+
+```bash
+ledger --source hylo lane-materialization \
+  --repo <repo> \
+  --trial-id <trial-id> \
+  --lane-id <lane-id> \
+  --registration-event-digest <registration-digest> \
+  --lane-started-event-digest <start-digest> \
+  --lane-lease-digest <lease-digest> \
+  --custody-input-fd <custodian-lane-source-fd> \
+  --lease-input-fd <retained-lease-source-fd> \
+  --materialization-output-fd <cas-materialization-sink-fd>
+
+cas trial run \
+  --trial trial.json \
+  --lane-id <lane-id> \
+  ... \
+  --materialization-fd <ledger-materialization-source-fd>
+```
+
+The v2 lane-start event binds `treatment_commitment`, not a raw target snapshot
+fingerprint. The materialization FD carries
+`hylo-lane-materialization-claim/v2`, including the selected treatment but no
+semantic role. The claim contains the exact private
+`hylo-target-common-projection-opening/v1`; CAS validates its whole-opening
+commitment and the nested `hylo-target-common-projection/v1` fingerprint before
+execution. Normal Ledger stdout contains only the safe
+`hylo-lane-materialization-receipt/v2`; retain one receipt per lane for reveal.
+CAS emits commitment-only `hylo-run-receipt/v2` and rejects raw target, factor,
+archive, or treatment fields in its public projection. Its FIR value is exactly
+`hylo-fir-public-projection/v1`; the full FIR stays private. The v1 receipt
+keeps its compatible full-FIR carrier.
+
+After each v2 run, verify the exact public join:
+
+```text
+hylo-lane-materialization-receipt/v2.claim_fingerprint
+  == hylo-run-receipt/v2.materialization.materialization_claim_fingerprint
+```
+
+Retain the joined receipt for reveal. Do not substitute a changed receipt,
+another lane's receipt, a duplicate, or a v1 materialization receipt.
+
+The public standalone `cas trial compile-replay` command is diagnostic-only.
+It rejects direct lanes, private case-blind source delivery, and
+`role_separated`/`sealed` assurance; its receipt says
+`execution_authority:false`. `cas trial run` consumes neither that receipt nor
+its DCP/RIP files; do not call it in an execution recipe.
+
+For case-blind materialization, the custodian projects the exact
+`hylo-source-selection-opening/v1` stored at `custody.source_selection` onto its
+own protected pipe; it does not deliver the full custody record to Seq:
+
+```bash
+seq hctp-source materialize \
+  --sealed-case <sealed-case> \
+  --trial trial.json \
+  --lane-id <lane-id> \
+  --seal-key-fd <custodian-seal-key-source-fd> \
+  --visible-output-fd <runner-visible-input-sink-fd> \
+  --source-selection-opening-fd <custodian-source-selection-opening-source-fd> \
+  --signing-seed-fd <materializer-signing-seed-source-fd> \
+  --output <safe-materialization-receipt>
+```
+
+When preflight freezes `source_profile_body_delivery:"source_profile_fd"`, add
+`--source-profile-output-fd <runner-source-profile-sink-fd>` and connect that
+protected output directly to `cas trial run --source-profile-fd`. Seq validates
+the opening commitment against the public trial and joins its nested exact
+signed receipt before releasing the visible input or historical profile. The
+public receipt contains commitments and fingerprints, not the opening or
+private bodies.
+
+## Phase 8 — Grade, reveal, and prove
+
+Record hard gates first, then absolute and pair grades under frozen producer,
+rubric, oracle, and judge contracts. Before reveal, public material contains no
+plaintext grade, pair winner, rationale, semantic arm map, full source receipt,
+raw target epoch, target common projection, intervention witness, treatment
+opening, or materialization body.
+
+For v2 trials, the native `hylo-grade-presentation-receipt/v1`,
+`hylo-grade-receipt/v1`, and `hylo-pair-grade-receipt/v1` shapes are closed and
+exact: unknown keys and undeclared nested fields are invalid. Every consumed
+public evidence, rationale, grade-receipt, pair-grade-receipt, and
+presentation-receipt reference must be exactly
+`artifact:sha256:<64 lowercase hex>` and exact-join its companion fingerprint.
+V1 trial carriers retain their established compatibility behavior.
+
+Reveal only when every required lane and grade is terminal and policy permits.
+The compiler's exact custody record is supplied through the admitted
+custodian's protected input descriptor via `--reveal-material-fd`, together
+with one safe lane-materialization receipt per lane:
+
+```bash
+ledger --source hylo reveal-trial \
+  --repo <repo> \
+  --reveal-material-fd <custodian-reveal-source-fd> \
+  --materialization-receipt lane-001-materialization-receipt.json
+```
+
+Repeat `--materialization-receipt` for every lane.
+
+`--reveal FILE` is legacy v1-only and accepts only
+`hylo-trial-reveal/v1`. A caller-authored v2 reveal is rejected. The v2 route
+must derive `hylo-trial-reveal/v2` from validated
+`hylo-trial-custody/v1` bytes delivered through `--reveal-material-fd`.
+Before append, Ledger exact-joins every supplied
+`hylo-lane-materialization-receipt/v2.claim_fingerprint` to the lane's
+`hylo-run-receipt/v2.materialization.materialization_claim_fingerprint`.
+Changed, missing, duplicate, and version-mixed per-lane safe-receipt sets fail
+without appending `trial_revealed`.
+
+Validated `hylo-trial-reveal/v2` is the first public semantic opening. It opens
+the arm map, treatments, target epoch, intervention witness, and target common
+projection; the full source-selection receipt remains custody-only. Custody
+bytes never enter argv, stdout, the event store, or a proof bundle.
+
+After reveal, derive:
+
+```text
+paired dimension deltas and hard-gate changes
+critical regressions
+dispersion and uncertainty
+independence-cluster coverage
+null/calibration result
+observable behavior delta
+diagnostic position/order effects
+qualification, noninferiority, or improvement claim class
+```
+
+Observe the derived result before closing the trial, then close it:
+
+```bash
+ledger --source hylo trial-result --repo <repo> --trial-id <trial-id> --format json
+ledger --source hylo close-trial --repo <repo> --trial-id <trial-id>
+```
+
+Proof occurs only after `close-trial`. When requested and authorized:
+
+```bash
+ledger --source hylo proof-artifact-set \
+  --repo <repo> --trial-id <trial-id> --output proof-artifacts.json
+ledger --source hylo export-proof \
+  --repo <repo> --trial-id <trial-id> --output proof.tar \
+  --sanitization-receipt proof-sanitization.json
+ledger --source hylo verify-proof --repo <repo> --input proof.tar
+```
+
+Proof verifies declared closure and anchors. It excludes private custody and
+lane claims/materializations and derives v2 semantic evidence only from the
+validated public reveal. It grants no edit, commit, push, or generalized causal
+authority. Public proof rejects private semantic keys while preserving
+schema-declared boolean non-disclosure observations such as
+`hidden_reference:false`.
+
+## Phase 9 — Fold the causal frontier
+
+Append or derive observable failure signatures, hypotheses, and bounded
+experiments. Use native `frontier` and `next-experiment` commands.
+
+```text
+RUN      one eligible intervention is non-dominated
+OBSERVE  one bounded read-only probe can distinguish alternatives
+STOP     no eligible intervention, or no bounded distinguishing probe exists
+```
+
+Every projection reports `authority_granted:false` and
+`target_mutated:false`. An owner-applied RUN intervention creates a new
+candidate identity, which must be evaluated by a new trial.
+
+## Protected descriptor contract
+
+Every secret-bearing or private semantic carrier uses a descriptor that is:
+
+```text
+already open before the product command starts
+unlinked and anonymous
+directional for the declared producer/consumer
+supplied under the admitted custodian, runner, source owner, or broker's custody
+distinct from every other sensitive descriptor
+numbered >=3
+bounded and one-shot where the native contract requires it
+```
+
+The CLI verifies descriptor shape, direction, and non-aliasing required by its
+contract. It does not authenticate the peer process or establish hostile
+same-user isolation.
+
+Never place a lease, seal key, signing seed, FD-delivered source-profile body,
+source-selection opening, target-common-projection opening, trial custody
+record, private lane claim, or grade opening in argv, an environment variable,
+stdin, stdout/stderr, a named FIFO, normal event storage, or a regular file.
+Shell regular-file redirection is not a protected-FD example. Open embedded
+lanes may carry the admitted source-profile body in the public trial projection,
+but never a prohibited historical response or source target text.
+
+## Allocation and chronology
+
+HCTP and the compatibility fold have different order laws:
+
+```text
+HCTP paired trial
+  semantic arms freeze before execution
+  lanes follow the frozen balanced A/B-B/A allocation
+  either semantic arm may execute first
+  comparison joins the two matching frozen lanes
+
+compatibility campaign fold
+  replay_baseline attempt must predate candidate attempt for one scenario
+```
+
+Do not impose the compatibility chronology on HCTP. Post-reveal
+`order_effects` is diagnostic: always report baseline-first and candidate-first
+counts and per-dimension records; `mean_second_minus_first` is non-null only
+when both orientations contribute. These observations are noncausal and do not
+alter claim eligibility.
+
+## Sealed assurance
+
+Sealed assurance requires an admitted broker with an authenticated binary and
+contract fingerprint. The broker owns role separation, anonymous descriptor
+custody, `commit-lane-start`, encrypted pending checkpoints, exact recovery,
+and non-disclosure. It must preserve `os_confinement:false`.
+
+The repository-owned `hctp-sealed-role-driver` lives in conformance/test
+infrastructure and is not installed product capability. The current native
+trial compiler returns `SealedBrokerUnavailable` for a sealed build request.
+Do not substitute the test driver, downgrade the label, or proceed through an
+open route. A caller integration may use a separately admitted broker only
+through the validator-backed native sealed contracts.
+Configured binary and contract hashes prove only commitment equality; they do
+not establish broker admission. No released native broker-admission validator
+or capability currently exists, so the surface checker keeps sealed mode
+blocked even when both configured hashes match.
+
+## Recovery
+
+Recovery never creates changed work:
+
+```text
+lost lane-start acknowledgement
+  -> present exact retained lease and lineage
+  -> recover existing start without append
+
+lost lane-finish acknowledgement
+  -> present exact retained receipt, lease, and lineage
+  -> recover existing terminal state without append
+
+changed input, lineage, lease, trial, or lane
+  -> fail
+```
+
+If executor liveness is unproved, do not declare a terminal receipt whose
+workspace could still change. A one-claim lane is never retried as a new
+execution.

--- a/codex/skills/hylo/scripts/check-operator-surface
+++ b/codex/skills/hylo/scripts/check-operator-surface
@@ -1,0 +1,732 @@
+#!/usr/bin/env -S uv run python
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+from typing import Any
+
+
+MODES = (
+    "operator",
+    "validate",
+    "extract",
+    "source-selection",
+    "open-direct-trial",
+    "historical-trial",
+    "case-blind-trial",
+    "sealed-trial",
+    "proof-export",
+)
+
+SURFACE_MANIFEST_SCHEMA = "hylo-operator-surface-manifest/v1"
+COMMAND_COMPONENTS = {"seq", "ledger-validator", "ledger-hylo", "cas"}
+CAPABILITY_COMPONENTS = {"seq", "ledger-hylo", "cas"}
+HISTORICAL_CASE_BLIND_MODE = "historical-case-blind-trial"
+LEDGER_V2_PROOF_PREREQUISITE_MODE = "ledger-v2-proof-prerequisites"
+
+CAS_PREFLIGHT_FIELDS = {
+    "source_profile_kind",
+    "compile_replay_required",
+    "replay_preparation_mode",
+    "source_profile_body_delivery",
+    "execution_route",
+    "required_lineage",
+}
+
+MODE_CLOSURE = {
+    "operator": {
+        "validate",
+        "extract",
+        "source-selection",
+        "open-direct-trial",
+        "historical-trial",
+        "case-blind-trial",
+        HISTORICAL_CASE_BLIND_MODE,
+        "proof-export",
+    },
+    "validate": {"validate"},
+    "extract": {"validate", "extract"},
+    "source-selection": {"source-selection"},
+    "open-direct-trial": {"open-direct-trial"},
+    "historical-trial": {"open-direct-trial", "historical-trial"},
+    "case-blind-trial": {
+        "source-selection",
+        "open-direct-trial",
+        "case-blind-trial",
+    },
+    "sealed-trial": {
+        "source-selection",
+        "open-direct-trial",
+        "case-blind-trial",
+        "sealed-trial",
+    },
+    "proof-export": {LEDGER_V2_PROOF_PREREQUISITE_MODE, "proof-export"},
+}
+
+
+class CheckFailure(RuntimeError):
+    pass
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Probe the installed native Hylo operator surface against a pinned "
+            "skills-zig manifest."
+        )
+    )
+    parser.add_argument("--mode", choices=MODES, default="operator")
+    parser.add_argument(
+        "--source-route",
+        choices=("direct", "historical_decision"),
+        help=(
+            "Frozen source route for case-blind-trial or sealed-trial; "
+            "defaults to direct"
+        ),
+    )
+    parser.add_argument(
+        "--surface-manifest",
+        default=os.environ.get("HYLO_OPERATOR_SURFACE_MANIFEST"),
+        help=(
+            "Pinned skills-zig hylo-operator-surface-manifest/v1 JSON; "
+            "defaults to HYLO_OPERATOR_SURFACE_MANIFEST"
+        ),
+    )
+    parser.add_argument("--seq", default=os.environ.get("HYLO_SEQ", "seq"))
+    parser.add_argument("--ledger", default=os.environ.get("HYLO_LEDGER", "ledger"))
+    parser.add_argument("--cas", default=os.environ.get("HYLO_CAS", "cas"))
+    parser.add_argument(
+        "--sealed-broker",
+        help="Configured external broker executable for sealed-trial mode",
+    )
+    parser.add_argument(
+        "--sealed-broker-sha256",
+        help="Expected sha256:<hex> binary commitment for --sealed-broker",
+    )
+    parser.add_argument(
+        "--sealed-broker-contract",
+        help="Configured external broker contract artifact for sealed-trial mode",
+    )
+    parser.add_argument(
+        "--sealed-broker-contract-sha256",
+        help="Expected sha256:<hex> commitment for --sealed-broker-contract",
+    )
+    parser.add_argument("--json", action="store_true", dest="json_output")
+    return parser.parse_args()
+
+
+def resolve_executable(value: str) -> str:
+    candidate = Path(value).expanduser()
+    if candidate.parent != Path(".") or candidate.is_absolute():
+        resolved = candidate.resolve(strict=True)
+        if not resolved.is_file() or not os.access(resolved, os.X_OK):
+            raise CheckFailure(f"not executable: {resolved}")
+        return str(resolved)
+    found = shutil.which(value)
+    if found is None:
+        raise CheckFailure(f"command not found on PATH: {value}")
+    return str(Path(found).resolve())
+
+
+def run(executable: str, *argv: str) -> str:
+    try:
+        completed = subprocess.run(
+            [executable, *argv],
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+            timeout=15,
+        )
+    except subprocess.TimeoutExpired as error:
+        raise CheckFailure(
+            f"{' '.join((executable, *argv))} exceeded the 15-second probe budget"
+        ) from error
+    if completed.returncode != 0:
+        detail = completed.stderr.strip() or completed.stdout.strip()
+        raise CheckFailure(
+            f"{' '.join((executable, *argv))} exited {completed.returncode}: {detail}"
+        )
+    return completed.stdout
+
+
+def require_tokens(surface: str, label: str, tokens: set[str]) -> None:
+    missing = sorted(token for token in tokens if token not in surface)
+    if missing:
+        raise CheckFailure(f"{label} is missing: {', '.join(missing)}")
+
+
+def load_json(surface: str, label: str) -> dict[str, Any]:
+    try:
+        value = json.loads(surface)
+    except json.JSONDecodeError as error:
+        raise CheckFailure(f"{label} did not return JSON: {error}") from error
+    if not isinstance(value, dict):
+        raise CheckFailure(f"{label} returned a non-object JSON value")
+    return value
+
+
+def require_exact_keys(
+    value: dict[str, Any], expected: set[str], label: str
+) -> None:
+    actual = set(value)
+    if actual == expected:
+        return
+    missing = sorted(expected - actual)
+    extra = sorted(actual - expected)
+    details = []
+    if missing:
+        details.append(f"missing {', '.join(missing)}")
+    if extra:
+        details.append(f"unexpected {', '.join(extra)}")
+    raise CheckFailure(f"{label} has invalid keys: {'; '.join(details)}")
+
+
+def string_tuple(value: Any, label: str) -> tuple[str, ...]:
+    if not isinstance(value, list) or not value:
+        raise CheckFailure(f"{label} must be a non-empty string array")
+    if not all(isinstance(item, str) and item for item in value):
+        raise CheckFailure(f"{label} must be a non-empty string array")
+    if len(value) != len(set(value)):
+        raise CheckFailure(f"{label} must not contain duplicates")
+    return tuple(value)
+
+
+def load_surface_manifest(value: str | os.PathLike[str] | None) -> dict[str, Any]:
+    if value is None or not str(value).strip():
+        raise CheckFailure(
+            "--surface-manifest or HYLO_OPERATOR_SURFACE_MANIFEST is required"
+        )
+    try:
+        path = Path(value).expanduser().resolve(strict=True)
+    except OSError as error:
+        raise CheckFailure(f"surface manifest is unavailable: {value}") from error
+    if not path.is_file():
+        raise CheckFailure(f"surface manifest is not a file: {path}")
+
+    payload = load_json(read_text(path), "Hylo operator surface manifest")
+    require_exact_keys(
+        payload,
+        {"schema", "commands", "required_capabilities"},
+        "Hylo operator surface manifest",
+    )
+    if payload["schema"] != SURFACE_MANIFEST_SCHEMA:
+        raise CheckFailure(
+            "Hylo operator surface manifest schema must be "
+            f"{SURFACE_MANIFEST_SCHEMA}"
+        )
+
+    base_modes = set().union(*MODE_CLOSURE.values())
+    commands_value = payload["commands"]
+    if not isinstance(commands_value, list) or not commands_value:
+        raise CheckFailure("surface manifest commands must be a non-empty array")
+    commands: list[dict[str, Any]] = []
+    command_identities: set[tuple[str, tuple[str, ...], str]] = set()
+    documented_commands: set[str] = set()
+    for index, raw in enumerate(commands_value):
+        label = f"surface manifest commands[{index}]"
+        if not isinstance(raw, dict):
+            raise CheckFailure(f"{label} must be an object")
+        require_exact_keys(
+            raw,
+            {
+                "component",
+                "modes",
+                "help_argv",
+                "help_token",
+                "documented_command",
+            },
+            label,
+        )
+        component = raw["component"]
+        if component not in COMMAND_COMPONENTS:
+            raise CheckFailure(f"{label}.component is unknown: {component}")
+        modes = string_tuple(raw["modes"], f"{label}.modes")
+        unknown_modes = sorted(set(modes) - base_modes)
+        if unknown_modes:
+            raise CheckFailure(
+                f"{label}.modes are unknown: {', '.join(unknown_modes)}"
+            )
+        help_argv = string_tuple(raw["help_argv"], f"{label}.help_argv")
+        help_token = raw["help_token"]
+        documented_command = raw["documented_command"]
+        if not isinstance(help_token, str) or not help_token.strip():
+            raise CheckFailure(f"{label}.help_token must be a non-empty string")
+        if not isinstance(documented_command, str) or not documented_command.strip():
+            raise CheckFailure(
+                f"{label}.documented_command must be a non-empty string"
+            )
+        identity = (component, help_argv, help_token)
+        if identity in command_identities:
+            raise CheckFailure(f"{label} duplicates a command help token")
+        if documented_command in documented_commands:
+            raise CheckFailure(f"{label} duplicates a documented command")
+        command_identities.add(identity)
+        documented_commands.add(documented_command)
+        commands.append(
+            {
+                "component": component,
+                "modes": modes,
+                "help_argv": help_argv,
+                "help_token": help_token,
+                "documented_command": documented_command,
+            }
+        )
+
+    capabilities_value = payload["required_capabilities"]
+    if not isinstance(capabilities_value, list) or not capabilities_value:
+        raise CheckFailure(
+            "surface manifest required_capabilities must be a non-empty array"
+        )
+    required_capabilities: list[dict[str, Any]] = []
+    capability_identities: set[tuple[str, str]] = set()
+    for index, raw in enumerate(capabilities_value):
+        label = f"surface manifest required_capabilities[{index}]"
+        if not isinstance(raw, dict):
+            raise CheckFailure(f"{label} must be an object")
+        require_exact_keys(raw, {"component", "mode", "keys"}, label)
+        component = raw["component"]
+        if component not in CAPABILITY_COMPONENTS:
+            raise CheckFailure(f"{label}.component is unknown: {component}")
+        mode = raw["mode"]
+        if mode not in base_modes:
+            raise CheckFailure(f"{label}.mode is unknown: {mode}")
+        keys = string_tuple(raw["keys"], f"{label}.keys")
+        identity = (component, mode)
+        if identity in capability_identities:
+            raise CheckFailure(f"{label} duplicates a component/mode requirement")
+        capability_identities.add(identity)
+        required_capabilities.append(
+            {"component": component, "mode": mode, "keys": keys}
+        )
+
+    return {
+        "schema": SURFACE_MANIFEST_SCHEMA,
+        "path": str(path),
+        "fingerprint": sha256_file(path),
+        "commands": tuple(commands),
+        "required_capabilities": tuple(required_capabilities),
+    }
+
+
+def read_text(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8")
+    except OSError as error:
+        raise CheckFailure(f"failed to read surface manifest: {path}") from error
+
+
+def command_surfaces(
+    manifest: dict[str, Any], component: str, closure: set[str]
+) -> dict[tuple[str, ...], set[str]]:
+    projected: dict[tuple[str, ...], set[str]] = {}
+    for command in manifest["commands"]:
+        if command["component"] != component:
+            continue
+        if not closure.intersection(command["modes"]):
+            continue
+        projected.setdefault(command["help_argv"], set()).add(
+            command["help_token"]
+        )
+    return projected
+
+
+def command_tokens(
+    manifest: dict[str, Any], component: str, closure: set[str]
+) -> set[str]:
+    return set().union(*command_surfaces(manifest, component, closure).values())
+
+
+def documented_commands(
+    manifest: dict[str, Any], closure: set[str]
+) -> set[str]:
+    return {
+        command["documented_command"]
+        for command in manifest["commands"]
+        if closure.intersection(command["modes"])
+    }
+
+
+def feature_requirements_by_mode(
+    manifest: dict[str, Any], component: str
+) -> dict[str, set[str]]:
+    return {
+        requirement["mode"]: set(requirement["keys"])
+        for requirement in manifest["required_capabilities"]
+        if requirement["component"] == component
+    }
+
+
+def check_command_surfaces(
+    manifest: dict[str, Any],
+    component: str,
+    executable: str,
+    closure: set[str],
+) -> None:
+    for argv, tokens in sorted(command_surfaces(manifest, component, closure).items()):
+        require_tokens(
+            run(executable, *argv),
+            f"{component} {' '.join(argv)}",
+            tokens,
+        )
+
+
+def nested_features(payload: dict[str, Any], owner: str) -> set[str]:
+    try:
+        features = payload[owner]["features"]
+    except (KeyError, TypeError) as error:
+        raise CheckFailure(f"{owner}.features is absent from capabilities") from error
+    if not isinstance(features, dict):
+        raise CheckFailure(f"{owner}.features is not an object")
+    return {name for name, enabled in features.items() if enabled is True}
+
+
+def ledger_features(payload: dict[str, Any]) -> set[str]:
+    features = payload.get("features")
+    if not isinstance(features, list) or not all(
+        isinstance(feature, str) for feature in features
+    ):
+        raise CheckFailure("Ledger capabilities features is not a string array")
+    return set(features)
+
+
+def required_features(closure: set[str], requirements: dict[str, set[str]]) -> set[str]:
+    return set().union(
+        *(requirements.get(mode, set()) for mode in closure),
+    )
+
+
+def requires_historical_profile_fd(closure: set[str]) -> bool:
+    return HISTORICAL_CASE_BLIND_MODE in closure
+
+
+def check_feature_set(label: str, available: set[str], required: set[str]) -> None:
+    missing = sorted(required - available)
+    if missing:
+        raise CheckFailure(f"{label} capabilities are missing: {', '.join(missing)}")
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as source:
+        for chunk in iter(lambda: source.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return f"sha256:{digest.hexdigest()}"
+
+
+def validate_fingerprint(value: str, label: str) -> None:
+    if len(value) != 71 or not value.startswith("sha256:"):
+        raise CheckFailure(f"{label} must be sha256:<64 lowercase hex>")
+    try:
+        int(value[7:], 16)
+    except ValueError as error:
+        raise CheckFailure(f"{label} must be sha256:<64 lowercase hex>") from error
+    if value != value.lower():
+        raise CheckFailure(f"{label} must be sha256:<64 lowercase hex>")
+
+
+def check_sealed_broker(args: argparse.Namespace) -> dict[str, Any]:
+    if not args.sealed_broker:
+        raise CheckFailure(
+            "sealed-trial requires --sealed-broker; no installed test driver is inferred"
+        )
+    if (
+        not args.sealed_broker_sha256
+        or not args.sealed_broker_contract
+        or not args.sealed_broker_contract_sha256
+    ):
+        raise CheckFailure(
+            "sealed-trial requires broker binary and contract artifacts with commitments"
+        )
+    validate_fingerprint(args.sealed_broker_sha256, "broker binary commitment")
+    validate_fingerprint(
+        args.sealed_broker_contract_sha256, "broker contract commitment"
+    )
+    executable = resolve_executable(args.sealed_broker)
+    actual = sha256_file(Path(executable))
+    if actual != args.sealed_broker_sha256:
+        raise CheckFailure(
+            f"sealed broker fingerprint mismatch: expected {args.sealed_broker_sha256}, got {actual}"
+        )
+    contract_path = Path(args.sealed_broker_contract).expanduser().resolve(strict=True)
+    if not contract_path.is_file():
+        raise CheckFailure(f"sealed broker contract is not a file: {contract_path}")
+    actual_contract = sha256_file(contract_path)
+    if actual_contract != args.sealed_broker_contract_sha256:
+        raise CheckFailure(
+            "sealed broker contract fingerprint mismatch: "
+            f"expected {args.sealed_broker_contract_sha256}, got {actual_contract}"
+        )
+    return {
+        "configured": True,
+        "commitments_verified": True,
+        "admitted": False,
+        "executable": executable,
+        "binary_fingerprint": actual,
+        "contract": str(contract_path),
+        "contract_fingerprint": actual_contract,
+        "os_confinement": False,
+    }
+
+
+def require_sealed_broker_admission(_: dict[str, Any]) -> None:
+    raise CheckFailure(
+        "matching caller-provided broker commitments do not establish broker "
+        "admission; no released native broker-admission validator or capability "
+        "is available"
+    )
+
+
+def project_mode(mode: str, source_route: str | None) -> tuple[set[str], str | None]:
+    if source_route is not None and mode not in {
+        "case-blind-trial",
+        "sealed-trial",
+    }:
+        raise CheckFailure(
+            "--source-route is valid only for case-blind-trial or sealed-trial"
+        )
+    closure = set(MODE_CLOSURE[mode])
+    if mode == "operator":
+        selected_route = "direct+historical_decision"
+    elif mode == "historical-trial":
+        selected_route = "historical_decision"
+    elif mode == "open-direct-trial":
+        selected_route = "direct"
+    elif mode in {"case-blind-trial", "sealed-trial"}:
+        selected_route = source_route or "direct"
+        if selected_route == "historical_decision":
+            closure.add("historical-trial")
+            closure.add(HISTORICAL_CASE_BLIND_MODE)
+    else:
+        selected_route = None
+    return closure, selected_route
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        closure, selected_route = project_mode(args.mode, args.source_route)
+        manifest = load_surface_manifest(args.surface_manifest)
+    except CheckFailure as error:
+        print(str(error), file=sys.stderr)
+        return 2
+    report: dict[str, Any] = {
+        "schema": "hylo-operator-surface-check/v1",
+        "mode": args.mode,
+        "source_route": selected_route,
+        "ready": False,
+        "checked_components": [],
+        "components": {},
+        "surface_manifest": {
+            "schema": manifest["schema"],
+            "path": manifest["path"],
+            "fingerprint": manifest["fingerprint"],
+        },
+        "sealed_broker": {
+            "admitted": False,
+            "inferred_from_installed_driver": False,
+        },
+    }
+
+    try:
+        needs_seq = bool(
+            closure
+            & {
+                "extract",
+                "source-selection",
+                "historical-trial",
+                "case-blind-trial",
+            }
+        )
+        needs_hylo_ledger = bool(
+            closure & {"open-direct-trial", "historical-trial", "proof-export"}
+        )
+        needs_cas = bool(
+            closure & {"open-direct-trial", "historical-trial", "case-blind-trial"}
+        )
+
+        ledger: str | None = None
+        if "validate" in closure:
+            ledger = resolve_executable(args.ledger)
+            check_command_surfaces(manifest, "ledger-validator", ledger, closure)
+            validate_help = run(ledger, "validate", "--help")
+            require_tokens(
+                validate_help,
+                "ledger validate help",
+                {"--input FILE|-"},
+            )
+            validator_commands = command_tokens(
+                manifest, "ledger-validator", closure
+            )
+            validator_commands.discard("ledger validate")
+            report["checked_components"].append("ledger-validator")
+            report["components"]["ledger-validator"] = {
+                "path": ledger,
+                "version": run(ledger, "--version").strip(),
+                "contracts": sorted(validator_commands),
+            }
+
+        if needs_seq:
+            seq = resolve_executable(args.seq)
+            seq_caps = load_json(
+                run(seq, "capabilities", "--format", "json"), "Seq capabilities"
+            )
+            seq_available = nested_features(seq_caps, "seq_capabilities")
+            required = required_features(
+                closure, feature_requirements_by_mode(manifest, "seq")
+            )
+            check_feature_set("Seq", seq_available, required)
+            check_command_surfaces(manifest, "seq", seq, closure)
+            if "extract" in closure:
+                require_tokens(
+                    run(seq, "hylo-extract", "--help"),
+                    "seq hylo-extract help",
+                    {
+                        "--root DIR",
+                        "--session-id ID",
+                        "--turn-index N",
+                        "--target-skill NAME",
+                        "--target-root DIR",
+                        "--context-policy dependency-closed",
+                        "--capture-world",
+                        "--output-root DIR",
+                        "--sealed-root DIR",
+                        "--seal-key-output-fd N",
+                    },
+                )
+            if closure & {"source-selection", "case-blind-trial"}:
+                hctp_help = run(seq, "hctp-source", "--help")
+                hctp_tokens = {
+                    "--manifest FILE",
+                    "--manifest-fd N",
+                    "--source-signing-seed-fd N",
+                    "--trial FILE",
+                }
+                if "case-blind-trial" in closure:
+                    hctp_tokens.update(
+                        {
+                            "--sealed-dir DIR",
+                            "--seal-key-output-fd N",
+                            "--seal-key-fd N",
+                            "--visible-output-fd N",
+                            "--source-selection-opening-fd N",
+                            "hylo-source-selection-opening/v1",
+                            "--signing-seed-fd N",
+                        }
+                    )
+                    if "historical-trial" in closure:
+                        hctp_tokens.add("--source-profile-output-fd N")
+                require_tokens(hctp_help, "seq hctp-source help", hctp_tokens)
+            report["checked_components"].append("seq")
+            report["components"]["seq"] = {
+                "path": seq,
+                "version": run(seq, "--version").strip(),
+                "required_features": sorted(required),
+            }
+
+        if needs_hylo_ledger:
+            ledger = ledger or resolve_executable(args.ledger)
+            hylo_help = run(ledger, "--source", "hylo", "--help")
+            hylo_caps = ledger_features(
+                load_json(
+                    run(ledger, "--source", "hylo", "capabilities"),
+                    "Ledger Hylo capabilities",
+                )
+            )
+            check_feature_set(
+                "Ledger Hylo",
+                hylo_caps,
+                required_features(
+                    closure,
+                    feature_requirements_by_mode(manifest, "ledger-hylo"),
+                ),
+            )
+            check_command_surfaces(manifest, "ledger-hylo", ledger, closure)
+            required_commands = command_tokens(manifest, "ledger-hylo", closure)
+            required_commands.discard("capabilities")
+            if "open-direct-trial" in closure:
+                require_tokens(
+                    hylo_help,
+                    "Ledger Hylo protected-FD help",
+                    {
+                        "--custody-output-fd N",
+                        "--custody-input-fd N",
+                        "--lease-input-fd N",
+                        "--materialization-output-fd N",
+                        "--reveal-material-fd N",
+                        "--materialization-receipt FILE",
+                    },
+                )
+            report["checked_components"].append("ledger-hylo")
+            report["components"]["ledger-hylo"] = {
+                "path": ledger,
+                "version": run(ledger, "--version").strip(),
+                "required_commands": sorted(required_commands),
+                "required_features": sorted(
+                    required_features(
+                        closure,
+                        feature_requirements_by_mode(manifest, "ledger-hylo"),
+                    )
+                ),
+            }
+
+        if needs_cas:
+            cas = resolve_executable(args.cas)
+            cas_caps = nested_features(
+                load_json(run(cas, "capabilities", "--json"), "CAS capabilities"),
+                "cas_capabilities",
+            )
+            cas_requirements = feature_requirements_by_mode(manifest, "cas")
+            check_feature_set(
+                "CAS", cas_caps, required_features(closure, cas_requirements)
+            )
+            check_command_surfaces(manifest, "cas", cas, closure)
+            trial_help = run(cas, "trial", "--help")
+            trial_tokens = {
+                "--lease-fd N",
+                "--input-fd N",
+                "--materialization-fd N",
+            }
+            if requires_historical_profile_fd(closure):
+                trial_tokens.add("--source-profile-fd N")
+            require_tokens(trial_help, "CAS trial help", trial_tokens)
+            report["checked_components"].append("cas")
+            report["components"]["cas"] = {
+                "path": cas,
+                "version": run(cas, "--version").strip(),
+                "required_commands": sorted(
+                    command_tokens(manifest, "cas", closure)
+                    - {"capabilities", "trial"}
+                ),
+                "required_features": sorted(
+                    required_features(closure, cas_requirements)
+                ),
+                "route_projection_fields": sorted(CAS_PREFLIGHT_FIELDS),
+            }
+
+        if "sealed-trial" in closure:
+            report["sealed_broker"] = check_sealed_broker(args)
+            require_sealed_broker_admission(report["sealed_broker"])
+
+        report["ready"] = True
+    except (CheckFailure, OSError) as error:
+        report["error"] = str(error)
+
+    if args.json_output:
+        print(json.dumps(report, indent=2, sort_keys=True))
+    elif report["ready"]:
+        checked = ", ".join(report["checked_components"])
+        print(f"Hylo operator surface: PASS ({args.mode}; {checked})")
+    else:
+        print(f"Hylo operator surface: BLOCKED ({report['error']})", file=sys.stderr)
+    return 0 if report["ready"] else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/codex/skills/hylo/tests/test_operator_recipe_contract.py
+++ b/codex/skills/hylo/tests/test_operator_recipe_contract.py
@@ -463,6 +463,20 @@ class HyloOperatorRecipeContractTests(unittest.TestCase):
         recipe_step = workflow.index("Execute pinned native operator recipe")
         self.assertLess(recipe_step, workflow.index("Verify documentation contract"))
 
+    def test_operator_contract_binds_the_exact_candidate_tuple(self) -> None:
+        workflow = read(OPERATOR_CONTRACT_WORKFLOW)
+        self.assertIn("name: Hylo candidate operator contract", workflow)
+        self.assertIn("ref: ${{ github.event.pull_request.head.sha }}", workflow)
+        self.assertIn(
+            'test "$dotfiles_commit" = "${{ github.event.pull_request.head.sha }}"',
+            workflow,
+        )
+        self.assertIn(
+            'test "$native_commit" = "${{ steps.native-surface.outputs.commit }}"',
+            workflow,
+        )
+        self.assertNotIn("ref: main", workflow)
+
     def test_registration_order_matches_the_native_transition_graph(self) -> None:
         section = markdown_section(self.orchestration, "Registration order")
         ordered_markers = (

--- a/codex/skills/hylo/tests/test_operator_recipe_contract.py
+++ b/codex/skills/hylo/tests/test_operator_recipe_contract.py
@@ -1,0 +1,1105 @@
+#!/usr/bin/env -S uv run python
+from __future__ import annotations
+
+import copy
+import json
+import os
+import re
+import runpy
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SKILL = ROOT / "SKILL.md"
+ORCHESTRATION = ROOT / "references" / "orchestration.md"
+CONTRACTS = ROOT / "references" / "contracts.md"
+GRADING = ROOT / "references" / "grading-and-progression.md"
+SURFACE_CHECKER = ROOT / "scripts" / "check-operator-surface"
+NATIVE_SURFACE_LOCK = ROOT / "native-surface.lock.json"
+OPERATOR_CONTRACT_WORKFLOW = ROOT.parents[2] / ".github" / "workflows" / "hylo-operator-contract.yml"
+SURFACE_MANIFEST_ENV = "HYLO_OPERATOR_SURFACE_MANIFEST"
+NATIVE_SURFACE_LOCK_SCHEMA = "hylo-native-surface-lock/v1"
+EXPECTED_ROUTE_SCHEMA = "hylo-operator-recipe-expectation/v1"
+EXPECTED_ROUTE_SEMANTIC_KEYS = (
+    "trial_boundary",
+    "execution_authorities",
+    "routes",
+    "allocation",
+    "sealed_product_boundary",
+    "candidate_lifecycle",
+)
+SHARED_VERSION_PROBES = frozenset(
+    {
+        "cas --version",
+        "ledger --version",
+        "seq --version",
+    }
+)
+ALLOWED_OWNER_SURFACE_PROBES = SHARED_VERSION_PROBES | {
+    "ledger --source hylo --help",
+}
+SUPPORTING_OWNER_SECTIONS = (
+    (ROOT.parent / "seq" / "SKILL.md", "Hylo CRF/HCTP product surface"),
+    (ROOT.parent / "cas" / "SKILL.md", "HCTP trial execution"),
+    (ROOT.parent / "ledger" / "SKILL.md", "Hylo CRF/HCTP authority"),
+    (ROOT.parent / "retrace" / "SKILL.md", "HCTP historical lane bridge"),
+)
+
+
+def read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def markdown_section(text: str, heading: str) -> str:
+    heading_match = re.search(
+        rf"^(?P<marks>#{{2,6}})\s+{re.escape(heading)}\s*$",
+        text,
+        flags=re.MULTILINE,
+    )
+    if heading_match is None:
+        raise ValueError(f"missing Markdown section: {heading}")
+    level = len(heading_match.group("marks"))
+    start = heading_match.end()
+    next_heading = re.search(rf"^#{{1,{level}}}\s+", text[start:], flags=re.MULTILINE)
+    end = start + next_heading.start() if next_heading else len(text)
+    return text[start:end]
+
+
+def shell_blocks(text: str) -> str:
+    return "\n".join(
+        match.group("body")
+        for match in re.finditer(
+            r"^```(?:bash|sh|shell|zsh)\s*$\n(?P<body>.*?)^```\s*$",
+            text,
+            flags=re.MULTILINE | re.DOTALL,
+        )
+    )
+
+
+def shell_command_identity(line: str) -> str | None:
+    tokens = line.strip().removesuffix("\\").split()
+    if not tokens or tokens[0] not in {"cas", "ledger", "seq"}:
+        return None
+
+    component = tokens[0]
+    if len(tokens) == 1:
+        return component
+    if tokens[1] == "--version":
+        return f"{component} --version"
+
+    if component == "ledger":
+        if tokens[1:3] == ["--source", "hylo"]:
+            return " ".join(tokens[:4])
+        if tokens[1] == "validate" and len(tokens) >= 3:
+            return " ".join(tokens[:3])
+        return " ".join(tokens[:2])
+
+    if component == "seq" and tokens[1] == "hctp-source" and len(tokens) >= 3:
+        return " ".join(tokens[:3])
+    if component == "cas" and tokens[1] == "trial" and len(tokens) >= 3:
+        return " ".join(tokens[:3])
+    return " ".join(tokens[:2])
+
+
+def documented_shell_command_inventory(
+    text: str,
+) -> tuple[set[str], set[str]]:
+    commands: set[str] = set()
+    shared_probes: set[str] = set()
+    for line in shell_blocks(text).splitlines():
+        identity = shell_command_identity(line)
+        if identity is None:
+            continue
+        if identity in SHARED_VERSION_PROBES:
+            shared_probes.add(identity)
+        else:
+            commands.add(identity)
+    return commands, shared_probes
+
+
+def command_component(identity: str) -> str | None:
+    if identity.startswith("ledger --source hylo "):
+        return "ledger-hylo"
+    if identity == "ledger validate" or identity.startswith("ledger validate "):
+        return "ledger-validator"
+    if identity == "seq" or identity.startswith("seq "):
+        return "seq"
+    if identity == "cas" or identity.startswith("cas "):
+        return "cas"
+    return None
+
+
+def documented_owner_command_inventory(
+    texts: tuple[str, ...],
+) -> tuple[dict[str, set[str]], set[str]]:
+    commands: dict[str, set[str]] = {}
+    probes: set[str] = set()
+    for text in texts:
+        for line in shell_blocks(text).splitlines():
+            identity = shell_command_identity(line)
+            if identity is None:
+                continue
+            if identity in ALLOWED_OWNER_SURFACE_PROBES:
+                probes.add(identity)
+                continue
+            component = command_component(identity)
+            if component is None:
+                continue
+            commands.setdefault(component, set()).add(identity)
+    return commands, probes
+
+
+def native_recipe_bindings(orchestration: str) -> tuple[tuple[str, str], ...]:
+    section = markdown_section(orchestration, "Native operator-recipe binding")
+    bindings: list[tuple[str, str]] = []
+    for line in section.splitlines():
+        cells = [cell.strip() for cell in line.strip().split("|")[1:-1]]
+        if len(cells) != 2 or not all(
+            len(cell) >= 2 and cell.startswith("`") and cell.endswith("`")
+            for cell in cells
+        ):
+            continue
+        bindings.append((cells[0][1:-1], cells[1][1:-1]))
+    return tuple(bindings)
+
+
+def native_recipe_semantic_binding(orchestration: str) -> dict[str, object]:
+    section = markdown_section(orchestration, "Native semantic binding")
+    blocks = re.findall(
+        r"^```json\s*$\n(?P<body>.*?)^```\s*$",
+        section,
+        flags=re.MULTILINE | re.DOTALL,
+    )
+    if len(blocks) != 1:
+        raise ValueError("Native semantic binding must contain exactly one JSON block")
+    payload = json.loads(blocks[0])
+    if not isinstance(payload, dict):
+        raise ValueError("Native semantic binding JSON must contain an object")
+    return payload
+
+
+def flatten_json(
+    value: object, prefix: tuple[str, ...] = ()
+) -> dict[str, tuple[str, object]]:
+    path = ".".join(prefix) if prefix else "$"
+    flattened: dict[str, tuple[str, object]] = {}
+    if isinstance(value, dict):
+        flattened[path] = ("object", len(value))
+        for key in sorted(value):
+            flattened.update(flatten_json(value[key], (*prefix, key)))
+    elif isinstance(value, list):
+        flattened[path] = ("array", len(value))
+        for index, item in enumerate(value):
+            flattened.update(flatten_json(item, (*prefix, f"[{index}]")))
+    else:
+        flattened[path] = (type(value).__name__, value)
+    return flattened
+
+
+def validate_native_semantic_binding(
+    expected_route: dict[str, object], documented: dict[str, object]
+) -> None:
+    expected_top_level = {
+        "schema",
+        "portable_sequence",
+        *EXPECTED_ROUTE_SEMANTIC_KEYS,
+    }
+    if set(expected_route) != expected_top_level:
+        raise ValueError(
+            "pinned expected route has an unbound or missing top-level semantic object"
+        )
+    if set(documented) != set(EXPECTED_ROUTE_SEMANTIC_KEYS):
+        raise ValueError(
+            "documented semantic binding must contain every pinned semantic object"
+        )
+
+    expected = {
+        key: expected_route[key] for key in EXPECTED_ROUTE_SEMANTIC_KEYS
+    }
+    expected_flat = flatten_json(expected)
+    documented_flat = flatten_json(documented)
+    if documented_flat == expected_flat:
+        return
+
+    changed_paths = sorted(
+        path
+        for path in set(expected_flat) | set(documented_flat)
+        if expected_flat.get(path) != documented_flat.get(path)
+    )
+    raise ValueError(
+        "documented semantic binding does not exactly match the pinned native route: "
+        + ", ".join(changed_paths)
+    )
+
+
+def load_expected_route(surface_manifest: dict[str, object]) -> dict[str, object]:
+    path = Path(str(surface_manifest["path"])).with_name("expected-route.json")
+    payload = json.loads(read(path))
+    if not isinstance(payload, dict):
+        raise ValueError("pinned expected-route.json must contain an object")
+    return {
+        "path": str(path.resolve(strict=True)),
+        "payload": payload,
+    }
+
+
+def validate_native_recipe_binding(
+    expected_route: dict[str, object],
+    bindings: tuple[tuple[str, str], ...],
+    surface_manifest: dict[str, object],
+) -> None:
+    if expected_route.get("schema") != EXPECTED_ROUTE_SCHEMA:
+        raise ValueError(f"expected route schema must be {EXPECTED_ROUTE_SCHEMA}")
+    expected_steps = expected_route.get("portable_sequence")
+    if not isinstance(expected_steps, list) or not all(
+        isinstance(step, str) and step for step in expected_steps
+    ):
+        raise ValueError("expected route portable_sequence must be a string array")
+    documented_steps = [step for step, _ in bindings]
+    if documented_steps != expected_steps:
+        raise ValueError(
+            "documented recipe steps do not exactly match the pinned portable sequence"
+        )
+
+    command_owners: dict[str, str] = {}
+    for command in surface_manifest["commands"]:
+        identity = command["documented_command"]
+        owner = command["component"]
+        prior = command_owners.setdefault(identity, owner)
+        if prior != owner:
+            raise ValueError(f"manifest command has multiple owners: {identity}")
+    for step, identity in bindings:
+        documented_owner = command_component(identity)
+        manifest_owner = command_owners.get(identity)
+        if documented_owner is None or manifest_owner != documented_owner:
+            raise ValueError(
+                f"recipe step {step} uses an unmanifested owner command: {identity}"
+            )
+
+
+class HyloOperatorRecipeContractTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.skill = read(SKILL)
+        cls.orchestration = read(ORCHESTRATION)
+        cls.contracts = read(CONTRACTS)
+        cls.grading = read(GRADING)
+        cls.documentation = "\n".join(
+            (cls.skill, cls.orchestration, cls.contracts, cls.grading)
+        )
+        cls.supporting_owner_documentation = tuple(
+            markdown_section(read(path), heading)
+            for path, heading in SUPPORTING_OWNER_SECTIONS
+        )
+        cls.checker = runpy.run_path(str(SURFACE_CHECKER))
+        manifest_path = os.environ.get(SURFACE_MANIFEST_ENV)
+        cls.surface_manifest = (
+            cls.checker["load_surface_manifest"](manifest_path)
+            if manifest_path
+            else None
+        )
+        cls.expected_route = (
+            load_expected_route(cls.surface_manifest)
+            if cls.surface_manifest is not None
+            else None
+        )
+
+    def require_surface_manifest(self) -> dict[str, object]:
+        if self.surface_manifest is None:
+            self.skipTest(
+                f"set {SURFACE_MANIFEST_ENV} to the pinned skills-zig manifest"
+            )
+        return self.surface_manifest
+
+    def require_expected_route(self) -> dict[str, object]:
+        if self.expected_route is None:
+            self.skipTest(
+                f"set {SURFACE_MANIFEST_ENV} to the pinned skills-zig manifest"
+            )
+        return self.expected_route
+
+    def test_operator_route_has_stable_owner_sections(self) -> None:
+        for heading in (
+            "Execution graph",
+            "Native operator-recipe binding",
+            "Source route table",
+            "Registration order",
+            "Lane execution",
+            "Allocation and chronology",
+            "Sealed assurance",
+            "Candidate lifecycle",
+        ):
+            with self.subTest(heading=heading):
+                self.assertRegex(
+                    self.orchestration,
+                    rf"(?m)^#{{2,3}}\s+{re.escape(heading)}\s*$",
+                )
+
+        for heading in (
+            "Mode-sensitive capability gate",
+            "Candidate lifecycle",
+            "Workflow",
+        ):
+            with self.subTest(heading=heading):
+                self.assertIn(f"## {heading}", self.skill)
+
+    def test_checker_uses_the_pinned_manifest_and_keeps_binary_overrides(self) -> None:
+        manifest = self.require_surface_manifest()
+        self.assertEqual("hylo-operator-surface-manifest/v1", manifest["schema"])
+        self.assertTrue(manifest["commands"])
+        self.assertTrue(manifest["required_capabilities"])
+        self.assertNotIn(
+            "hctp-sealed-role-driver",
+            "\n".join(
+                command["documented_command"] for command in manifest["commands"]
+            ),
+        )
+
+        checker_source = read(SURFACE_CHECKER)
+        self.assertIn("--surface-manifest", checker_source)
+        self.assertIn("HYLO_OPERATOR_SURFACE_MANIFEST", checker_source)
+        for binary_flag in ("--seq", "--ledger", "--cas"):
+            with self.subTest(binary_flag=binary_flag):
+                self.assertIn(binary_flag, checker_source)
+        for retired_inventory in (
+            "SEQ_FEATURES =",
+            "LEDGER_FEATURES =",
+            "CAS_FEATURES =",
+            "LEDGER_TRIAL_COMMANDS =",
+            "LEDGER_VALIDATE_CONTRACTS =",
+            "CAS_OPERATOR_TRIAL_COMMANDS =",
+        ):
+            with self.subTest(retired_inventory=retired_inventory):
+                self.assertNotIn(retired_inventory, checker_source)
+
+    def test_native_surface_lock_is_an_exact_immutable_source_address(self) -> None:
+        lock = json.loads(read(NATIVE_SURFACE_LOCK))
+        self.assertEqual(
+            {"schema", "repository", "commit"},
+            set(lock),
+        )
+        self.assertEqual(NATIVE_SURFACE_LOCK_SCHEMA, lock["schema"])
+        self.assertEqual("tkersey/skills-zig", lock["repository"])
+        self.assertRegex(lock["commit"], r"\A[0-9a-f]{40}\Z")
+
+    def test_documentation_projects_the_exact_pinned_native_recipe(self) -> None:
+        manifest = self.require_surface_manifest()
+        expected = self.require_expected_route()
+        expected_path = Path(str(manifest["path"])).with_name("expected-route.json")
+        self.assertEqual(expected_path.resolve(strict=True), Path(expected["path"]))
+
+        bindings = native_recipe_bindings(self.orchestration)
+        self.assertTrue(bindings)
+        validate_native_recipe_binding(expected["payload"], bindings, manifest)
+        semantic_binding = native_recipe_semantic_binding(self.orchestration)
+        validate_native_semantic_binding(expected["payload"], semantic_binding)
+
+    def test_native_recipe_binding_rejects_sequence_and_owner_drift(self) -> None:
+        manifest = self.require_surface_manifest()
+        expected = self.require_expected_route()["payload"]
+        bindings = native_recipe_bindings(self.orchestration)
+        sequence = list(expected["portable_sequence"])
+
+        sequence_variants = {
+            "missing": sequence[:-1],
+            "added": sequence + ["unreleased_step"],
+            "reordered": [sequence[1], sequence[0], *sequence[2:]],
+        }
+        for label, variant in sequence_variants.items():
+            changed = dict(expected)
+            changed["portable_sequence"] = variant
+            with self.subTest(label=label), self.assertRaisesRegex(
+                ValueError, "do not exactly match"
+            ):
+                validate_native_recipe_binding(changed, bindings, manifest)
+
+        unmanifested = list(bindings)
+        unmanifested[0] = (unmanifested[0][0], "seq unreleased-command")
+        with self.assertRaisesRegex(ValueError, "unmanifested owner command"):
+            validate_native_recipe_binding(expected, tuple(unmanifested), manifest)
+
+    def test_native_semantic_binding_rejects_each_object_drift(self) -> None:
+        expected = self.require_expected_route()["payload"]
+        documented = native_recipe_semantic_binding(self.orchestration)
+        flattened = flatten_json(documented)
+        self.assertGreater(len(flattened), len(EXPECTED_ROUTE_SEMANTIC_KEYS))
+
+        for semantic_key in EXPECTED_ROUTE_SEMANTIC_KEYS:
+            changed = copy.deepcopy(expected)
+            changed[semantic_key] = {"deliberate_drift": True}
+            with self.subTest(semantic_key=semantic_key), self.assertRaisesRegex(
+                ValueError, "does not exactly match"
+            ):
+                validate_native_semantic_binding(changed, documented)
+
+        diagnostic = documented["routes"]["diagnostic_only"]
+        self.assertFalse(diagnostic["registration_allowed"])
+        self.assertIn(
+            "trial compilation, registration, and comparison execution forbidden",
+            self.documentation,
+        )
+
+    def test_operator_contract_actions_are_immutable_full_sha_pins(self) -> None:
+        workflow = read(OPERATOR_CONTRACT_WORKFLOW)
+        action_refs = re.findall(r"(?m)^\s*uses:\s*([^\s#]+)", workflow)
+        self.assertTrue(action_refs)
+        for action_ref in action_refs:
+            with self.subTest(action_ref=action_ref):
+                self.assertRegex(action_ref, r"\A[^@\s]+@[0-9a-f]{40}\Z")
+
+    def test_operator_contract_executes_the_pinned_native_recipe_lanes(self) -> None:
+        workflow = read(OPERATOR_CONTRACT_WORKFLOW)
+        self.assertIn("permissions:\n  contents: read", workflow)
+        self.assertGreaterEqual(workflow.count("persist-credentials: false"), 2)
+        portable = "test-hylo-operator-recipe"
+        executable = "test-hylo-operator-recipe-executable"
+        self.assertIn(portable, workflow)
+        self.assertIn(executable, workflow)
+        recipe_step = workflow.index("Execute pinned native operator recipe")
+        self.assertLess(recipe_step, workflow.index("Verify documentation contract"))
+
+    def test_registration_order_matches_the_native_transition_graph(self) -> None:
+        section = markdown_section(self.orchestration, "Registration order")
+        ordered_markers = (
+            "campaign_created",
+            "target_bundle_admitted",
+            "scenario_admitted",
+            "owner-applied change",
+            "doctor and inspect admission state",
+            "compile trial",
+            "validate trial",
+            "source-validate completed trial",
+            "register trial",
+        )
+        positions = []
+        for marker in ordered_markers:
+            with self.subTest(marker=marker):
+                self.assertIn(marker, section)
+            positions.append(section.index(marker))
+        self.assertEqual(sorted(positions), positions)
+
+        self.assertIn("A trial is additive to an admitted campaign", self.documentation)
+
+    def test_lane_source_materialization_precedes_start_and_private_treatment(self) -> None:
+        for heading in ("Direct lane", "Historical lane"):
+            section = markdown_section(self.orchestration, heading)
+            with self.subTest(heading=heading):
+                self.assertLess(
+                    section.index("materialize the exact visible input"),
+                    section.index("start-lane or commit-lane-start"),
+                )
+                self.assertLess(
+                    section.index("start-lane or commit-lane-start"),
+                    section.index("materialize the selected treatment"),
+                )
+                self.assertLess(
+                    section.index("materialize the selected treatment"),
+                    section.index("cas trial run"),
+                )
+
+    def test_direct_and_historical_routes_are_distinct(self) -> None:
+        route_table = markdown_section(self.orchestration, "Source route table")
+        direct_lane = markdown_section(self.orchestration, "Direct lane")
+        historical_lane = markdown_section(self.orchestration, "Historical lane")
+        for marker in (
+            'source_profile.kind == "direct"',
+            'source_profile.kind == "historical_decision"',
+            "replay_eligible:false",
+        ):
+            with self.subTest(marker=marker):
+                self.assertIn(marker, route_table)
+
+        normalized_direct = " ".join(direct_lane.split()).lower()
+        self.assertRegex(
+            normalized_direct,
+            r"compile-replay.{0,100}(?:skip|forbid|must not|forbidden)",
+        )
+        normalized_historical = " ".join(historical_lane.split()).lower()
+        self.assertRegex(
+            normalized_historical,
+            r"cas.{0,180}(?:dcp/rip|replay).{0,120}(?:internal|internally)",
+        )
+        normalized_route = " ".join(route_table.split()).lower()
+        self.assertRegex(
+            normalized_route,
+            r"replay_eligible:false.{0,300}diagnostic_only.{0,120}(?:forbid|forbidden)",
+        )
+        self.assertIn("never upgraded by changing its label", normalized_route)
+
+    def test_preflight_projection_uses_canonical_field_names(self) -> None:
+        checker = runpy.run_path(str(SURFACE_CHECKER))
+        expected = {
+            "source_profile_kind",
+            "compile_replay_required",
+            "replay_preparation_mode",
+            "source_profile_body_delivery",
+            "execution_route",
+            "required_lineage",
+        }
+        self.assertEqual(expected, checker["CAS_PREFLIGHT_FIELDS"])
+        cas_skill = read(ROOT.parent / "cas" / "SKILL.md")
+        for field in expected:
+            with self.subTest(field=field):
+                self.assertIn(field, self.documentation)
+                self.assertIn(field, cas_skill)
+        for retired in ("source_kind", "historical_replay_required"):
+            with self.subTest(retired=retired):
+                self.assertNotIn(retired, self.documentation)
+                self.assertNotIn(retired, cas_skill)
+
+    def test_replay_preparation_is_integrated_and_not_an_operator_step(self) -> None:
+        manifest = self.require_surface_manifest()
+        closure, _ = self.checker["project_mode"]("open-direct-trial", None)
+        operator_commands = self.checker["command_tokens"](
+            manifest, "cas", closure
+        ) - {"capabilities", "trial"}
+        self.assertNotIn("compile-replay", operator_commands)
+        self.assertEqual(
+            {"preflight", "run", "status", "cleanup"}, operator_commands
+        )
+
+        cas_skill = read(ROOT.parent / "cas" / "SKILL.md")
+        supporting = "\n".join(
+            (
+                self.documentation,
+                cas_skill,
+                read(ROOT.parent / "seq" / "SKILL.md"),
+                read(ROOT.parent / "ledger" / "SKILL.md"),
+                read(ROOT.parent / "retrace" / "SKILL.md"),
+            )
+        )
+        normalized = " ".join(supporting.split())
+        for marker in (
+            'compile_replay_required:false',
+            'replay_preparation_mode:"none"',
+            'replay_preparation_mode:"integrated_run"',
+            "execution_authority:false",
+            "--source-profile-fd",
+        ):
+            with self.subTest(marker=marker):
+                self.assertIn(marker, normalized)
+        self.assertNotIn("compile_replay_required:true", normalized)
+        self.assertRegex(
+            normalized,
+            r"run.{0,100}(?:consumes neither|does not consume).{0,120}(?:receipt|dcp/rip)",
+        )
+        self.assertRegex(
+            normalized,
+            r"protected.{0,120}directly.{0,80}cas trial run --source-profile-fd",
+        )
+
+    def test_source_receipt_validation_follows_trial_construction(self) -> None:
+        section = markdown_section(
+            self.orchestration, "Phase 6 — Compile and register the trial"
+        )
+        self.assertIn("--custody-output-fd", section)
+        self.assertIn("hylo-trial-build-receipt/v2", section)
+        self.assertIn("custody_material_delivered:true", section)
+        self.assertLess(section.index("compile-trial"), section.index("validate-trial"))
+        self.assertLess(
+            section.index("validate-trial"), section.index("hctp-source validate")
+        )
+        self.assertLess(
+            section.index("hctp-source validate"), section.index("register-trial")
+        )
+        self.assertIn("--custody-input-fd", section)
+
+    def test_private_v2_lane_materialization_precedes_cas_run(self) -> None:
+        section = markdown_section(self.orchestration, "Lane execution")
+        bridge = markdown_section(self.orchestration, "Private treatment bridge")
+        for marker in (
+            "hylo-trial/v2",
+            "lane-materialization",
+            "--custody-input-fd",
+            "--lease-input-fd",
+            "--materialization-output-fd",
+            "--materialization-fd",
+            "hylo-lane-materialization-receipt/v2",
+            "hylo-run-receipt/v2",
+        ):
+            with self.subTest(marker=marker):
+                self.assertIn(marker, bridge)
+        self.assertLess(bridge.index("lane-materialization"), bridge.index("cas trial run"))
+        self.assertIn("treatment_commitment", bridge)
+        self.assertIn("commitment-only", bridge)
+        self.assertIn("--materialization-fd", section)
+
+    def test_private_v2_start_and_case_materialization_use_exact_openings(self) -> None:
+        lane_execution = markdown_section(self.orchestration, "Lane execution")
+        private_bridge = markdown_section(
+            self.orchestration, "Private treatment bridge"
+        )
+        for marker in (
+            "start-lane",
+            "--custody-input-fd",
+            "hylo-source-selection-opening/v1",
+            "--source-selection-opening-fd",
+            "hylo-target-common-projection-opening/v1",
+        ):
+            with self.subTest(marker=marker):
+                self.assertIn(marker, lane_execution + private_bridge)
+
+        seq_skill = read(ROOT.parent / "seq" / "SKILL.md")
+        self.assertIn("--source-selection-opening-fd", seq_skill)
+        self.assertIn("hylo-source-selection-opening/v1", seq_skill)
+        ledger_skill = read(ROOT.parent / "ledger" / "SKILL.md")
+        self.assertIn("start-lane", ledger_skill)
+        self.assertIn("--custody-input-fd", ledger_skill)
+        cas_skill = read(ROOT.parent / "cas" / "SKILL.md")
+        self.assertIn("hylo-target-common-projection-opening/v1", cas_skill)
+
+    def test_private_v2_public_and_custody_carriers_are_explicit(self) -> None:
+        compiler = markdown_section(
+            self.orchestration, "Phase 6 — Compile and register the trial"
+        )
+        reveal = markdown_section(
+            self.orchestration, "Phase 8 — Grade, reveal, and prove"
+        )
+        for marker in (
+            "hylo-trial/v2",
+            "hylo-trial-custody/v1",
+            "artifact:sha256:<64 lowercase hex>",
+        ):
+            with self.subTest(marker=marker):
+                self.assertIn(marker, compiler)
+        self.assertNotIn("hylo-trial-reveal-material/v1", compiler)
+        for marker in (
+            "hylo-trial-reveal/v2",
+            "full source-selection receipt remains custody-only",
+            "excludes private custody",
+        ):
+            with self.subTest(marker=marker):
+                self.assertIn(marker, reveal)
+
+        blinding = markdown_section(self.grading, "Blinding and commitments")
+        for marker in (
+            "full source-selection receipt",
+            "raw before/after target fingerprints",
+            "target common projection",
+            "intervention witness",
+            "treatment opening or materialization body",
+        ):
+            with self.subTest(marker=marker):
+                self.assertIn(marker, blinding)
+
+    def test_reveal_result_close_and_proof_follow_native_lifecycle(self) -> None:
+        phase = markdown_section(
+            self.orchestration, "Phase 8 — Grade, reveal, and prove"
+        )
+        ordered_commands = (
+            "ledger --source hylo reveal-trial",
+            "ledger --source hylo trial-result --repo <repo> "
+            "--trial-id <trial-id> --format json",
+            "ledger --source hylo close-trial --repo <repo> --trial-id <trial-id>",
+            "ledger --source hylo proof-artifact-set",
+        )
+        positions = []
+        for command in ordered_commands:
+            with self.subTest(command=command):
+                self.assertIn(command, phase)
+            positions.append(phase.index(command))
+        self.assertEqual(sorted(positions), positions)
+        self.assertIn("Observe the derived result before closing the trial", phase)
+        self.assertIn("Proof occurs only after `close-trial`", phase)
+
+    def test_v2_source_profile_and_fir_are_safe_public_projections(self) -> None:
+        supporting = "\n".join(
+            read(ROOT.parent / name / "SKILL.md")
+            for name in ("cas", "seq", "ledger", "retrace")
+        )
+        normalized_documentation = " ".join(self.documentation.split())
+        normalized_supporting = " ".join(supporting.split())
+        for marker in (
+            "units[*].source_profile",
+            "exact native safe projection",
+            "hylo-fir-public-projection/v1",
+            "full FIR",
+            "v1",
+        ):
+            with self.subTest(marker=marker):
+                self.assertIn(marker, normalized_documentation)
+                self.assertIn(marker, normalized_supporting)
+        self.assertRegex(
+            " ".join((self.documentation + supporting).split()),
+            r"v1.{0,160}(?:compatible|established).{0,80}full-FIR carrier",
+        )
+
+    def test_documented_native_command_inventory_is_complete(self) -> None:
+        manifest = self.require_surface_manifest()
+        operator_closure, _ = self.checker["project_mode"]("operator", None)
+        manifest_commands = [
+            command
+            for command in manifest["commands"]
+            if operator_closure.intersection(command["modes"])
+        ]
+        self.assertTrue(manifest_commands)
+        for command in manifest_commands:
+            documented = command["documented_command"]
+            help_token = command["help_token"]
+            with self.subTest(command=documented):
+                self.assertTrue(
+                    documented in self.documentation
+                    or help_token in self.documentation,
+                    f"manifest command is not documented: {documented}",
+                )
+
+        examples = shell_blocks(self.documentation)
+        self.assertNotRegex(examples, r"(?m)^\s*cas\s+trial\s+compile-replay\b")
+
+    def test_documented_operator_commands_are_owned_by_the_native_manifest(self) -> None:
+        manifest = self.require_surface_manifest()
+        manifest_by_component: dict[str, set[str]] = {}
+        for command in manifest["commands"]:
+            manifest_by_component.setdefault(command["component"], set()).add(
+                command["documented_command"]
+            )
+
+        documented_by_component, probes = documented_owner_command_inventory(
+            (self.documentation, *self.supporting_owner_documentation)
+        )
+        for _, identity in native_recipe_bindings(self.orchestration):
+            component = command_component(identity)
+            self.assertIsNotNone(component)
+            documented_by_component.setdefault(component, set()).add(identity)
+
+        self.assertEqual(ALLOWED_OWNER_SURFACE_PROBES, probes)
+        for component, documented_commands in sorted(
+            documented_by_component.items()
+        ):
+            missing = sorted(
+                documented_commands - manifest_by_component.get(component, set())
+            )
+            with self.subTest(component=component):
+                self.assertFalse(
+                    missing,
+                    "documented owner commands are absent from the native manifest: "
+                    + ", ".join(missing),
+                )
+
+    def test_reverse_inventory_exposes_an_unmanifested_command(self) -> None:
+        manifest = self.require_surface_manifest()
+        manifest_commands = {
+            command["documented_command"]
+            for command in manifest["commands"]
+            if command["component"] == "ledger-hylo"
+        }
+        documented_by_component, probes = documented_owner_command_inventory(
+            (
+                "```bash\nledger --source hylo unmanifested-command --repo REPO\n```\n",
+            )
+        )
+        self.assertEqual(set(), probes)
+        self.assertEqual(
+            {"ledger --source hylo unmanifested-command"},
+            documented_by_component["ledger-hylo"] - manifest_commands,
+        )
+
+    def test_balanced_allocation_is_not_compatibility_chronology(self) -> None:
+        section = markdown_section(self.orchestration, "Allocation and chronology")
+        normalized = " ".join(section.split()).lower()
+        for marker in ("a/b", "b/a", "either semantic arm", "compatibility"):
+            with self.subTest(marker=marker):
+                self.assertIn(marker, normalized)
+        self.assertRegex(
+            normalized,
+            r"compatibility.{0,500}baseline.{0,180}(?:predate|before).{0,120}candidate",
+        )
+
+    def test_sealed_route_requires_an_admitted_external_broker(self) -> None:
+        section = markdown_section(self.orchestration, "Sealed assurance")
+        normalized = " ".join(section.split()).lower()
+        for marker in (
+            "admitted broker",
+            "hctp-sealed-role-driver",
+            "conformance",
+            "not installed product capability",
+            "os_confinement:false",
+        ):
+            with self.subTest(marker=marker):
+                self.assertIn(marker, normalized)
+
+        # Mentioning the fixture is allowed; presenting it as an executable
+        # command in a shell block is not.
+        driver_invocation = re.compile(r"(?m)^\s*(?:\S*/)?hctp-sealed-role-driver\b")
+        self.assertIsNone(driver_invocation.search(shell_blocks(self.documentation)))
+
+    def test_matching_broker_commitments_do_not_establish_admission(self) -> None:
+        check_sealed_broker = self.checker["check_sealed_broker"]
+        require_admission = self.checker["require_sealed_broker_admission"]
+        sha256_file = self.checker["sha256_file"]
+        check_failure = self.checker["CheckFailure"]
+
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            broker = root / "broker"
+            broker.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+            broker.chmod(0o700)
+            contract = root / "broker-contract.json"
+            contract.write_text('{"schema":"test-only"}\n', encoding="utf-8")
+            args = SimpleNamespace(
+                sealed_broker=str(broker),
+                sealed_broker_sha256=sha256_file(broker),
+                sealed_broker_contract=str(contract),
+                sealed_broker_contract_sha256=sha256_file(contract),
+            )
+
+            evidence = check_sealed_broker(args)
+            self.assertTrue(evidence["configured"])
+            self.assertTrue(evidence["commitments_verified"])
+            self.assertFalse(evidence["admitted"])
+            with self.assertRaisesRegex(
+                check_failure,
+                "matching caller-provided broker commitments do not establish",
+            ):
+                require_admission(evidence)
+
+    def test_candidate_evaluation_and_derivation_are_separate_lifecycles(self) -> None:
+        section = markdown_section(self.orchestration, "Candidate lifecycle")
+        normalized = " ".join(section.split()).lower()
+        for marker in (
+            "evaluate existing candidate",
+            "derive next candidate",
+            "owner",
+            "run",
+            "new evaluation trial",
+        ):
+            with self.subTest(marker=marker):
+                self.assertIn(marker, normalized)
+        self.assertIn("authority_granted:false", self.documentation)
+
+    def test_protected_fd_examples_do_not_use_named_file_redirection(self) -> None:
+        unsafe = re.compile(r"(?m)(?:^|\s)(?:[3-9]|[1-9][0-9]+)(?:>|<)(?![&])")
+        self.assertIsNone(unsafe.search(shell_blocks(self.documentation)))
+
+    def test_live_probe_keeps_case_blinding_orthogonal_to_source_route(self) -> None:
+        manifest = self.require_surface_manifest()
+        project_mode = self.checker["project_mode"]
+        required_features = self.checker["required_features"]
+        requires_historical_profile_fd = self.checker[
+            "requires_historical_profile_fd"
+        ]
+        cas_features = self.checker["feature_requirements_by_mode"](
+            manifest, "cas"
+        )
+        seq_features = self.checker["feature_requirements_by_mode"](
+            manifest, "seq"
+        )
+
+        direct, direct_route = project_mode("case-blind-trial", None)
+        historical, historical_route = project_mode(
+            "case-blind-trial", "historical_decision"
+        )
+        operator, operator_route = project_mode("operator", None)
+        sealed_direct, sealed_direct_route = project_mode("sealed-trial", None)
+        sealed_historical, sealed_historical_route = project_mode(
+            "sealed-trial", "historical_decision"
+        )
+        plain_historical, plain_historical_route = project_mode(
+            "historical-trial", None
+        )
+
+        self.assertEqual("direct", direct_route)
+        self.assertNotIn("historical-trial", direct)
+        self.assertNotIn("historical-case-blind-trial", direct)
+        self.assertEqual("historical_decision", historical_route)
+        self.assertIn("historical-trial", historical)
+        self.assertIn("historical-case-blind-trial", historical)
+        self.assertEqual("direct+historical_decision", operator_route)
+        self.assertIn("historical-trial", operator)
+        self.assertIn("historical-case-blind-trial", operator)
+        self.assertEqual("direct", sealed_direct_route)
+        self.assertNotIn("historical-trial", sealed_direct)
+        self.assertNotIn("historical-case-blind-trial", sealed_direct)
+        self.assertEqual("historical_decision", sealed_historical_route)
+        self.assertIn("historical-trial", sealed_historical)
+        self.assertIn("historical-case-blind-trial", sealed_historical)
+        self.assertEqual("historical_decision", plain_historical_route)
+        self.assertIn("historical-trial", plain_historical)
+        self.assertNotIn("historical-case-blind-trial", plain_historical)
+
+        direct_caps = required_features(direct, cas_features)
+        historical_caps = required_features(historical, cas_features)
+        self.assertNotIn("hylo_internal_historical_replay_v1", direct_caps)
+        self.assertNotIn("dcp_v2", direct_caps)
+        self.assertIn("hylo_internal_historical_replay_v1", historical_caps)
+        self.assertIn("dcp_v2", historical_caps)
+
+        direct_seq_caps = required_features(direct, seq_features)
+        historical_seq_caps = required_features(historical, seq_features)
+        plain_historical_seq_caps = required_features(
+            plain_historical, seq_features
+        )
+        self.assertIn("hctp_source_selection_opening_fd_v1", direct_seq_caps)
+        self.assertNotIn("hctp_historical_profile_v1", direct_seq_caps)
+        self.assertNotIn("hctp_case_blind_source_profile_fd_v1", direct_seq_caps)
+        self.assertIn("hctp_historical_profile_v1", historical_seq_caps)
+        self.assertIn(
+            "hctp_case_blind_source_profile_fd_v1", historical_seq_caps
+        )
+        self.assertIn(
+            "hctp_historical_profile_v1", plain_historical_seq_caps
+        )
+        self.assertNotIn(
+            "hctp_case_blind_source_profile_fd_v1",
+            plain_historical_seq_caps,
+        )
+        self.assertFalse(requires_historical_profile_fd(direct))
+        self.assertTrue(requires_historical_profile_fd(historical))
+        self.assertFalse(requires_historical_profile_fd(plain_historical))
+
+    def test_proof_export_requires_v2_trial_custody_and_proof_capabilities(self) -> None:
+        manifest = self.require_surface_manifest()
+        project_mode = self.checker["project_mode"]
+        required_features = self.checker["required_features"]
+        ledger_requirements = self.checker["feature_requirements_by_mode"](
+            manifest, "ledger-hylo"
+        )
+
+        closure, selected_route = project_mode("proof-export", None)
+        self.assertIsNone(selected_route)
+        self.assertNotIn("open-direct-trial", closure)
+        self.assertIn("ledger-v2-proof-prerequisites", closure)
+        self.assertIn("proof-export", closure)
+        self.assertNotIn("historical-trial", closure)
+        required = required_features(closure, ledger_requirements)
+        for capability in (
+            "hylo_trial_v2",
+            "hylo_private_trial_custody_v1",
+            "hylo_trial_custody_fd_v1",
+            "hylo_private_lane_start_custody_fd_v1",
+            "hylo_reveal_material_fd_v1",
+            "hylo_proof_bundle_v1",
+            "hylo_external_proof_anchor_v1",
+        ):
+            with self.subTest(capability=capability):
+                self.assertIn(capability, required)
+
+        cas_requirements = self.checker["feature_requirements_by_mode"](
+            manifest, "cas"
+        )
+        self.assertEqual(set(), required_features(closure, cas_requirements))
+
+    def test_proof_export_needs_v2_ledger_but_does_not_resolve_cas(self) -> None:
+        manifest = self.require_surface_manifest()
+        closure, _ = self.checker["project_mode"]("proof-export", None)
+        ledger_requirements = self.checker["feature_requirements_by_mode"](
+            manifest, "ledger-hylo"
+        )
+        required = self.checker["required_features"](closure, ledger_requirements)
+
+        def write_fake_ledger(path: Path, features: set[str]) -> None:
+            capabilities = json.dumps(
+                {"schema": "hylo-capabilities/v1", "features": sorted(features)},
+                separators=(",", ":"),
+            )
+            path.write_text(
+                "#!/bin/sh\n"
+                'case "$*" in\n'
+                '  "--version") printf \'ledger 0.10.6\\n\' ;;\n'
+                '  "--source hylo capabilities") '
+                f"printf '%s\\n' '{capabilities}' ;;\n"
+                '  "--source hylo --help") '
+                "printf '%s\\n' capabilities proof-artifact-set export-proof "
+                "verify-proof ;;\n"
+                "  *) exit 64 ;;\n"
+                "esac\n",
+                encoding="utf-8",
+            )
+            path.chmod(0o700)
+
+        def run_checker(ledger: Path) -> subprocess.CompletedProcess[str]:
+            return subprocess.run(
+                [
+                    sys.executable,
+                    str(SURFACE_CHECKER),
+                    "--mode",
+                    "proof-export",
+                    "--surface-manifest",
+                    str(manifest["path"]),
+                    "--ledger",
+                    str(ledger),
+                    "--cas",
+                    "/definitely/not/an/installed/cas",
+                    "--json",
+                ],
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                check=False,
+            )
+
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            current = root / "ledger-current"
+            write_fake_ledger(current, required)
+            current_result = run_checker(current)
+            self.assertEqual(0, current_result.returncode, current_result.stderr)
+            current_report = json.loads(current_result.stdout)
+            self.assertTrue(current_report["ready"])
+            self.assertEqual(["ledger-hylo"], current_report["checked_components"])
+            self.assertNotIn("cas", current_report["components"])
+
+            legacy = root / "ledger-v1-only"
+            write_fake_ledger(
+                legacy,
+                {
+                    "hylo_trial_v1",
+                    "hylo_proof_bundle_v1",
+                    "hylo_external_proof_anchor_v1",
+                },
+            )
+            legacy_result = run_checker(legacy)
+            self.assertEqual(2, legacy_result.returncode)
+            legacy_report = json.loads(legacy_result.stdout)
+            self.assertFalse(legacy_report["ready"])
+            self.assertIn("hylo_trial_v2", legacy_report["error"])
+
+    def test_documented_capability_keys_are_the_live_probe_keys(self) -> None:
+        manifest = self.require_surface_manifest()
+        for component in ("seq", "ledger-hylo", "cas"):
+            requirements = self.checker["feature_requirements_by_mode"](
+                manifest, component
+            )
+            configured = set().union(*requirements.values())
+            with self.subTest(component=component):
+                self.assertTrue(configured)
+            keys = configured
+            for key in keys:
+                with self.subTest(key=key):
+                    self.assertIn(key, self.skill)
+
+        seq_requirements = self.checker["feature_requirements_by_mode"](
+            manifest, "seq"
+        )
+        route_sensitive_keys = set().union(
+            seq_requirements["case-blind-trial"],
+            seq_requirements["historical-trial"],
+            seq_requirements["historical-case-blind-trial"],
+        )
+        for key in route_sensitive_keys:
+            with self.subTest(key=key):
+                self.assertIn(key, self.documentation)
+
+    def test_supporting_skills_name_every_component_capability(self) -> None:
+        manifest = self.require_surface_manifest()
+        supporting_skills = {
+            "seq": read(ROOT.parent / "seq" / "SKILL.md"),
+            "ledger-hylo": read(ROOT.parent / "ledger" / "SKILL.md"),
+            "cas": read(ROOT.parent / "cas" / "SKILL.md"),
+        }
+        for component, skill in supporting_skills.items():
+            requirements = self.checker["feature_requirements_by_mode"](
+                manifest, component
+            )
+            for key in set().union(*requirements.values()):
+                with self.subTest(component=component, key=key):
+                    self.assertIn(key, skill)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/codex/skills/ledger/SKILL.md
+++ b/codex/skills/ledger/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ledger
-description: "Ensure a `ledger` command is available on PATH, coordinate the shared Learnings/Synesthesia/Negative Ledger lifecycle checkpoint and repo-local source-memory reconciliation, address Universalist plans and receipts, and route pure artifact validation without bypassing source authority. Use before a workflow's first Ledger command, at material validation or delivery checkpoints, when the command is missing, or for ledger status, migration, doctor, harvest planning, memory-admission handoff, reconciliation, Universalist plan addressing or receipt emission, or artifact validation."
+description: "Ensure a `ledger` command is available on PATH, coordinate the shared Learnings/Synesthesia/Negative Ledger lifecycle checkpoint and repo-local source-memory reconciliation, address Universalist plans and receipts, route Hylo campaign/trial operations, and perform pure artifact validation without bypassing source authority. Use before a workflow's first Ledger command, at material validation or delivery checkpoints, when the command is missing, or for ledger status, migration, doctor, harvest planning, memory-admission handoff, reconciliation, Universalist plan addressing or receipt emission, Hylo CRF/HCTP lifecycle work, or artifact validation."
 ---
 
 # Ledger
@@ -96,6 +96,235 @@ Operational, non-memory artifacts:
 
 - `.ledger/universalist/plan-{plan-id}.md`, addressed exclusively by
   `ledger --source universalist`; do not harvest these plans into memory.
+
+## Hylo CRF/HCTP authority
+
+After `$ledger ensure`, use the portable validator when only artifact structure
+is in scope:
+
+```bash
+ledger validate hylo-trial --input trial.json
+```
+
+This root artifact validator is platform-neutral, reads no Hylo store, and
+grants no campaign, execution, reveal, proof, or mutation authority. Only root
+`ledger validate ...` artifact validators are portable. Operational commands
+under `ledger --source hylo`, including `doctor`, remain gated by the shared
+macOS product-admission law. On an admitted macOS build, probe:
+
+```bash
+ledger --source hylo capabilities
+ledger --source hylo --help
+```
+
+The capabilities response is `hylo-capabilities/v1`; `features` is an array of
+exact strings rather than a map of Boolean aliases. The private-v2 route
+requires:
+
+```text
+hylo_trial_v2
+hylo_lane_leases_v1
+hylo_trial_compiler_v1
+hylo_reveal_material_fd_v1
+hylo_private_trial_custody_v1
+hylo_lane_materialization_v1
+hylo_signed_attestations_v1
+hylo_trial_custody_fd_v1
+hylo_private_lane_start_custody_fd_v1
+hylo_trial_build_receipt_v2
+hylo_lane_materialization_receipt_v2
+hylo_run_receipt_v2
+hylo_trial_reveal_v2
+```
+
+`hylo_trial_v1` remains an explicit legacy compatibility feature; it does not
+satisfy private-v2 custody.
+
+Proof export additionally requires:
+
+```text
+hylo_proof_bundle_v1
+hylo_external_proof_anchor_v1
+```
+
+### Campaign admission before trial registration
+
+An HCTP trial is additive to an admitted parent campaign, not a campaign
+substitute. Preserve this order:
+
+```text
+ledger --source hylo validate-campaign
+-> append campaign_created
+-> append every required target_bundle_admitted
+-> append every scenario_admitted in the complete manifest
+-> append the owner-applied change_recorded intent
+-> ledger --source hylo doctor
+-> ledger --source hylo compile-trial (or construct a validator-backed trial)
+-> ledger --source hylo validate-trial
+-> seq hctp-source validate
+-> ledger --source hylo register-trial with --custody-input-fd for v2
+```
+
+The private-v2 campaign must opt into `hylo-trial/v2` (and MAY also retain
+`hylo-trial/v1` compatibility) and set
+`trial_policy.source_route_admission:"required"`. Registration derives campaign,
+scenario, target, and promotion-coverage authority from immutable campaign
+events. It fails without complete admission; low-level `append` never owns
+trial lifecycle events.
+
+`compile-trial` consumes the current admitted campaign, one exact signed source
+receipt, frozen before/after target identities, and an already owner-applied
+candidate:
+
+```bash
+ledger --source hylo compile-trial \
+  --repo <repo> \
+  --request trial-build-request.json \
+  --source-receipt selection.json \
+  --output trial.json \
+  --custody-output-fd <anonymous-private-write-fd>
+```
+
+The custody endpoint must be an unlinked anonymous directional pipe supplied
+under the admitted custodian's custody. The CLI verifies descriptor shape and
+direction, not peer-process identity, and a regular file is invalid. The
+compiler atomically creates the opaque public `trial.json` path before
+delivering private `hylo-trial-custody/v1`. It attempts to remove the public
+output when private delivery fails; `TrialOutputRollbackFailed` means that path
+may remain as an uncommitted recovery artifact. The public-file and private-pipe
+sinks are not crash-atomic. Artifact presence or a partial custody stream is not
+completion: require the emitted
+`hylo-trial-build-receipt/v2` with `custody_material_delivered:true` before
+proceeding to source validation or registration. The public trial, normal
+stdout, and event store never contain semantic arm mappings, treatment
+materializations, target openings, witness/common-projection bodies, or the
+full source receipt.
+
+The compiler emits each public v2 `units[*].source_profile` as the exact native
+safe projection. Exact-key validation rejects semantic extras; full historical
+profile material remains outside the public trial. For v2 run evidence, Ledger
+accepts and persists only the exact `hylo-fir-public-projection/v1`; the full
+FIR remains private. The v1 path retains its established full-FIR carrier.
+
+The custodian retains the exact custody record outside public artifacts and
+re-delivers it over fresh protected pipes for registration, each new v2 lane
+start or caller-retained start commit, each lane materialization, and reveal.
+Register v2 with:
+
+```bash
+ledger --source hylo register-trial \
+  --repo <repo> \
+  --trial trial.json \
+  --custody-input-fd <anonymous-private-read-fd>
+```
+
+The event persists only the public `hylo-trial/v2` and a validated nonsemantic
+custody-commitment observation. Later reveal consumes the same exact custody
+record through `--reveal-material-fd <anonymous-private-read-fd>`. Do not
+demonstrate any protected FD with shell regular-file redirection.
+
+The earlier `validate-trial`, source validation, and registration preflight are
+necessary but are not append authority. For private v2, Ledger reacquires
+exclusive store ownership, reloads the exact append snapshot, and reruns the
+full semantic trial-against-campaign validation on the custody-backed trial
+before applying or appending `trial_registered`. Any stale semantic binding
+fails without append. V1 retains its established public-trial registration
+path.
+
+A new v2 lane start also consumes custody while Ledger holds the repository
+observation locks and validates the private target treatment:
+
+```bash
+ledger --source hylo start-lane \
+  --repo <repo> \
+  --campaign-id <campaign-id> \
+  --trial-id <trial-id> \
+  --lane-id <lane-id> \
+  --runner-id <runner-id> \
+  --custody-input-fd <custodian-start-source-fd> \
+  --lease-output-fd <runner-lease-sink-fd>
+```
+
+`commit-lane-start` requires the same custody input when committing a new v2
+start from a caller-retained lease. Exact already-started recovery uses the
+retained lease and re-emits existing state without rereading custody.
+
+For each started v2 lane, `lane-materialization` consumes a fresh custody FD
+and the exact retained lease and emits the selected treatment only to a private
+output FD:
+
+```bash
+ledger --source hylo lane-materialization \
+  --repo <repo> \
+  --trial-id <trial-id> \
+  --lane-id <lane-id> \
+  --registration-event-digest <registration-digest> \
+  --lane-started-event-digest <start-digest> \
+  --lane-lease-digest <lease-digest> \
+  --custody-input-fd <custodian-source-fd> \
+  --lease-input-fd <retained-lease-source-fd> \
+  --materialization-output-fd <cas-sink-fd>
+```
+
+Normal stdout contains only `hylo-lane-materialization-receipt/v2`; retain it
+for reveal. The FD-delivered claim is lease-bound, contains no semantic role,
+and must not enter public artifacts or proof bundles. The claim includes the
+exact `hylo-target-common-projection-opening/v1`; CAS validates its public
+commitment and nested projection fingerprint before execution.
+
+For every v2 lane, the safe receipt's `claim_fingerprint` must exact-join
+`hylo-run-receipt/v2.materialization.materialization_claim_fingerprint`.
+Reveal accepts exactly one matching
+`hylo-lane-materialization-receipt/v2` per lane; changed, missing, duplicate,
+wrong-lane, wrong-trial, or version-mixed per-lane safe receipts fail before
+append.
+
+`ledger --source hylo reveal-trial --reveal FILE` is legacy v1-only and
+accepts only `hylo-trial-reveal/v1`. It cannot import a caller-authored v2
+reveal. V2 requires validated `hylo-trial-custody/v1` provenance over
+`--reveal-material-fd` plus every joined lane-materialization receipt; Ledger
+derives `hylo-trial-reveal/v2` before the high-level append.
+
+For v2 grading, `hylo-grade-presentation-receipt/v1`,
+`hylo-grade-receipt/v1`, and `hylo-pair-grade-receipt/v1` are closed and exact
+native shapes. All consumed public evidence, rationale, grade-receipt,
+pair-grade-receipt, and presentation-receipt references use exactly
+`artifact:sha256:<64 lowercase hex>` and exact-join companion fingerprints.
+Public proof rejects private semantic keys but permits schema-declared boolean
+non-disclosure observations such as `hidden_reference:false`. V1 grade
+carriers retain their established compatibility behavior; proof sanitization
+applies across versions without changing v1 trial semantics.
+
+`compile-trial` validates live campaign head, complete scenario and target
+admission, source-route bindings, authoritative historical governance for
+`practice_repair` and `promotion`, target snapshots, and the applied change
+before generating opaque arm IDs and balanced A/B-B/A allocation. Native
+`compile-trial` currently rejects every sealed request as
+`SealedBrokerUnavailable`; a separately validator-backed sealed trial still
+requires an admitted external broker.
+
+The request's `factor.verifier.fingerprint` must equal the SHA-256 content
+fingerprint of the executing Ledger binary. Its `sealing` object must contain
+`reveal_scope` (`trial` or `campaign_holdout`), `case_materializer_ref`, and
+`case_materializer_fingerprint`; `case_materializer_contract` may be omitted.
+For `open` and `result_blind`, the materializer values must be null. For
+`case_blind`, the ref and fingerprint must be strings and the contract must be
+an object. Visibility and commitment fields are compiler-generated and
+rejected if caller-supplied.
+
+HCTP lane execution follows its frozen balanced order; either semantic arm may
+run first. The rule that a `replay_baseline` attempt must predate its candidate
+belongs only to the legacy compatibility campaign fold. `RUN` selects a bounded
+next experiment but grants no target mutation authority; a new owner-applied
+candidate requires a new evaluation trial.
+
+CAS preflight reports `compile_replay_required:false` for both direct and
+historical lanes. Direct uses `replay_preparation_mode:"none"`; historical uses
+`replay_preparation_mode:"integrated_run"`. Historical case-blind source
+profiles travel through a protected FD directly into
+`cas trial run --source-profile-fd`. Standalone `compile-replay` is
+non-authorizing diagnostic infrastructure and contributes no input to an
+accountable lane run.
 
 Stateless, non-authorizing observations:
 
@@ -287,7 +516,7 @@ lookup preserve read access to legacy `.ledger/universalist-plan-{plan-id}.md`
 files without rewriting them; the namespaced path is canonical when both
 layouts contain the same id.
 
-Ledger 0.10.4 or newer, paired with Skills Seq 0.3.51 or newer, emits the
+Ledger 0.10.6 or newer, paired with Skills Seq 0.3.52 or newer, emits the
 consequential root receipt selected by Universalist:
 
 ```bash

--- a/codex/skills/retrace/SKILL.md
+++ b/codex/skills/retrace/SKILL.md
@@ -95,6 +95,82 @@ retrace_inquiry_plan / RIP-v1
 decision_reconstruction_record / DRR-v1
 ```
 
+## HCTP historical lane bridge
+
+Before the first native Ledger command in this workflow, load `$ledger` and
+complete `$ledger ensure` once. Reuse that readiness for every later Ledger
+command.
+
+When a Retrace source becomes a Hylo `historical_decision` lane, preserve this native evidence chain:
+
+```text
+SGG-v1 -> pre_decision DCP-v2 -> source-target-text witness
+-> one-lane/one-replay RIP-v1 -> FIR-v1 with the frozen lineage
+```
+
+Seq derives `hylo-source-route-admission/v1` from a validated CRF episode and
+source profile, then binds the admission into the selection core covered by the
+source-owner attestation in `hylo-source-selection-receipt/v1`. Retrace evidence
+cannot relabel a replay-ineligible episode as direct execution. The routing law
+is:
+
+```text
+replay_eligible:true + direct profile -> direct comparison may be admitted
+replay_eligible:false + direct profile -> diagnostic_only; comparison forbidden
+replay_eligible:true + valid historical_decision -> historical replay may be admitted
+replay_eligible:false + valid historical_decision -> historical replay may be admitted,
+  with effective reconstruction capped by CRF fidelity
+absent or invalid historical governance -> compilation fails;
+  source remains diagnostic evidence only
+```
+
+A historical profile requires governed SGG evidence, a DCP target-text witness,
+`retrace_mode:"replay"`, `required_lineage`, `required_fir_version:"FIR-v1"`,
+and an explicit reconstructability class with retained limitations. Generic
+Retrace may admit `declared_uncontrolled` with that limitation, but HCTP
+`practice_repair` and `promotion` require authoritative governance at the
+effective Ledger/CAS gate.
+
+During HCTP execution, `cas trial run` privately compiles the lane DCP/RIP and
+binds their fingerprints before the one-shot claim. A successful replay must
+verify the FIR/native-receipt lineage; a terminal failure records FIR
+unavailability. Standalone `cas trial compile-replay` is an open, embedded,
+historical diagnostic with `execution_authority:false`; `run` consumes neither
+its receipt nor its DCP/RIP files. It is not the case-blind or sealed execution
+path. Historical preflight reports `compile_replay_required:false` and
+`replay_preparation_mode:"integrated_run"`.
+For case-blind lanes, never expose source target text, source-profile bodies,
+rejected routes, or historical answers through controller-visible artifacts.
+For v2, public `units[*].source_profile` is always the exact native safe
+projection with no semantic extras. V1 retains its established source-profile
+contract.
+
+Generic Retrace may retain the full `FIR-v1` under its owning lifecycle. An
+HCTP v2 public run receipt carries only the exact
+`hylo-fir-public-projection/v1`; its full FIR remains private. The v1 HCTP path
+retains its compatible full-FIR carrier. Never treat the v2 projection as a
+substitute for private FIR validation.
+
+Historical source-profile delivery is independent of private-v2 treatment
+custody. Every `hylo-trial/v2` lane also receives one lease-bound treatment
+claim from `ledger --source hylo lane-materialization` through CAS
+`--materialization-fd`; that claim discloses no semantic arm role.
+
+Case-blind source release has its own custody projection: Seq receives the
+exact `hylo-source-selection-opening/v1` through
+`--source-selection-opening-fd`, while CAS receives the historical profile
+directly on the protected FD named by `cas trial run --source-profile-fd` only
+when preflight freezes that delivery. The
+lease-bound treatment claim separately carries the private
+`hylo-target-common-projection-opening/v1`. Do not substitute one carrier for
+another or expose any of their bodies through a public receipt.
+
+The staged baseline/intervention sequence below describes an ordinary Retrace
+experiment. If its artifacts feed an HCTP paired trial, follow the trial's
+frozen balanced A/B-B/A lane order; either semantic arm may run first. A
+baseline-before-candidate chronology rule applies only to the legacy Hylo
+compatibility fold, not to HCTP lane execution.
+
 ## Modes
 ```text
 explain        contemporaneous rationale reconstruction

--- a/codex/skills/seq/SKILL.md
+++ b/codex/skills/seq/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: seq
-description: "Mine Codex session JSONL and memory artifacts with the Zig `seq` CLI. Use for explicit `$seq`, artifact/session/tool/memory/plan forensics, skill activation and outcome audits, decision provenance, `$tune` evidence, `$retrace` source capsules, review-compiler provenance, watched-session deltas, worker attribution, or reproducible historical reports. Prefer the narrowest lifted command and preserve denominators, provenance, contamination, and uncertainty."
+description: "Mine Codex session JSONL and memory artifacts with the Zig `seq` CLI. Use for explicit `$seq`, artifact/session/tool/memory/plan forensics, Hylo CRF extraction and governed HCTP source selection, skill activation and outcome audits, decision provenance, `$tune` evidence, `$retrace` source capsules, review-compiler provenance, watched-session deltas, worker attribution, or reproducible historical reports. Prefer the narrowest lifted command and preserve denominators, provenance, contamination, and uncertainty."
 metadata:
   version: "1.2.0"
 ---
@@ -33,6 +33,7 @@ Primary local sources:
 State the denominator and exclusion policy before counts.
 
 ## Capability-first rule
+
 For current or post-change audits, run:
 ```bash
 seq --version
@@ -41,6 +42,142 @@ seq capabilities --format json
 ```
 Use the installed lifted surface as source of truth.
 Do not recreate a newer native classifier with broad transcript searches when the installed binary is old.
+
+## Hylo CRF/HCTP product surface
+
+`seq hylo-extract` and `seq hctp-source` are admitted macOS product commands.
+Portable trial validation belongs to Ledger and must not fail merely because
+these Seq commands are unavailable. On an admitted macOS build, require the
+exact `seq_capabilities.features` keys needed by the selected route:
+
+```text
+hylo_extract_v1
+hctp_source_selection_v1
+hctp_source_route_admission_v1
+hctp_independence_clusters_v1
+hctp_sealed_case_v1
+hctp_materializer_v1
+hctp_source_materialization_v1
+hctp_source_selection_opening_fd_v1
+hctp_historical_profile_v1
+hctp_case_blind_source_profile_fd_v1
+```
+
+Use `hylo_extract_v1` for CRF extraction. Use
+`hctp_source_selection_v1`, `hctp_source_route_admission_v1`, and
+`hctp_independence_clusters_v1` for governed source compilation and validation.
+Case-blind execution additionally requires `hctp_sealed_case_v1`,
+`hctp_materializer_v1`, `hctp_source_materialization_v1`, and
+`hctp_source_selection_opening_fd_v1`. Historical case-blind delivery also
+requires `hctp_historical_profile_v1` and
+`hctp_case_blind_source_profile_fd_v1`. These are exact emitted keys; do not
+infer them from command presence. On non-macOS builds, the product commands and
+their feature keys are absent.
+
+### Source compile and trial validation order
+
+Before the first native Ledger command in this workflow, load `$ledger` and
+complete `$ledger ensure` once. Reuse that readiness for the remaining Ledger
+commands.
+
+Compile source selection before constructing the trial, but validate the
+receipt against the completed trial only after campaign admission and trial
+construction:
+
+```text
+seq hctp-source compile
+-> admit campaign, target bundles, and complete scenario manifest
+-> ledger --source hylo compile-trial (or construct the validator-backed trial)
+-> ledger --source hylo validate-trial
+-> seq hctp-source validate
+-> ledger --source hylo register-trial with private custody
+```
+
+Representative commands, with sensitive descriptors supplied by an admitted
+caller or custodian, are:
+
+```bash
+seq hctp-source compile \
+  --manifest source.json \
+  --output selection.json \
+  --source-signing-seed-fd <protected-source-seed-fd>
+
+ledger --source hylo validate-trial --repo <repo> --trial trial.json
+seq hctp-source validate --receipt selection.json --trial trial.json
+ledger --source hylo register-trial \
+  --repo <repo> \
+  --trial trial.json \
+  --custody-input-fd <custodian-registration-source-fd>
+```
+
+`hctp-source compile` derives each required
+`hylo-source-route-admission/v1` from the CRF episode and source profile, then
+binds it into the selection core covered by the source-owner attestation in
+`hylo-source-selection-receipt/v1`; callers do not supply or relabel that
+projection. A direct profile is comparison-eligible only when the CRF episode
+has `fidelity.replay_eligible:true`. Otherwise its route is `diagnostic_only`.
+A governed `historical_decision` profile may independently admit
+`historical_replay`, while retaining the CRF reconstruction ceiling and
+limitations. For `practice_repair` and `promotion`, historical governance must
+be authoritative at the effective Ledger/CAS gate.
+
+For `hylo-trial/v2`, the exact signed receipt is a private compiler/custody
+input. The public trial carries only its normalized
+`artifact:sha256:<64 lowercase hex>` reference, matching fingerprint, and
+salted commitment; it never preserves the caller's local receipt path.
+`hctp-source validate` joins the external receipt to those public
+bindings and the completed unit/scenario/source projections; registration then
+requires the compiler-produced `hylo-trial-custody/v1` through a protected FD.
+The public trial and event store never embed the full receipt or its sealed-case
+locator.
+
+For v2, each public `units[*].source_profile` is the exact native safe
+projection. `hctp-source validate` rejects unknown or semantic extra keys while
+joining the projection to the signed source receipt. A full historical profile
+body, source target text, rationale, rejected routes, and hidden references do
+not enter the public trial.
+
+For case-blind materialization, deliver visible input through
+`--visible-output-fd` and the historical profile, when required, through
+`--source-profile-output-fd`. Both are protected anonymous directional pipes
+supplied under the admitted receiver's custody. The CLIs verify descriptor
+shape and direction, not peer-process identity. Never replace them with regular
+files, argv, environment variables, or normal stdout. Receipt output contains
+commitments and fingerprints, not plaintext hidden references or source-profile
+bodies.
+
+For `hylo-trial/v2`, Seq also requires the exact private
+`hylo-source-selection-opening/v1` on
+`--source-selection-opening-fd`. The custodian projects only
+`custody.source_selection` onto that protected pipe; the full
+`hylo-trial-custody/v1` is not a Seq input. Seq validates the whole opening
+commitment against the public trial, then validates and joins its nested exact
+signed source receipt before releasing case material. A v2 trial rejects an
+embedded full receipt or a missing opening FD; v1 retains its embedded receipt
+carrier and rejects the v2-only FD.
+
+```bash
+seq hctp-source materialize \
+  --sealed-case <sealed-case> \
+  --trial trial.json \
+  --lane-id <lane-id> \
+  --seal-key-fd <custodian-seal-key-source-fd> \
+  --visible-output-fd <runner-visible-input-sink-fd> \
+  --source-selection-opening-fd <custodian-source-selection-opening-source-fd> \
+  --signing-seed-fd <materializer-signing-seed-source-fd> \
+  --output <safe-materialization-receipt>
+```
+
+Add `--source-profile-output-fd <runner-source-profile-sink-fd>` only for a
+historical lane whose preflight projection freezes FD delivery. Connect that
+protected output directly to `cas trial run --source-profile-fd`; it is not an
+input to standalone `compile-replay` or a controller-visible intermediate.
+
+Seq source materialization and Ledger treatment materialization are distinct.
+Seq releases one visible case and, when required, one historical source profile.
+Ledger later releases the selected treatment under the retained lane lease via
+`ledger --source hylo lane-materialization`; CAS receives that claim through
+its separate `--materialization-fd`.
 
 ## Routing ladder
 ### Skill decisions and tuning


### PR DESCRIPTION
## Summary

This rewrites the `$hylo` operator route around the executable native CRF/HCTP state machine and pins it to `tkersey/skills-zig@ff6a26e0fe39e789db4a2932fb428129411ecebc` from [skills-zig#84](https://github.com/tkersey/skills-zig/pull/84).

The documentation now makes these transitions explicit:

- Compile source selection, admit the parent campaign/scenarios/target bundles, construct the trial, validate the source receipt against that trial, then register.
- Route direct and historical lanes separately. Every private-v2 historical lane uses `source_profile_fd`; integrated CAS execution prepares DCP/RIP before claim. Standalone `compile-replay` is diagnostic-only.
- Treat `replay_eligible:false` as a real non-upgrading gate.
- Preserve balanced A/B-B/A HCTP execution order while retaining baseline-before-candidate chronology only for the legacy campaign fold.
- Require an explicitly admitted external broker for sealed assurance; the repository driver remains conformance-only.
- Distinguish evaluating an existing owner-applied candidate from deriving the next candidate through the causal frontier.
- Describe the public-file/private-FD compiler boundary as receipt-gated recovery, not cross-resource crash atomicity.

## Operator contract

- Adds `references/orchestration.md` as the complete executable state machine.
- Adds a mode-sensitive native surface probe and a pinned machine-readable surface lock.
- Adds a 33-case documentation contract test and a macOS CI workflow that checks out and exercises the pinned native commit.
- Synchronizes `$seq`, `$cas`, `$ledger`, and `$retrace` with the same capability, custody, lifecycle, and compatibility laws.
- Keeps `authority_granted:false`, `os_confinement:false`, private semantic material, leases, signing seeds, openings, and custody keys explicit at their owning boundaries.

## Validation

```text
HYLO_OPERATOR_SURFACE_MANIFEST=<skills-zig>/testdata/hctp-v1/operator-recipe/operator-surface-manifest.json \
  uv run python codex/skills/hylo/tests/test_operator_recipe_contract.py
  33/33 passed

uv run --with pyyaml <quick_validate.py> codex/skills/{hylo,seq,cas,ledger,retrace}
  5/5 skills valid

actionlint .github/workflows/hylo-operator-contract.yml
  clean

git diff --check
  clean

check-operator-surface --mode operator against the committed native binaries
  ready:true
  Seq 0.3.52
  Ledger 0.10.6
  CAS 0.2.81
  source_route: direct+historical_decision
  sealed broker admitted:false; inferred:false
```

A final independent docs audit found and closed one ambiguity: embedded historical source-profile delivery is now explicitly limited to legacy v1 or standalone diagnostics; every v2 historical execution requires `source_profile_fd`.

## Merge order

1. Merge this documentation PR first.
2. Rebase or update [skills-zig#84](https://github.com/tkersey/skills-zig/pull/84) if needed, then merge it.

This PR's candidate CI checks out the exact native commit, asserts both candidate SHAs, and executes the native recipe. The native PR no longer depends on `dotfiles@main`; after merge, skills-zig's published-contract workflow checks its current `main` against dotfiles `main`. Merge dotfiles first so that post-merge gate observes compatible published branches.

<!-- ship-proof:start -->
## Summary
- Finalize the exact Hylo documentation/native candidate pair for guarded landing.

## Proof
- operator-contract: pass at dotfiles 59d46d22b2d96333b93f7a71089977c33d2cdd2a against skills-zig ff6a26e0fe39e789db4a2932fb428129411ecebc.
- Review threads: complete inventory, 0 unresolved.

## Scope
- repository: tkersey/dotfiles
- branch: agent/hylo-workflow-closure-docs
- head: 59d46d22b2d96333b93f7a71089977c33d2cdd2a
- base: main
- base SHA: c278fd08328b96bd4914af0fac90fc18684f327f

## Risks
- The published main-to-main observation is intentionally deferred until skills-zig lands.

## Follow-ups
- Land this PR before skills-zig#84, then verify the release and tap chain.

## Readiness
- Operation: update-and-promote
- Final state: ready
- SHIP-v1 compatibility mode: promote-draft
- Reason: exact-head validation is complete and no blockers remain.
- Caveats: none
<!-- ship-proof:end -->