### PR TITLE
Enable implicit creative-problem-solver routing

### DIFF
--- a/codex/skills/creative-problem-solver/SKILL.md
+++ b/codex/skills/creative-problem-solver/SKILL.md
@@ -1,11 +1,39 @@
 ---
 name: creative-problem-solver
-description: "Lateral-thinking playbook returning a five-tier strategy portfolio (Quick Win through Moonshot) with a default-basin check. Use for options, alternatives, trade-offs, stalled/repeated failures, creative reframing, or strategic path selection before execution."
+description: "Generate a compact five-tier strategy portfolio when the user needs multiple materially different paths before execution. Implicitly invoke for explicit requests for options, alternatives, trade-offs, reframing, or help escaping a repeated stall/failure. Do not activate for direct implementation, single-answer advice, repository-evidence opportunity mining ($ideate), or detailed planning ($plan)."
 ---
 
 # Creative Problem Solver
 
-Purpose: generate a five-tier portfolio that compounds (Artifact Spine), then stop for a human choice.
+Purpose: when a strategy choice is still open, generate a five-tier portfolio that compounds through an Artifact Spine, then stop for a human choice.
+
+## Activation boundary
+
+Implicit invocation is enabled. The activation signal is an **unresolved strategy choice plus a request for divergent options**. Difficulty alone is not enough.
+
+### Activate when
+
+- The user explicitly asks for options, alternatives, trade-offs, a strategy portfolio, fresh angles, reframing, or "what else could we try?"
+- Progress is stalled or repeated attempts fail, and selecting a materially different approach is the next task.
+- A multi-constraint or high-uncertainty decision would benefit from several distinct conceptual frames before execution.
+- The user asks to brainstorm or ideate in the ordinary sense without requesting repository evidence mining, tickets, a detailed plan, or implementation.
+- The primary deliverable is at least three materially different paths and a human choice among them.
+
+### Do not activate; route elsewhere
+
+- Direct implementation, debugging, review, or execution after an approach is selected: use the normal task flow or the owning implementation/review skill.
+- A single factual answer, a straightforward recommendation, or comparison of a small known set where a portfolio would add ceremony: answer directly.
+- Evidence-backed repository or product opportunity mining, ranked improvement discovery, or choosing what to plan next: use `$ideate`.
+- Turning a selected direction into a detailed implementation plan, specification, or work graph: use `$plan` or `$spec-pipeline` as appropriate.
+- Architecture or codebase understanding without a request for divergent paths: use direct analysis or `$codebase-archaeology`.
+- The user already chose a tier or path and asks to execute it: hand off to the execution owner; do not regenerate the portfolio.
+
+### Tie-breakers
+
+- Explicit `$creative-problem-solver` invocation wins unless a safety or domain-specific boundary requires another owner.
+- `$ideate` wins when repository evidence mining and ranked opportunities are central to the request.
+- `$plan` wins when the direction is already selected and the requested output is an execution plan.
+- Activate this skill when the requested outcome is a choice set; do not activate when the requested outcome is one answer, one plan, or one implementation.
 
 ## Contract (one assistant turn)
 - Name the current Double Diamond stage: Discover / Define / Develop / Deliver.
@@ -19,9 +47,10 @@ Purpose: generate a five-tier portfolio that compounds (Artifact Spine), then st
 - Keep output compact: target <= 60 lines; 1-3 bullets per section.
 
 ## When to use
+- The next useful action is selecting among materially different paths, not executing one.
 - Progress is stalled or blocked.
 - Repeated attempts fail the same way.
-- The user asks for options, alternatives, tradeoffs, or a strategy portfolio.
+- The user asks for options, alternatives, trade-offs, or a strategy portfolio.
 - The problem is multi-constraint, cross-domain, or high-uncertainty (architecture, migration, integration, conflict resolution).
 
 ## Quick start
@@ -48,7 +77,7 @@ Purpose: generate a five-tier portfolio that compounds (Artifact Spine), then st
 - Visionary: only when asked for long-horizon strategy or systemic change.
 
 ## Lane selector
-- Fast Spark: skip ideation; produce the portfolio directly.
+- Fast Spark: skip broad candidate generation; produce the portfolio directly.
 - Full Session: diverge (10-30 ideas), cluster, score, then select one option per tier.
 
 ## Reframe selection (required)
@@ -76,7 +105,6 @@ Purpose: generate a five-tier portfolio that compounds (Artifact Spine), then st
 - Ensure at least two tiers come from different conceptual frames, not just different sizes of the same idea.
 - Valid frame shifts include substrate, interface, constraint, proof surface, incentive, time horizon, operating model, or user ritual.
 - If the five tiers cannot honestly diverge, say so and mark the portfolio as same-basin.
-
 
 ## Accretion (required)
 - Accretive artifact: a durable asset you keep even if the option is wrong (measurement, harness, spec, test, automation, interface, dataset, doc).
@@ -192,10 +220,21 @@ Scores (S/A/E/R/Sp):
 Human Input Required: pick a tier (Quick Win .. Moonshot) or update constraints.
 ```
 
-## Activation cues
-- "need options" / "alternatives" / "tradeoffs" / "portfolio"
-- "brainstorm" / "ideate"
-- "stuck" / "blocked" / "nothing works"
-- "outside the box" / "fresh angles"
-- "ambiguous" / "uncertain" / "unknowns"
-- "architecture" / "system design" / "migration" / "integration"
+## Routing examples
+
+### Should activate
+
+- "Give me several materially different ways to reduce onboarding drop-off before we choose one."
+- "We have tried tuning the query twice and are still stuck. What else could we try?"
+- "Reframe this migration problem and show the trade-offs among distinct paths."
+- "Brainstorm a strategy portfolio for entering this market; do not execute anything yet."
+- "The problem is still ambiguous; give me learning moves rather than a build plan."
+
+### Should not activate
+
+- "Implement the selected cache design and run the tests." -> implementation owner
+- "Mine this repository for evidence-backed product and DX opportunities." -> `$ideate`
+- "Turn the chosen event-sourcing direction into a detailed implementation plan." -> `$plan`
+- "Explain this repository's architecture and data flow." -> direct analysis or `$codebase-archaeology`
+- "Review this pull request for defects." -> review owner
+- "We chose the Quick Win. Build it now." -> execution owner

--- a/codex/skills/creative-problem-solver/agents/openai.yaml
+++ b/codex/skills/creative-problem-solver/agents/openai.yaml
@@ -1,6 +1,11 @@
 policy:
-  allow_implicit_invocation: false
+  allow_implicit_invocation: true
 interface:
   display_name: "Creative Problem Solver"
-  short_description: "Help with Creative Problem Solver tasks"
-  default_prompt: "Use $creative-problem-solver for this task."
+  short_description: "Generate materially different strategy options before execution"
+  default_prompt: >-
+    Use $creative-problem-solver when the user needs multiple materially different
+    options, trade-offs, or reframing before choosing a path. Produce the five-tier
+    portfolio and stop for human selection. Do not take over direct implementation,
+    single-answer advice, evidence-backed repository opportunity mining ($ideate),
+    or detailed planning ($plan).

--- a/codex/skills/creative-problem-solver/evals/routing-cases.json
+++ b/codex/skills/creative-problem-solver/evals/routing-cases.json
@@ -1,0 +1,93 @@
+{
+  "cases": [
+    {
+      "activate": true,
+      "id": "explicit-options",
+      "prompt": "Give me several materially different ways to reduce onboarding drop-off before we choose one."
+    },
+    {
+      "activate": true,
+      "id": "tradeoff-portfolio",
+      "prompt": "Map the trade-offs between building, buying, and partnering, then include a credible moonshot."
+    },
+    {
+      "activate": true,
+      "id": "stalled-repeated-failure",
+      "prompt": "We have tried tuning the query twice and are still stuck. What else could we try?"
+    },
+    {
+      "activate": true,
+      "id": "reframe-migration",
+      "prompt": "Reframe this migration problem and show several distinct paths before execution."
+    },
+    {
+      "activate": true,
+      "id": "ordinary-brainstorm",
+      "prompt": "Brainstorm a strategy portfolio for entering this market; do not execute anything yet."
+    },
+    {
+      "activate": true,
+      "id": "architecture-choice-set",
+      "prompt": "Show several architecture paths for multi-region failover and how we could learn before committing."
+    },
+    {
+      "activate": true,
+      "id": "ambiguous-learning-moves",
+      "prompt": "The problem is still ambiguous; give me learning moves rather than a build plan."
+    },
+    {
+      "activate": true,
+      "id": "explicit-skill",
+      "prompt": "Use $creative-problem-solver to generate a five-tier portfolio for this decision."
+    },
+    {
+      "activate": false,
+      "id": "direct-implementation",
+      "owner": "implementation",
+      "prompt": "Implement the selected cache design and run the tests."
+    },
+    {
+      "activate": false,
+      "id": "single-factual-answer",
+      "owner": "direct",
+      "prompt": "What does this compiler error mean?"
+    },
+    {
+      "activate": false,
+      "id": "repo-opportunity-mining",
+      "owner": "ideate",
+      "prompt": "Mine this repository for evidence-backed product and DX opportunities and rank what to plan next."
+    },
+    {
+      "activate": false,
+      "id": "selected-direction-plan",
+      "owner": "plan",
+      "prompt": "Turn the chosen event-sourcing direction into a detailed implementation plan."
+    },
+    {
+      "activate": false,
+      "id": "architecture-onboarding",
+      "owner": "codebase-archaeology",
+      "prompt": "Explain this repository's architecture and data flow so I can get oriented."
+    },
+    {
+      "activate": false,
+      "id": "pull-request-review",
+      "owner": "review",
+      "prompt": "Review this pull request for defects."
+    },
+    {
+      "activate": false,
+      "id": "chosen-tier-execution",
+      "owner": "implementation",
+      "prompt": "We chose the Quick Win. Build it now."
+    },
+    {
+      "activate": false,
+      "id": "small-known-comparison",
+      "owner": "direct",
+      "prompt": "Compare these two already-selected retry policies and recommend one."
+    }
+  ],
+  "schema": "creative-problem-solver-routing-cases/v1"
+}

--- a/codex/skills/creative-problem-solver/tests/test_activation_contract.py
+++ b/codex/skills/creative-problem-solver/tests/test_activation_contract.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SKILL = (ROOT / "SKILL.md").read_text(encoding="utf-8")
+AGENT = (ROOT / "agents" / "openai.yaml").read_text(encoding="utf-8")
+CORPUS = json.loads((ROOT / "evals" / "routing-cases.json").read_text(encoding="utf-8"))
+
+
+class ActivationContractTests(unittest.TestCase):
+    def test_implicit_invocation_is_enabled(self) -> None:
+        self.assertIn("allow_implicit_invocation: true", AGENT)
+        self.assertNotIn("allow_implicit_invocation: false", AGENT)
+
+    def test_frontmatter_names_positive_and_negative_boundaries(self) -> None:
+        frontmatter = SKILL.split("---", 2)[1]
+        for phrase in (
+            "multiple materially different paths",
+            "options, alternatives, trade-offs, reframing",
+            "direct implementation",
+            "repository-evidence opportunity mining ($ideate)",
+            "detailed planning ($plan)",
+        ):
+            self.assertIn(phrase, frontmatter)
+
+    def test_activation_boundary_is_early_and_explicit(self) -> None:
+        self.assertLess(SKILL.index("## Activation boundary"), SKILL.index("## Contract"))
+        for phrase in (
+            "unresolved strategy choice plus a request for divergent options",
+            "The primary deliverable is at least three materially different paths",
+            "Do not activate; route elsewhere",
+            "$ideate` wins",
+            "$plan` wins",
+            "one answer, one plan, or one implementation",
+        ):
+            self.assertIn(phrase, SKILL)
+
+    def test_interface_prompt_preserves_the_stop_boundary(self) -> None:
+        for phrase in (
+            "multiple materially different",
+            "stop for human selection",
+            "direct implementation",
+            "($ideate)",
+            "($plan)",
+        ):
+            self.assertIn(phrase, AGENT)
+
+    def test_routing_corpus_covers_positives_and_near_misses(self) -> None:
+        self.assertEqual("creative-problem-solver-routing-cases/v1", CORPUS["schema"])
+        positives = [case for case in CORPUS["cases"] if case["activate"]]
+        negatives = [case for case in CORPUS["cases"] if not case["activate"]]
+        self.assertGreaterEqual(len(positives), 8)
+        self.assertGreaterEqual(len(negatives), 8)
+        owners = {case["owner"] for case in negatives}
+        self.assertTrue(
+            {"direct", "implementation", "ideate", "plan", "codebase-archaeology", "review"}
+            <= owners
+        )
+
+    def test_routing_examples_match_the_corpus_boundaries(self) -> None:
+        for phrase in (
+            "Should activate",
+            "Should not activate",
+            "Mine this repository for evidence-backed product and DX opportunities",
+            "Turn the chosen event-sourcing direction into a detailed implementation plan",
+            "We chose the Quick Win. Build it now.",
+        ):
+            self.assertIn(phrase, SKILL)
+
+    def test_skill_stays_within_a_compact_package_budget(self) -> None:
+        self.assertLessEqual(len(SKILL.splitlines()), 280)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- enable implicit invocation for `$creative-problem-solver`
- narrow activation to unresolved strategy choices whose primary deliverable is a set of materially different paths before execution
- preserve the five-tier portfolio and mandatory human-selection stop
- route direct implementation, single-answer advice, repository opportunity mining, detailed planning, architecture onboarding, and review requests to their existing owners
- add a 16-case positive/near-miss routing corpus and seven focused activation-contract tests

## Why

The skill had useful natural-language triggers but was reachable only through explicit `$creative-problem-solver` selection. Its previous cue list was also too broad—terms such as “brainstorm,” “blocked,” and “architecture” could not safely become implicit triggers without a stronger ownership boundary.

This change makes implicit routing available while defining the actual signal: an unresolved strategy choice plus a request for divergent options. Difficulty by itself does not activate the skill.

## Boundary law

The prompt-to-skill boundary activates `$creative-problem-solver` only when the requested outcome is a choice set—normally at least three materially different paths followed by human selection.

The boundary preserves:

- explicit `$creative-problem-solver` invocation
- the Quick Win through Moonshot portfolio
- Artifact Spine, signal, and escape-hatch requirements
- the stop before execution

The boundary rejects:

- one answer, one plan, or one implementation
- evidence-backed repository opportunity mining, which remains owned by `$ideate`
- detailed planning after direction selection, which remains owned by `$plan` or `$spec-pipeline`
- architecture onboarding without divergent-path generation, which remains direct analysis or `$codebase-archaeology`

Falsifier: a near-miss routing case activates the skill, or a positive choice-set case cannot satisfy the documented activation contract.

## Validation

Run against an exact local reconstruction of the branch files:

```text
uv run --no-project python -m unittest discover \
  -s creative-problem-solver/tests -p 'test_*.py' -v
  7/7 passed

uv run --no-project python -m py_compile \
  creative-problem-solver/tests/test_activation_contract.py
  pass
```

Additional checks:

- agent metadata parses as YAML and sets `allow_implicit_invocation: true`
- frontmatter parses; description length is 399 characters
- routing corpus parses as JSON, contains 16 unique cases, and gives every negative case an explicit owner
- `SKILL.md` remains compact at 240 lines
- connector readback matched the validated Git blob SHA for all four changed files
- branch is exactly four commits ahead of `main`, zero behind, and changes only `codex/skills/creative-problem-solver/**`

The execution environment had no repository checkout and could not reach GitHub from the local container, so the repository-wide `quick_validate.py` entrypoint and source-memory checkpoint CLI were not run directly. The PR remains draft for repository-integrated validation; connector-generated file commits should be squash-merged.
