### PR TITLE
logophile: add saltatory breakthrough doctrine

### DIFF
--- a/codex/skills/logophile/agents/openai.yaml
+++ b/codex/skills/logophile/agents/openai.yaml
@@ -2,17 +2,22 @@ policy:
   allow_implicit_invocation: true
 interface:
   display_name: "Logophile"
-  short_description: "Precision wording, doctrine, activation phrases, and behavioral upgrades"
+  short_description: "Precision wording, doctrine, activation phrases, behavioral upgrades, and breakthrough language"
   default_prompt: >
     Use $logophile for wording, naming, doctrine-word selection, terse activation-phrase selection,
-    persona naming, old-versus-new wording comparison, or human-facing language surfaces. When a
-    candidate may replace existing wording, read references/behavioral_upgrade.md, treat the baseline
-    as the incumbent, classify the policy delta, and return retain, replace, specialize, pair, sequence,
-    or benchmark rather than assuming denser vocabulary is better. Read
+    persona naming, old-versus-new wording comparison, breakthrough language, or human-facing language
+    surfaces. When a candidate may replace existing wording, read references/behavioral_upgrade.md,
+    treat the baseline as the incumbent, classify the policy delta, and return retain, replace,
+    specialize, pair, sequence, or benchmark rather than assuming denser vocabulary is better. Read
     references/behavioral_upgrade_probe_cases.md for acceptance boundaries. Use the read-only
     activation_upgrade_arbiter for anonymized A/B outputs when independent adjudication is warranted.
-    For depth or deliberation wording, read references/depth_deliberation_doctrine.md and preserve the
-    distinctions among RUMINATIVE, APORETIC, DELIBERATIVE, DIALECTICAL, INCUBATIVE, RECURSIVE,
-    METACOGNITIVE, CIRCUMSPECTIVE, ABDUCTIVE, SYNOPTIC, CONTEMPLATIVE, PERCOLATIVE, REFLECTIVE,
-    EXCAVATORY, DEPTH-FIRST, ETIOLOGICAL, STRATIGRAPHIC, and FOUNDATIONAL. Keep runtime activation
-    phrases irreducibly short.
+    For breakthrough, leap, step-change, or discontinuity wording, read
+    references/breakthrough_doctrine.md and references/breakthrough_probe_cases.md. Preserve the
+    distinctions among SALTATORY, AUDACIOUS, POIETIC, CATALYTIC, BIFURCATIVE, PARADIGMATIC,
+    EXAPTIVE, RECOMBINATIVE, EMERGENT, and MULTIPLICATIVE; do not call novelty, magnitude, or a large
+    rewrite a breakthrough without an incumbent frontier and a discontinuity. For depth or
+    deliberation wording, read references/depth_deliberation_doctrine.md and preserve the distinctions
+    among RUMINATIVE, APORETIC, DELIBERATIVE, DIALECTICAL, INCUBATIVE, RECURSIVE, METACOGNITIVE,
+    CIRCUMSPECTIVE, ABDUCTIVE, SYNOPTIC, CONTEMPLATIVE, PERCOLATIVE, REFLECTIVE, EXCAVATORY,
+    DEPTH-FIRST, ETIOLOGICAL, STRATIGRAPHIC, and FOUNDATIONAL. Keep runtime activation phrases
+    irreducibly short.

--- a/codex/skills/logophile/references/breakthrough_doctrine.md
+++ b/codex/skills/logophile/references/breakthrough_doctrine.md
@@ -1,0 +1,356 @@
+# Breakthrough Doctrine
+
+Use this reference when the task asks for a breakthrough, leap, step-change, discontinuous advance, regime shift, or language intended to activate those behaviors.
+
+## Governing operator
+
+## `saltatory`
+
+`SALTATORY` means:
+
+> Seek a discontinuous advance beyond the incumbent frontier rather than another improvement within the inherited solution basin.
+
+A saltatory candidate changes what is reachable. It may:
+
+- change the problem class;
+- invalidate a limiting assumption;
+- replace the governing representation;
+- collapse an order of work;
+- expose a new control point;
+- create a previously unavailable capability;
+- cross into a qualitatively different operating regime; or
+- make a formerly difficult outcome structurally easy or inevitable.
+
+Magnitude, novelty, confidence, and patch size are not sufficient. A candidate is saltatory only when it creates a demonstrable discontinuity relative to the incumbent.
+
+## Runtime activation
+
+Preferred normal form:
+
+```text
+Be saltatory.
+```
+
+High-amplitude fragment form:
+
+```text
+BE SALTATORY
+```
+
+Use the fragment form only when the surrounding prompt is already an imperative escalation such as `$glaze`. Do not automatically add punctuation when the caller requires exact terminal wording.
+
+A lower-register alternative is:
+
+```text
+Find the leap.
+```
+
+Treat `Be saltatory.` and `Find the leap.` as behavioral-upgrade candidates rather than assuming the formal term will always outperform the plainer phrase.
+
+## Internal decode
+
+```text
+incumbent frontier
+  -> limiting assumption
+  -> discontinuity mechanism
+  -> newly reachable state
+  -> proof of step-change
+```
+
+Prompt-ready doctrine:
+
+```md
+Operate in SALTATORY mode.
+
+Do not optimize only within the inherited frame or local basin.
+Seek the representation, invariant, recombination, control point, or regime change
+that creates a discontinuous advance relative to the incumbent frontier.
+
+Do not announce a breakthrough from novelty or magnitude alone.
+Name the limiting assumption, the newly reachable state, and the evidence that the
+candidate is a leap rather than another increment.
+```
+
+## Saltation Test
+
+Use only when correctness, handoff, adjudication, or publication depends on the breakthrough claim:
+
+```md
+Saltation Test:
+- incumbent frontier:
+- limiting assumption:
+- candidate leap:
+- discontinuity mechanism:
+- newly reachable state:
+- why ordinary incremental improvement cannot produce it:
+- proof signal:
+- remaining uncertainty:
+- verdict: saltatory | catalytic-only | incremental | speculative | rejected
+```
+
+The artifact is optional for terse activation. The breakthrough claim is not optional: when a result is described as saltatory, the discontinuity must be supportable.
+
+## Breakthrough topology
+
+A useful breakthrough stack is:
+
+```text
+EXCAVATORY
+  -> APORETIC
+  -> AUDACIOUS
+  -> POIETIC
+  -> SALTATORY
+```
+
+Its roles are:
+
+- `EXCAVATORY`: descend beneath the first explanation to the governing layer;
+- `APORETIC`: keep a genuine contradiction or underdetermination open;
+- `AUDACIOUS`: admit consequential possibilities ordinary caution suppresses;
+- `POIETIC`: bring a new form, representation, or construction into being;
+- `SALTATORY`: demand that the resulting move create a discontinuity relative to the incumbent.
+
+`SALTATORY` is the terminal outcome pressure. The preceding modes create the conditions for the leap; they do not prove one occurred.
+
+## Adjacent breakthrough operators
+
+### `audacious`
+
+Admit higher-upside, more structural, less deferential candidates.
+
+- Governs: option admission.
+- Does not imply: invention or breakthrough.
+- Shadow risk: scope inflation or theatrical ambition.
+
+### `poietic`
+
+Bring a new form, representation, artifact, or possibility into being.
+
+- Governs: creation.
+- Does not imply: the new form is better or discontinuous.
+- Shadow risk: novelty without utility.
+
+### `catalytic`
+
+Trigger disproportionate downstream change through a relatively small intervention.
+
+- Governs: leverage ratio.
+- Cash-out when needed: catalyst, downstream chain, amplification evidence.
+- Distinction: a catalytic move can be small and may or may not cross a new frontier.
+
+### `bifurcative`
+
+Cross a threshold at which the system enters a qualitatively different regime.
+
+- Governs: regime transition.
+- Cash-out when needed: threshold, pre-state, post-state, stability change.
+- Distinction: narrower and more dynamical than `saltatory`.
+
+### `paradigmatic`
+
+Replace the governing frame, questions, ontology, or standards by which the problem is understood.
+
+- Governs: frame replacement.
+- Cash-out when needed: old frame, new frame, previously invisible possibilities.
+- Distinction: a paradigmatic shift can enable a breakthrough but is not automatically a useful result.
+
+### `exaptive`
+
+Repurpose an existing structure, capability, or artifact for a function it was not originally built to serve.
+
+- Governs: novel reuse.
+- Cash-out when needed: original function, new function, transfer mechanism.
+- Distinction: breakthrough through repurposing rather than creation from scratch.
+
+### `recombinative`
+
+Combine existing primitives across boundaries to create a capability none provides alone.
+
+- Governs: novel composition.
+- Cash-out when needed: source primitives, cross-boundary composition, emergent capability.
+- Distinction: recombination can be useful without being saltatory.
+
+### `emergent`
+
+Produce system-level behavior that is not apparent from components considered separately.
+
+- Governs: whole-system novelty.
+- Cash-out when needed: local rules, interaction pattern, emergent observation.
+- Distinction: describes where the capability appears, not whether it is a breakthrough.
+
+### `multiplicative`
+
+Increase capability or leverage through compounding interaction rather than additive accumulation.
+
+- Governs: compounding value.
+- Cash-out when needed: factors, interaction term, resulting leverage.
+- Distinction: multiplicative improvement can remain within the incumbent regime.
+
+### `transformative`
+
+Materially alter the future state, workflow, or capability envelope.
+
+- Governs: large consequential change.
+- Warning: broad and easy to overclaim; prefer a more exact operator when the mechanism is known.
+
+### `disruptive`
+
+Displace an incumbent trajectory, institution, market, or operating model.
+
+- Governs: displacement.
+- Warning: often misused as praise. Do not use it as a generic synonym for innovative or saltatory.
+
+## Core distinctions
+
+```text
+AUDACIOUS  -> admit the consequential possibility
+POIETIC    -> create the new form
+CATALYTIC  -> cause disproportionate downstream change
+BIFURCATIVE -> cross into a different regime
+PARADIGMATIC -> replace the governing frame
+EXAPTIVE   -> repurpose an existing capability
+RECOMBINATIVE -> combine existing primitives into a new capability
+SALTATORY  -> create a discontinuous advance beyond the incumbent frontier
+```
+
+A strong generic sequence is:
+
+```text
+AUDACIOUS -> POIETIC -> SALTATORY
+```
+
+For systems work:
+
+```text
+EXCAVATORY -> BIFURCATIVE -> SALTATORY
+```
+
+For breakthrough through existing assets:
+
+```text
+EXAPTIVE -> RECOMBINATIVE -> CATALYTIC
+```
+
+## Selection rules
+
+Use `saltatory` when:
+
+- the user explicitly asks for a breakthrough, leap, or step-change;
+- incremental improvements appear bounded by a governing assumption;
+- the task seeks a new capability envelope rather than a better local score;
+- a representation, invariant, or control-point change could collapse the problem;
+- the intended final pressure is discontinuity, not merely boldness or creativity.
+
+Use another operator when:
+
+- the candidate set is timid: `audacious`;
+- the task needs a new construction: `poietic`;
+- a small lever creates disproportionate effects: `catalytic`;
+- the system crosses a qualitative threshold: `bifurcative`;
+- an old capability gains a new purpose: `exaptive`;
+- existing primitives should be recombined: `recombinative`;
+- the governing frame itself must change: `paradigmatic`.
+
+Prefer incremental doctrine when the objective is bounded optimization, reliability, cleanup, compatibility, or a known local defect. A breakthrough posture is not automatically superior.
+
+## Stopping rule
+
+Stop the breakthrough search when one of these holds:
+
+- a candidate demonstrates a credible discontinuity and has a proof path;
+- the remaining candidates are only larger, stranger, or more novel increments;
+- the current objective is already dominated by a simpler incremental move;
+- the evidence or authority boundary prevents adjudicating the leap;
+- further search produces no new discontinuity mechanism.
+
+`SALTATORY` must not become an instruction to search forever.
+
+## Failure modes
+
+Reject:
+
+- breakthrough theater: announcing a leap without an incumbent comparison;
+- novelty bias: preferring unfamiliarity over usefulness;
+- magnitude bias: treating a larger change as a deeper advance;
+- grandiosity: inflating scope to make the work feel consequential;
+- regime hallucination: claiming a qualitative transition without evidence;
+- proxy optimization: calling a visible metric jump a system breakthrough;
+- solutionism: forcing a breakthrough posture onto a task that needs a reliable increment;
+- post hoc saltation: describing an ordinary improvement as discontinuous after the fact;
+- unbounded search: withholding a good solution while waiting for a mythical leap.
+
+## Behavioral-upgrade discipline
+
+`SALTATORY` is a formal doctrine candidate and a terse activation phrase. It starts as `theoretical` or `promising`, not `validated`.
+
+When replacing an incumbent phrase such as `Find the leap.`, compare:
+
+- activation immediacy;
+- lexical familiarity;
+- decoding cost;
+- cadence;
+- task-family coverage;
+- predicted median, ceiling, and variance;
+- rate of genuine discontinuity versus breakthrough theater.
+
+Use `retain`, `replace`, `specialize`, `pair`, `sequence`, or `benchmark` from [behavioral_upgrade.md](behavioral_upgrade.md). Do not promote `Be saltatory.` merely because the word is denser.
+
+## Recommended activation stacks
+
+### Break the incumbent basin
+
+```text
+Use fresh eyes. Be audacious. Operate poietically. Be saltatory.
+```
+
+```text
+reset the frame -> widen the candidates -> create a new form -> demand a leap
+```
+
+### Find the governing leap
+
+```text
+Be excavatory. Find the bifurcation. Be saltatory.
+```
+
+```text
+descend to the controlling layer -> identify the regime threshold -> cross the frontier
+```
+
+### High-temperature search with selection
+
+```text
+Be reckless. Be saltatory. Be Optimal.
+```
+
+The first phrase widens speculative search, the second demands discontinuity, and the third adjudicates against the real objective and constraints.
+
+## Quality gate
+
+A saltatory recommendation is ready only when:
+
+1. the incumbent frontier is named;
+2. the limiting assumption or regime is explicit;
+3. the candidate changes what is reachable;
+4. novelty and size are not being mistaken for discontinuity;
+5. the mechanism is distinguishable from audacity, poiesis, catalysis, or bifurcation;
+6. the proof burden matches the strength of the breakthrough claim;
+7. a simpler incremental move has been considered;
+8. the runtime phrase remains short;
+9. the result states what would falsify the saltatory classification.
+
+## Bottom line
+
+```text
+SALTATORY = discontinuous advance beyond the incumbent frontier
+```
+
+The compact command is:
+
+```text
+Be saltatory.
+```
+
+The proof obligation is:
+
+> Name the frontier, the limiting assumption, the newly reachable state, and the evidence that the move is a leap rather than an increment.

--- a/codex/skills/logophile/references/breakthrough_probe_cases.md
+++ b/codex/skills/logophile/references/breakthrough_probe_cases.md
@@ -1,0 +1,302 @@
+# Breakthrough Doctrine Probe Cases
+
+Use these probes to verify that `$logophile` treats `SALTATORY` as discontinuity-seeking doctrine rather than a prestigious synonym for bold, creative, large, or innovative.
+
+## Should trigger `SALTATORY`
+
+### Breakthrough doctrine word
+
+```text
+What is a doctrine word for breakthroughs?
+```
+
+Expected:
+
+- best formal operator: `saltatory`;
+- runtime form: `Be saltatory.`;
+- define a breakthrough as a discontinuous advance beyond the incumbent frontier;
+- distinguish the outcome from audacity and poiesis;
+- do not claim that every novel or large change is saltatory.
+
+### Change what is reachable
+
+```text
+I do not want another local optimization. I want a move that changes what the system can do.
+```
+
+Expected:
+
+- `saltatory`;
+- identify the incumbent capability frontier and limiting assumption;
+- search for a representation, invariant, control point, or regime change;
+- request a proof signal for the newly reachable state.
+
+### Collapse an order of work
+
+```text
+Find a design that turns this recurring multi-stage process into one structural consequence.
+```
+
+Expected:
+
+- `saltatory` may lead;
+- companions may include `reifying`, `canonicalizing`, `catalytic`, or `actuating`;
+- explain the discontinuity as an order-of-work collapse, not merely fewer lines.
+
+### Exact `$glaze` fragment
+
+```text
+Give me the saltatory terminal fragment for the glaze escalation. It must end exactly with those words.
+```
+
+Expected runtime output:
+
+```text
+BE SALTATORY
+```
+
+Do not append punctuation or explanation when the exact fragment is requested.
+
+## Adjacent-operator probes
+
+### Audacious versus saltatory
+
+```text
+Should I call a very bold proposal audacious or saltatory?
+```
+
+Expected:
+
+- `audacious` if the claim is only that the proposal admits a consequential or unconventional possibility;
+- `saltatory` only when it creates a discontinuity relative to the incumbent frontier;
+- a proposal can be audacious but incremental;
+- no prestige bonus for `saltatory`.
+
+### Poietic versus saltatory
+
+```text
+The agent invented a new representation. Is that poietic or saltatory?
+```
+
+Expected:
+
+- `poietic` because a new form was created;
+- add `saltatory` only if the form changes what is reachable or crosses the incumbent frontier;
+- invention is not sufficient proof of breakthrough.
+
+### Catalytic versus saltatory
+
+```text
+One small configuration change unlocks many downstream improvements. What doctrine word fits?
+```
+
+Expected:
+
+- `catalytic` leads because the mechanism is disproportionate downstream change from a small intervention;
+- it may also be `saltatory` if the intervention creates a newly reachable capability regime;
+- distinguish leverage ratio from frontier discontinuity.
+
+### Bifurcative versus saltatory
+
+```text
+At this threshold the system enters a qualitatively different stable regime.
+```
+
+Expected:
+
+- `bifurcative` leads;
+- `saltatory` may describe the resulting advance;
+- require threshold, pre-state, post-state, and stability evidence.
+
+### Paradigmatic versus saltatory
+
+```text
+The proposal replaces the governing frame and changes which questions are meaningful.
+```
+
+Expected:
+
+- `paradigmatic` leads;
+- `saltatory` applies only if the frame replacement creates a demonstrable advance;
+- a new paradigm can be wrong or unproductive.
+
+### Exaptive breakthrough
+
+```text
+An existing subsystem can be repurposed for a capability nobody designed it to provide.
+```
+
+Expected:
+
+- `exaptive` leads;
+- companions may include `recombinative`, `catalytic`, and `saltatory`;
+- name original function, new function, and transfer mechanism.
+
+### Recombinative breakthrough
+
+```text
+The breakthrough comes from combining two existing primitives across a boundary.
+```
+
+Expected:
+
+- `recombinative` names the mechanism;
+- `saltatory` names the discontinuous outcome if established;
+- preserve both terms when they have distinct roles.
+
+## Should not trigger `SALTATORY`
+
+### Ordinary bounded optimization
+
+```text
+Make this endpoint five percent faster without changing behavior.
+```
+
+Expected:
+
+- use performance doctrine such as `incremental`, `locality-aware`, `cache-conscious`, or `work-efficient` depending on evidence;
+- do not use `saltatory` unless the approach unexpectedly changes the capability frontier;
+- a numerical improvement alone is not a breakthrough.
+
+### Straightforward defect repair
+
+```text
+Fix this null dereference and add a regression test.
+```
+
+Expected:
+
+- ordinary soundness, accretive, surgical, and traceable doctrine;
+- no breakthrough posture unless the defect exposes a governing architectural discontinuity;
+- do not inflate the task.
+
+### Broad ideation only
+
+```text
+Generate twenty creative alternatives.
+```
+
+Expected:
+
+- `divergent`, `generative`, `poietic`, or `combinatorial`;
+- `saltatory` only if the request also demands a leap beyond the incumbent frontier;
+- candidate volume is not discontinuity.
+
+### Large rewrite
+
+```text
+Rewrite the entire subsystem from scratch.
+```
+
+Expected:
+
+- do not infer `saltatory` from size;
+- first ask what new capability or discontinuity the rewrite creates;
+- large surface may be dilutive rather than breakthrough-producing.
+
+### Unfalsifiable hype
+
+```text
+Describe this ordinary release as revolutionary and disruptive.
+```
+
+Expected:
+
+- reject the inflation;
+- preserve evidence and scope;
+- prefer the exact capability delta;
+- do not use `saltatory`, `paradigmatic`, or `disruptive` without support.
+
+## Behavioral-upgrade probes
+
+### Formal term versus plain phrase
+
+```text
+Should `Find the leap.` be replaced everywhere with `Be saltatory.`?
+```
+
+Expected:
+
+- incumbent role: demand a discontinuous candidate;
+- candidate role: same general direction with higher specificity and higher decoding cost;
+- relation: `refinement` plus `register-shift`, possibly `specialization` depending usage;
+- compare familiarity, immediacy, cadence, median, ceiling, variance, and task coverage;
+- verdict: `benchmark` unless matched evidence establishes dominance;
+- formal doctrine may be `SALTATORY` while runtime wording remains `Find the leap.`.
+
+### Saltatory as terminal pressure
+
+```text
+Should SALTATORY replace AUDACIOUS in this stack?
+```
+
+Expected:
+
+- usually no;
+- `AUDACIOUS` widens candidate admission;
+- `SALTATORY` demands a discontinuous result;
+- use `pair` or `sequence` when both roles are needed;
+- recommended order: `AUDACIOUS -> POIETIC -> SALTATORY`.
+
+### Stack topology
+
+```text
+Evaluate this stack: EXCAVATORY + APORETIC + AUDACIOUS + POIETIC + SALTATORY.
+```
+
+Expected:
+
+- map roles: deepen -> hold-open -> diverge -> create -> demand discontinuity;
+- recognize coherent progression;
+- flag missing selection, verification, or stopping behavior if the surrounding workflow lacks it;
+- do not treat the stack itself as proof of a breakthrough.
+
+## Claim-strength probes
+
+### Candidate versus demonstrated breakthrough
+
+```text
+We found an unusual design that might change the problem class. Can we call it saltatory?
+```
+
+Expected:
+
+- classify as a `saltatory candidate` or `speculative saltation` until evidence exists;
+- request incumbent frontier, limiting assumption, newly reachable state, and proof signal;
+- do not upgrade possibility into demonstrated outcome.
+
+### Incremental path still dominates
+
+```text
+A radical option exists, but the simple local change meets the objective with much lower risk.
+```
+
+Expected:
+
+- allow `retain` or incremental route selection;
+- `SALTATORY` is not automatically superior;
+- use `dominance-tested` or `Be Optimal.` to adjudicate;
+- avoid breakthrough theater.
+
+## Quality checks
+
+A correct response must:
+
+- define `saltatory` by discontinuity relative to an incumbent frontier;
+- distinguish it from `audacious`, `poietic`, `catalytic`, `bifurcative`, and `paradigmatic`;
+- keep runtime activation terse;
+- preserve exact caller punctuation requirements;
+- allow ordinary incremental work to remain the right answer;
+- mark unproven breakthroughs as candidates or speculative;
+- name the proof burden when the breakthrough claim matters;
+- use behavioral-upgrade adjudication for replacement claims.
+
+Reject responses that:
+
+- use `saltatory` as praise;
+- equate novelty, size, creativity, or boldness with breakthrough;
+- claim a leap without an incumbent comparison;
+- force a breakthrough search onto bounded routine work;
+- require a ledger merely to emit the terse activation phrase;
+- add punctuation after an exact requested terminal fragment;
+- treat the doctrine stack as evidence that a breakthrough occurred.

--- a/codex/skills/logophile/references/composition.md
+++ b/codex/skills/logophile/references/composition.md
@@ -47,6 +47,32 @@ Use `$logophile` to sharpen the Actuation Bottom Line:
 
 Do not soften an executable next step into a vague recommendation.
 
+## After breakthrough or innovation workflows
+
+Use [breakthrough_doctrine.md](breakthrough_doctrine.md) when the output claims or seeks a breakthrough, leap, step-change, regime transition, or newly reachable capability.
+
+Preserve:
+
+- the incumbent frontier;
+- the limiting assumption;
+- the discontinuity mechanism;
+- the newly reachable state;
+- the evidence that the result is a leap rather than an increment;
+- the remaining uncertainty and falsifier.
+
+Keep the operator distinctions explicit:
+
+- `AUDACIOUS` admits consequential candidates;
+- `POIETIC` creates a new form;
+- `CATALYTIC` creates disproportionate downstream change;
+- `BIFURCATIVE` crosses into a different regime;
+- `PARADIGMATIC` replaces the governing frame;
+- `SALTATORY` creates a discontinuous advance beyond the incumbent frontier.
+
+Do not polish novelty, magnitude, a large rewrite, or a metric jump into a breakthrough claim. When the evidence is incomplete, say `saltatory candidate`, `speculative saltation`, or use a weaker adjacent term.
+
+For terse activation, prefer `Be saltatory.` or the caller's exact requested fragment. For behavioral replacement claims, route through [behavioral_upgrade.md](behavioral_upgrade.md) rather than assuming the formal term outperforms `Find the leap.` or another plain phrase.
+
 ## After $seq or $learnings
 
 Use `$logophile` to make forensic/cartographic/precedential outputs readable without losing provenance:

--- a/codex/skills/logophile/references/doctrine_phrases.md
+++ b/codex/skills/logophile/references/doctrine_phrases.md
@@ -7,7 +7,7 @@ In this repo, **doctrine** is compact language selected to induce a useful and r
 Doctrine can work through two distinct mechanisms:
 
 - **operator doctrine** specifies a bounded procedure: `ablative`, `actuating`, `adjudicative`, `forensic`;
-- **activation doctrine** evokes a capability state: `Be bolder.`, `Use fresh eyes.`, `Be excavatory.`, `Be aporetic.`, `Be Optimal.`, `Be like Mike.`
+- **activation doctrine** evokes a capability state: `Be bolder.`, `Use fresh eyes.`, `Be excavatory.`, `Be aporetic.`, `Be saltatory.`, `Be Optimal.`, `Be like Mike.`
 
 Operator doctrine compresses a rubric. Activation doctrine compresses permission, ambition, identity, attention, or search posture.
 
@@ -101,6 +101,7 @@ reset the frame -> widen the search -> select the best admissible move
 | `Be like Mike.` | activate elite standards, fundamentals, finishing, competitiveness, and ownership | execution quality, pressure, completion | persona theater or importing irrelevant traits |
 | `Be excavatory.` | descend below the first plausible explanation until the governing layer changes the model or route | shallow diagnosis, symptom patches, hidden ownership or invariant breaks | depth theater or endless regress |
 | `Be aporetic.` | preserve a genuine unresolved difficulty until its missing distinction or decisive evidence becomes explicit | contradictory evidence, underdetermined high-judgment decisions | indecision or token burn |
+| `Be saltatory.` | seek a discontinuous advance beyond the incumbent frontier rather than another increment within the inherited basin | breakthrough search, capability leaps, problem-class changes, regime transitions | breakthrough theater, novelty bias, or scope inflation |
 | `Reject the obvious answer.` | treat the first fluent answer as a candidate | anchoring, consensus, rubber-stamping | novelty bias against a correct simple answer |
 | `Be reckless.` | expand the speculative search beyond convention and feasibility | read-only divergent exploration | operational recklessness or unsupported claims |
 | `Find the lever.` | identify the control point that changes system state | analysis that has not become action | activity mistaken for movement |
@@ -248,6 +249,36 @@ Keep a genuine contradiction or underdetermination open long enough to expose th
 
 Aporia must sharpen the decision surface. Do not reward indefinite rumination, ambiguity theater, or refusal to make a reversible decision.
 
+### Be saltatory
+
+**Runtime form:**
+
+```text
+Be saltatory.
+```
+
+Exact high-amplitude fragment when explicitly required:
+
+```text
+BE SALTATORY
+```
+
+**Intended shift:**
+
+Leave the inherited local basin and seek a representation, invariant, recombination, control point, or regime transition that creates a discontinuous advance relative to the incumbent frontier.
+
+**Internal decode:**
+
+```text
+incumbent frontier -> limiting assumption -> discontinuity mechanism -> newly reachable state
+```
+
+**Shadow risk:**
+
+Do not mistake novelty, magnitude, a large rewrite, or a visible metric jump for a breakthrough. The leap must be evidenced, not announced.
+
+See [breakthrough_doctrine.md](breakthrough_doctrine.md) for adjacent operators and [breakthrough_probe_cases.md](breakthrough_probe_cases.md) for acceptance boundaries.
+
 ### Perform no smallness
 
 **Runtime form:**
@@ -296,6 +327,18 @@ Be excavatory. Be aporetic.
 
 The first phrase descends below the obvious layer. The second prevents a real contradiction from being prematurely flattened.
 
+### Create a breakthrough candidate
+
+```text
+Be audacious. Operate poietically. Be saltatory.
+```
+
+```text
+admit the consequential possibility -> create the new form -> demand a discontinuous advance
+```
+
+The stack generates a candidate; it does not prove that the result is a breakthrough.
+
 ### Find and select the strongest move
 
 ```text
@@ -336,6 +379,8 @@ Use **Be excavatory** when the first explanation is too shallow or symptom-shape
 
 Use **Be aporetic** when a real contradiction or underdetermination is being prematurely collapsed.
 
+Use **Be saltatory** when the task seeks a discontinuous advance beyond an explicit incumbent frontier rather than another local increment.
+
 Use **Perform no smallness** when the problem has been framed below its true stakes.
 
 Use **Be reckless** only for speculative search that remains separated from action.
@@ -349,6 +394,7 @@ Reject or repair:
 - `Be like Mike.` when local context clearly points to a different Mike and no convention resolves it;
 - `Be excavatory.` used to reward verbosity rather than explanatory descent;
 - `Be aporetic.` used to avoid a reversible decision after sufficient evidence exists;
+- `Be saltatory.` used as praise for novelty, size, or a large rewrite without a demonstrated discontinuity;
 - phrase stacks made entirely of synonyms;
 - a long explanation appended to a phrase whose value is brevity;
 - runtime ledgers produced only to prove that an activation phrase was used;

--- a/codex/skills/logophile/references/precision_lexicon.md
+++ b/codex/skills/logophile/references/precision_lexicon.md
@@ -6,6 +6,8 @@ For formal computer-science terms, preserve the proof burden. A sharper term is 
 
 For explanatory depth and productive non-closure, see [depth_deliberation_doctrine.md](depth_deliberation_doctrine.md) and [depth_deliberation_probe_cases.md](depth_deliberation_probe_cases.md).
 
+For breakthrough, leap, and discontinuity language, see [breakthrough_doctrine.md](breakthrough_doctrine.md) and [breakthrough_probe_cases.md](breakthrough_probe_cases.md).
+
 ## Generic -> sharper defaults
 
 - `improve` -> `tighten`, `harden`, `simplify`, `stabilize`, `clarify`, `validate`, `defuse`, `accelerate`, `actuate`, `normalize`, `converge`, or `incrementalize` when the local gain is clear.
@@ -23,6 +25,9 @@ For explanatory depth and productive non-closure, see [depth_deliberation_doctri
 - `account for` -> `reconcile`, `attribute`, `conserve`, or `amortize` depending whether the task balances surfaces, assigns causes/owners, proves nothing appeared/disappeared without a transition, or distributes cost across a sequence.
 - `dig deeper` -> `be excavatory` when the task should descend through causal, representational, historical, ownership, or invariant layers until the route changes.
 - `ruminate harder` -> `be aporetic` when a genuine contradiction or underdetermination must remain open long enough to expose the missing distinction or decisive evidence.
+- `breakthrough` -> `saltatory advance` only when the result creates a discontinuity relative to an explicit incumbent frontier.
+- `big improvement` / `step-change` -> `catalytic`, `bifurcative`, `multiplicative`, or `saltatory` depending whether the mechanism is disproportionate leverage, regime transition, compounding interaction, or a newly reachable capability frontier.
+- `creative breakthrough` -> `poietic and saltatory` only when a new form is created and that form demonstrably changes what is reachable.
 
 ## Coding and review language
 
@@ -151,6 +156,8 @@ For explanatory depth and productive non-closure, see [depth_deliberation_doctri
 - `think deeply` -> `derive the governing invariant and test the strongest countercase`.
 - `dig deeper` -> `be excavatory: descend until another layer no longer changes the model, owner, route, or proof burden`.
 - `ruminate harder` -> `be aporetic: preserve the genuine unresolved difficulty until the missing distinction, evidence, or decision condition is explicit`.
+- `find a breakthrough` -> `be saltatory: seek a discontinuous advance beyond the incumbent frontier and name the newly reachable state`.
+- `change the game` -> `seek a saltatory or paradigmatic move` only when the result changes the capability frontier or governing frame.
 - `take action` -> `actuate the lever and prove the system moved`.
 - `start over` -> `rebaseline to the current authoritative state and invalidate stale receipts`.
 - `systems thinking` -> `map cybernetic feedback loops, control points, signals, delays, and second-order effects`.
@@ -177,4 +184,5 @@ Do not replace if:
 - the formal term would imply a guarantee that has not been checked;
 - `excavatory` would reward depth theater rather than a changed explanatory model;
 - `aporetic` would reward indefinite indecision rather than sharpening a real difficulty;
+- `saltatory` would reward novelty, magnitude, or a large rewrite without a discontinuity relative to an incumbent frontier;
 - a lighter adjacent term is more honest.


### PR DESCRIPTION
## Summary

- add `SALTATORY` as the doctrine for seeking a discontinuous advance beyond an explicit incumbent frontier
- add a dedicated breakthrough reference with the Saltation Test, stopping rule, failure modes, and the topology `EXCAVATORY -> APORETIC -> AUDACIOUS -> POIETIC -> SALTATORY`
- distinguish `SALTATORY` from `AUDACIOUS`, `POIETIC`, `CATALYTIC`, `BIFURCATIVE`, `PARADIGMATIC`, `EXAPTIVE`, `RECOMBINATIVE`, `EMERGENT`, and `MULTIPLICATIVE`
- add probe coverage that rejects novelty, magnitude, a large rewrite, or a metric jump as sufficient evidence of a breakthrough
- add `Be saltatory.` and exact fragment `BE SALTATORY` to activation-phrase guidance while preserving behavioral-upgrade adjudication against plainer incumbents such as `Find the leap.`
- extend the precision lexicon and composition guidance so breakthrough claims preserve the incumbent frontier, limiting assumption, discontinuity mechanism, newly reachable state, and proof burden
- route `$logophile` to the new references from `agents/openai.yaml`

## Governing definition

> `SALTATORY` seeks a discontinuous advance beyond the incumbent frontier rather than another improvement within the inherited solution basin.

The leap must be evidenced, not announced. Novelty, confidence, patch size, and magnitude are insufficient without a newly reachable state and a credible discontinuity mechanism.

## Ownership

This PR changes only `codex/skills/logophile/**`. It owns the doctrine definition, adjacent vocabulary, activation guidance, lexicon mappings, probes, and composition rules.

The consumer-only `$glaze` terminal activation is isolated in the companion PR from `agent/glaze-saltatory-activation`.

## Validation

- branch is current with `main`
- diff is limited to six `codex/skills/logophile/**` files
- connector rereads confirm `Be saltatory.` and exact fragment `BE SALTATORY`
- the default prompt explicitly routes breakthrough requests to both new reference files
- activation guidance does not require a receipt merely to emit the terse phrase
- breakthrough claims remain evidence-bound and may resolve to incremental, speculative, catalytic-only, or rejected
- no implementation authority, mutation boundary, implicit-invocation policy, or publication authority changed

<!-- ship-proof:start -->
## Summary
- Adds evidence-bound `SALTATORY` breakthrough doctrine, activation guidance, probe cases, and manifest routing within `codex/skills/logophile/**`.

## Proof
- skill package validation: pass
- manifest, reference-link, stopping-rule, probe, and exact-fragment semantic verifier: pass
- `git diff --check 077adce3d7b913c5edf32311dad97dc46361e651..0de3a3968bc6f25a61a2c7d27d8cd0db8b005b6a`: pass
- exact-head detached worktree cleanliness: pass

## Scope
- repository: `tkersey/dotfiles`
- branch: `agent/logophile-saltatory-doctrine`
- head: `0de3a3968bc6f25a61a2c7d27d8cd0db8b005b6a`
- base: `main`
- base SHA: `077adce3d7b913c5edf32311dad97dc46361e651`

## Risks
- Behavioral superiority of `Be saltatory.` over a plainer incumbent remains unbenchmarked; the doctrine requires behavioral-upgrade adjudication before any replacement claim.

## Follow-ups
- Companion PR #134 consumes the exact terminal fragment in `$glaze`.

## Readiness
- Operation: update-and-promote
- Final state: ready
- SHIP-v1 compatibility mode: promote-draft
- Reason: exact-head validation passes and no implementation task remains open.
- Caveats: activation efficacy remains explicitly unvalidated, without weakening the package's structural or semantic proof.
<!-- ship-proof:end -->