### PR TITLE
Harden creative-problem-solver framing and routing

### DIFF
--- a/codex/skills/creative-problem-solver/SKILL.md
+++ b/codex/skills/creative-problem-solver/SKILL.md
@@ -47,7 +47,7 @@ Implicit invocation is enabled. The activation signal is an **unresolved strateg
 
 - Name the lane and Double Diamond stage.
 - State the problem, success criteria, and evidence posture: known facts versus assumptions or hypotheses.
-- Reframe once, then run a Frame Shift Check. Never promote an unsupported mechanism, bottleneck, or causal story to fact.
+- Reframe once, then run an Aha Check: name the restructuring insight and its evidence status. Never promote an unsupported mechanism, bottleneck, or causal story to fact.
 - Name the default solution basin and ensure at least two tiers use genuinely different conceptual frames.
 - Include all five tiers: Quick Win, Strategic Play, Advantage Play, Transformative Move, Moonshot.
 - For every tier: accretive artifact, falsifiable expected signal with a timebox, and escape hatch.
@@ -61,7 +61,7 @@ Implicit invocation is enabled. The activation signal is an **unresolved strateg
 3. Define gate: one-line problem statement + success criteria; mark material unknowns.
 4. Evidence posture: separate facts from assumptions and hypotheses.
 5. Reframe using the stage default or the user's requested technique.
-6. Frame Shift Check. If there is no material shift, run one second and final pass with a different operator.
+6. Aha Check. State the restructuring insight, representational shift, and evidence status. If no material Aha appears, run one second and final pass with a different operator.
 7. Diversity gate: name the default basin and at least two distinct frames.
 8. Define an Artifact Spine of 1-3 durable assets that higher tiers can reuse.
 9. Generate the five-tier portfolio.
@@ -95,13 +95,15 @@ Implicit invocation is enabled. The activation signal is an **unresolved strateg
 - Honor a user-requested technique when it is usable; do not silently replace it with a "nearest supported" technique.
 - Chat disclosure: `Reframe used: <technique>` plus one line explaining why.
 
-## Frame Shift Check
+## Aha Check
 
-- State the baseline frame and the alternative frame in one line.
-- State evidence status: fact, supported inference, or hypothesis.
-- A frame shift is material only if it changes the candidate field, proof surface, ordering, or decision criteria.
+- **Aha is the restructuring insight**: the moment the problem is re-represented so a different candidate field becomes visible.
+- Make the representational change explicit: from the baseline frame to the alternative frame.
+- Output one compact line: `Aha: <restructuring insight> [evidence: fact | supported inference | hypothesis]`.
+- An Aha is material only if it changes the candidate field, proof surface, ordering, or decision criteria.
+- An Aha may be a hypothesis. Creative force does not upgrade its factual status.
 - If the mechanism is unverified, label it as a hypothesis and make validation part of the expected signal.
-- If no material shift appears after the second pass, state `No material reframe after second pass`, continue with the strongest grounded portfolio available, and mark same-basin honestly. Do not manufacture diversity.
+- If no material Aha appears after the second pass, state `Aha: N/A after second pass`, continue with the strongest grounded portfolio available, and mark same-basin honestly. Do not manufacture an Aha or diversity.
 
 ## Diversity guard
 
@@ -168,7 +170,7 @@ Moonshot — <move> [frame: <frame>]
 
 - Lane + stage.
 - Problem + success criteria + evidence posture.
-- Reframe used + Frame Shift Check + default basin.
+- Reframe used + Aha Check + default basin.
 - Compact Artifact Spine.
 - Five-tier portfolio.
 - Selection guidance + `Human Input Required`.
@@ -199,8 +201,8 @@ Evidence: latency and targets are known; the bottleneck is unknown.
 
 Reframe used: SCAMPER
 Why: mutate the existing request path before assuming a replacement is necessary.
-Frame shift: from "tune the query engine" to "allocate latency end-to-end; query, serialization, payload, cache, and transport are competing hypotheses."
-Evidence status: hypothesis; tracing decides which budget dominates.
+Aha: latency is a budget-allocation problem across the whole request path, not necessarily a query-engine problem. [evidence: hypothesis]
+Why it matters: query, serialization, payload, cache, and transport become competing hypotheses; tracing decides which budget dominates.
 Default basin: tune the query engine directly.
 Frames: proof surface, constraint budget, operating model, interface, substrate.
 

--- a/codex/skills/creative-problem-solver/SKILL.md
+++ b/codex/skills/creative-problem-solver/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: creative-problem-solver
-description: "Generate a compact five-tier strategy portfolio when the next task is choosing among materially different paths. Implicitly invoke for explicit requests for options, alternatives, trade-offs, reframing, or help escaping repeated failure. A skill-name mention is not invocation. Do not activate for direct implementation, single-answer advice, skill analysis/tuning, repository-evidence opportunity mining ($ideate), or detailed planning ($plan)."
+description: "Generate a compact five-tier strategy portfolio when the next task is choosing among materially different paths. Implicitly invoke for explicit requests for options, alternatives, trade-offs, reframing, or help escaping repeated failure. A name-only or meta mention does not authorize the portfolio route. Do not activate for direct implementation, single-answer advice, skill analysis/tuning, repository-evidence opportunity mining ($ideate), or detailed planning ($plan)."
 ---
 
 # Creative Problem Solver
@@ -9,7 +9,7 @@ Purpose: when a strategy choice is still open, generate a five-tier portfolio th
 
 ## Activation boundary
 
-Implicit invocation is enabled. The activation signal is an **unresolved strategy choice plus a request for divergent options**. Difficulty, uncertainty, or creativity language alone is not enough.
+Implicit invocation is enabled. Host loading is not portfolio authorization. The portfolio route requires an **unresolved strategy choice plus a request for divergent options**. Difficulty, uncertainty, creativity language, or a name-only or meta mention is not enough.
 
 ### Activate when
 
@@ -32,12 +32,12 @@ Implicit invocation is enabled. The activation signal is an **unresolved strateg
 
 ### Skill-name rule
 
-- Imperative requests such as "use", "run", or "apply `$creative-problem-solver`" count as explicit invocation.
-- Merely mentioning, quoting, explaining, reviewing, tuning, or editing `$creative-problem-solver` does not invoke it.
+- Imperative requests to "use", "run", or "apply `$creative-problem-solver`" **to generate a strategy portfolio** explicitly authorize the portfolio route.
+- A name-only or meta mention may load the package under host policy, but it routes to the task owner—or to direct clarification when no task exists—and does not authorize portfolio generation.
 
 ### Tie-breakers
 
-- Explicit imperative invocation wins unless safety, a domain-specific owner, or a contradictory execution request requires another route.
+- Explicit imperative portfolio invocation wins unless safety, a domain-specific owner, a meta-task owner, or a contradictory execution request requires another route.
 - `$ideate` wins when repository evidence mining and ranked opportunities are central.
 - `$plan` wins when the direction is selected and the requested output is an execution policy or detailed plan.
 - `$tune` / `$refine` win when the object of work is the skill package itself.
@@ -47,12 +47,12 @@ Implicit invocation is enabled. The activation signal is an **unresolved strateg
 
 - Name the lane and Double Diamond stage.
 - State the problem, success criteria, and evidence posture: known facts versus assumptions or hypotheses.
-- Reframe once, then run an Aha Check: name the restructuring insight and its evidence status. Never promote an unsupported mechanism, bottleneck, or causal story to fact.
-- Name the default solution basin and ensure at least two tiers use genuinely different conceptual frames.
+- Reframe once, then run an Aha Check: state the restructuring insight separately from its evidence basis and any empirical claim. Never promote an unsupported mechanism, bottleneck, or causal story to fact.
+- Name the default solution basin and use at least two genuinely different conceptual frames when honest; otherwise mark the portfolio same-basin rather than manufacturing diversity.
 - Include all five tiers: Quick Win, Strategic Play, Advantage Play, Transformative Move, Moonshot.
 - For every tier: accretive artifact, falsifiable expected signal with a timebox, and escape hatch.
 - Give conditional selection guidance, then stop for human input before execution.
-- Keep the visible process proportional: Fast Spark targets <=45 lines; Full Session targets <=70 lines.
+- Keep the visible process proportional: Fast Spark must fit <=45 non-empty output lines; Full Session must fit <=70 non-empty output lines. Count before replying and compress optional detail rather than exceed the lane budget.
 
 ## Workflow
 
@@ -61,11 +61,13 @@ Implicit invocation is enabled. The activation signal is an **unresolved strateg
 3. Define gate: one-line problem statement + success criteria; mark material unknowns.
 4. Evidence posture: separate facts from assumptions and hypotheses.
 5. Reframe using the stage default or the user's requested technique.
-6. Aha Check. State the restructuring insight, representational shift, and evidence status. If no material Aha appears, run one second and final pass with a different operator.
-7. Diversity gate: name the default basin and at least two distinct frames.
+6. Aha Check. State the restructuring insight, then classify its basis and any empirical claim. If no material Aha appears, run one second and final pass with a different operator.
+7. Diversity gate: name the default basin and at least two distinct frames, or explicitly mark same-basin when honest divergence is unavailable.
 8. Define an Artifact Spine of 1-3 durable assets that higher tiers can reuse.
-9. Generate the five-tier portfolio.
+9. Generate the five-tier portfolio, then silently verify exact spine-name reuse, mutually exclusive and exhaustive outcomes, retained proof, evidence labels, literal entailment of every fact, and the lane line count; repair every miss before replying.
 10. Give selection guidance and ask the user to choose a tier or update constraints.
+
+Definition Gate fields are: domain; symptom, actors, and problem topology; desired outcome and success criteria; metric, threshold, and measurement basis; representative workload population and selection rule; constraints and guardrails. If any field in the first two groups is missing, use Discover; if every field there is recorded or inapplicable but any later field is missing, use Define. In either case, add `Interpretation (assumption): ...` and do not silently choose a domain or metric. When target success is unknown, output `Target success: unknown` separately from `Portfolio success: <decision progress>`; never substitute process success for the target outcome. While any Definition Gate field is missing, all five tiers must reduce uncertainty without proposing solution prototypes: do not choose an index, cache, interface, engine, substrate, or other implementation candidate. The Quick Win signal passes only when every Definition Gate field is explicitly recorded or marked inapplicable; make every later tier conditional on that gate. The Quick Win signal and every later prerequisite clause must spell out all six field groups rather than refer to "the gate," "each field," or a nearby artifact. Preserve tier semantics even here: a Transformative probe must test a changed interface, operating model, governing constraint, or user ritual rather than merely inventorying the current one. The Moonshot may test discontinuous learning or proof leverage, but its signal still needs a predeclared discontinuous threshold rather than mere completeness.
 
 ## Double Diamond alignment
 
@@ -79,11 +81,14 @@ Implicit invocation is enabled. The activation signal is an **unresolved strateg
 - Pragmatic (default): every tier is a bounded, reversible next move that can produce evidence this week.
 - Visionary: use only when the user asks for long-horizon strategy or systemic change.
 - Tiers describe the ambition of the hypothesis, not the size of the first commitment. A Moonshot is the smallest proof-bearing probe of discontinuous upside, not an unbounded rewrite.
+- In Pragmatic mode, every tier's expected-signal timebox covers a first probe of at most one week. A longer rollout horizon may be context, but cannot replace this first signal.
+- Put every escape hatch before an irreversible boundary. Quarantine or containment after authority or data has crossed that boundary is not reversibility.
 
 ## Lane selector
 
-- Fast Spark: skip broad candidate generation and surface only the minimum decision-useful structure.
-- Full Session: generate 10-30 candidates, cluster by frame, winnow, and surface the assumptions and trade-offs that changed the selection.
+- Fast Spark: default when context is sufficient and the user wants decision-useful options without exhaustive candidate work; skip broad generation and surface only the minimum decision-useful structure.
+- Full Session: use when the user explicitly asks for deep or exhaustive exploration, or when high stakes, irreversibility, or coupled constraints make candidate generation and winnowing decision-relevant; generate 10-30 candidates, cluster by frame, and surface what changed the selection.
+- If lane choice is unclear, choose Fast Spark. Difficulty alone does not justify Full Session.
 
 ## Reframe selection
 
@@ -91,7 +96,7 @@ Implicit invocation is enabled. The activation signal is an **unresolved strateg
 - Define default -> How Might We.
 - Develop default -> SCAMPER for an existing system; First Principles for greenfield work.
 - Deliver default -> Pre-mortem.
-- Second pass -> choose a materially different operator, usually First Principles, Inversion, or Analogy.
+- Second pass -> only when the first yields no material Aha, choose a materially different operator, declare `Second reframe used: <technique>` before the Aha, and never credit an undeclared operator later.
 - Honor a user-requested technique when it is usable; do not silently replace it with a "nearest supported" technique.
 - Chat disclosure: `Reframe used: <technique>` plus one line explaining why.
 
@@ -99,10 +104,14 @@ Implicit invocation is enabled. The activation signal is an **unresolved strateg
 
 - **Aha is the restructuring insight**: the moment the problem is re-represented so a different candidate field becomes visible.
 - Make the representational change explicit: from the baseline frame to the alternative frame.
-- Output one compact line: `Aha: <restructuring insight> [evidence: fact | supported inference | hypothesis]`.
+- Output `Aha: <restructuring insight>` without an epistemic label; a representational operation is not itself a factual proposition.
+- Follow with `Aha basis: <why this shift is warranted> [evidence: fact | supported inference]`.
+- Put any testable mechanism or outcome on a separate optional line: `Claim: <claim> [evidence: fact | supported inference | hypothesis]`.
 - An Aha is material only if it changes the candidate field, proof surface, ordering, or decision criteria.
-- An Aha may be a hypothesis. Creative force does not upgrade its factual status.
-- If the mechanism is unverified, label it as a hypothesis and make validation part of the expected signal.
+- Creative force does not upgrade a basis or claim's factual status. Use `hypothesis` only for a concrete claim with a real falsifier.
+- For a `Claim` labeled fact or supported inference, name its source or support in the evidence posture or adjacent to the Claim.
+- If a claim is an unverified mechanism or outcome, label it as a hypothesis and make validation part of an expected signal.
+- For every `Claim` labeled hypothesis, one expected signal must include `Claim falsifier: <observation>` and test that exact claim, not a neighboring assertion.
 - If no material Aha appears after the second pass, state `Aha: N/A after second pass`, continue with the strongest grounded portfolio available, and mark same-basin honestly. Do not manufacture an Aha or diversity.
 
 ## Diversity guard
@@ -110,16 +119,17 @@ Implicit invocation is enabled. The activation signal is an **unresolved strateg
 - Name the default solution basin before generating tiers.
 - Ensure at least two tiers shift frame, not merely cost or scope.
 - Useful frame shifts include substrate, interface, constraint, proof surface, incentive, time horizon, operating model, user ritual, or authority boundary.
-- Put the frame in each option heading, for example `Quick Win — Instrument first [proof surface]`.
+- Put the frame in each option heading, for example `Quick Win — Instrument first [frame: proof surface]`.
 - If the five tiers cannot honestly diverge, say so and mark the portfolio as same-basin.
 
 ## Accretion
 
 - An accretive artifact is a durable asset retained even when an option is wrong: measurement, harness, spec, test, automation, interface, dataset, or decision record.
-- Define 1-3 Artifact Spine assets shared across tiers. Each tier's artifact must belong to the spine or explicitly justify a different spine.
+- Define 1-3 Artifact Spine assets shared across tiers, each with a stable name and home. Every `Accretive artifact` line must repeat at least one exact declared asset name or home; an unqualified new artifact is invalid. If reuse is honestly impossible, declare and justify a replacement spine before the portfolio.
+- Every escape hatch must name the proof artifact retained after a prototype or production change is removed. Retaining only an undeclared by-product does not satisfy accretion. The retained artifact proves only observations bound by the signal; do not call ritual or artifact completion proof of benefit without a comparator and outcome predicate.
 - Fast Spark: give each spine asset's purpose and home; put the timebox in the option signal.
-- Full Session: also give the minimal interface and explain how the ladder compounds.
-- Expected signals must be falsifiable and timeboxed. Do not promise an outcome that the current evidence cannot support.
+- Full Session: repeat each asset's purpose and home, add its minimal interface, and explain how the ladder compounds.
+- Expected signals must be timeboxed and partition every outcome with mutually exclusive, exhaustive clauses. Use `Inconclusive iff any of <named prerequisites> is missing -> <next disposition>; otherwise Pass iff <success>; Fail otherwise`; for a legitimate measured third state, use `Pass iff <success>; Fail iff <falsifier>; Inconclusive otherwise -> <next disposition>`; omit Inconclusive when Pass and Fail are complements. Every value or predicate consumed by Pass must be established or named separately in Inconclusive. Every missing-prerequisite Inconclusive clause must use the exact `any of ... is missing` form and put all missing prerequisites in that one list, never an ambiguous combined negation. Quantified item outcomes use integer counts such as `at least 1 of n`, not fractional item grammar. Relative terms such as dominant, material, acceptable, stable, comparable, beyond noise, best, ranking, or percentage improvement require a named baseline or denominator, comparison rule, predeclared threshold, and replication count repeated in the signal; references to recorded or agreed criteria do not satisfy this rule. Terms such as `complete`, `representative`, `correct`, or `compatible` require their operational fields or selection rule in the signal, not an adjective standing in for a predicate. Any use of `falsify` or `falsifier` must state the predeclared observation predicate for each hypothesis. A universal, `every`, `all`, or Cartesian-product predicate must predeclare a nonzero finite denominator; an empty set is Inconclusive or Fail, never Pass. When a required threshold is unknown, resolve that threshold instead of claiming an unspecified target will be met. Do not promise an outcome that the current evidence cannot support.
 
 ## Tier semantics
 
@@ -133,35 +143,35 @@ Implicit invocation is enabled. The activation signal is an **unresolved strateg
 
 ```text
 Quick Win — <move> [frame: <frame>]
-- Accretive artifact (spine):
-- Expected signal + timebox:
-- Escape hatch:
+- Accretive artifact (spine): <exact declared spine name/home> — <addition>
+- Expected signal + timebox: <time>; Inconclusive iff any of <named prerequisites> is missing -> <next disposition>; otherwise Pass iff <success>; Fail otherwise
+- Escape hatch: <pre-irreversible stop>; retain <exact spine proof>
 
 Strategic Play — <move> [frame: <frame>]
-- Accretive artifact (spine):
-- Expected signal + timebox:
-- Escape hatch:
+- Accretive artifact (spine): <exact declared spine name/home> — <addition>
+- Expected signal + timebox: <time>; Inconclusive iff any of <named prerequisites> is missing -> <next disposition>; otherwise Pass iff <success>; Fail otherwise
+- Escape hatch: <pre-irreversible stop>; retain <exact spine proof>
 
 Advantage Play — <move> [frame: <frame>]
-- Accretive artifact (spine):
-- Expected signal + timebox:
-- Escape hatch:
+- Accretive artifact (spine): <exact declared spine name/home> — <addition>
+- Expected signal + timebox: <time>; Inconclusive iff any of <named prerequisites> is missing -> <next disposition>; otherwise Pass iff <success>; Fail otherwise
+- Escape hatch: <pre-irreversible stop>; retain <exact spine proof>
 
 Transformative Move — <move> [frame: <frame>]
-- Accretive artifact (spine):
-- Expected signal + timebox:
-- Escape hatch:
+- Accretive artifact (spine): <exact declared spine name/home> — <addition>
+- Expected signal + timebox: <time>; Inconclusive iff any of <named prerequisites> is missing -> <next disposition>; otherwise Pass iff <success>; Fail otherwise
+- Escape hatch: <pre-irreversible stop>; retain <exact spine proof>
 
 Moonshot — <move> [frame: <frame>]
-- Accretive artifact (spine):
-- Expected signal + timebox:
-- Escape hatch:
+- Accretive artifact (spine): <exact declared spine name/home> — <addition>
+- Expected signal + timebox: <time>; Inconclusive iff any of <named prerequisites> is missing -> <next disposition>; otherwise Pass iff <success>; Fail otherwise
+- Escape hatch: <pre-irreversible stop>; retain <exact spine proof>
 ```
 
 ## Selection guidance
 
-- Fast Spark: name the best learning bet, best near-term outcome bet, and boldest bounded probe; give a conditional recommendation.
-- Full Session: optionally score Impact, Information, Accretion, Confidence, Reversibility, and Time-to-signal from 1-5. Do not rank by a summed total; identify Pareto leaders and explain the trade-off.
+- Fast Spark: name the best learning bet, best near-term outcome bet, and boldest bounded probe; give a conditional recommendation. When target success is unknown, output `Best near-term outcome bet: none; basis: target success is undefined. [evidence: fact]` rather than relabeling decision progress as the target outcome. Treat every unmeasured `best` or recommendation ranking as supported inference or hypothesis, never fact; name its basis and end it with that evidence label.
+- Full Session: optionally score Impact, Information, Accretion, Confidence, Reversibility, and Time-to-signal from 1-5. Use 5 for the more favorable end of every dimension; for Time-to-signal, 5 means faster. Do not rank by a summed total. Compute dominance across all displayed dimensions and output `Pareto leaders: <every non-dominated tier by name>` plus the trade-off; if dominance was not checked, omit the Pareto claim. End every `best` selection and recommendation line with `[evidence: fact | supported inference | hypothesis]` and name its basis.
 - A recommendation is not execution authorization.
 
 ## Deliverable format
@@ -178,9 +188,9 @@ Moonshot — <move> [frame: <frame>]
 ### Full Session
 
 - Everything in Fast Spark.
-- Candidate-field summary and the frames that survived winnowing.
+- Candidate-field summary and frames that survived winnowing; evidence-label every causal or decision-shaping inference, including stage choice, reframe `Why`, winnowing, diversity/same-basin disposition, score interpretation, and recommendations.
 - Optional scorecard with brief rationale.
-- Compact facts / risks / assets and assumptions / constraints.
+- Explicit compact lines labeled `Facts:`, `Risks:`, `Assets:`, `Assumptions:`, and `Constraints:`.
 - Detailed Artifact Spine ladder.
 
 After human selection:
@@ -197,46 +207,50 @@ Stage: Develop
 
 Problem: Search API p95 latency is ~800ms; target <=200ms at current infra cost.
 Success: p95<=200ms, p99<=400ms, CPU +<=10%, no relevancy regression.
-Evidence: latency and targets are known; the bottleneck is unknown.
+Definition Gate: domain=Search API; symptom/actors/topology=p95 ~800ms across API clients -> search service -> query engine -> serialization/transport; desired outcome/success=p95<=200ms and p99<=400ms; metric/threshold/basis=pooled fixed-fixture latency and relevancy diff across exactly 5 batches; representative workload population/selection rule=fixed dataset stratified by current request-size and filter-shape distributions; constraints/guardrails=current infra cost, CPU +<=10%, and no relevancy regression.
+Evidence: latency, gate fields, and targets are known; the bottleneck is unknown.
 
 Reframe used: SCAMPER
 Why: mutate the existing request path before assuming a replacement is necessary.
-Aha: latency is a budget-allocation problem across the whole request path, not necessarily a query-engine problem. [evidence: hypothesis]
+Aha: shift from query-only optimization to whole-path budget allocation.
+Aha basis: the reported p95 spans the listed request path, and the bottleneck is unknown. [evidence: fact]
+Claim: across repeated fixed-fixture batches, the pooled mean non-query share among requests in each batch's slowest 1% is >=10%. [evidence: hypothesis]
 Why it matters: query, serialization, payload, cache, and transport become competing hypotheses; tracing decides which budget dominates.
 Default basin: tune the query engine directly.
 Frames: proof surface, constraint budget, operating model, interface, substrate.
-
 Artifact Spine:
-- bench/search/: fixed dataset + p50/p95/p99 + relevancy diff; home: repo benchmark suite.
+- bench/search/: fixed dataset + immutable pre-change baseline + candidate adapters + p50/p95/p99 + relevancy diff; home: repo benchmark suite.
 - perf/tracing/: query/serialization/transport breakdown; home: repo performance tooling.
-
+- contracts/search-response/: opt-in response contract + conformance fixtures; home: repo contract tests.
 Quick Win — Instrument the latency budget [frame: proof surface]
-- Accretive artifact (spine): baseline run + three worst traces in perf/tracing/.
-- Expected signal + timebox: stable budget breakdown and top contributors within 1 day.
-- Escape hatch: disable high-overhead tracing; retain the harness and sampled traces.
+- Accretive artifact (spine): exactly 5 fixed-fixture batch results and all 50 slowest-1% request decompositions in perf/tracing/, keyed to the bench/search/ harness.
+- Expected signal + timebox: within 1 day, run exactly 5 fixed-fixture batches of exactly 1,000 requests and decompose the 10 slowest requests in each batch; Pass iff the 95% bootstrap CI lower bound for pooled mean non-query share is >=10%; Claim falsifier: Fail iff its upper bound is <10%; Inconclusive otherwise -> run one additional predeclared set of exactly 5 such batches before selection.
+- Escape hatch: disable high-overhead tracing; retain the bench/search/ harness plus perf/tracing/ batch results and every slowest-1% request decomposition.
 
 Strategic Play — Attack the measured largest budget [frame: constraint]
-- Accretive artifact (spine): harness-backed optimization in the measured dominant stage.
-- Expected signal + timebox: >=30% p95 improvement on the harness within 2 days, with no relevancy regression.
-- Escape hatch: feature flag or revert; retain the benchmark and diagnosis.
+- Accretive artifact (spine): measured-stage experiment fixture + before/after result in bench/search/.
+- Expected signal + timebox: within 2 days, run the candidate and immutable pre-change bench/search/ baseline for exactly 5 fixed-fixture batches of exactly 1,000 requests each, including exactly 100 predeclared relevancy cases per batch; let B=baseline pooled p95 and C=candidate pooled p95; Pass iff (B-C)/B >=30% and all 500 candidate relevancy results match baseline; Fail otherwise.
+- Escape hatch: feature flag or revert the production change; retain the bench/search/ fixture, result, and diagnosis.
 
 Advantage Play — Make latency a continuous contract [frame: operating model]
-- Accretive artifact (spine): performance budget check and trend history in bench/search/.
-- Expected signal + timebox: a seeded regression is caught before merge within 2 days.
-- Escape hatch: begin as an advisory check; keep the trend data if gating is noisy.
+- Accretive artifact (spine): predeclared >=20%-over-baseline seeded fixture, performance budget check, and trend history in bench/search/.
+- Expected signal + timebox: within 2 days, inject a predeclared fixture whose p95 is >=20% above the fixed bench/search/ baseline; Pass iff two consecutive check runs both reject it before merge; Fail otherwise.
+- Escape hatch: begin as an advisory check; keep the bench/search/ seeded fixture, check, and trend data if gating is noisy.
 
 Transformative Move — Change the response contract [frame: interface]
-- Accretive artifact (spine): opt-in streaming or pagination contract measured by the harness.
-- Expected signal + timebox: first useful bytes arrive <=200ms on large-result fixtures within 3 days.
-- Escape hatch: retain the current response as default and keep the prototype opt-in.
+- Accretive artifact (spine): opt-in contract + conformance fixtures in contracts/search-response/, measured by bench/search/.
+- Expected signal + timebox: within 3 days, across two runs per fixture, Pass iff first useful bytes arrive <=200ms on all exactly 10 predeclared fixtures with a >=1 MiB response body; Fail otherwise.
+- Escape hatch: disable the opt-in endpoint, retain the current response as default, and keep contracts/search-response/ fixtures plus bench/search/ results.
 
 Moonshot — Run an architecture bakeoff [frame: substrate]
-- Accretive artifact (spine): reusable evaluation kit comparing engines and transport shapes.
-- Expected signal + timebox: one candidate shows >=3x tail improvement on fixed fixtures within 1 week.
-- Escape hatch: stop before migration; keep the kit as durable decision evidence.
+- Accretive artifact (spine): evaluation adapter + fixed fixtures in bench/search/ comparing engines and transport shapes.
+- Expected signal + timebox: within 1 week, run exactly 3 candidates and the immutable pre-change bench/search/ baseline for exactly 5 fixed-fixture batches each; let B=baseline pooled p99 and C_i=each candidate's pooled p99; Pass iff at least one of the 3 satisfies 3*C_i <= B; Fail otherwise.
+- Escape hatch: stop before migration; keep the bench/search/ adapter, fixtures, and results as durable decision evidence.
 
-Selection guidance: Quick Win is the best learning bet; Strategic is the best near-term outcome bet once traces identify the budget; Moonshot is the boldest bounded probe.
-Conditional recommendation: start with Quick Win, then choose Strategic or Transformative from measured evidence.
+Best learning bet: Quick Win, because it identifies which path budget owns the uncertainty. [evidence: supported inference]
+Best near-term outcome bet: Strategic after tracing, because it attacks the measured largest budget against the fixed baseline. [evidence: supported inference]
+Boldest bounded probe: Moonshot, because three candidates test discontinuous latency upside before migration. [evidence: supported inference]
+Conditional recommendation: start with Quick Win, then choose Strategic or Transformative from measured evidence because both preserve the shared proof spine. [evidence: supported inference]
 Human Input Required: choose a tier or update the constraints.
 ```
 
@@ -252,6 +266,8 @@ Human Input Required: choose a tier or update the constraints.
 
 ### Should not activate
 
+- "`$creative-problem-solver`" -> direct clarification; no portfolio object is authorized.
+- "Use `$creative-problem-solver`." -> direct clarification until a portfolio object is supplied.
 - "Do a deep analysis of my `$creative-problem-solver` skill." -> direct analysis / `$tune`
 - "Patch `$creative-problem-solver` so it stops over-triggering." -> `$tune` / `$refine`
 - "I am blocked by this compiler error. What else can I try?" -> debugging owner

--- a/codex/skills/creative-problem-solver/SKILL.md
+++ b/codex/skills/creative-problem-solver/SKILL.md
@@ -1,223 +1,241 @@
 ---
 name: creative-problem-solver
-description: "Generate a compact five-tier strategy portfolio when the user needs multiple materially different paths before execution. Implicitly invoke for explicit requests for options, alternatives, trade-offs, reframing, or help escaping a repeated stall/failure. Do not activate for direct implementation, single-answer advice, repository-evidence opportunity mining ($ideate), or detailed planning ($plan)."
+description: "Generate a compact five-tier strategy portfolio when the next task is choosing among materially different paths. Implicitly invoke for explicit requests for options, alternatives, trade-offs, reframing, or help escaping repeated failure. A skill-name mention is not invocation. Do not activate for direct implementation, single-answer advice, skill analysis/tuning, repository-evidence opportunity mining ($ideate), or detailed planning ($plan)."
 ---
 
 # Creative Problem Solver
 
-Purpose: when a strategy choice is still open, generate a five-tier portfolio that compounds through an Artifact Spine, then stop for a human choice.
+Purpose: when a strategy choice is still open, generate a five-tier portfolio that escapes the default solution basin, compounds through an Artifact Spine, and stops for a human choice.
 
 ## Activation boundary
 
-Implicit invocation is enabled. The activation signal is an **unresolved strategy choice plus a request for divergent options**. Difficulty alone is not enough.
+Implicit invocation is enabled. The activation signal is an **unresolved strategy choice plus a request for divergent options**. Difficulty, uncertainty, or creativity language alone is not enough.
 
 ### Activate when
 
-- The user explicitly asks for options, alternatives, trade-offs, a strategy portfolio, fresh angles, reframing, or "what else could we try?"
-- Progress is stalled or repeated attempts fail, and selecting a materially different approach is the next task.
-- A multi-constraint or high-uncertainty decision would benefit from several distinct conceptual frames before execution.
-- The user asks to brainstorm or ideate in the ordinary sense without requesting repository evidence mining, tickets, a detailed plan, or implementation.
-- The primary deliverable is at least three materially different paths and a human choice among them.
+- The user asks for options, alternatives, trade-offs, fresh angles, reframing, a strategy portfolio, or "what else could we try?"
+- Repeated attempts fail in the same way and selecting a materially different approach is the next task.
+- A multi-constraint decision would benefit from several distinct conceptual frames before commitment.
+- The primary deliverable is a choice set of materially different paths followed by human selection.
+- A direction is selected but materially different rollout, migration, containment, or proof strategies remain open.
 
 ### Do not activate; route elsewhere
 
-- Direct implementation, debugging, review, or execution after an approach is selected: use the normal task flow or the owning implementation/review skill.
-- A single factual answer, a straightforward recommendation, or comparison of a small known set where a portfolio would add ceremony: answer directly.
+- Direct implementation, debugging, review, or execution after an approach is selected: use the owning workflow.
+- Mixed requests where options are subordinate to "choose and implement now": the execution owner may use this reasoning internally, but this skill must not seize the turn and discard the requested execution.
+- A factual answer, ordinary creative generation such as names or copy, or comparison of a small known set where a portfolio adds ceremony: answer directly.
 - Evidence-backed repository or product opportunity mining, ranked improvement discovery, or choosing what to plan next: use `$ideate`.
-- Turning a selected direction into a detailed implementation plan, specification, or work graph: use `$plan` or `$spec-pipeline` as appropriate.
+- Turning a selected direction into a detailed implementation plan, specification, or work graph: use `$plan` or `$spec-pipeline`.
 - Architecture or codebase understanding without a request for divergent paths: use direct analysis or `$codebase-archaeology`.
+- Analysis, explanation, review, tuning, testing, or editing of this skill itself: use direct analysis, `$tune`, or `$refine` as appropriate.
 - The user already chose a tier or path and asks to execute it: hand off to the execution owner; do not regenerate the portfolio.
+
+### Skill-name rule
+
+- Imperative requests such as "use", "run", or "apply `$creative-problem-solver`" count as explicit invocation.
+- Merely mentioning, quoting, explaining, reviewing, tuning, or editing `$creative-problem-solver` does not invoke it.
 
 ### Tie-breakers
 
-- Explicit `$creative-problem-solver` invocation wins unless a safety or domain-specific boundary requires another owner.
-- `$ideate` wins when repository evidence mining and ranked opportunities are central to the request.
-- `$plan` wins when the direction is already selected and the requested output is an execution plan.
-- Activate this skill when the requested outcome is a choice set; do not activate when the requested outcome is one answer, one plan, or one implementation.
+- Explicit imperative invocation wins unless safety, a domain-specific owner, or a contradictory execution request requires another route.
+- `$ideate` wins when repository evidence mining and ranked opportunities are central.
+- `$plan` wins when the direction is selected and the requested output is an execution policy or detailed plan.
+- `$tune` / `$refine` win when the object of work is the skill package itself.
+- Activate when the requested outcome is a choice set; do not activate when the outcome is one answer, one plan, or one implementation.
 
-## Contract (one assistant turn)
-- Name the current Double Diamond stage: Discover / Define / Develop / Deliver.
-- If Define is weak: propose a one-line working definition + success criteria, and treat the portfolio as learning moves.
-- Deliver options, then stop and ask for human input before executing.
-- Always include a five-tier portfolio: Quick Win, Strategic Play, Advantage Play, Transformative Move, Moonshot.
-- Before generating tiers, name the default solution basin and ensure at least two tiers come from different conceptual frames.
-- For each option: accretive artifact + expected signal + escape hatch.
-- Run an Aha Check after reframing.
-- Keep a short Knowledge Snapshot (facts/risks/assets) + Decision Log.
-- Keep output compact: target <= 60 lines; 1-3 bullets per section.
+## Contract
 
-## When to use
-- The next useful action is selecting among materially different paths, not executing one.
-- Progress is stalled or blocked.
-- Repeated attempts fail the same way.
-- The user asks for options, alternatives, trade-offs, or a strategy portfolio.
-- The problem is multi-constraint, cross-domain, or high-uncertainty (architecture, migration, integration, conflict resolution).
+- Name the lane and Double Diamond stage.
+- State the problem, success criteria, and evidence posture: known facts versus assumptions or hypotheses.
+- Reframe once, then run a Frame Shift Check. Never promote an unsupported mechanism, bottleneck, or causal story to fact.
+- Name the default solution basin and ensure at least two tiers use genuinely different conceptual frames.
+- Include all five tiers: Quick Win, Strategic Play, Advantage Play, Transformative Move, Moonshot.
+- For every tier: accretive artifact, falsifiable expected signal with a timebox, and escape hatch.
+- Give conditional selection guidance, then stop for human input before execution.
+- Keep the visible process proportional: Fast Spark targets <=45 lines; Full Session targets <=70 lines.
 
-## Quick start
-1. Choose Double Diamond stage: Discover / Define / Develop / Deliver.
+## Workflow
+
+1. Choose stage: Discover / Define / Develop / Deliver.
 2. Choose lane: Fast Spark or Full Session.
-3. Reframe once using the supported technique for the stage.
-4. Aha Check. If none, run one second and final pass with First Principles.
-5. Define gate: state a one-line problem statement + success criteria (or mark unknown and ask).
-6. Diversity gate: name the default solution basin and choose at least two different conceptual frames for the tiers.
-7. Define an Artifact Spine (1-3 shared artifacts) so the tiers can stack.
-8. Generate the five-tier portfolio (learning moves in Discover/Define; solution moves in Develop/Deliver).
-9. Score options (1-5): Signal, Accretion, Ease, Reversibility, Speed.
-10. Ask the user to choose a tier or update constraints.
-11. Close with an Insights Summary.
+3. Define gate: one-line problem statement + success criteria; mark material unknowns.
+4. Evidence posture: separate facts from assumptions and hypotheses.
+5. Reframe using the stage default or the user's requested technique.
+6. Frame Shift Check. If there is no material shift, run one second and final pass with a different operator.
+7. Diversity gate: name the default basin and at least two distinct frames.
+8. Define an Artifact Spine of 1-3 durable assets that higher tiers can reuse.
+9. Generate the five-tier portfolio.
+10. Give selection guidance and ask the user to choose a tier or update constraints.
 
 ## Double Diamond alignment
-- Discover (diverge): broaden context; focus options on learning (research, instrumentation, repro, characterization).
-- Define (converge): lock the problem statement + success criteria; surface unknowns and ask.
-- Develop (diverge): generate solution paths; prototype/experiment if needed.
-- Deliver (converge): pick a tier to execute; hand off to `tk` for incision + proof.
+
+- Discover: relevant facts, actors, or problem topology are unclear; tiers are learning and observation moves.
+- Define: the decision definition, success criteria, or constraints are unclear; tiers test competing definitions.
+- Develop: the problem is sufficiently defined and materially different solution paths remain open.
+- Deliver: the core direction is selected, but rollout, migration, containment, or proof strategies remain open. Do not use Deliver to regenerate competing core solutions.
 
 ## Mode check
-- Pragmatic (default): ship-this-week options only.
-- Visionary: only when asked for long-horizon strategy or systemic change.
+
+- Pragmatic (default): every tier is a bounded, reversible next move that can produce evidence this week.
+- Visionary: use only when the user asks for long-horizon strategy or systemic change.
+- Tiers describe the ambition of the hypothesis, not the size of the first commitment. A Moonshot is the smallest proof-bearing probe of discontinuous upside, not an unbounded rewrite.
 
 ## Lane selector
-- Fast Spark: skip broad candidate generation; produce the portfolio directly.
-- Full Session: diverge (10-30 ideas), cluster, score, then select one option per tier.
 
-## Reframe selection (required)
-- Supported techniques:
-  - Discover default -> Assumption Mapping
-  - Define default -> How Might We
-  - Develop default -> SCAMPER
-  - Deliver default -> Pre-mortem
-  - Final fallback -> First Principles
-- Rule: start with the stage default. If there is no Aha, run exactly one second pass with First Principles.
-- If the user asks for an out-of-catalog technique, choose the nearest supported technique and disclose the supported `Reframe used`.
-- Chat disclosure: include only `Reframe used: <technique>` + a one-line `why`.
+- Fast Spark: skip broad candidate generation and surface only the minimum decision-useful structure.
+- Full Session: generate 10-30 candidates, cluster by frame, winnow, and surface the assumptions and trade-offs that changed the selection.
 
-## Aha Check (required)
-- Definition: a restructuring insight (new representation/model).
-- Output: one-line insight. If none after the second pass, state `N/A after second pass` and continue with the most conservative portfolio that still satisfies the contract.
+## Reframe selection
 
-## Portfolio rule
-- Every response must include all five tiers.
-- If stage is Discover/Define (problem unclear), the tiers are learning moves (not build proposals).
-- If stage is Develop/Deliver (problem clear), the tiers are solution moves.
+- Discover default -> Assumption Mapping.
+- Define default -> How Might We.
+- Develop default -> SCAMPER for an existing system; First Principles for greenfield work.
+- Deliver default -> Pre-mortem.
+- Second pass -> choose a materially different operator, usually First Principles, Inversion, or Analogy.
+- Honor a user-requested technique when it is usable; do not silently replace it with a "nearest supported" technique.
+- Chat disclosure: `Reframe used: <technique>` plus one line explaining why.
+
+## Frame Shift Check
+
+- State the baseline frame and the alternative frame in one line.
+- State evidence status: fact, supported inference, or hypothesis.
+- A frame shift is material only if it changes the candidate field, proof surface, ordering, or decision criteria.
+- If the mechanism is unverified, label it as a hypothesis and make validation part of the expected signal.
+- If no material shift appears after the second pass, state `No material reframe after second pass`, continue with the strongest grounded portfolio available, and mark same-basin honestly. Do not manufacture diversity.
 
 ## Diversity guard
+
 - Name the default solution basin before generating tiers.
-- Ensure at least two tiers come from different conceptual frames, not just different sizes of the same idea.
-- Valid frame shifts include substrate, interface, constraint, proof surface, incentive, time horizon, operating model, or user ritual.
+- Ensure at least two tiers shift frame, not merely cost or scope.
+- Useful frame shifts include substrate, interface, constraint, proof surface, incentive, time horizon, operating model, user ritual, or authority boundary.
+- Put the frame in each option heading, for example `Quick Win — Instrument first [proof surface]`.
 - If the five tiers cannot honestly diverge, say so and mark the portfolio as same-basin.
 
-## Accretion (required)
-- Accretive artifact: a durable asset you keep even if the option is wrong (measurement, harness, spec, test, automation, interface, dataset, doc).
-- Rule: every tier must name one accretive artifact.
-- Artifact Spine: define 1-3 named artifacts shared across tiers; each tier's artifact must be one of these or an extension of one (otherwise explicitly state why it is a different spine).
-- Spine output: for each spine artifact, include purpose + minimal shape/interface + timebox + where it lives (repo path or conceptual home).
-- Ladder: prefer stacking (Quick Win builds the base; higher tiers reuse/extend it). If it does not ladder, say so explicitly.
+## Accretion
+
+- An accretive artifact is a durable asset retained even when an option is wrong: measurement, harness, spec, test, automation, interface, dataset, or decision record.
+- Define 1-3 Artifact Spine assets shared across tiers. Each tier's artifact must belong to the spine or explicitly justify a different spine.
+- Fast Spark: give each spine asset's purpose and home; put the timebox in the option signal.
+- Full Session: also give the minimal interface and explain how the ladder compounds.
+- Expected signals must be falsifiable and timeboxed. Do not promise an outcome that the current evidence cannot support.
+
+## Tier semantics
+
+- Quick Win: cheapest reversible move that improves the decision or outcome now.
+- Strategic Play: strongest path within the current operating model.
+- Advantage Play: creates a reusable capability, compounding asset, or asymmetric option.
+- Transformative Move: changes an interface, operating model, governing constraint, or user ritual.
+- Moonshot: tests discontinuous upside through the smallest bounded proof-bearing probe.
 
 ## Option template
+
 ```text
-Quick Win:
+Quick Win — <move> [frame: <frame>]
 - Accretive artifact (spine):
-- Expected signal:
+- Expected signal + timebox:
 - Escape hatch:
 
-Strategic Play:
+Strategic Play — <move> [frame: <frame>]
 - Accretive artifact (spine):
-- Expected signal:
+- Expected signal + timebox:
 - Escape hatch:
 
-Advantage Play:
+Advantage Play — <move> [frame: <frame>]
 - Accretive artifact (spine):
-- Expected signal:
+- Expected signal + timebox:
 - Escape hatch:
 
-Transformative Move:
+Transformative Move — <move> [frame: <frame>]
 - Accretive artifact (spine):
-- Expected signal:
+- Expected signal + timebox:
 - Escape hatch:
 
-Moonshot:
+Moonshot — <move> [frame: <frame>]
 - Accretive artifact (spine):
-- Expected signal:
+- Expected signal + timebox:
 - Escape hatch:
 ```
 
-## Scoring rubric (1-5, no weights)
-- Signal: how much new information this yields.
-- Accretion: durable value you keep even if you're wrong.
-- Ease: effort/complexity to try.
-- Reversibility: ease of undoing.
-- Speed: time-to-learn.
+## Selection guidance
 
-Preference: high Signal + Accretion + Reversibility, then Ease + Speed.
+- Fast Spark: name the best learning bet, best near-term outcome bet, and boldest bounded probe; give a conditional recommendation.
+- Full Session: optionally score Impact, Information, Accretion, Confidence, Reversibility, and Time-to-signal from 1-5. Do not rank by a summed total; identify Pareto leaders and explain the trade-off.
+- A recommendation is not execution authorization.
 
 ## Deliverable format
-- Lane (Fast Spark / Full Session).
-- Double Diamond stage (Discover / Define / Develop / Deliver).
-- Problem statement + success criteria (or marked unknown).
-- Reframe used.
-- Aha Check (one line).
-- Default solution basin + diversity guard.
-- Artifact Spine (1-3 shared artifacts; purpose + minimal interface + where it lives).
-- Five-tier portfolio with accretive artifacts + signals + escape hatches.
-- Scorecard + brief rationale.
-- Knowledge Snapshot (facts/risks/assets; 1-3 bullets).
-- Decision Log + Assumptions/Constraints.
-- Human Input Required (choose tier or update constraints).
-- If execution is chosen: hand off to `tk`.
-- Insights Summary.
 
-## Fast Spark example (compact)
+### Fast Spark
+
+- Lane + stage.
+- Problem + success criteria + evidence posture.
+- Reframe used + Frame Shift Check + default basin.
+- Compact Artifact Spine.
+- Five-tier portfolio.
+- Selection guidance + `Human Input Required`.
+
+### Full Session
+
+- Everything in Fast Spark.
+- Candidate-field summary and the frames that survived winnowing.
+- Optional scorecard with brief rationale.
+- Compact facts / risks / assets and assumptions / constraints.
+- Detailed Artifact Spine ladder.
+
+After human selection:
+
+- If the direction needs an execution policy or detailed plan, hand off to `$plan`.
+- If it is directly implementable and execution is authorized, hand off to the owning implementation workflow.
+- This skill never owns repository mutation.
+
+## Fast Spark example
+
 ```text
 Lane: Fast Spark
-Stage: Deliver
+Stage: Develop
 
-Problem: Search API p95 latency is ~800ms; target <= 200ms at current infra cost.
+Problem: Search API p95 latency is ~800ms; target <=200ms at current infra cost.
 Success: p95<=200ms, p99<=400ms, CPU +<=10%, no relevancy regression.
+Evidence: latency and targets are known; the bottleneck is unknown.
 
-Reframe used: Pre-mortem
-Why: the current system already exists, so the main risk is choosing a move that adds work without cutting the real latency driver.
-Aha: The dominant cost is JSON serialization + payload size, not the query.
-
+Reframe used: SCAMPER
+Why: mutate the existing request path before assuming a replacement is necessary.
+Frame shift: from "tune the query engine" to "allocate latency end-to-end; query, serialization, payload, cache, and transport are competing hypotheses."
+Evidence status: hypothesis; tracing decides which budget dominates.
 Default basin: tune the query engine directly.
-Diversity guard: Quick Win/Strategic stay in measurement + payload reduction; Transformative shifts the interface to streaming; Moonshot shifts the substrate to engine bakeoff.
+Frames: proof surface, constraint budget, operating model, interface, substrate.
 
 Artifact Spine:
-- bench/search/ (perf harness + fixed dataset; outputs: p50/p95/p99 + diff)
-- perf/tracing/ (capture scripts + flamegraphs; timebox: 30m per hypothesis)
+- bench/search/: fixed dataset + p50/p95/p99 + relevancy diff; home: repo benchmark suite.
+- perf/tracing/: query/serialization/transport breakdown; home: repo performance tooling.
 
-Quick Win:
-- Accretive artifact (spine): baseline run + 3 worst traces captured in perf/tracing/
-- Expected signal: stable baseline + top-3 hotspot list within 1 day
-- Escape hatch: disable extra tracing if overhead/noise
+Quick Win — Instrument the latency budget [frame: proof surface]
+- Accretive artifact (spine): baseline run + three worst traces in perf/tracing/.
+- Expected signal + timebox: stable budget breakdown and top contributors within 1 day.
+- Escape hatch: disable high-overhead tracing; retain the harness and sampled traces.
 
-Strategic Play:
-- Accretive artifact (spine): harness-backed PR reducing payload/serialization (bench/search/ diffs)
-- Expected signal: p95 improves >= 30% on harness with no regression
-- Escape hatch: guard behind flag; revert commit
+Strategic Play — Attack the measured largest budget [frame: constraint]
+- Accretive artifact (spine): harness-backed optimization in the measured dominant stage.
+- Expected signal + timebox: >=30% p95 improvement on the harness within 2 days, with no relevancy regression.
+- Escape hatch: feature flag or revert; retain the benchmark and diagnosis.
 
-Advantage Play:
-- Accretive artifact (spine): cache experiment wired into harness (hit-rate + tail tracked)
-- Expected signal: p95 meets target for warm traffic; CPU stays flat
-- Escape hatch: kill-switch cache and keep harness
+Advantage Play — Make latency a continuous contract [frame: operating model]
+- Accretive artifact (spine): performance budget check and trend history in bench/search/.
+- Expected signal + timebox: a seeded regression is caught before merge within 2 days.
+- Escape hatch: begin as an advisory check; keep the trend data if gating is noisy.
 
-Transformative Move:
-- Accretive artifact (spine): response contract + streaming plan validated by harness
-- Expected signal: tail latency collapses under large result sets
-- Escape hatch: ship streaming as opt-in client capability
+Transformative Move — Change the response contract [frame: interface]
+- Accretive artifact (spine): opt-in streaming or pagination contract measured by the harness.
+- Expected signal + timebox: first useful bytes arrive <=200ms on large-result fixtures within 3 days.
+- Escape hatch: retain the current response as default and keep the prototype opt-in.
 
-Moonshot:
-- Accretive artifact (spine): evaluation kit (dataset + harness) to compare engines/architectures
-- Expected signal: order-of-magnitude tail improvement in a bakeoff
-- Escape hatch: keep kit as decision tool; no migration until winner is clear
+Moonshot — Run an architecture bakeoff [frame: substrate]
+- Accretive artifact (spine): reusable evaluation kit comparing engines and transport shapes.
+- Expected signal + timebox: one candidate shows >=3x tail improvement on fixed fixtures within 1 week.
+- Escape hatch: stop before migration; keep the kit as durable decision evidence.
 
-Scores (S/A/E/R/Sp):
-- Quick Win: 5/5/5/5/5
-- Strategic: 4/4/4/4/4
-- Advantage: 4/4/3/3/3
-- Transformative: 4/5/2/3/2
-- Moonshot: 3/5/1/2/1
-
-Human Input Required: pick a tier (Quick Win .. Moonshot) or update constraints.
+Selection guidance: Quick Win is the best learning bet; Strategic is the best near-term outcome bet once traces identify the budget; Moonshot is the boldest bounded probe.
+Conditional recommendation: start with Quick Win, then choose Strategic or Transformative from measured evidence.
+Human Input Required: choose a tier or update the constraints.
 ```
 
 ## Routing examples
@@ -227,14 +245,18 @@ Human Input Required: pick a tier (Quick Win .. Moonshot) or update constraints.
 - "Give me several materially different ways to reduce onboarding drop-off before we choose one."
 - "We have tried tuning the query twice and are still stuck. What else could we try?"
 - "Reframe this migration problem and show the trade-offs among distinct paths."
-- "Brainstorm a strategy portfolio for entering this market; do not execute anything yet."
-- "The problem is still ambiguous; give me learning moves rather than a build plan."
+- "The problem is ambiguous; give me learning moves rather than a build plan."
+- "We selected event sourcing; show materially different rollout and containment strategies before execution."
 
 ### Should not activate
 
-- "Implement the selected cache design and run the tests." -> implementation owner
+- "Do a deep analysis of my `$creative-problem-solver` skill." -> direct analysis / `$tune`
+- "Patch `$creative-problem-solver` so it stops over-triggering." -> `$tune` / `$refine`
+- "I am blocked by this compiler error. What else can I try?" -> debugging owner
+- "Brainstorm twenty names for this command." -> direct creative generation
+- "Give me options, choose the best, and implement it now." -> execution owner; portfolio may be internal
 - "Mine this repository for evidence-backed product and DX opportunities." -> `$ideate`
 - "Turn the chosen event-sourcing direction into a detailed implementation plan." -> `$plan`
-- "Explain this repository's architecture and data flow." -> direct analysis or `$codebase-archaeology`
+- "Explain this repository's architecture and data flow." -> direct analysis / `$codebase-archaeology`
 - "Review this pull request for defects." -> review owner
 - "We chose the Quick Win. Build it now." -> execution owner

--- a/codex/skills/creative-problem-solver/agents/openai.yaml
+++ b/codex/skills/creative-problem-solver/agents/openai.yaml
@@ -3,10 +3,4 @@ policy:
 interface:
   display_name: "Creative Problem Solver"
   short_description: "Generate materially different strategy options before execution"
-  default_prompt: >-
-    Use $creative-problem-solver when the next task is choosing among materially
-    different paths, trade-offs, or reframings. A mention of the skill is not an
-    invocation. Produce the five-tier portfolio with an evidence-aware Aha and
-    materially different frame shifts, give conditional selection guidance, and
-    stop for human selection. Do not take over direct implementation, skill analysis
-    or tuning, repository opportunity mining ($ideate), or detailed planning ($plan).
+  default_prompt: "Use $creative-problem-solver to generate a five-tier portfolio for this decision."

--- a/codex/skills/creative-problem-solver/agents/openai.yaml
+++ b/codex/skills/creative-problem-solver/agents/openai.yaml
@@ -6,7 +6,7 @@ interface:
   default_prompt: >-
     Use $creative-problem-solver when the next task is choosing among materially
     different paths, trade-offs, or reframings. A mention of the skill is not an
-    invocation. Produce the five-tier portfolio with evidence-aware frame shifts,
-    give conditional selection guidance, and stop for human selection. Do not take
-    over direct implementation, skill analysis or tuning, repository opportunity
-    mining ($ideate), or detailed planning ($plan).
+    invocation. Produce the five-tier portfolio with an evidence-aware Aha and
+    materially different frame shifts, give conditional selection guidance, and
+    stop for human selection. Do not take over direct implementation, skill analysis
+    or tuning, repository opportunity mining ($ideate), or detailed planning ($plan).

--- a/codex/skills/creative-problem-solver/agents/openai.yaml
+++ b/codex/skills/creative-problem-solver/agents/openai.yaml
@@ -4,8 +4,9 @@ interface:
   display_name: "Creative Problem Solver"
   short_description: "Generate materially different strategy options before execution"
   default_prompt: >-
-    Use $creative-problem-solver when the user needs multiple materially different
-    options, trade-offs, or reframing before choosing a path. Produce the five-tier
-    portfolio and stop for human selection. Do not take over direct implementation,
-    single-answer advice, evidence-backed repository opportunity mining ($ideate),
-    or detailed planning ($plan).
+    Use $creative-problem-solver when the next task is choosing among materially
+    different paths, trade-offs, or reframings. A mention of the skill is not an
+    invocation. Produce the five-tier portfolio with evidence-aware frame shifts,
+    give conditional selection guidance, and stop for human selection. Do not take
+    over direct implementation, skill analysis or tuning, repository opportunity
+    mining ($ideate), or detailed planning ($plan).

--- a/codex/skills/creative-problem-solver/evals/routing-cases.json
+++ b/codex/skills/creative-problem-solver/evals/routing-cases.json
@@ -1,145 +1,140 @@
 {
   "cases": [
     {
-      "activate": true,
       "id": "explicit-options",
-      "prompt": "Give me several materially different ways to reduce onboarding drop-off before we choose one."
+      "prompt": "Give me several materially different ways to reduce onboarding drop-off before we choose one.",
+      "route": "creative-problem-solver"
     },
     {
-      "activate": true,
       "id": "tradeoff-portfolio",
-      "prompt": "Map the trade-offs between building, buying, and partnering, then include a credible moonshot."
+      "prompt": "Map the trade-offs between building, buying, and partnering, then include a credible moonshot.",
+      "route": "creative-problem-solver"
     },
     {
-      "activate": true,
       "id": "stalled-repeated-failure",
-      "prompt": "We have tried tuning the query twice and are still stuck. What else could we try?"
+      "prompt": "We have tried tuning the query twice and are still stuck. What else could we try?",
+      "route": "creative-problem-solver"
     },
     {
-      "activate": true,
       "id": "reframe-migration",
-      "prompt": "Reframe this migration problem and show several distinct paths before execution."
+      "prompt": "Reframe this migration problem and show several distinct paths before execution.",
+      "route": "creative-problem-solver"
     },
     {
-      "activate": true,
       "id": "ordinary-strategy-brainstorm",
-      "prompt": "Brainstorm a strategy portfolio for entering this market; do not execute anything yet."
+      "prompt": "Brainstorm a strategy portfolio for entering this market; do not execute anything yet.",
+      "route": "creative-problem-solver"
     },
     {
-      "activate": true,
       "id": "architecture-choice-set",
-      "prompt": "Show several architecture paths for multi-region failover and how we could learn before committing."
+      "prompt": "Show several architecture paths for multi-region failover and how we could learn before committing.",
+      "route": "creative-problem-solver"
     },
     {
-      "activate": true,
       "id": "ambiguous-learning-moves",
-      "prompt": "The problem is still ambiguous; give me learning moves rather than a build plan."
+      "prompt": "The problem is still ambiguous; give me learning moves rather than a build plan.",
+      "route": "creative-problem-solver"
     },
     {
-      "activate": true,
       "id": "explicit-skill-imperative",
-      "prompt": "Use $creative-problem-solver to generate a five-tier portfolio for this decision."
+      "prompt": "Use $creative-problem-solver to generate a five-tier portfolio for this decision.",
+      "route": "creative-problem-solver"
     },
     {
-      "activate": true,
       "id": "selected-direction-rollout-options",
-      "prompt": "We selected event sourcing; show materially different rollout, containment, and proof strategies before execution."
+      "prompt": "We selected event sourcing; show materially different rollout, containment, and proof strategies before execution.",
+      "route": "creative-problem-solver"
     },
     {
-      "activate": true,
       "id": "high-uncertainty-cross-domain-choice",
-      "prompt": "We need several distinct ways to redesign this partner integration across product, legal, and operations before choosing a path."
+      "prompt": "We need several distinct ways to redesign this partner integration across product, legal, and operations before choosing a path.",
+      "route": "creative-problem-solver"
     },
     {
-      "activate": false,
+      "id": "bare-skill-name",
+      "prompt": "$creative-problem-solver",
+      "route": "direct"
+    },
+    {
+      "id": "imperative-skill-without-portfolio-object",
+      "prompt": "Use $creative-problem-solver.",
+      "route": "direct"
+    },
+    {
       "id": "direct-implementation",
-      "owner": "implementation",
-      "prompt": "Implement the selected cache design and run the tests."
+      "prompt": "Implement the selected cache design and run the tests.",
+      "route": "implementation"
     },
     {
-      "activate": false,
       "id": "single-factual-answer",
-      "owner": "direct",
-      "prompt": "What does this compiler error mean?"
+      "prompt": "What does this compiler error mean?",
+      "route": "direct"
     },
     {
-      "activate": false,
       "id": "repo-opportunity-mining",
-      "owner": "ideate",
-      "prompt": "Mine this repository for evidence-backed product and DX opportunities and rank what to plan next."
+      "prompt": "Mine this repository for evidence-backed product and DX opportunities and rank what to plan next.",
+      "route": "ideate"
     },
     {
-      "activate": false,
       "id": "selected-direction-plan",
-      "owner": "plan",
-      "prompt": "Turn the chosen event-sourcing direction into a detailed implementation plan."
+      "prompt": "Turn the chosen event-sourcing direction into a detailed implementation plan.",
+      "route": "plan"
     },
     {
-      "activate": false,
       "id": "architecture-onboarding",
-      "owner": "codebase-archaeology",
-      "prompt": "Explain this repository's architecture and data flow so I can get oriented."
+      "prompt": "Explain this repository's architecture and data flow so I can get oriented.",
+      "route": "codebase-archaeology"
     },
     {
-      "activate": false,
       "id": "pull-request-review",
-      "owner": "review",
-      "prompt": "Review this pull request for defects."
+      "prompt": "Review this pull request for defects.",
+      "route": "review"
     },
     {
-      "activate": false,
       "id": "chosen-tier-execution",
-      "owner": "implementation",
-      "prompt": "We chose the Quick Win. Build it now."
+      "prompt": "We chose the Quick Win. Build it now.",
+      "route": "implementation"
     },
     {
-      "activate": false,
       "id": "small-known-comparison",
-      "owner": "direct",
-      "prompt": "Compare these two already-selected retry policies and recommend one."
+      "prompt": "Compare these two already-selected retry policies and recommend one.",
+      "route": "direct"
     },
     {
-      "activate": false,
       "id": "skill-analysis-mention",
-      "owner": "tune",
-      "prompt": "Do a deep analysis of my $creative-problem-solver skill."
+      "prompt": "Do a deep analysis of my $creative-problem-solver skill.",
+      "route": "tune"
     },
     {
-      "activate": false,
       "id": "skill-edit-mention",
-      "owner": "tune",
-      "prompt": "Patch $creative-problem-solver so it stops over-triggering."
+      "prompt": "Patch $creative-problem-solver so it stops over-triggering.",
+      "route": "tune"
     },
     {
-      "activate": false,
       "id": "skill-refine-brief",
-      "owner": "refine",
-      "prompt": "Apply this complete REFINE-SKILL-v3 brief to $creative-problem-solver and validate the package."
+      "prompt": "Apply this complete REFINE-SKILL-v3 brief to $creative-problem-solver and validate the package.",
+      "route": "refine"
     },
     {
-      "activate": false,
       "id": "keyword-bearing-debugging",
-      "owner": "debugging",
-      "prompt": "I am blocked by this compiler error. What else can I try?"
+      "prompt": "I am blocked by this compiler error. What else can I try?",
+      "route": "debugging"
     },
     {
-      "activate": false,
       "id": "ordinary-name-brainstorm",
-      "owner": "direct",
-      "prompt": "Brainstorm twenty names for this command."
+      "prompt": "Brainstorm twenty names for this command.",
+      "route": "direct"
     },
     {
-      "activate": false,
       "id": "mixed-options-and-implementation",
-      "owner": "implementation",
-      "prompt": "Give me several options, choose the best one, and implement it now."
+      "prompt": "Give me several options, choose the best one, and implement it now.",
+      "route": "implementation"
     },
     {
-      "activate": false,
       "id": "explain-skill-concept",
-      "owner": "direct",
-      "prompt": "What does $creative-problem-solver mean by Artifact Spine?"
+      "prompt": "What does $creative-problem-solver mean by Artifact Spine?",
+      "route": "direct"
     }
   ],
-  "schema": "creative-problem-solver-routing-cases/v1"
+  "schema": "creative-problem-solver-routing-cases/v2"
 }

--- a/codex/skills/creative-problem-solver/evals/routing-cases.json
+++ b/codex/skills/creative-problem-solver/evals/routing-cases.json
@@ -22,7 +22,7 @@
     },
     {
       "activate": true,
-      "id": "ordinary-brainstorm",
+      "id": "ordinary-strategy-brainstorm",
       "prompt": "Brainstorm a strategy portfolio for entering this market; do not execute anything yet."
     },
     {
@@ -37,8 +37,18 @@
     },
     {
       "activate": true,
-      "id": "explicit-skill",
+      "id": "explicit-skill-imperative",
       "prompt": "Use $creative-problem-solver to generate a five-tier portfolio for this decision."
+    },
+    {
+      "activate": true,
+      "id": "selected-direction-rollout-options",
+      "prompt": "We selected event sourcing; show materially different rollout, containment, and proof strategies before execution."
+    },
+    {
+      "activate": true,
+      "id": "high-uncertainty-cross-domain-choice",
+      "prompt": "We need several distinct ways to redesign this partner integration across product, legal, and operations before choosing a path."
     },
     {
       "activate": false,
@@ -87,6 +97,48 @@
       "id": "small-known-comparison",
       "owner": "direct",
       "prompt": "Compare these two already-selected retry policies and recommend one."
+    },
+    {
+      "activate": false,
+      "id": "skill-analysis-mention",
+      "owner": "tune",
+      "prompt": "Do a deep analysis of my $creative-problem-solver skill."
+    },
+    {
+      "activate": false,
+      "id": "skill-edit-mention",
+      "owner": "tune",
+      "prompt": "Patch $creative-problem-solver so it stops over-triggering."
+    },
+    {
+      "activate": false,
+      "id": "skill-refine-brief",
+      "owner": "refine",
+      "prompt": "Apply this complete REFINE-SKILL-v3 brief to $creative-problem-solver and validate the package."
+    },
+    {
+      "activate": false,
+      "id": "keyword-bearing-debugging",
+      "owner": "debugging",
+      "prompt": "I am blocked by this compiler error. What else can I try?"
+    },
+    {
+      "activate": false,
+      "id": "ordinary-name-brainstorm",
+      "owner": "direct",
+      "prompt": "Brainstorm twenty names for this command."
+    },
+    {
+      "activate": false,
+      "id": "mixed-options-and-implementation",
+      "owner": "implementation",
+      "prompt": "Give me several options, choose the best one, and implement it now."
+    },
+    {
+      "activate": false,
+      "id": "explain-skill-concept",
+      "owner": "direct",
+      "prompt": "What does $creative-problem-solver mean by Artifact Spine?"
     }
   ],
   "schema": "creative-problem-solver-routing-cases/v1"

--- a/codex/skills/creative-problem-solver/tests/test_activation_contract.py
+++ b/codex/skills/creative-problem-solver/tests/test_activation_contract.py
@@ -1,18 +1,226 @@
+"""Run: uv run --with pyyaml -- python3 -m unittest discover -s codex/skills/creative-problem-solver/tests -p 'test_*.py' -v"""
+
 from __future__ import annotations
 
 import json
 from pathlib import Path
+import re
 import unittest
+
+import yaml
 
 
 ROOT = Path(__file__).resolve().parents[1]
 SKILL = (ROOT / "SKILL.md").read_text(encoding="utf-8")
 AGENT = (ROOT / "agents" / "openai.yaml").read_text(encoding="utf-8")
-CORPUS = json.loads((ROOT / "evals" / "routing-cases.json").read_text(encoding="utf-8"))
+AGENT_DATA = yaml.safe_load(AGENT)
+
+
+def reject_duplicate_keys(pairs: list[tuple[str, object]]) -> dict[str, object]:
+    result: dict[str, object] = {}
+    for key, value in pairs:
+        if key in result:
+            raise ValueError(f"duplicate JSON key: {key}")
+        result[key] = value
+    return result
+
+
+CORPUS = json.loads(
+    (ROOT / "evals" / "routing-cases.json").read_text(encoding="utf-8"),
+    object_pairs_hook=reject_duplicate_keys,
+)
+
+FAST_SPARK_LINE_LIMIT = 45
+FULL_SESSION_LINE_LIMIT = 70
+
+EXPECTED_AGENT = """policy:
+  allow_implicit_invocation: true
+interface:
+  display_name: "Creative Problem Solver"
+  short_description: "Generate materially different strategy options before execution"
+  default_prompt: "Use $creative-problem-solver to generate a five-tier portfolio for this decision."
+"""
+
+EXPECTED_CASES = {
+    "explicit-options": (
+        "Give me several materially different ways to reduce onboarding drop-off before we choose one.",
+        "creative-problem-solver",
+    ),
+    "tradeoff-portfolio": (
+        "Map the trade-offs between building, buying, and partnering, then include a credible moonshot.",
+        "creative-problem-solver",
+    ),
+    "stalled-repeated-failure": (
+        "We have tried tuning the query twice and are still stuck. What else could we try?",
+        "creative-problem-solver",
+    ),
+    "reframe-migration": (
+        "Reframe this migration problem and show several distinct paths before execution.",
+        "creative-problem-solver",
+    ),
+    "ordinary-strategy-brainstorm": (
+        "Brainstorm a strategy portfolio for entering this market; do not execute anything yet.",
+        "creative-problem-solver",
+    ),
+    "architecture-choice-set": (
+        "Show several architecture paths for multi-region failover and how we could learn before committing.",
+        "creative-problem-solver",
+    ),
+    "ambiguous-learning-moves": (
+        "The problem is still ambiguous; give me learning moves rather than a build plan.",
+        "creative-problem-solver",
+    ),
+    "explicit-skill-imperative": (
+        "Use $creative-problem-solver to generate a five-tier portfolio for this decision.",
+        "creative-problem-solver",
+    ),
+    "selected-direction-rollout-options": (
+        "We selected event sourcing; show materially different rollout, containment, and proof strategies before execution.",
+        "creative-problem-solver",
+    ),
+    "high-uncertainty-cross-domain-choice": (
+        "We need several distinct ways to redesign this partner integration across product, legal, and operations before choosing a path.",
+        "creative-problem-solver",
+    ),
+    "bare-skill-name": ("$creative-problem-solver", "direct"),
+    "imperative-skill-without-portfolio-object": (
+        "Use $creative-problem-solver.",
+        "direct",
+    ),
+    "direct-implementation": (
+        "Implement the selected cache design and run the tests.",
+        "implementation",
+    ),
+    "single-factual-answer": ("What does this compiler error mean?", "direct"),
+    "repo-opportunity-mining": (
+        "Mine this repository for evidence-backed product and DX opportunities and rank what to plan next.",
+        "ideate",
+    ),
+    "selected-direction-plan": (
+        "Turn the chosen event-sourcing direction into a detailed implementation plan.",
+        "plan",
+    ),
+    "architecture-onboarding": (
+        "Explain this repository's architecture and data flow so I can get oriented.",
+        "codebase-archaeology",
+    ),
+    "pull-request-review": ("Review this pull request for defects.", "review"),
+    "chosen-tier-execution": ("We chose the Quick Win. Build it now.", "implementation"),
+    "small-known-comparison": (
+        "Compare these two already-selected retry policies and recommend one.",
+        "direct",
+    ),
+    "skill-analysis-mention": (
+        "Do a deep analysis of my $creative-problem-solver skill.",
+        "tune",
+    ),
+    "skill-edit-mention": (
+        "Patch $creative-problem-solver so it stops over-triggering.",
+        "tune",
+    ),
+    "skill-refine-brief": (
+        "Apply this complete REFINE-SKILL-v3 brief to $creative-problem-solver and validate the package.",
+        "refine",
+    ),
+    "keyword-bearing-debugging": (
+        "I am blocked by this compiler error. What else can I try?",
+        "debugging",
+    ),
+    "ordinary-name-brainstorm": ("Brainstorm twenty names for this command.", "direct"),
+    "mixed-options-and-implementation": (
+        "Give me several options, choose the best one, and implement it now.",
+        "implementation",
+    ),
+    "explain-skill-concept": (
+        "What does $creative-problem-solver mean by Artifact Spine?",
+        "direct",
+    ),
+}
+
+TIER_NAMES = (
+    "Quick Win",
+    "Strategic Play",
+    "Advantage Play",
+    "Transformative Move",
+    "Moonshot",
+)
+
+SPINE_HOMES = (
+    "bench/search/",
+    "perf/tracing/",
+    "contracts/search-response/",
+)
+
+EXPECTED_SIGNALS = {
+    "Quick Win": (
+        "within 1 day, run exactly 5 fixed-fixture batches of exactly 1,000 requests and "
+        "decompose the 10 slowest requests in each batch; Pass iff the 95% bootstrap CI "
+        "lower bound for pooled mean non-query share is >=10%; Claim falsifier: Fail iff "
+        "its upper bound is <10%; Inconclusive otherwise -> run one additional "
+        "predeclared set of exactly 5 such batches before selection."
+    ),
+    "Strategic Play": (
+        "within 2 days, run the candidate and immutable pre-change bench/search/ baseline "
+        "for exactly 5 fixed-fixture batches of exactly 1,000 requests each, including "
+        "exactly 100 predeclared relevancy cases per batch; let B=baseline pooled p95 and "
+        "C=candidate pooled p95; Pass iff (B-C)/B >=30% and all 500 candidate relevancy "
+        "results match baseline; Fail otherwise."
+    ),
+    "Advantage Play": (
+        "within 2 days, inject a predeclared fixture whose p95 is >=20% above the fixed "
+        "bench/search/ baseline; Pass iff two consecutive check runs both reject it "
+        "before merge; Fail otherwise."
+    ),
+    "Transformative Move": (
+        "within 3 days, across two runs per fixture, Pass iff first useful bytes arrive "
+        "<=200ms on all exactly 10 predeclared fixtures with a >=1 MiB response body; "
+        "Fail otherwise."
+    ),
+    "Moonshot": (
+        "within 1 week, run exactly 3 candidates and the immutable pre-change bench/search/ "
+        "baseline for exactly 5 fixed-fixture batches each; let B=baseline pooled p99 and "
+        "C_i=each candidate's pooled p99; Pass iff at least one of the 3 satisfies "
+        "3*C_i <= B; "
+        "Fail otherwise."
+    ),
+}
+
+EXPECTED_ESCAPES = {
+    "Quick Win": (
+        "disable high-overhead tracing; retain the bench/search/ harness plus "
+        "perf/tracing/ batch results and every slowest-1% request decomposition."
+    ),
+    "Strategic Play": (
+        "feature flag or revert the production change; retain the bench/search/ "
+        "fixture, result, and diagnosis."
+    ),
+    "Advantage Play": (
+        "begin as an advisory check; keep the bench/search/ seeded fixture, check, and "
+        "trend data if gating is noisy."
+    ),
+    "Transformative Move": (
+        "disable the opt-in endpoint, retain the current response as default, and "
+        "keep contracts/search-response/ fixtures plus bench/search/ results."
+    ),
+    "Moonshot": (
+        "stop before migration; keep the bench/search/ adapter, fixtures, and results "
+        "as durable decision evidence."
+    ),
+}
 
 
 def skill_section(start: str, end: str) -> str:
     return SKILL.split(start, 1)[1].split(end, 1)[0]
+
+
+def fast_spark_example() -> str:
+    section = skill_section("## Fast Spark example", "## Routing examples")
+    return section.split("```text", 1)[1].split("```", 1)[0]
+
+
+def declared_spine_homes(example: str) -> tuple[str, ...]:
+    spine = example.split("Artifact Spine:", 1)[1].split("Quick Win —", 1)[0]
+    return tuple(re.findall(r"^- ([^:]+/):", spine, re.MULTILINE))
 
 
 class ActivationContractTests(unittest.TestCase):
@@ -25,7 +233,7 @@ class ActivationContractTests(unittest.TestCase):
         for phrase in (
             "next task is choosing among materially different paths",
             "options, alternatives, trade-offs, reframing",
-            "A skill-name mention is not invocation",
+            "A name-only or meta mention does not authorize the portfolio route",
             "direct implementation",
             "skill analysis/tuning",
             "repository-evidence opportunity mining ($ideate)",
@@ -33,75 +241,154 @@ class ActivationContractTests(unittest.TestCase):
         ):
             self.assertIn(phrase, frontmatter)
 
-    def test_activation_boundary_distinguishes_invocation_from_reference(self) -> None:
+    def test_activation_boundary_separates_host_loading_from_portfolio_route(self) -> None:
         self.assertLess(SKILL.index("## Activation boundary"), SKILL.index("## Contract"))
         for phrase in (
-            "unresolved strategy choice plus a request for divergent options",
-            "Difficulty, uncertainty, or creativity language alone is not enough",
-            "### Skill-name rule",
-            "Imperative requests",
-            "Merely mentioning, quoting, explaining, reviewing, tuning, or editing",
+            "Host loading is not portfolio authorization",
+            "portfolio route requires",
+            "Difficulty, uncertainty, creativity language",
+            "to generate a strategy portfolio",
+            "may load the package under host policy",
+            "does not authorize portfolio generation",
             "$tune` / `$refine` win",
         ):
             self.assertIn(phrase, SKILL)
 
     def test_mixed_intent_does_not_discard_execution(self) -> None:
-        self.assertIn(
-            "the execution owner may use this reasoning internally",
-            SKILL,
-        )
-        self.assertIn(
-            "must not seize the turn and discard the requested execution",
-            SKILL,
-        )
+        self.assertIn("the execution owner may use this reasoning internally", SKILL)
+        self.assertIn("must not seize the turn and discard the requested execution", SKILL)
 
-    def test_interface_prompt_preserves_meta_and_stop_boundaries(self) -> None:
-        for phrase in (
-            "next task is choosing among materially",
-            "mention of the skill is not an",
-            "evidence-aware Aha",
-            "materially different frame shifts",
-            "stop for human selection",
-            "skill analysis",
-            "or tuning",
-            "($ideate)",
-            "($plan)",
-        ):
-            self.assertIn(phrase, AGENT)
+    def test_interface_prompt_preserves_owner_and_stop_boundaries(self) -> None:
+        self.assertEqual(EXPECTED_AGENT, AGENT)
+        self.assertEqual({"policy", "interface"}, set(AGENT_DATA))
+        self.assertIs(True, AGENT_DATA["policy"]["allow_implicit_invocation"])
+        self.assertIsInstance(AGENT_DATA["interface"]["display_name"], str)
+        self.assertIsInstance(AGENT_DATA["interface"]["short_description"], str)
+        self.assertIsInstance(AGENT_DATA["interface"]["default_prompt"], str)
+        self.assertEqual(
+            EXPECTED_CASES["explicit-skill-imperative"][0],
+            AGENT_DATA["interface"]["default_prompt"],
+        )
 
     def test_stage_model_keeps_develop_and_deliver_distinct(self) -> None:
         stage = skill_section("## Double Diamond alignment", "## Mode check")
         self.assertIn("Develop: the problem is sufficiently defined", stage)
         self.assertIn("Deliver: the core direction is selected", stage)
         self.assertIn("Do not use Deliver to regenerate competing core solutions", stage)
+        self.assertIn("Definition Gate fields are:", SKILL)
+        self.assertIn("symptom, actors, and problem topology", SKILL)
+        self.assertIn("desired outcome and success criteria", SKILL)
+        self.assertIn("metric, threshold, and measurement basis", SKILL)
+        self.assertIn("representative workload", SKILL)
+        self.assertIn("constraints and guardrails", SKILL)
+        self.assertIn("If any field in the first two groups is missing, use Discover", SKILL)
+        self.assertIn("if every field there is recorded or inapplicable", SKILL)
+        self.assertIn("but any later field is missing, use Define", SKILL)
+        self.assertIn("do not silently choose a domain or metric", SKILL)
+        self.assertIn("Interpretation (assumption): ...", SKILL)
+        self.assertIn("Target success: unknown", SKILL)
+        self.assertIn("Portfolio success: <decision progress>", SKILL)
+        self.assertIn("never substitute process success for the target outcome", SKILL)
+        self.assertIn("While any Definition Gate field is missing", SKILL)
+        self.assertIn("all five tiers must reduce uncertainty without proposing solution prototypes", SKILL)
+        self.assertIn("do not choose an index, cache, interface, engine, substrate", SKILL)
+        self.assertIn("Quick Win signal passes only when every Definition Gate field", SKILL)
+        self.assertIn("explicitly recorded or marked inapplicable", SKILL)
+        self.assertIn("make every later tier conditional on that gate", SKILL)
+        self.assertIn(
+            "The Quick Win signal and every later prerequisite clause must spell out all "
+            "six field groups rather than refer to \"the gate,\" \"each field,\" or a "
+            "nearby artifact.",
+            SKILL,
+        )
+        self.assertIn(
+            "Preserve tier semantics even here: a Transformative probe must test a "
+            "changed interface, operating model, governing constraint, or user ritual "
+            "rather than merely inventorying the current one.",
+            SKILL,
+        )
+        self.assertIn("test discontinuous learning or proof leverage", SKILL)
+        self.assertIn("predeclared discontinuous threshold rather than mere completeness", SKILL)
+        self.assertIn("silently verify exact spine-name reuse", SKILL)
+        self.assertIn("mutually exclusive and exhaustive outcomes", SKILL)
+        self.assertIn("literal entailment of every fact", SKILL)
+        self.assertIn("repair every miss before replying", SKILL)
 
     def test_aha_check_preserves_creative_insight_and_evidence_discipline(self) -> None:
         for phrase in (
             "## Aha Check",
             "Aha is the restructuring insight",
             "from the baseline frame to the alternative frame",
-            "fact | supported inference | hypothesis",
-            "An Aha may be a hypothesis",
+            "without an epistemic label",
+            "a representational operation is not itself a factual proposition",
+            "Aha basis: <why this shift is warranted> [evidence: fact | supported inference]",
+            "Claim: <claim> [evidence: fact | supported inference | hypothesis]",
+            "Use `hypothesis` only for a concrete claim with a real falsifier",
+            "For a `Claim` labeled fact or supported inference",
+            "name its source or support in the evidence posture or adjacent to the Claim",
             "Never promote an unsupported mechanism, bottleneck, or causal story to fact",
-            "make validation part of the expected signal",
+            "make validation part of an expected signal",
+            "For every `Claim` labeled hypothesis",
+            "one expected signal must include `Claim falsifier: <observation>`",
+            "test that exact claim, not a neighboring assertion",
+            "Second reframe used: <technique>",
+            "never credit an undeclared operator later",
             "Aha: N/A after second pass",
         ):
             self.assertIn(phrase, SKILL)
         self.assertNotIn("## Frame Shift Check", SKILL)
 
-    def test_pragmatic_mode_bounds_every_tier(self) -> None:
+    def test_pragmatic_mode_and_same_basin_exception_are_bounded(self) -> None:
+        contract = skill_section("## Contract", "## Workflow")
+        diversity = skill_section("## Diversity guard", "## Accretion")
         for phrase in (
             "every tier is a bounded, reversible next move",
             "Tiers describe the ambition of the hypothesis, not the size of the first commitment",
             "smallest proof-bearing probe of discontinuous upside",
+            "first probe of at most one week",
+            "cannot replace this first signal",
+            "Put every escape hatch before an irreversible boundary",
+            "is not reversibility",
         ):
             self.assertIn(phrase, SKILL)
+        self.assertIn("when honest", contract)
+        self.assertIn("same-basin rather than manufacturing diversity", contract)
+        self.assertIn("Do not manufacture an Aha or diversity", SKILL)
+        self.assertIn("mark the portfolio as same-basin", diversity)
 
-    def test_fast_and_full_lanes_have_distinct_visible_surfaces(self) -> None:
+    def test_lane_selector_and_visible_surfaces_are_decision_complete(self) -> None:
+        lane = skill_section("## Lane selector", "## Reframe selection")
         deliverable = skill_section("## Deliverable format", "## Fast Spark example")
+        budgets = re.search(
+            r"Fast Spark must fit <=(\d+) non-empty output lines; "
+            r"Full Session must fit <=(\d+) non-empty output lines",
+            SKILL,
+        )
+        self.assertIsNotNone(budgets)
+        assert budgets is not None
+        self.assertEqual(
+            (FAST_SPARK_LINE_LIMIT, FULL_SESSION_LINE_LIMIT),
+            tuple(int(value) for value in budgets.groups()),
+        )
+        for phrase in (
+            "Fast Spark: default when context is sufficient",
+            "Full Session: use when the user explicitly asks for deep or exhaustive exploration",
+            "high stakes, irreversibility, or coupled constraints",
+            "If lane choice is unclear, choose Fast Spark",
+            "Difficulty alone does not justify Full Session",
+        ):
+            self.assertIn(phrase, lane)
         self.assertIn("### Fast Spark", deliverable)
         self.assertIn("### Full Session", deliverable)
         self.assertIn("Optional scorecard", deliverable)
+        self.assertIn(
+            "evidence-label every causal or decision-shaping inference, including "
+            "stage choice, reframe `Why`, winnowing, diversity/same-basin disposition, "
+            "score interpretation, and recommendations",
+            deliverable,
+        )
+        for label in ("Facts:", "Risks:", "Assets:", "Assumptions:", "Constraints:"):
+            self.assertIn(label, deliverable)
         fast = deliverable.split("### Fast Spark", 1)[1].split("### Full Session", 1)[0]
         self.assertNotIn("scorecard", fast.lower())
         self.assertNotIn("Decision Log", deliverable)
@@ -110,14 +397,66 @@ class ActivationContractTests(unittest.TestCase):
     def test_tier_semantics_and_selection_avoid_quick_win_default(self) -> None:
         for phrase in (
             "Quick Win: cheapest reversible move",
+            "Strategic Play: strongest path within the current operating model",
             "Advantage Play: creates a reusable capability",
             "Transformative Move: changes an interface",
             "Moonshot: tests discontinuous upside",
             "best learning bet, best near-term outcome bet, and boldest bounded probe",
+            "Best near-term outcome bet: none; basis: target success is undefined. "
+            "[evidence: fact]",
+            "rather than relabeling decision progress as the target outcome",
+            "Treat every unmeasured `best` or recommendation ranking as supported "
+            "inference or hypothesis, never fact",
+            "name its basis and end it with that evidence label",
+            "Impact, Information, Accretion, Confidence, Reversibility, and Time-to-signal",
+            "for Time-to-signal, 5 means faster",
             "Do not rank by a summed total",
+            "Compute dominance across all displayed dimensions",
+            "Pareto leaders: <every non-dominated tier by name>",
+            "if dominance was not checked, omit the Pareto claim",
+            "End every `best` selection and recommendation line with",
+            "and name its basis",
             "A recommendation is not execution authorization",
         ):
             self.assertIn(phrase, SKILL)
+
+    def test_artifact_spine_requires_named_reuse_and_retention(self) -> None:
+        accretion = skill_section("## Accretion", "## Tier semantics")
+        for phrase in (
+            "each with a stable name and home",
+            "Every `Accretive artifact` line must repeat at least one exact declared asset name or home",
+            "an unqualified new artifact is invalid",
+            "declare and justify a replacement spine before the portfolio",
+            "Every escape hatch must name the proof artifact retained",
+            "Retaining only an undeclared by-product does not satisfy accretion",
+            "The retained artifact proves only observations bound by the signal",
+            "do not call ritual or artifact completion proof of benefit without a comparator",
+            "Full Session: repeat each asset's purpose and home, add its minimal interface",
+            "partition every outcome with mutually exclusive, exhaustive clauses",
+            "Inconclusive iff any of <named prerequisites> is missing -> <next disposition>",
+            "otherwise Pass iff <success>; Fail otherwise",
+            "for a legitimate measured third state",
+            "Fail iff <falsifier>; Inconclusive otherwise -> <next disposition>",
+            "omit Inconclusive when Pass and Fail are complements",
+            "Every value or predicate consumed by Pass must be established or named "
+            "separately in Inconclusive",
+            "Every missing-prerequisite Inconclusive clause must use the exact `any of "
+            "... is missing` form",
+            "put all missing prerequisites in that one list",
+            "Quantified item outcomes use integer counts such as `at least 1 of n`",
+            "require a named baseline or denominator, comparison rule, predeclared threshold, and replication count",
+            "references to recorded or agreed criteria do not satisfy this rule",
+            "stable, comparable, beyond noise",
+            "Terms such as `complete`, `representative`, `correct`, or `compatible` "
+            "require their operational fields or selection rule in the signal, not an "
+            "adjective standing in for a predicate.",
+            "Any use of `falsify` or `falsifier` must state the predeclared observation "
+            "predicate for each hypothesis",
+            "must predeclare a nonzero finite denominator; an empty set is Inconclusive "
+            "or Fail, never Pass",
+            "resolve that threshold instead of claiming an unspecified target will be met",
+        ):
+            self.assertIn(phrase, accretion)
 
     def test_execution_handoff_has_no_stale_tk_owner(self) -> None:
         self.assertNotIn("`tk`", SKILL)
@@ -128,74 +467,160 @@ class ActivationContractTests(unittest.TestCase):
         ):
             self.assertIn(phrase, SKILL)
 
-    def test_fast_spark_example_conforms_and_does_not_invent_a_bottleneck(self) -> None:
-        example_section = skill_section("## Fast Spark example", "## Routing examples")
-        example = example_section.split("```text", 1)[1].split("```", 1)[0]
-        for phrase in (
-            "Lane: Fast Spark",
-            "Stage: Develop",
-            "Evidence:",
-            "Aha:",
-            "[evidence: hypothesis]",
-            "Why it matters:",
-            "Default basin:",
-            "Artifact Spine:",
-            "Quick Win —",
-            "Strategic Play —",
-            "Advantage Play —",
-            "Transformative Move —",
-            "Moonshot —",
-            "Selection guidance:",
-            "Conditional recommendation:",
-            "Human Input Required:",
-        ):
-            self.assertIn(phrase, example)
-        self.assertEqual(5, example.count("- Accretive artifact (spine):"))
-        self.assertEqual(5, example.count("- Expected signal + timebox:"))
-        self.assertEqual(5, example.count("- Escape hatch:"))
-        self.assertNotIn("dominant cost is", example.lower())
-        self.assertLessEqual(len(example.splitlines()), 65)
-
-    def test_routing_corpus_covers_adversarial_near_misses(self) -> None:
-        self.assertEqual("creative-problem-solver-routing-cases/v1", CORPUS["schema"])
-        cases = CORPUS["cases"]
-        ids = [case["id"] for case in cases]
-        self.assertEqual(len(ids), len(set(ids)))
-        positives = [case for case in cases if case["activate"]]
-        negatives = [case for case in cases if not case["activate"]]
-        self.assertGreaterEqual(len(positives), 10)
-        self.assertGreaterEqual(len(negatives), 15)
-        self.assertTrue(
-            {
-                "direct",
-                "implementation",
-                "ideate",
-                "plan",
-                "codebase-archaeology",
-                "review",
-                "tune",
-                "refine",
-                "debugging",
-            }
-            <= {case["owner"] for case in negatives}
+    def test_fast_spark_example_enforces_evidence_spine_diversity_and_stop(self) -> None:
+        example = fast_spark_example()
+        self.assertIn(
+            "Evidence: latency, gate fields, and targets are known; the bottleneck is unknown.",
+            example,
         )
-        for required_id in (
-            "explicit-skill-imperative",
-            "selected-direction-rollout-options",
-            "skill-analysis-mention",
-            "skill-edit-mention",
-            "skill-refine-brief",
-            "keyword-bearing-debugging",
-            "ordinary-name-brainstorm",
-            "mixed-options-and-implementation",
-            "explain-skill-concept",
+        self.assertEqual(
+            "Stage: Develop",
+            next(line for line in example.splitlines() if line.startswith("Stage: ")),
+        )
+        gate_line = next(
+            line for line in example.splitlines() if line.startswith("Definition Gate: ")
+        )
+        for field in (
+            "domain=",
+            "symptom/actors/topology=",
+            "desired outcome/success=",
+            "metric/threshold/basis=",
+            "representative workload population/selection rule=",
+            "constraints/guardrails=",
         ):
-            self.assertIn(required_id, ids)
+            self.assertIn(field, gate_line)
+        self.assertIn(
+            "symptom/actors/topology=p95 ~800ms across API clients -> search service -> "
+            "query engine -> serialization/transport",
+            gate_line,
+        )
+        self.assertNotRegex(gate_line, r"(?i)\b(?:unknown|missing)\b")
+        self.assertIn(
+            "exactly 5 fixed-fixture batch results and all 50 slowest-1% request decompositions",
+            example,
+        )
+        aha_line = next(line for line in example.splitlines() if line.startswith("Aha: "))
+        claim_line = next(line for line in example.splitlines() if line.startswith("Claim: "))
+        self.assertNotIn("[evidence:", aha_line)
+        self.assertIn("Aha basis:", example)
+        self.assertIn(
+            "Aha basis: the reported p95 spans the listed request path, and the bottleneck "
+            "is unknown. [evidence: fact]",
+            example,
+        )
+        self.assertEqual(
+            "Claim: across repeated fixed-fixture batches, the pooled mean non-query "
+            "share among requests in each batch's slowest 1% is >=10%. "
+            "[evidence: hypothesis]",
+            claim_line,
+        )
+        self.assertIn("[evidence: hypothesis]", example)
+        hypothesis_claims = [
+            line
+            for line in example.splitlines()
+            if line.startswith("Claim: ") and "[evidence: hypothesis]" in line
+        ]
+        self.assertEqual(1, len(hypothesis_claims))
+        self.assertEqual(len(hypothesis_claims), example.count("Claim falsifier:"))
+        self.assertNotIn("dominant cost is", example.lower())
+
+        declared_spine = declared_spine_homes(example)
+        self.assertEqual(SPINE_HOMES, declared_spine)
+
+        heading_pattern = re.compile(
+            r"^(Quick Win|Strategic Play|Advantage Play|Transformative Move|Moonshot)"
+            r" .+ \[frame: ([^\]]+)\]$",
+            re.MULTILINE,
+        )
+        headings = heading_pattern.findall(example)
+        self.assertEqual(list(TIER_NAMES), [name for name, _ in headings])
+        self.assertGreaterEqual(len({frame for _, frame in headings}), 2)
+
+        for index, tier in enumerate(TIER_NAMES):
+            start = example.index(f"{tier} —")
+            end = (
+                example.index(f"{TIER_NAMES[index + 1]} —")
+                if index + 1 < len(TIER_NAMES)
+                else example.index("Best learning bet:")
+            )
+            block = example[start:end]
+            artifact = re.search(r"^- Accretive artifact \(spine\): (.+)$", block, re.MULTILINE)
+            signal = re.search(r"^- Expected signal \+ timebox: (.+)$", block, re.MULTILINE)
+            escape = re.search(r"^- Escape hatch: (.+)$", block, re.MULTILINE)
+            self.assertIsNotNone(artifact, tier)
+            self.assertIsNotNone(signal, tier)
+            self.assertIsNotNone(escape, tier)
+            assert artifact is not None
+            assert signal is not None
+            assert escape is not None
+            self.assertTrue(any(home in artifact.group(1) for home in declared_spine), tier)
+            self.assertTrue(any(home in escape.group(1) for home in declared_spine), tier)
+            for value in (artifact.group(1), signal.group(1), escape.group(1)):
+                self.assertNotRegex(
+                    value,
+                    r"(?i)\b(?:TBD|TODO|placeholder)\b|<[A-Za-z][A-Za-z0-9 _-]*>",
+                    tier,
+                )
+            self.assertRegex(signal.group(1), r"\b(?:within|day|week|hour|minute)s?\b", tier)
+            self.assertRegex(escape.group(1), r"\b(?:retain|keep)\b", tier)
+            self.assertEqual(EXPECTED_SIGNALS[tier], signal.group(1), tier)
+            self.assertEqual(EXPECTED_ESCAPES[tier], escape.group(1), tier)
+
+            duration = re.search(
+                r"\bwithin (\d+) (minute|hour|day|week)s?\b",
+                signal.group(1).lower(),
+            )
+            self.assertIsNotNone(duration, tier)
+            assert duration is not None
+            count = int(duration.group(1))
+            unit_days = {"minute": 1 / 1440, "hour": 1 / 24, "day": 1, "week": 7}
+            self.assertLessEqual(count * unit_days[duration.group(2)], 7, tier)
+
+        self.assertTrue(
+            example.strip().endswith(
+                "Human Input Required: choose a tier or update the constraints."
+            )
+        )
+        for line in (
+            "Best learning bet: Quick Win, because it identifies which path budget owns "
+            "the uncertainty. [evidence: supported inference]",
+            "Best near-term outcome bet: Strategic after tracing, because it attacks the "
+            "measured largest budget against the fixed baseline. [evidence: supported inference]",
+            "Boldest bounded probe: Moonshot, because three candidates test discontinuous "
+            "latency upside before migration. [evidence: supported inference]",
+            "Conditional recommendation: start with Quick Win, then choose Strategic or "
+            "Transformative from measured evidence because both preserve the shared proof "
+            "spine. [evidence: supported inference]",
+        ):
+            self.assertIn(line, example)
+        nonempty_lines = [line for line in example.splitlines() if line.strip()]
+        self.assertLessEqual(len(nonempty_lines), FAST_SPARK_LINE_LIMIT)
+
+    def test_routing_corpus_is_a_total_exact_semantic_case_map(self) -> None:
+        self.assertEqual({"schema", "cases"}, set(CORPUS))
+        self.assertEqual("creative-problem-solver-routing-cases/v2", CORPUS["schema"])
+        cases = CORPUS["cases"]
+        self.assertEqual(len(EXPECTED_CASES), len(cases))
+        by_id = {case["id"]: case for case in cases}
+        self.assertEqual(set(EXPECTED_CASES), set(by_id))
+
+        for case_id, case in by_id.items():
+            self.assertEqual({"id", "prompt", "route"}, set(case), case_id)
+            self.assertIsInstance(case["prompt"], str, case_id)
+            self.assertTrue(case["prompt"].strip(), case_id)
+
+        actual_cases = {
+            case_id: (case["prompt"], case["route"])
+            for case_id, case in by_id.items()
+        }
+        self.assertEqual(EXPECTED_CASES, actual_cases)
 
     def test_routing_examples_surface_the_hard_boundaries(self) -> None:
         routing = SKILL.split("## Routing examples", 1)[1]
         for phrase in (
             "deep analysis of my `$creative-problem-solver` skill",
+            '"`$creative-problem-solver`" -> direct clarification',
+            '"Use `$creative-problem-solver`." -> direct clarification',
             "Patch `$creative-problem-solver`",
             "blocked by this compiler error",
             "Brainstorm twenty names",

--- a/codex/skills/creative-problem-solver/tests/test_activation_contract.py
+++ b/codex/skills/creative-problem-solver/tests/test_activation_contract.py
@@ -59,9 +59,11 @@ class ActivationContractTests(unittest.TestCase):
         for phrase in (
             "next task is choosing among materially",
             "mention of the skill is not an",
-            "evidence-aware frame shifts",
+            "evidence-aware Aha",
+            "materially different frame shifts",
             "stop for human selection",
-            "skill analysis or tuning",
+            "skill analysis",
+            "or tuning",
             "($ideate)",
             "($plan)",
         ):
@@ -73,16 +75,19 @@ class ActivationContractTests(unittest.TestCase):
         self.assertIn("Deliver: the core direction is selected", stage)
         self.assertIn("Do not use Deliver to regenerate competing core solutions", stage)
 
-    def test_frame_shift_contract_is_evidence_aware(self) -> None:
+    def test_aha_check_preserves_creative_insight_and_evidence_discipline(self) -> None:
         for phrase in (
-            "## Frame Shift Check",
-            "fact, supported inference, or hypothesis",
+            "## Aha Check",
+            "Aha is the restructuring insight",
+            "from the baseline frame to the alternative frame",
+            "fact | supported inference | hypothesis",
+            "An Aha may be a hypothesis",
             "Never promote an unsupported mechanism, bottleneck, or causal story to fact",
             "make validation part of the expected signal",
-            "No material reframe after second pass",
+            "Aha: N/A after second pass",
         ):
             self.assertIn(phrase, SKILL)
-        self.assertNotIn("Aha Check", SKILL)
+        self.assertNotIn("## Frame Shift Check", SKILL)
 
     def test_pragmatic_mode_bounds_every_tier(self) -> None:
         for phrase in (
@@ -130,8 +135,9 @@ class ActivationContractTests(unittest.TestCase):
             "Lane: Fast Spark",
             "Stage: Develop",
             "Evidence:",
-            "Frame shift:",
-            "Evidence status: hypothesis",
+            "Aha:",
+            "[evidence: hypothesis]",
+            "Why it matters:",
             "Default basin:",
             "Artifact Spine:",
             "Quick Win —",

--- a/codex/skills/creative-problem-solver/tests/test_activation_contract.py
+++ b/codex/skills/creative-problem-solver/tests/test_activation_contract.py
@@ -11,67 +11,194 @@ AGENT = (ROOT / "agents" / "openai.yaml").read_text(encoding="utf-8")
 CORPUS = json.loads((ROOT / "evals" / "routing-cases.json").read_text(encoding="utf-8"))
 
 
+def skill_section(start: str, end: str) -> str:
+    return SKILL.split(start, 1)[1].split(end, 1)[0]
+
+
 class ActivationContractTests(unittest.TestCase):
     def test_implicit_invocation_is_enabled(self) -> None:
         self.assertIn("allow_implicit_invocation: true", AGENT)
         self.assertNotIn("allow_implicit_invocation: false", AGENT)
 
-    def test_frontmatter_names_positive_and_negative_boundaries(self) -> None:
+    def test_frontmatter_names_positive_negative_and_meta_boundaries(self) -> None:
         frontmatter = SKILL.split("---", 2)[1]
         for phrase in (
-            "multiple materially different paths",
+            "next task is choosing among materially different paths",
             "options, alternatives, trade-offs, reframing",
+            "A skill-name mention is not invocation",
             "direct implementation",
+            "skill analysis/tuning",
             "repository-evidence opportunity mining ($ideate)",
             "detailed planning ($plan)",
         ):
             self.assertIn(phrase, frontmatter)
 
-    def test_activation_boundary_is_early_and_explicit(self) -> None:
+    def test_activation_boundary_distinguishes_invocation_from_reference(self) -> None:
         self.assertLess(SKILL.index("## Activation boundary"), SKILL.index("## Contract"))
         for phrase in (
             "unresolved strategy choice plus a request for divergent options",
-            "The primary deliverable is at least three materially different paths",
-            "Do not activate; route elsewhere",
-            "$ideate` wins",
-            "$plan` wins",
-            "one answer, one plan, or one implementation",
+            "Difficulty, uncertainty, or creativity language alone is not enough",
+            "### Skill-name rule",
+            "Imperative requests",
+            "Merely mentioning, quoting, explaining, reviewing, tuning, or editing",
+            "$tune` / `$refine` win",
         ):
             self.assertIn(phrase, SKILL)
 
-    def test_interface_prompt_preserves_the_stop_boundary(self) -> None:
+    def test_mixed_intent_does_not_discard_execution(self) -> None:
+        self.assertIn(
+            "the execution owner may use this reasoning internally",
+            SKILL,
+        )
+        self.assertIn(
+            "must not seize the turn and discard the requested execution",
+            SKILL,
+        )
+
+    def test_interface_prompt_preserves_meta_and_stop_boundaries(self) -> None:
         for phrase in (
-            "multiple materially different",
+            "next task is choosing among materially",
+            "mention of the skill is not an",
+            "evidence-aware frame shifts",
             "stop for human selection",
-            "direct implementation",
+            "skill analysis or tuning",
             "($ideate)",
             "($plan)",
         ):
             self.assertIn(phrase, AGENT)
 
-    def test_routing_corpus_covers_positives_and_near_misses(self) -> None:
-        self.assertEqual("creative-problem-solver-routing-cases/v1", CORPUS["schema"])
-        positives = [case for case in CORPUS["cases"] if case["activate"]]
-        negatives = [case for case in CORPUS["cases"] if not case["activate"]]
-        self.assertGreaterEqual(len(positives), 8)
-        self.assertGreaterEqual(len(negatives), 8)
-        owners = {case["owner"] for case in negatives}
-        self.assertTrue(
-            {"direct", "implementation", "ideate", "plan", "codebase-archaeology", "review"}
-            <= owners
-        )
+    def test_stage_model_keeps_develop_and_deliver_distinct(self) -> None:
+        stage = skill_section("## Double Diamond alignment", "## Mode check")
+        self.assertIn("Develop: the problem is sufficiently defined", stage)
+        self.assertIn("Deliver: the core direction is selected", stage)
+        self.assertIn("Do not use Deliver to regenerate competing core solutions", stage)
 
-    def test_routing_examples_match_the_corpus_boundaries(self) -> None:
+    def test_frame_shift_contract_is_evidence_aware(self) -> None:
         for phrase in (
-            "Should activate",
-            "Should not activate",
-            "Mine this repository for evidence-backed product and DX opportunities",
-            "Turn the chosen event-sourcing direction into a detailed implementation plan",
-            "We chose the Quick Win. Build it now.",
+            "## Frame Shift Check",
+            "fact, supported inference, or hypothesis",
+            "Never promote an unsupported mechanism, bottleneck, or causal story to fact",
+            "make validation part of the expected signal",
+            "No material reframe after second pass",
+        ):
+            self.assertIn(phrase, SKILL)
+        self.assertNotIn("Aha Check", SKILL)
+
+    def test_pragmatic_mode_bounds_every_tier(self) -> None:
+        for phrase in (
+            "every tier is a bounded, reversible next move",
+            "Tiers describe the ambition of the hypothesis, not the size of the first commitment",
+            "smallest proof-bearing probe of discontinuous upside",
         ):
             self.assertIn(phrase, SKILL)
 
-    def test_skill_stays_within_a_compact_package_budget(self) -> None:
+    def test_fast_and_full_lanes_have_distinct_visible_surfaces(self) -> None:
+        deliverable = skill_section("## Deliverable format", "## Fast Spark example")
+        self.assertIn("### Fast Spark", deliverable)
+        self.assertIn("### Full Session", deliverable)
+        self.assertIn("Optional scorecard", deliverable)
+        fast = deliverable.split("### Fast Spark", 1)[1].split("### Full Session", 1)[0]
+        self.assertNotIn("scorecard", fast.lower())
+        self.assertNotIn("Decision Log", deliverable)
+        self.assertNotIn("Insights Summary", deliverable)
+
+    def test_tier_semantics_and_selection_avoid_quick_win_default(self) -> None:
+        for phrase in (
+            "Quick Win: cheapest reversible move",
+            "Advantage Play: creates a reusable capability",
+            "Transformative Move: changes an interface",
+            "Moonshot: tests discontinuous upside",
+            "best learning bet, best near-term outcome bet, and boldest bounded probe",
+            "Do not rank by a summed total",
+            "A recommendation is not execution authorization",
+        ):
+            self.assertIn(phrase, SKILL)
+
+    def test_execution_handoff_has_no_stale_tk_owner(self) -> None:
+        self.assertNotIn("`tk`", SKILL)
+        for phrase in (
+            "hand off to `$plan`",
+            "owning implementation workflow",
+            "This skill never owns repository mutation",
+        ):
+            self.assertIn(phrase, SKILL)
+
+    def test_fast_spark_example_conforms_and_does_not_invent_a_bottleneck(self) -> None:
+        example_section = skill_section("## Fast Spark example", "## Routing examples")
+        example = example_section.split("```text", 1)[1].split("```", 1)[0]
+        for phrase in (
+            "Lane: Fast Spark",
+            "Stage: Develop",
+            "Evidence:",
+            "Frame shift:",
+            "Evidence status: hypothesis",
+            "Default basin:",
+            "Artifact Spine:",
+            "Quick Win —",
+            "Strategic Play —",
+            "Advantage Play —",
+            "Transformative Move —",
+            "Moonshot —",
+            "Selection guidance:",
+            "Conditional recommendation:",
+            "Human Input Required:",
+        ):
+            self.assertIn(phrase, example)
+        self.assertEqual(5, example.count("- Accretive artifact (spine):"))
+        self.assertEqual(5, example.count("- Expected signal + timebox:"))
+        self.assertEqual(5, example.count("- Escape hatch:"))
+        self.assertNotIn("dominant cost is", example.lower())
+        self.assertLessEqual(len(example.splitlines()), 65)
+
+    def test_routing_corpus_covers_adversarial_near_misses(self) -> None:
+        self.assertEqual("creative-problem-solver-routing-cases/v1", CORPUS["schema"])
+        cases = CORPUS["cases"]
+        ids = [case["id"] for case in cases]
+        self.assertEqual(len(ids), len(set(ids)))
+        positives = [case for case in cases if case["activate"]]
+        negatives = [case for case in cases if not case["activate"]]
+        self.assertGreaterEqual(len(positives), 10)
+        self.assertGreaterEqual(len(negatives), 15)
+        self.assertTrue(
+            {
+                "direct",
+                "implementation",
+                "ideate",
+                "plan",
+                "codebase-archaeology",
+                "review",
+                "tune",
+                "refine",
+                "debugging",
+            }
+            <= {case["owner"] for case in negatives}
+        )
+        for required_id in (
+            "explicit-skill-imperative",
+            "selected-direction-rollout-options",
+            "skill-analysis-mention",
+            "skill-edit-mention",
+            "skill-refine-brief",
+            "keyword-bearing-debugging",
+            "ordinary-name-brainstorm",
+            "mixed-options-and-implementation",
+            "explain-skill-concept",
+        ):
+            self.assertIn(required_id, ids)
+
+    def test_routing_examples_surface_the_hard_boundaries(self) -> None:
+        routing = SKILL.split("## Routing examples", 1)[1]
+        for phrase in (
+            "deep analysis of my `$creative-problem-solver` skill",
+            "Patch `$creative-problem-solver`",
+            "blocked by this compiler error",
+            "Brainstorm twenty names",
+            "choose the best, and implement it now",
+            "We selected event sourcing",
+        ):
+            self.assertIn(phrase, routing)
+
+    def test_skill_stays_within_compact_package_budget(self) -> None:
         self.assertLessEqual(len(SKILL.splitlines()), 280)
 
 


### PR DESCRIPTION
## Summary

- separate host loading from semantic portfolio authorization, including an exact 27-case routing map
- preserve Aha as the representational insight while separating its factual basis and any falsifiable claim
- close the six-part Definition Gate before solution prototypes and make every option signal operational, exhaustive, and non-vacuous
- preserve distinct five-tier functions, reusable Artifact Spine assets, evidence-bound retained proof, and explicitly labeled selection judgments
- replace permissive text checks with a typed manifest check, duplicate-rejecting exact JSON validation, and focused cross-surface contract tests

## Why

The previous draft encoded the intended workflow but left several ways for the implementation to satisfy the words while violating the contract:

- mentioning the skill could be mistaken for authorizing a portfolio
- an Aha could silently elevate an inference to fact
- missing prerequisites or empty comparison sets could still produce `Pass`
- retained artifacts could be called proof without being bound to the declared signal
- unmeasured rankings and recommendations could appear factual
- later tiers could collapse into larger versions of the same intervention

This revision makes those boundaries explicit without adding a runtime subsystem or a separate decision-contract artifact.

## Behavioral contract

- bare or meta-level skill mentions stay with direct clarification, analysis, or editing; a concrete request for a portfolio routes to `$creative-problem-solver`
- the Definition Gate covers the target, current behavior, success criteria, representative workload population and selection rule, constraints, and risk tolerance; until it closes, no solution prototypes are emitted
- each signal declares its baseline, denominator, comparison, threshold, repetitions, prerequisites, and mutually exclusive outcome disposition; empty universal sets cannot pass
- every tier changes a distinct interface, operating model, constraint, or ritual, including in Discover
- Artifact Spine names and homes remain exact from declaration through option and escape, and retained proof supports only observations bound by the signal
- unknown target success yields no near-term outcome winner; every unmeasured ranking or recommendation is labeled as supported inference or hypothesis with its basis

## Validation

Validated at head `132c992be0d67878a575641fc0c66945eb826a83` against current `main` `86b16cc6da5c7a7b218255b63099790e9eaaee0c`:

```text
uv run --with pyyaml -- python3 -m unittest discover -s codex/skills/creative-problem-solver/tests -p 'test_*.py' -v
16/16 passed

uv run --with pyyaml -- /Users/tk/.dotfiles/codex/skills/.system/skill-creator/scripts/quick_validate.py codex/skills/creative-problem-solver
Skill is valid!

git diff --check
pass
```

Additional evidence:

- `SKILL.md`: 280 lines; canonical Fast Spark example: 43/45 non-empty output lines
- duplicate-rejecting routing corpus: 27 exact cases
- independent no-context probes: Fast Spark 42/45 and Full Session 51/70 non-empty lines, with no contract violations found
- independent cold review found no material defect on the final file-hash tuple
- a real `--no-commit --no-ff` merge onto current `main` was conflict-free; all 16 tests, package validation, and diff checks also passed in that merged tree

## Residual risk

The deterministic suite enforces the package contract, not live model routing or generated output. Those behaviors remain empirical; the Full Session 70-line budget is covered by a clean no-context probe rather than a deterministic fixture.

## Scope

The PR changes only these four files under `codex/skills/creative-problem-solver/`:

- `SKILL.md`
- `agents/openai.yaml`
- `evals/routing-cases.json`
- `tests/test_activation_contract.py`

It adds no dependency, runtime subsystem, telemetry, decision receipt, or separate decision-contract file. The PR remains draft for human review.
