### PR TITLE
logophile: adjudicate behavioral upgrades against incumbents

### DIFF
--- a/codex/agents/activation-upgrade-arbiter.toml
+++ b/codex/agents/activation-upgrade-arbiter.toml
@@ -1,0 +1,88 @@
+name = "activation_upgrade_arbiter"
+description = "Read-only blinded evaluator for baseline-versus-candidate activation phrases, doctrine wording, and prompt upgrades. Judges behavioral outcomes rather than lexical sophistication."
+model_reasoning_effort = "high"
+sandbox_mode = "read-only"
+nickname_candidates = ["Activation Arbiter", "Incumbent Judge", "Prompt Upgrade Skeptic"]
+
+developer_instructions = '''
+You are a read-only specialist for `$logophile` Behavioral Upgrade mode.
+
+Mission:
+- Adjudicate anonymized baseline/candidate outputs under declared criteria.
+- Judge behavioral performance, not vocabulary rarity, elegance, novelty, or presumed recency.
+- Treat the incumbent as retained unless the evidence establishes a meaningful advantage.
+- Distinguish output quality from causal claims about the prompt or doctrine phrase.
+
+Assignment contract:
+- Work only from the supplied assignment and anonymized candidates.
+- Do not infer which candidate is the baseline, newer wording, or user preference.
+- Do not edit files, prompts, skills, tests, or repository state.
+- Do not spawn subagents.
+- Do not speak directly to the user.
+- Return exactly one YAML packet and no prose.
+
+Return:
+
+activation_upgrade_arbitration:
+  packet_version: AUA-v1
+  assignment_id: "..."
+  task_family: "..."
+  objective: "..."
+  constraints: []
+  evaluation_criteria:
+    - criterion: correctness
+      weight: "..."
+    - criterion: route_quality
+      weight: "..."
+    - criterion: material_frame_novelty
+      weight: "..."
+    - criterion: proof_quality
+      weight: "..."
+    - criterion: completion
+      weight: "..."
+    - criterion: calibration
+      weight: "..."
+    - criterion: overreach
+      weight: "..."
+    - criterion: verbosity
+      weight: "..."
+    - criterion: token_cost
+      weight: "..."
+  candidates:
+    - candidate_id: A
+      criterion_scores: {}
+      strengths: []
+      failures: []
+      evidence_refs: []
+    - candidate_id: B
+      criterion_scores: {}
+      strengths: []
+      failures: []
+      evidence_refs: []
+  pairwise:
+    winner: A | B | tie | insufficient
+    dispositive_factors: []
+    confidence: high | medium | low | unknown
+  behavioral_claim:
+    matched_conditions: yes | no | unknown
+    causal_attribution_allowed: yes | no
+    confounders: []
+  upgrade_disposition:
+    verdict: retain | replace | specialize | pair | sequence | benchmark
+    runtime_form: "..."
+    evidence_status: theoretical | promising | observed-useful | validated | task-specific | retired
+    what_would_change_the_verdict: []
+  final_call: usable | partial | insufficient | blocked
+
+Rules:
+- Correctness, task fit, and proof dominate novelty and style.
+- A more sophisticated term receives no bonus.
+- A longer answer receives no bonus.
+- A more creative answer loses when it creates factual error, route drift, or unbounded scope.
+- If run conditions differ materially, set causal_attribution_allowed=no.
+- If neither candidate dominates, return tie or insufficient.
+- If a candidate is better only for a narrow task family, use specialize or task-specific.
+- If candidates serve distinct roles, use pair or sequence rather than forcing replacement.
+- Never report global optimality from a small or unmatched sample.
+- Cite supplied task/output identifiers, score evidence, and concrete failure surfaces.
+'''

--- a/codex/skills/logophile/agents/openai.yaml
+++ b/codex/skills/logophile/agents/openai.yaml
@@ -2,11 +2,17 @@ policy:
   allow_implicit_invocation: true
 interface:
   display_name: "Logophile"
-  short_description: "Precision wording, doctrine, activation phrases, and cognitive-depth vocabulary"
+  short_description: "Precision wording, doctrine, activation phrases, and behavioral upgrades"
   default_prompt: >
     Use $logophile for wording, naming, doctrine-word selection, terse activation-phrase selection,
-    persona naming, or human-facing language surfaces. For depth or deliberation wording, read
-    references/depth_deliberation_doctrine.md and preserve the distinctions among RUMINATIVE,
-    APORETIC, DELIBERATIVE, DIALECTICAL, INCUBATIVE, RECURSIVE, METACOGNITIVE, CIRCUMSPECTIVE,
-    ABDUCTIVE, SYNOPTIC, CONTEMPLATIVE, PERCOLATIVE, REFLECTIVE, EXCAVATORY, DEPTH-FIRST,
-    ETIOLOGICAL, STRATIGRAPHIC, and FOUNDATIONAL. Keep runtime activation phrases irreducibly short.
+    persona naming, old-versus-new wording comparison, or human-facing language surfaces. When a
+    candidate may replace existing wording, read references/behavioral_upgrade.md, treat the baseline
+    as the incumbent, classify the policy delta, and return retain, replace, specialize, pair, sequence,
+    or benchmark rather than assuming denser vocabulary is better. Read
+    references/behavioral_upgrade_probe_cases.md for acceptance boundaries. Use the read-only
+    activation_upgrade_arbiter for anonymized A/B outputs when independent adjudication is warranted.
+    For depth or deliberation wording, read references/depth_deliberation_doctrine.md and preserve the
+    distinctions among RUMINATIVE, APORETIC, DELIBERATIVE, DIALECTICAL, INCUBATIVE, RECURSIVE,
+    METACOGNITIVE, CIRCUMSPECTIVE, ABDUCTIVE, SYNOPTIC, CONTEMPLATIVE, PERCOLATIVE, REFLECTIVE,
+    EXCAVATORY, DEPTH-FIRST, ETIOLOGICAL, STRATIGRAPHIC, and FOUNDATIONAL. Keep runtime activation
+    phrases irreducibly short.

--- a/codex/skills/logophile/references/behavioral_upgrade.md
+++ b/codex/skills/logophile/references/behavioral_upgrade.md
@@ -1,0 +1,494 @@
+# Behavioral Upgrade Adjudication
+
+Use this reference when `$logophile` is asked whether new wording, doctrine, a persona, a prompt, or an activation phrase is actually better than an existing version.
+
+The governing invariant is:
+
+> **The baseline is the incumbent. Do not replace it unless the candidate dominates behaviorally, not merely lexically.**
+
+Semantic precision is evidence, not victory. A rarer, denser, or more elegant term may have a higher conceptual ceiling while producing a lower median outcome, higher decoding cost, narrower task coverage, or more variance.
+
+## Scope
+
+Use Behavioral Upgrade mode for:
+
+- old-versus-new prompt comparison;
+- doctrine-word replacement;
+- activation-phrase replacement;
+- skill, mode, persona, label, or heading upgrades where behavior matters;
+- deciding whether a specialist term should replace a broad default;
+- comparing terse exhortations with formal doctrine;
+- evaluating a phrase stack as a small control program;
+- planning or interpreting matched A/B trials.
+
+Do not use it for ordinary copyediting when the user only wants cleaner prose and no behavioral policy is at stake.
+
+## Output modes
+
+### `upgrade-fast`
+
+Return only:
+
+```md
+Verdict: retain | replace | specialize | pair | sequence | benchmark
+Runtime Form:
+[final wording]
+```
+
+### `upgrade-annotated`
+
+Return the full Behavioral Upgrade Verdict, including role, policy delta, activation profile, stack effect, and evidence status.
+
+### `upgrade-benchmark`
+
+Return either:
+
+- a matched benchmark plan; or
+- an anonymized benchmark verdict when candidate outputs are supplied.
+
+Do not claim a behavioral winner from semantics alone.
+
+## Core workflow
+
+```text
+BASELINE
+  -> ROLE MAP
+  -> CANDIDATE LATTICE
+  -> POLICY-DELTA CLASSIFICATION
+  -> ACTIVATION PROFILE
+  -> STACK TOPOLOGY
+  -> CONTRASTIVE ADJUDICATION
+  -> ABLATION TEST
+  -> EMPIRICAL GATE
+  -> VERDICT
+```
+
+## 1. Baseline: model the incumbent before editing
+
+Treat the current wording as a functioning design, not raw material that must be improved.
+
+Record what it already buys:
+
+- task role;
+- semantic breadth;
+- activation immediacy;
+- familiarity;
+- decoding cost;
+- cadence and memorability;
+- emotional or motivational force;
+- task-family coverage;
+- stopping behavior;
+- known success evidence;
+- known failure modes.
+
+A candidate does not win merely because its dictionary definition is more exact.
+
+## 2. Role map
+
+Assign each phrase or doctrine unit one or more operational roles:
+
+```text
+RESET          loosen anchoring and rebind attention
+MAP            inspect the terrain and boundaries
+DEEPEN         descend below the first explanation
+DELIBERATE     reconsider or compare serious alternatives
+HOLD-OPEN      preserve a genuine unresolved difficulty
+DIVERGE        widen the candidate set
+CREATE         produce a new form, representation, or possibility
+SELECT         choose among serious candidates
+ACTUATE        change the system state
+VERIFY         demand evidence or a witness
+CONVERGE       close ambiguity or iteration under a stop rule
+STOP           identify the dispositive layer or completion condition
+```
+
+Hard rule:
+
+> A replacement that changes the role is a policy change, not a wording upgrade.
+
+Example:
+
+```text
+RUMINATE HARDER -> DELIBERATE
+BE APORETIC     -> HOLD-OPEN
+```
+
+That is a specialization and role shift, not a semantics-preserving substitution.
+
+## 3. Candidate lattice
+
+Generate candidates at multiple levels rather than assuming the formal doctrine word is the best runtime expression:
+
+```text
+plain phrase
+formal doctrine word
+specialist doctrine word
+persona or exemplar
+phrase pair / sequence
+no-change incumbent
+```
+
+Example:
+
+```text
+Formal doctrine: AUDACIOUS
+Plain runtime:   Be bolder.
+Specialist form: Challenge the inherited boundary.
+```
+
+The final answer may retain the plain phrase while recording the formal operator internally.
+
+## 4. Policy-delta classification
+
+Classify every proposed replacement as exactly one primary relation:
+
+```text
+equivalent
+refinement
+specialization
+generalization
+intensity-shift
+register-shift
+orthogonal-shift
+polarity-shift
+unknown
+```
+
+Definitions:
+
+- **equivalent**: same role and practical task coverage, with no material policy change;
+- **refinement**: same role, clearer procedure or stopping condition;
+- **specialization**: narrower trigger or task family;
+- **generalization**: broader trigger or task family;
+- **intensity-shift**: same direction, different activation amplitude;
+- **register-shift**: same intended behavior, different familiarity or decoding burden;
+- **orthogonal-shift**: activates a different dimension;
+- **polarity-shift**: reverses or materially redirects the posture;
+- **unknown**: evidence cannot support a confident relation.
+
+Hard rules:
+
+- A specialization must not silently displace a general-purpose default.
+- A register shift must justify its decoding cost.
+- An intensity shift must name its overreach risk.
+- An unknown relation defaults to `benchmark`, not `replace`.
+
+## 5. Activation profile
+
+Use this comparison when behavior, not just prose, matters:
+
+```yaml
+activation_profile:
+  baseline: "..."
+  candidate: "..."
+  intended_role: "..."
+  policy_relation: equivalent | refinement | specialization | generalization | intensity-shift | register-shift | orthogonal-shift | polarity-shift | unknown
+
+  semantic_specificity: lower | equal | higher | unknown
+  activation_immediacy: lower | equal | higher | unknown
+  lexical_familiarity: lower | equal | higher | unknown
+  decoding_cost: lower | equal | higher | unknown
+  task_coverage: narrower | equal | broader | unknown
+  cadence_fit: worse | equal | better | unknown
+  token_cost: lower | equal | higher | unknown
+
+  predicted_median: lower | equal | higher | unknown
+  behavioral_ceiling: lower | equal | higher | unknown
+  output_variance: lower | equal | higher | unknown
+  shadow_risk: lower | equal | higher | unknown
+
+  formal_doctrine: "..."
+  runtime_form: "..."
+  evidence_status: theoretical | promising | observed-useful | validated | task-specific | retired
+  verdict: retain | replace | specialize | pair | sequence | benchmark
+```
+
+Never fabricate precision in these fields. `unknown` is valid.
+
+## 6. Stack topology
+
+A doctrine or activation stack is a small control program. Evaluate order and missing roles, not only word overlap.
+
+Common topology:
+
+```text
+RESET
+  -> MAP / DEEPEN
+  -> DELIBERATE / HOLD-OPEN
+  -> DIVERGE
+  -> CREATE
+  -> SELECT
+  -> ACTUATE
+  -> VERIFY
+  -> STOP
+```
+
+Not every stack needs every role. Flag:
+
+- expansion without selection;
+- deliberation without a stopping operator;
+- action before sufficient understanding;
+- verification before a claim exists;
+- `APORETIC` without an eventual `DISPOSITIVE`, `ADJUDICATIVE`, or experiment boundary;
+- `EXCAVATORY` after the dispositive layer is already known;
+- `AUDACIOUS + POIETIC` without a criterion that rejects useless novelty;
+- multiple synonyms that amplify confidence but not intelligence;
+- a formal term that weakens the original cadence or immediacy.
+
+## 7. Contrastive adjudication
+
+Evaluate the baseline and candidate against the same task distribution.
+
+Ask:
+
+- What does the candidate add?
+- What does it remove?
+- What does it narrow?
+- What does it make slower to decode?
+- What new failure mode does it introduce?
+- What known baseline strength is at risk?
+- Does the candidate change median reliability, ceiling, or variance?
+- Would a pair or sequence preserve both advantages?
+
+Do not describe the candidate in isolation.
+
+## 8. Ablation test
+
+For each new word in a phrase stack, remove it and ask whether a distinct behavioral function disappears.
+
+```text
+full stack
+minus candidate A
+minus candidate B
+baseline plus A
+baseline plus B
+baseline plus A plus B
+```
+
+If removing a word does not change the predicted role map, the word is redundant.
+
+When several replacements are proposed, change one variable at a time before judging the package.
+
+## 9. Verdicts
+
+### `retain`
+
+The incumbent remains the best default.
+
+Use when the candidate is only more sophisticated, narrower, slower to decode, or unsupported.
+
+### `replace`
+
+The candidate preserves the intended role and is predicted or demonstrated to dominate the baseline across the intended task distribution.
+
+### `specialize`
+
+Keep the incumbent as the broad default and add the candidate for a narrower trigger.
+
+Example:
+
+```text
+Default:     Ruminate harder.
+Specialist:  Be aporetic.  # genuine contradiction or underdetermination
+```
+
+### `pair`
+
+Use both when they activate distinct simultaneous roles without destructive interference.
+
+### `sequence`
+
+Use both in order when one prepares the state for the next.
+
+Example:
+
+```text
+Be bolder. Be Optimal.
+```
+
+### `benchmark`
+
+Semantics cannot establish the winner. Run matched trials.
+
+## 10. Formal doctrine versus runtime activation
+
+Never assume the formal operator should replace the plain activation phrase.
+
+```text
+formal doctrine != automatically best runtime wording
+```
+
+Examples:
+
+```text
+Formal Doctrine: AUDACIOUS
+Runtime Form:    Be bolder.
+```
+
+```text
+Formal Doctrine: POIETIC
+Runtime Form:    Operate poietically.
+Alternative:     Create a new form.
+```
+
+```text
+Formal Doctrine: APORETIC
+Broad Runtime:   Ruminate harder.
+Specialist Form: Remain with the contradiction.
+```
+
+Optimize runtime activation for behavioral leverage per token, not terminological prestige.
+
+## 11. Empirical gate
+
+Activation phrases are empirical hypotheses. For consequential replacements, prefer a matched evaluation.
+
+Minimum benchmark design:
+
+1. Select representative tasks from the intended distribution.
+2. Hold model, settings, tools, context, and evaluation budget constant.
+3. Run baseline and candidate independently.
+4. Change one phrase at a time when possible.
+5. Randomize and anonymize output order.
+6. Evaluate correctness before novelty.
+7. Record token and verbosity cost.
+8. Repeat enough tasks to expose variance.
+9. Retain the incumbent unless the candidate shows a meaningful advantage.
+
+Suggested evaluation dimensions:
+
+```text
+correctness
+material frame novelty
+route quality
+proof quality
+completion
+calibration
+overreach
+verbosity
+token cost
+user preference
+```
+
+A blind evaluator must not reward the candidate for rarer vocabulary, apparent sophistication, or knowledge of which version is newer.
+
+## 12. Activation arbiter handoff
+
+Use `activation_upgrade_arbiter` when anonymized baseline/candidate outputs are available or when a high-value replacement needs independent adjudication.
+
+The generator should not be the sole judge of its own language.
+
+The arbiter must:
+
+- receive candidate IDs without baseline/new labels;
+- score against declared criteria;
+- name decisive differences and failure modes;
+- return `tie` or `insufficient` when dominance is not established;
+- never infer that more novel wording is better;
+- preserve the incumbent when evidence is weak.
+
+## 13. Evidence status
+
+Track phrase and doctrine candidates internally as:
+
+```text
+theoretical     semantic mechanism only
+promising       plausible mechanism plus limited encouraging use
+observed-useful repeated use with route or outcome improvement
+validated       matched evaluation supports the claim
+task-specific   useful only for a named task family
+retired         noise, overreach, regression, or no net gain
+```
+
+A newly coined term starts as `theoretical` or `promising`, never `validated`.
+
+## Behavioral Upgrade Verdict
+
+Use this shape in `upgrade-annotated`:
+
+```md
+Behavioral Upgrade Verdict:
+- baseline:
+- intended role:
+- candidate:
+- policy relation:
+- semantic gain:
+- activation gain:
+- activation loss:
+- task coverage:
+- predicted median / ceiling / variance:
+- decoding and token cost:
+- stack effect:
+- formal doctrine:
+- recommended runtime form:
+- evidence status:
+- verdict: retain | replace | specialize | pair | sequence | benchmark
+- confidence:
+- next empirical test:
+```
+
+Put the final runtime wording at the tail.
+
+## Worked example: `$glaze`
+
+Baseline roles:
+
+```text
+DIG DEEPER       -> DEEPEN
+RUMINATE HARDER  -> DELIBERATE
+BE BOLDER        -> DIVERGE / AMPLIFY
+MORE CREATIVE    -> CREATE
+USE FRESH EYES   -> RESET
+```
+
+Candidate roles:
+
+```text
+BE EXCAVATORY       -> DEEPEN
+BE APORETIC          -> HOLD-OPEN
+BE AUDACIOUS         -> DIVERGE / AMPLIFY
+OPERATE POIETICALLY  -> CREATE
+USE FRESH EYES       -> RESET
+```
+
+Likely initial verdicts without benchmark evidence:
+
+| Baseline | Candidate | Relation | Initial verdict |
+|---|---|---|---|
+| `DIG DEEPER` | `BE EXCAVATORY` | refinement + register shift | replace or benchmark |
+| `RUMINATE HARDER` | `BE APORETIC` | specialization + role shift | specialize |
+| `BE BOLDER` | `BE AUDACIOUS` | near-equivalent + register shift | benchmark |
+| `MORE CREATIVE` | `OPERATE POIETICALLY` | specialization toward form-creation | specialize or benchmark |
+| `USE FRESH EYES` | unchanged | retained | retain |
+
+This table is more trustworthy than declaring every denser term an upgrade.
+
+## Anti-patterns
+
+Reject:
+
+- lexical novelty presented as behavioral superiority;
+- replacing a broad phrase with a specialist term without changing the trigger;
+- changing several phrases at once and attributing the result to each one;
+- evaluating the candidate but not the baseline;
+- ignoring familiarity, cadence, or decoding cost;
+- claiming global optimality from a small task sample;
+- letting the generator grade its own unblinded outputs;
+- rewarding verbosity, confidence, or rare vocabulary;
+- forcing a replacement when `retain` or `specialize` is more accurate;
+- treating user preference as proof of correctness, or correctness as proof of preferred style.
+
+## Quality gate
+
+A behavioral-upgrade recommendation is ready only when:
+
+1. the incumbent's strengths are named;
+2. baseline and candidate roles are explicit;
+3. the policy relation is classified;
+4. specialization and register shifts are not hidden;
+5. median, ceiling, variance, coverage, and decoding cost are considered;
+6. the stack remains topologically coherent;
+7. `retain`, `specialize`, and `benchmark` are treated as successful outcomes;
+8. empirical claims match the evidence;
+9. the final runtime wording is short and copy-pasteable;
+10. the recommendation explains what evidence would overturn it.

--- a/codex/skills/logophile/references/behavioral_upgrade_probe_cases.md
+++ b/codex/skills/logophile/references/behavioral_upgrade_probe_cases.md
@@ -1,0 +1,326 @@
+# Behavioral Upgrade Probe Cases
+
+Use these probes to verify that `$logophile` treats an existing phrase as an incumbent and distinguishes semantic precision from behavioral superiority.
+
+## Should trigger Behavioral Upgrade mode
+
+### Refinement that may replace
+
+```text
+Would `Be excavatory.` perform better than `Dig deeper.` for root-cause work?
+```
+
+Expected:
+
+- baseline role: `DEEPEN`;
+- candidate role: `DEEPEN`;
+- relation: `refinement` plus `register-shift`;
+- name improved stopping semantics;
+- name lower familiarity / higher decoding cost;
+- verdict: `replace` only for a root-cause-heavy task distribution, otherwise `benchmark`;
+- do not claim proof from semantics alone.
+
+### Specialization must not silently replace the default
+
+```text
+Replace `Ruminate harder.` with `Be aporetic.` everywhere.
+```
+
+Expected:
+
+- baseline role: `DELIBERATE`;
+- candidate role: `HOLD-OPEN`;
+- relation: `specialization` plus role shift;
+- verdict: `specialize`, not universal `replace`;
+- broad default may remain `Ruminate harder.`;
+- specialist trigger: genuine contradiction or underdetermination.
+
+### Formal doctrine may not be the best runtime phrase
+
+```text
+Is `AUDACIOUS` a better activation phrase than `Be bolder.`?
+```
+
+Expected:
+
+- formal doctrine: `AUDACIOUS`;
+- runtime incumbent: `Be bolder.`;
+- relation: near-equivalent plus register shift;
+- compare immediacy, familiarity, cadence, and task coverage;
+- verdict: `benchmark` or retain plain runtime wording;
+- do not prefer the rarer word merely because it is denser.
+
+### Creative versus poietic
+
+```text
+Should `MORE CREATIVE!` become `OPERATE POIETICALLY!`?
+```
+
+Expected:
+
+- baseline role: broad `CREATE / DIVERGE`;
+- candidate role: `CREATE NEW FORM`;
+- relation: specialization plus register shift;
+- candidate may have higher ceiling for architecture and invention;
+- baseline may have higher median and broader coverage;
+- verdict: `specialize` or `benchmark`.
+
+### Retain is a successful result
+
+```text
+Upgrade `Use fresh eyes.` with a more sophisticated doctrine word.
+```
+
+Expected:
+
+- model the incumbent's low decoding cost, broad de-anchoring effect, cadence, and memorability;
+- generate candidates, but allow `retain`;
+- reject change when no candidate behaviorally dominates;
+- final runtime form may remain exactly `Use fresh eyes.`.
+
+### Pair or sequence instead of replace
+
+```text
+Compare `Be bolder.` and `Be Optimal.`. Should one replace the other?
+```
+
+Expected:
+
+- roles are distinct: `DIVERGE` then `SELECT`;
+- relation: complementary, not equivalent;
+- verdict: `sequence`;
+- runtime form:
+
+```text
+Be bolder. Be Optimal.
+```
+
+### Stack topology
+
+```text
+Evaluate this doctrine stack: `Use fresh eyes. Be aporetic. Be audacious. Operate poietically.`
+```
+
+Expected:
+
+- map `RESET -> HOLD-OPEN -> DIVERGE -> CREATE`;
+- flag missing selection/convergence/stop role;
+- recommend a selector or stopping companion such as `Be Optimal.`, `ADJUDICATIVE`, or `DISPOSITIVE` depending context;
+- do not call the stack complete merely because each phrase is individually meaningful.
+
+### Multi-replacement ablation
+
+```text
+Tell me whether all four phrase substitutions in this prompt improved it.
+```
+
+Expected:
+
+- refuse package-level attribution without one-at-a-time comparison;
+- propose baseline, A-only, B-only, and combined variants;
+- classify each replacement separately;
+- identify interaction effects;
+- verdict may be mixed.
+
+### Benchmark requested
+
+```text
+Design a fair benchmark for `BE BOLDER! MORE CREATIVE!` versus `BE AUDACIOUS! OPERATE POIETICALLY!`.
+```
+
+Expected:
+
+- matched task distribution;
+- same model, settings, tools, context, and budget;
+- independent runs;
+- randomized anonymized output order;
+- correctness before novelty;
+- score route quality, frame novelty, proof, completion, overreach, verbosity, and token cost;
+- use `activation_upgrade_arbiter` when available;
+- preserve a `tie` / `insufficient` result.
+
+### Candidate outputs supplied
+
+```text
+Here are anonymized outputs A and B from matched prompts. Which activation phrase is better?
+```
+
+Expected:
+
+- judge outputs against declared criteria without trying to infer which is newer;
+- avoid rewarding vocabulary sophistication;
+- separate output quality from causal attribution;
+- return winner, tie, or insufficient;
+- name confounders if the run conditions were not matched.
+
+### Existing prompt is a functioning design
+
+```text
+Rewrite this activation prompt with the most precise possible vocabulary.
+```
+
+Expected:
+
+- do not automatically rewrite;
+- first identify whether this is ordinary wording or a behavioral-upgrade request;
+- preserve incumbent cadence, familiarity, and activation force as first-class values;
+- return `retain` when precision would lower behavioral leverage per token.
+
+## Policy-delta distinction probes
+
+### Equivalent versus refinement
+
+```text
+Is this replacement equivalent or a refinement?
+```
+
+Expected:
+
+- equivalent: same role, coverage, trigger, and practical behavior;
+- refinement: same role but clearer procedure, boundary, or stopping rule;
+- do not use `equivalent` merely because dictionary meanings overlap.
+
+### Specialization versus intensity shift
+
+```text
+Does `Be aporetic.` simply intensify `Ruminate harder.`?
+```
+
+Expected:
+
+- no;
+- `aporetic` narrows the trigger to a genuine unresolved difficulty;
+- relation: specialization / role shift, not intensity shift.
+
+### Register shift
+
+```text
+Does replacing a plain phrase with a Greek-derived adjective improve it?
+```
+
+Expected:
+
+- evaluate familiarity, decoding cost, cadence, audience, and model activation;
+- register shift is not an automatic gain;
+- use `benchmark` when behavior is uncertain.
+
+### Generalization
+
+```text
+Can this specialist phrase become the repo-wide default?
+```
+
+Expected:
+
+- test whether task coverage truly broadens without losing role precision;
+- require evidence across the intended task distribution;
+- default to `specialize` or `benchmark` if the term is narrow.
+
+## Evidence-status probes
+
+### New term
+
+```text
+We just coined this doctrine word. Mark it validated.
+```
+
+Expected:
+
+- refuse;
+- initial status: `theoretical` or `promising`;
+- semantic plausibility is not validation.
+
+### Repeated favorable anecdotes
+
+```text
+It worked in three memorable sessions, so it is universally better.
+```
+
+Expected:
+
+- identify selection bias and task-family limits;
+- status may become `observed-useful` or `task-specific`;
+- universal replacement still requires matched evidence.
+
+### Known regression
+
+```text
+The candidate produces more novel answers but more factual errors.
+```
+
+Expected:
+
+- correctness dominates novelty;
+- candidate may be retained only for quarantined divergent exploration;
+- otherwise downgrade or retire.
+
+## Should not trigger Behavioral Upgrade mode
+
+### Ordinary rewrite
+
+```text
+Tighten this paragraph without changing its meaning.
+```
+
+Expected:
+
+- use ordinary `fast`, `annotated`, or `delta` mode;
+- do not build an Activation Profile.
+
+### Naming without incumbent behavior
+
+```text
+Give me five names for this new subagent.
+```
+
+Expected:
+
+- use naming mode;
+- no baseline adjudication unless an existing name is being replaced.
+
+### Operational benchmark execution without wording scope
+
+```text
+Run this benchmark suite and fix the failures.
+```
+
+Expected:
+
+- this is an operational implementation/verification workflow;
+- `$logophile` may sharpen the benchmark description, but must not replace the owning execution skill.
+
+### Code behavior comparison
+
+```text
+Which implementation is faster and more correct?
+```
+
+Expected:
+
+- not a logophile task unless the user asks how to phrase the comparison or doctrine;
+- route to the relevant engineering and verification workflow.
+
+## Quality checks
+
+A Behavioral Upgrade answer must:
+
+- treat the baseline as incumbent;
+- map baseline and candidate roles;
+- classify the policy relation;
+- preserve `retain`, `specialize`, and `benchmark` as valid outcomes;
+- distinguish formal doctrine from runtime activation;
+- consider median, ceiling, variance, task coverage, familiarity, cadence, and decoding cost;
+- inspect stack topology when multiple phrases are involved;
+- avoid causal claims unsupported by matched evidence;
+- put the final runtime wording at the tail.
+
+Reject answers that:
+
+- choose the denser word by default;
+- silently replace a broad phrase with a specialist term;
+- call semantic specificity behavioral proof;
+- ignore incumbent strengths;
+- change multiple variables and attribute the result to each one;
+- let the generator perform an unblinded self-evaluation;
+- claim `optimal`, `validated`, or `universally better` without sufficient evidence;
+- treat a longer rubric as automatically superior to a terse activation phrase.

--- a/codex/skills/logophile/references/composition.md
+++ b/codex/skills/logophile/references/composition.md
@@ -84,6 +84,22 @@ Use `$logophile` to sharpen:
 
 Keep the operating mode (`ADJUDICATIVE`) separate from an explicitly requested persona (`Arbiter`).
 
+## Before replacing doctrine, prompts, or activation wording
+
+Use [behavioral_upgrade.md](behavioral_upgrade.md) whenever new wording may displace an existing phrase that already steers behavior.
+
+- Treat the baseline as the incumbent, not as text that must be rewritten.
+- Map baseline and candidate roles before comparing vocabulary.
+- Classify the policy relation: `equivalent`, `refinement`, `specialization`, `generalization`, `intensity-shift`, `register-shift`, `orthogonal-shift`, `polarity-shift`, or `unknown`.
+- Preserve broad defaults when a candidate is only a specialist mode.
+- Keep formal doctrine separate from runtime activation; `AUDACIOUS` may be the operator while `Be bolder.` remains the better runtime phrase.
+- Treat familiarity, cadence, decoding cost, task coverage, median reliability, ceiling, and variance as first-class comparison axes.
+- Return `retain`, `replace`, `specialize`, `pair`, `sequence`, or `benchmark`.
+- Use [behavioral_upgrade_probe_cases.md](behavioral_upgrade_probe_cases.md) for acceptance boundaries.
+- Use `activation_upgrade_arbiter` for blinded A/B adjudication when matched outputs are available.
+
+Do not let semantic density, Greek or Latin register, novelty, or the generator's preference substitute for behavioral evidence.
+
 ## Naming skills, modes, and personas
 
 Prefer names that encode the job or success condition:
@@ -110,5 +126,7 @@ When another skill asks for a doctrine stack, return:
 3. cash-out artifacts;
 4. optional persona and core command when requested;
 5. final copy-paste block.
+
+When the stack replaces an incumbent, add a Behavioral Upgrade Verdict before finalizing it.
 
 Do not execute the operational workflow unless explicitly asked.


### PR DESCRIPTION
## Summary

- add a dedicated `$logophile` Behavioral Upgrade workflow for old-versus-new prompts, doctrine words, activation phrases, personas, and naming surfaces
- make the existing wording the incumbent and require behavioral dominance—not lexical density—before replacement
- classify replacements as `equivalent`, `refinement`, `specialization`, `generalization`, `intensity-shift`, `register-shift`, `orthogonal-shift`, `polarity-shift`, or `unknown`
- add role mapping, activation profiles, stack-topology checks, one-variable ablation, evidence statuses, and the verdicts `retain`, `replace`, `specialize`, `pair`, `sequence`, and `benchmark`
- distinguish formal doctrine from runtime activation so a precise operator such as `AUDACIOUS` does not automatically displace a terse phrase such as `Be bolder.`
- add matched A/B benchmark guidance with randomized anonymized outputs and correctness-first scoring
- add a read-only `activation_upgrade_arbiter` that judges anonymized candidates without rewarding novelty, rare vocabulary, or presumed recency
- add focused positive, negative, specialization, register-shift, topology, and empirical-evidence probes
- route `$logophile` through the new references from `agents/openai.yaml` and composition guidance

## Governing invariant

> The baseline is the incumbent. Do not replace it unless the candidate dominates behaviorally, not merely lexically.

This directly addresses the failure exposed by the `$glaze` comparison: `APORETIC` is semantically sharper than `RUMINATIVE`, but it is also a narrower policy that should normally specialize rather than silently replace a broad deliberation cue.

## Key behavior

The new workflow evaluates:

- incumbent strengths: familiarity, cadence, immediacy, breadth, stopping behavior, and known evidence
- policy role: reset, deepen, deliberate, hold-open, diverge, create, select, actuate, verify, converge, or stop
- behavioral tradeoffs: predicted median, ceiling, variance, task coverage, decoding cost, shadow risk, and token cost
- stack topology: whether expansion has selection, deliberation has closure, and specialist modes have correct triggers
- empirical status: `theoretical`, `promising`, `observed-useful`, `validated`, `task-specific`, or `retired`

## Files

- `codex/skills/logophile/references/behavioral_upgrade.md`
- `codex/skills/logophile/references/behavioral_upgrade_probe_cases.md`
- `codex/skills/logophile/references/composition.md`
- `codex/skills/logophile/agents/openai.yaml`
- `codex/agents/activation-upgrade-arbiter.toml`

## Validation

- branch is current with `main`
- diff is limited to `$logophile` integration plus its dedicated read-only arbiter
- updated YAML parses successfully
- new TOML agent configuration parses successfully
- connector rereads confirm the new references, routing paths, and agent name at branch head
- no implementation authority, implicit invocation policy, mutation boundary, or publication authority was widened
