### PR TITLE
Require historical source-profile FD readiness

### DIFF
--- a/codex/skills/hylo/scripts/check-operator-surface
+++ b/codex/skills/hylo/scripts/check-operator-surface
@@ -403,7 +403,7 @@ def required_features(closure: set[str], requirements: dict[str, set[str]]) -> s
 
 
 def requires_historical_profile_fd(closure: set[str]) -> bool:
-    return HISTORICAL_CASE_BLIND_MODE in closure
+    return "historical-trial" in closure
 
 
 def check_feature_set(label: str, available: set[str], required: set[str]) -> None:

--- a/codex/skills/hylo/tests/test_operator_recipe_contract.py
+++ b/codex/skills/hylo/tests/test_operator_recipe_contract.py
@@ -890,6 +890,22 @@ class HyloOperatorRecipeContractTests(unittest.TestCase):
         unsafe = re.compile(r"(?m)(?:^|\s)(?:[3-9]|[1-9][0-9]+)(?:>|<)(?![&])")
         self.assertIsNone(unsafe.search(shell_blocks(self.documentation)))
 
+    def test_plain_historical_probe_requires_source_profile_fd(self) -> None:
+        closure, selected_route = self.checker["project_mode"](
+            "historical-trial", None
+        )
+
+        self.assertEqual("historical_decision", selected_route)
+        self.assertTrue(self.checker["requires_historical_profile_fd"](closure))
+        with self.assertRaisesRegex(
+            self.checker["CheckFailure"], "--source-profile-fd N"
+        ):
+            self.checker["require_tokens"](
+                "--lease-fd N --input-fd N --materialization-fd N",
+                "CAS trial help",
+                {"--source-profile-fd N"},
+            )
+
     def test_live_probe_keeps_case_blinding_orthogonal_to_source_route(self) -> None:
         manifest = self.require_surface_manifest()
         project_mode = self.checker["project_mode"]
@@ -964,7 +980,7 @@ class HyloOperatorRecipeContractTests(unittest.TestCase):
         )
         self.assertFalse(requires_historical_profile_fd(direct))
         self.assertTrue(requires_historical_profile_fd(historical))
-        self.assertFalse(requires_historical_profile_fd(plain_historical))
+        self.assertTrue(requires_historical_profile_fd(plain_historical))
 
     def test_proof_export_requires_v2_trial_custody_and_proof_capabilities(self) -> None:
         manifest = self.require_surface_manifest()


### PR DESCRIPTION
## Summary

- require `--source-profile-fd N` whenever the projected mode includes `historical-trial`
- add a focused fail-closed regression and update the manifest-bound mode projection assertion

## Why

A post-merge review thread on #115 identified that plain `historical-trial` lacks the case-blind-only marker previously used by `requires_historical_profile_fd`. The readiness probe could therefore accept a CAS surface that could not receive the mandatory v2 historical source profile. This repair keys the obligation to the historical route while keeping case visibility orthogonal.

## Validation

- `HYLO_OPERATOR_SURFACE_MANIFEST=... uv run codex/skills/hylo/tests/test_operator_recipe_contract.py` — 34/34 pass
- `uv run --with pyyaml -- python3 .../quick_validate.py codex/skills/hylo` — pass
- installed historical probe against Seq 0.3.52, Ledger 0.10.7, and CAS 0.2.82 — `ready:true`
- `git diff --check` — pass

Follow-up to https://github.com/tkersey/dotfiles/pull/115#discussion_r3608534801.