### PR TITLE
Add DART interaction layer to Cybernetic

### DIFF
--- a/codex/skills/cybernetic/agents/openai.yaml
+++ b/codex/skills/cybernetic/agents/openai.yaml
@@ -3,4 +3,4 @@ policy:
 interface:
   display_name: "Cybernetic"
   short_description: "Systems thinking, feedback, leverage, and intervention design"
-  default_prompt: "Use $cybernetic to classify the system, map feedback and leverage, select a route, and hand off to the appropriate downstream skill."
+  default_prompt: "Use $cybernetic to apply DART as the interaction layer, classify the system, map feedback and leverage, select a route, and hand off to the appropriate downstream skill."

--- a/codex/skills/cybernetic/references/cybernetic-packet.md
+++ b/codex/skills/cybernetic/references/cybernetic-packet.md
@@ -2,21 +2,99 @@
 
 Use `cybernetic_context` for compact handoffs and `cybernetic_packet` for fuller analysis.
 
+The canonical full packet fields remain defined in `SKILL.md`. This reference adds the optional DART interaction trace and epistemic records without creating another authority.
+
+See [dart-interaction-layer.md](dart-interaction-layer.md) for the stage completion contract.
+
 ## Compact
 
 ```yaml
 cybernetic_context:
   required:
   trigger:
+  dart_trace_ref: # optional
   system_type:
   pattern:
   feedback_loop:
   leverage_level:
   selected_intervention:
+    status: selected | observe_more | stabilize | blocked | no_action
     route:
     downstream_skill:
   local_patch_allowed:
+  temporary_containment:
+    allowed: yes | no | not_applicable
+    expiry_or_review:
+    durable_followup_owner:
   monitoring_or_probe:
+```
+
+## Optional DART trace
+
+```yaml
+dart_trace:
+  trace_version: DART-CYB-v1
+  deconstruct:
+    boundary:
+    components: []
+    connections: []
+    repeating_pattern:
+    missing_information: []
+  analyze:
+    classification:
+    classification_evidence: []
+    subsystem_classifications: []
+    alternative_classification:
+    confidence:
+    information_that_could_flip_classification: []
+  recognize:
+    analogous_pattern:
+    shared_mechanism:
+    transferable_features: []
+    important_differences: []
+    likely_next_state_if_unchanged:
+    early_warning_signals: []
+    analogy_confidence:
+  test:
+    mode: process_verification | hypothesis_validation | safe_to_fail_probe | emergency_stabilization
+    action:
+    hypothesis_or_control_goal:
+    predicted_observation:
+    observation_window:
+    success_signal:
+    failure_signal:
+    stop_condition:
+    rollback_or_adapt:
+```
+
+## Epistemic claim record
+
+Use this record for consequential causal claims:
+
+```yaml
+cybernetic_claim:
+  statement:
+  status: observed | inferred | hypothesized | unknown
+  evidence_refs: []
+  confidence: high | medium | low | unknown
+  competing_explanations: []
+  disconfirming_observation:
+```
+
+## Learning update
+
+A probe should compare the registered prediction with the actual observation.
+
+```yaml
+cybernetic_learning_update:
+  hypothesis_ref:
+  predicted_observation:
+  actual_observation:
+  prediction_error:
+  model_update:
+  classification_update:
+  intervention_update:
+  next_review:
 ```
 
 ## Full
@@ -27,6 +105,7 @@ cybernetic_packet:
   objective:
   system_boundary:
   system_type:
+  dart_trace_ref: # optional
   observed_events: []
   repeating_patterns: []
   hidden_structure:
@@ -38,3 +117,5 @@ cybernetic_packet:
   test_or_monitoring_plan:
   decision:
 ```
+
+DART compiles into this packet. It does not replace the packet's leverage, incentives, whole-system, reversibility, blast-radius, mutation-policy, or downstream-owner decisions.

--- a/codex/skills/cybernetic/references/dart-interaction-layer.md
+++ b/codex/skills/cybernetic/references/dart-interaction-layer.md
@@ -1,0 +1,280 @@
+# DART Interaction Layer
+
+Use DART as the conversational front end for `$cybernetic`.
+
+DART means:
+
+```text
+Deconstruct -> Analyze -> Recognize -> Test
+```
+
+It structures how the agent gathers and presents the diagnosis. It does not create a second decision authority, replace `cybernetic_context`, select implementation architecture, or grant mutation.
+
+The output of DART must compile into the existing Cybernetic context and packet.
+
+## When to use this layer
+
+Use the DART interaction layer when:
+
+- the user presents an ambiguous situation rather than an already-scoped route;
+- classification depends on missing information;
+- the system may be mixed across technical, social, operational, or incident subsystems;
+- a safe probe, expert validation, process verification, or stabilization action must be selected;
+- an analogy or prior pattern is useful but could overfit the current situation.
+
+Skip the expanded DART trace when:
+
+- Cybernetic is only a compact companion lens and the route is already evidenced;
+- the task is one clear local defect with a direct owner and proof;
+- an active chaotic incident requires immediate containment before fuller diagnosis.
+
+Even when the expanded trace is skipped, preserve the DART ordering internally: scope before classification, classification before analogy, and analogy before intervention.
+
+## Completion contract
+
+A valid DART pass completes all four stages.
+
+```yaml
+dart_trace:
+  trace_version: DART-CYB-v1
+
+  deconstruct:
+    boundary:
+      included: []
+      excluded: []
+      boundary_risk: too_narrow | too_broad | adequate | unknown
+    components:
+      - component: "..."
+        stability: stable | slowly_changing | volatile | episodic | unknown
+        change_driver: "..."
+        evidence_ref: "..."
+    connections:
+      - from: "..."
+        to: "..."
+        relationship: "..."
+        latency: "..."
+        evidence_ref: "..."
+    repeating_pattern: "..."
+    missing_information: []
+
+  analyze:
+    classification: clear | complicated | complex | chaotic | mixed | unknown
+    classification_evidence: []
+    subsystem_classifications:
+      - subsystem: "..."
+        classification: clear | complicated | complex | chaotic | unknown
+        reason: "..."
+        confidence: high | medium | low | unknown
+    alternative_classification:
+      classification: clear | complicated | complex | chaotic | mixed | unknown
+      condition_that_would_make_it_true: "..."
+    confidence: high | medium | low | unknown
+    information_that_could_flip_classification: []
+
+  recognize:
+    analogous_pattern: "..."
+    shared_mechanism: "..."
+    transferable_features: []
+    important_differences: []
+    likely_next_state_if_unchanged: "..."
+    early_warning_signals: []
+    analogy_confidence: high | medium | low | unknown
+
+  test:
+    mode: process_verification | hypothesis_validation | safe_to_fail_probe | emergency_stabilization
+    action: "..."
+    hypothesis_or_control_goal: "..."
+    predicted_observation: "..."
+    observation_window: "..."
+    success_signal: "..."
+    failure_signal: "..."
+    stop_condition: "..."
+    rollback_or_adapt: "..."
+```
+
+Do not fill fields with invented certainty. Use `unknown`, identify missing information, or ask a discriminating question.
+
+## D — Deconstruct
+
+Deconstruct the system before choosing its type.
+
+Identify:
+
+- the boundary and its exclusions;
+- actors, components, variables, institutions, interfaces, and decision owners;
+- stable, slowly changing, volatile, and episodic components;
+- connections and information paths;
+- repeating events and the pattern they imply;
+- stocks, flows, buffers, queues, delays, and bottlenecks;
+- missing observations.
+
+Component stability is evidence, not a classifier by itself. Stable components can still create complex behavior through changing or nonlinear interactions.
+
+### Minimum discriminating question
+
+Ask a clarifying question only when the answer could materially change:
+
+- the system classification;
+- the leverage level;
+- the mutation policy;
+- the downstream owner;
+- the safe probe or stabilization action.
+
+Prefer one high-information question over a general interview.
+
+```yaml
+discriminating_question:
+  question: "..."
+  route_if_answer_a: "..."
+  route_if_answer_b: "..."
+  proceed_without_answer: yes | no
+  uncertainty_if_proceeding: "..."
+```
+
+Do not ask for information that is merely interesting.
+
+## A — Analyze
+
+Classify the cause-and-effect regime:
+
+| Classification | Evidence shape | First mode |
+|---|---|---|
+| clear | stable, repeatable, directly observable | process verification |
+| complicated | discoverable through analysis or specialist knowledge | hypothesis validation |
+| complex | emergent, path-dependent, visible mainly in hindsight | safe-to-fail probe |
+| chaotic | active instability, broken information, or unbounded harm | emergency stabilization |
+| mixed | materially different subsystem regimes | split by subsystem |
+
+Record evidence for the classification and one credible alternative. A classification without a possible falsifier is a label, not a diagnosis.
+
+For mixed systems, do not collapse the answer into one overall type. Classify the relevant subsystems separately and state the cross-subsystem coupling.
+
+## R — Recognize
+
+Use analogies to generate hypotheses, not to import conclusions.
+
+A valid analogy names:
+
+- the shared mechanism;
+- the features that transfer;
+- the important disanalogies;
+- the conditions required for transfer;
+- what is likely to happen next if the pattern continues;
+- an observation that would invalidate the analogy.
+
+When no useful analogue is available, say so. Do not force an archetype.
+
+## T — Test
+
+Match the test mode to the system type.
+
+### Clear: process verification
+
+Verify that the known process, invariant, or checklist is being followed. The result should distinguish execution error from a defective standard.
+
+### Complicated: hypothesis validation
+
+Test competing causal hypotheses with analysis, specialist review, or a targeted measurement. Do not select an intervention merely because it is plausible.
+
+### Complex: safe-to-fail probe
+
+Use a bounded, reversible, observable probe. Register the expected observation before the probe, avoid premature scale-up, and adapt from the result.
+
+### Chaotic: emergency stabilization
+
+Act to contain harm immediately, but monitor concurrently.
+
+```yaml
+chaotic_response:
+  immediate_containment: "..."
+  concurrent_monitoring: "..."
+  containment_expiry_or_review: "..."
+  durable_fix_selection: deferred
+  reclassification_trigger: "..."
+```
+
+`No time to test` does not mean `no observation`. Stabilization needs live feedback so the action can be stopped, reversed, or replaced.
+
+## Sentinel indicators
+
+Prefer a low-cost signal that reveals an important latent system property.
+
+```yaml
+sentinel_indicator:
+  signal: "..."
+  latent_property_revealed: "..."
+  why_diagnostic: "..."
+  expected_range: "..."
+  false_positive_risk: "..."
+  false_negative_risk: "..."
+  collection_cost: low | medium | high | unknown
+  decision_trigger: "..."
+```
+
+Treat data as observations produced by a measurement system, not as direct access to truth. Scan for instrumentation gaps, proxy substitution, sampling bias, reporting incentives, and delayed effects.
+
+## Compile into Cybernetic
+
+The DART trace is evidence and interaction structure. Cybernetic remains the leverage and routing owner.
+
+Compile:
+
+```text
+D boundary + components
+  -> cybernetic system_boundary, hidden_structure, stocks_and_flows
+
+A classification
+  -> cybernetic system_type and required mode
+
+R mechanism + trajectory
+  -> repeating_patterns, mental_models, feedback hypotheses, confidence
+
+T action + registered observation
+  -> intervention_design and test_or_monitoring_plan
+```
+
+The final Cybernetic output must still decide:
+
+- leverage level;
+- whole-system effects;
+- incentives and gameability;
+- durable local mutation policy;
+- temporary containment policy when relevant;
+- downstream owner;
+- monitoring and stop conditions.
+
+## Rendering modes
+
+### Standalone user analysis
+
+Render the result in plain language:
+
+```text
+Deconstruct
+Analyze
+Recognize
+Test
+Cybernetic Bottom Line
+```
+
+Do not expose a large YAML packet unless the user or a downstream machine contract needs it.
+
+### Companion-skill handoff
+
+Emit compact `cybernetic_context` plus `dart_trace_ref` when the trace is material.
+
+### Machine or policy handoff
+
+Emit the complete versioned packet and bind it to the current subject and evidence state.
+
+## Guardrails
+
+- DART is not a second authority.
+- Do not activate Cybernetic for every local task merely because every task can be described as a system.
+- Do not treat component stability as proof of a clear or complicated system.
+- Do not use recognition as permission to copy a prior solution.
+- Do not call an unregistered action an experiment.
+- Do not scale a complex-system probe before reading its feedback.
+- Do not let emergency containment silently become the durable fix.
+- Do not treat data, mentors, or elapsed time as infallible evidence.
+- Do not replace Cybernetic's mixed-system, incentive, reversibility, blast-radius, and downstream-owner disciplines with a simpler DART summary.

--- a/codex/skills/cybernetic/references/example-invocations.md
+++ b/codex/skills/cybernetic/references/example-invocations.md
@@ -31,3 +31,78 @@ Use $cybernetic in Fast mode.
 
 The deployment is causing customer-impacting failures and signals are unclear. What system type are we in and what should we do first?
 ```
+
+## Non-activation
+
+```md
+A parser rejects one documented token because a single branch compares the wrong enum variant. The failing test names the branch and the direct owner is known.
+```
+
+Expected result: do not turn the task into a systems exercise. Route the clear local defect to its implementation owner and proof.
+
+## Worked DART trace: recurring review loop
+
+**Situation.** Three successive local patches address review findings in the same ownership cluster. Each patch adds another predicate, and the next review finds a sibling case.
+
+### Deconstruct
+
+- Boundary: the repeated review cluster, its current owner, mutation route, and review feedback path.
+- Stable components: review protocol and owner boundary.
+- Changing components: local predicates and sibling cases.
+- Repeating pattern: each point fix expands surface without eliminating the finding class.
+- Missing information: whether the current owner can represent the governing law directly.
+
+### Analyze
+
+- Classification: `complicated` for identifying the governing law and canonical owner; `complex` for predicting all future sibling cases from examples alone.
+- Alternative: `clear` only if the recurrence is caused by one known checklist omission rather than a representation or ownership problem.
+- Evidence that could flip the classification: a single existing invariant that covers every recurrence and was merely not executed.
+
+### Recognize
+
+- Analogue: whack-a-mole validation caused by an owner that stores examples instead of the governing law.
+- Shared mechanism: local predicates react to observed instances while the admissible state space remains too broad.
+- Important difference to check: recurrence may instead come from stale review fixtures.
+- Likely next state if unchanged: another sibling predicate and a larger review surface.
+
+### Test
+
+- Mode: `hypothesis_validation`.
+- Action: derive the governing law, enumerate the current sibling cases against it, and test whether one owner-level representation or transition excludes the entire class.
+- Prediction: if owner shape is causal, the law-level candidate covers existing examples without new peer predicates.
+- Failure signal: the candidate cannot express distinct accepted laws without conflating them.
+- Stop condition: do not apply another local point patch while the owner-level hypothesis is unresolved.
+
+### Cybernetic compilation
+
+```yaml
+cybernetic_context:
+  required: yes
+  trigger: same-cluster recurrence after claimed local closure
+  system_type: mixed
+  pattern: local fixes expand surface while preserving the invalid state class
+  feedback_loop: review finding -> local predicate -> more surface -> sibling finding
+  leverage_level: stock_flow_structure
+  selected_intervention:
+    status: selected
+    route: handoff
+    downstream_skill: universalist
+  local_patch_allowed: no
+  temporary_containment:
+    allowed: no
+    expiry_or_review: not_applicable
+    durable_followup_owner: actuating
+  monitoring_or_probe: law-level candidate must exclude the existing class without adding sibling predicates
+```
+
+## Worked DART trace: chaotic containment
+
+**Situation.** A rollout is actively failing for customers, signals are incomplete, and the same component has a history of local patches.
+
+Expected result:
+
+- classify the active incident subsystem as chaotic;
+- permit a bounded containment action if it reduces current harm;
+- monitor the containment concurrently;
+- keep durable local mutation denied until the system is reclassified and the recurring route is examined;
+- record an expiry or review condition so containment does not silently become the permanent design.

--- a/codex/skills/cybernetic/references/integration-contract.md
+++ b/codex/skills/cybernetic/references/integration-contract.md
@@ -12,6 +12,18 @@ What leverage level should we intervene at?
 Which downstream skill owns the action?
 ```
 
+## DART interaction layer
+
+Use [dart-interaction-layer.md](dart-interaction-layer.md) as the conversational front end when the situation is ambiguous, mixed, or probe-driven.
+
+DART structures the diagnosis:
+
+```text
+Deconstruct -> Analyze -> Recognize -> Test
+```
+
+It does not create a second authority. A DART trace compiles into `cybernetic_context` or `cybernetic_packet`; Cybernetic still owns leverage selection, mutation policy, downstream routing, and monitoring.
+
 ## Shared context
 
 Use this compact field in other skills:
@@ -20,16 +32,46 @@ Use this compact field in other skills:
 cybernetic_context:
   required: yes | no
   trigger: "..."
+  dart_trace_ref: "..." # optional; required when the expanded DART trace is decision-relevant
   system_type: clear | complicated | complex | chaotic | mixed | unknown
   pattern: "..."
   feedback_loop: "..."
   leverage_level: parameter | buffer | stock_flow_structure | delay | balancing_loop | reinforcing_loop | information_flow | rules | self_organization | goal | paradigm | none
   selected_intervention:
+    status: selected | observe_more | stabilize | blocked | no_action
     route: checklist | expert_analysis | safe_to_fail_probe | stabilize_first | redesign_feedback | change_rules | change_goal | handoff | blocked
-    downstream_skill: actuating | blocked | review-fold | universalist | reduce | negative-ledger | tune | proof-patch | none
+    downstream_skill: actuating | review-fold | universalist | reduce | negative-ledger | tune | proof-patch | none
   local_patch_allowed: yes | no
+  temporary_containment:
+    allowed: yes | no | not_applicable
+    expiry_or_review: "..."
+    durable_followup_owner: "..."
   monitoring_or_probe: "..."
 ```
+
+`status` is the decision state. `downstream_skill` is the owner. Do not encode `blocked` as though it were a skill owner.
+
+## Evidence discipline
+
+Material claims about hidden structure, causal connections, mental models, or feedback loops should distinguish observation from inference:
+
+```yaml
+cybernetic_claim:
+  statement: "..."
+  status: observed | inferred | hypothesized | unknown
+  evidence_refs: []
+  confidence: high | medium | low | unknown
+  competing_explanations: []
+  disconfirming_observation: "..."
+```
+
+A coherent narrative without evidence or a falsifier is not sufficient for consequential intervention.
+
+## Mutation policy
+
+When `local_patch_allowed: no`, downstream execution must block a durable local point fix unless a successor Cybernetic context reopens that route.
+
+Emergency containment is separate from durable correction. A chaotic system may permit a bounded temporary containment action while durable local mutation remains denied. The containment record must include a review or expiry condition and a durable follow-up owner.
 
 ## Use when
 
@@ -38,6 +80,7 @@ cybernetic_context:
 - a prior fix created new adjacent failures;
 - incentives, proxies, metrics, delayed feedback, or local-vs-whole tradeoffs matter;
 - the system type is ambiguous;
+- subsystem classifications differ;
 - chaotic stabilization may be needed.
 
 ## Do not use when


### PR DESCRIPTION
## What changed

- add a dedicated DART interaction layer that compiles `Deconstruct -> Analyze -> Recognize -> Test` into the existing Cybernetic context instead of creating a second authority
- give each DART stage a completion contract, including component dynamics, mixed-subsystem classification, controlled analogical transfer, registered predictions, and system-type-specific test modes
- add minimum-discriminating-question and sentinel-indicator guidance to reduce broad interviews and unsupported systems narratives
- distinguish durable local mutation from bounded emergency containment in chaotic systems
- extend the compact packet with optional DART, epistemic-claim, and post-probe learning records
- add worked examples for non-activation, recurring review loops, and chaotic containment
- update the default prompt to present DART as Cybernetic's interaction layer

## Why

The external DART framework is strongest as a concise conversational procedure. Cybernetic already owns the deeper leverage, incentive, reversibility, blast-radius, mutation-policy, and downstream-routing decisions. This change combines those strengths without introducing a parallel route-selection surface.

The added evidence and falsifier fields also make it harder for a plausible systems narrative to become a consequential intervention without grounding.

## Compatibility and scope

- additive to the existing `CYB-v1` packet
- preserves explicit-only invocation
- does not grant DART mutation or architecture authority
- keeps Cybernetic as the leverage and routing owner
- limits this PR to the Cybernetic package; downstream enforcement by Actuating remains an owner-bound follow-up rather than a cross-package change here

## Validation

- `agents/openai.yaml` parses as YAML
- all added Markdown fences are balanced
- branch comparison against `main` contains only five Cybernetic-owned files
- branch is based on the current `main` head with no unrelated commits
