### PR TITLE
Bind Reduce as Actuating's minimization pass

### DIFF
--- a/codex/skills/actuating/SKILL.md
+++ b/codex/skills/actuating/SKILL.md
@@ -18,7 +18,8 @@ Use exactly four authoritative per-goal artifact families:
    `$review-fold`.
 3. `construction-contract/v1` — the selected architecture, proof obligations,
    preserved observations, and retirements, authored by `$actuating` using
-   `$universalist`.
+   `$universalist`; `$reduce` may supply non-authoritative minimization
+   evidence.
 4. `actuating-evidence-event/v1` — append-only observations whose event bodies
    retain their domain owners.
 
@@ -48,7 +49,11 @@ Actuating owns:
 - application of the closure theorem and authorship of its semantic receipt.
 
 `$review-fold` must classify witnessed facts before Actuating selects any
-repair. Review prose and suggested patches never grant mutation.
+repair. `$reduce` may minimize admissible Constructions by factoring obligations,
+testing congruent quotients or ablations, and checking recomposition, but its
+Reduction Certificate is supporting evidence only. Neither review prose nor
+`$reduce` selects a Construction, Repair Disposition, operation, next action, or
+closure.
 
 Ledger may materialize, canonicalize, validate, append, replay, and emit
 requested disposable structural projections. Ledger never executes repository
@@ -163,14 +168,15 @@ already-valid observations. A witnessed example is not resolved until the
 Construction excludes its class or proves it instance-specific.
 
 Before dispatching fresh review after a repair, classify the production delta.
-If it introduces a new algorithm, compatibility branch, semantic helper
-family, or more than 50 net production lines, perform exactly one
-proof-preserving reduction pass. Collapse duplicate paths, return semantics to
-the canonical owner, or retire dominated residue where proof permits. If no
-reduction preserves the Goal laws and observations, record the specific
-compatibility or representation obstruction. The threshold triggers one pass;
-it is not a hard line budget, does not force deletion, and does not authorize a
-recursive reduction loop for the same delta.
+If it introduces a new algorithm, compatibility branch, semantic helper family,
+or more than 50 net production lines, invoke `$reduce` for exactly one
+proof-preserving reduction pass. It may collapse duplicate paths, return
+semantics to the canonical owner, or retire dominated residue where proof
+permits; its result is supporting evidence, and Actuating still selects the
+Construction and next operation. If no reduction preserves the Goal laws and
+observations, record the specific compatibility or representation obstruction.
+The threshold is not a hard line budget, does not force deletion, and does not
+authorize a recursive reduction loop for the same delta.
 
 ## Review convergence
 

--- a/codex/skills/actuating/references/construction-contract.md
+++ b/codex/skills/actuating/references/construction-contract.md
@@ -116,6 +116,10 @@ This is a view over the existing Construction decision, not another authority
 artifact. A finding authorizes the invariant, not its suggested implementation.
 The selected route is the least additive route that satisfies the law; an
 `add` route explains why `delete`, `consolidate`, and `edit` are insufficient.
+`$reduce` may supply the evidence for `Why not smaller?` by factoring live
+obligations, testing congruent quotients or ablations, and checking
+recomposition. Its Reduction Certificate belongs only in `supporting_refs`;
+Actuating still selects the Construction and Repair Disposition.
 
 One Construction selects the canonical owner, representation or machine,
 interpreter or handler, proof strategy, scope, and retirements. Executors,
@@ -149,12 +153,14 @@ cannot manufacture a winner.
 
 ## Review-repair reduction
 
-Before fresh review, classify the repair's production delta. A new algorithm,
-compatibility branch, semantic helper family, or more than 50 net production
-lines triggers exactly one proof-preserving reduction pass. The pass may
-collapse duplicate paths, return semantics to the canonical owner, or retire
-dominated residue. When no reduction preserves the Goal laws and observations,
-record the specific compatibility or representation obstruction instead.
+Before fresh review, classify the repair's production delta. Any new algorithm,
+compatibility branch, semantic helper family, or delta over 50 net production
+lines triggers `$reduce` for exactly one proof-preserving reduction pass. Reduce
+may collapse duplicate paths, return semantics to the canonical owner, or retire
+dominated residue. Its result remains supporting evidence; Actuating selects
+the Construction and next operation. When no reduction preserves the Goal laws
+and observations, record the specific compatibility or representation
+obstruction instead.
 
 The trigger is not a hard line budget, does not force deletion, and does not
 repeat recursively for the same delta. Fresh review evaluates the reduced

--- a/codex/skills/actuating/references/decision-contract.yaml
+++ b/codex/skills/actuating/references/decision-contract.yaml
@@ -54,18 +54,18 @@ skill_decision_contract:
       expected_routes: [ACT-IMPLEMENT, ACT-TRIAGE, ACT-REMEDIATION, ACT-REVIEW-CLOSEOUT, ACT-SHIP-HANDOFF, ACT-CLOSE]
       prohibited_routes: []
       required_artifacts: [goal-contract/v3, counterexample-set/v1 when classified findings exist, construction-contract/v1, actuating-evidence-event/v1]
-      success_signals: [exactly four authoritative families, Actuating selects the Construction and next action, Actuating owns the static Review Contract and semantic closure receipt, Ledger remains a structural artifact substrate, Ship alone owns public effects]
-      failure_signals: [a finding selects mutation directly, Ledger or an executor selects architecture or a next action, Ledger emits semantic workflow state or closure, peer policy or resolution state participates, a public effect bypasses Ship]
-      rationale: Source authority, construction, falsification, and observation remain distinct without duplicated control truth.
+      success_signals: [exactly four authoritative families, Actuating selects the Construction and next action, Reduce remains non-authoritative supporting evidence, Actuating owns the static Review Contract and semantic closure receipt, Ledger remains a structural artifact substrate, Ship alone owns public effects]
+      failure_signals: [a finding selects mutation directly, $reduce selects a Construction or Repair Disposition or operation or next action or closure, Ledger or an executor selects architecture or a next action, Ledger emits semantic workflow state or closure, peer policy or resolution state participates, a public effect bypasses Ship]
+      rationale: Source authority, construction, falsification, observation, and bounded minimization remain distinct without duplicated control truth.
 
     - clause_id: ACT-REVIEW-001
       trigger_refs: [ACT-BARE, ACT-MODE, ACT-REVIEW-DEFAULT]
       expected_routes: [ACT-TRIAGE, ACT-REMEDIATION, ACT-REVIEW-CLOSEOUT, ACT-CLOSE]
       prohibited_routes: []
       required_artifacts: [Actuating-owned actuating-review-contract/v1, five request bindings before initial dispatch, exact CAS owner receipts, current Counterexample Set after findings, successor Construction before accepted-class mutation, review observations in the Evidence Ledger]
-      success_signals: [Actuating maps CAS owner facts to semantic credit, accepted-class mutation follows a Law Owner Route Why-not-smaller Falsifier disposition, named additive deltas receive one proof-preserving reduction pass or a compatibility or representation obstruction before fresh review, initial 1+4 launches concurrently, siblings are non-cancelling, verdictless failure earns no credit and recovers only its request once, full-wave standard clean counts as one, four later standard cleans run serially, five consecutive standard cleans close the current subject, material change resets all review credit]
-      failure_signals: [Ledger hardcodes the Review Contract, Ledger dispatches or interprets CAS, Ledger computes review credit, review prose grants mutation, a suggested implementation bypasses Construction selection, a named additive delta reaches fresh review without its one reduction pass or obstruction, sibling cancellation, whole-wave transport retry, indefinite retry, review credit crosses a material change]
-      rationale: Review independently falsifies while Actuating owns orchestration, least-additive repair selection, and the bounded reduction check.
+      success_signals: [Actuating maps CAS owner facts to semantic credit, accepted-class mutation follows a Law Owner Route Why-not-smaller Falsifier disposition, named additive deltas route through $reduce as supporting evidence and receive one reduction pass or obstruction before fresh review, initial 1+4 launches concurrently, siblings are non-cancelling, verdictless failure earns no credit and recovers only its request once, full-wave standard clean counts as one, four later standard cleans run serially, five consecutive standard cleans close the current subject, material change resets all review credit]
+      failure_signals: [Ledger hardcodes the Review Contract, Ledger dispatches or interprets CAS, Ledger computes review credit, review prose grants mutation, a suggested implementation bypasses Construction selection, $reduce grants mutation or bypasses Actuating selection, a named additive delta reaches fresh review without its one reduction pass or obstruction, sibling cancellation, whole-wave transport retry, indefinite retry, review credit crosses a material change]
+      rationale: Review independently falsifies while Actuating owns orchestration, least-additive repair selection, the bounded Reduce check, and every successor decision.
 
     - clause_id: ACT-CLOSURE-001
       trigger_refs: [ACT-BARE, ACT-MODE]

--- a/codex/skills/actuating/tests/test_reduce_role_contract.py
+++ b/codex/skills/actuating/tests/test_reduce_role_contract.py
@@ -1,0 +1,35 @@
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SKILL = (ROOT / "SKILL.md").read_text(encoding="utf-8")
+CONSTRUCTION = (ROOT / "references" / "construction-contract.md").read_text(
+    encoding="utf-8"
+)
+DECISION = (ROOT / "references" / "decision-contract.yaml").read_text(
+    encoding="utf-8"
+)
+
+
+class ReduceRoleContractTests(unittest.TestCase):
+    def test_reduce_is_bounded_supporting_evidence(self) -> None:
+        for phrase in (
+            "`$reduce` may supply non-authoritative minimization",
+            "Reduction Certificate is supporting evidence only",
+            "Neither review prose nor\n`$reduce` selects a Construction",
+            "invoke `$reduce` for exactly one\nproof-preserving reduction pass",
+        ):
+            self.assertIn(phrase, SKILL)
+        for phrase in (
+            "`$reduce` may supply the evidence for `Why not smaller?`",
+            "Reduction Certificate belongs only in `supporting_refs`",
+            "`$reduce` for exactly one proof-preserving reduction pass",
+        ):
+            self.assertIn(phrase, CONSTRUCTION)
+        self.assertIn("Reduce remains non-authoritative supporting evidence", DECISION)
+        self.assertIn("$reduce grants mutation or bypasses Actuating selection", DECISION)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- define `$reduce` as a bounded, non-authoritative Construction-minimization pass inside `$actuating`
- allow Reduction Certificates to support `Why not smaller?`, candidate minimization, triggered review-repair reduction, and recomposition without granting semantic or mutation authority
- keep Construction selection, Repair Disposition, exact operations, next actions, and closure exclusively with Actuating
- add a focused contract test for the ownership boundary

## Why

Actuating already required a proof-preserving reduction pass for additive review repairs, but the owner and authority boundary were implicit. This makes the existing rule executable as a skill handoff without introducing a fifth artifact family or a peer workflow governor.

## Impact

The change is doctrine- and contract-only. It does not change the Construction schema, Ledger runtime, review topology, or publication/closure rules.

## Validation

- focused test logic executed against the fetched branch surfaces with `python -m unittest tests/test_reduce_role_contract.py -v` — pass
- `decision-contract.yaml` parsed with `yaml.safe_load` — pass
- existing bounded-reduction phrase assertions checked against the changed surfaces — pass
- Actuating package line budget: `1922 < 1956`
- GitHub reported no status checks for the current head