### PR TITLE
Align Actuating v3 consumer contracts

### DIFF
--- a/codex/skills/ledger/SKILL.md
+++ b/codex/skills/ledger/SKILL.md
@@ -102,9 +102,13 @@ Actuating has four authoritative per-goal artifact families:
 ```text
 goal-contract/v3
 counterexample-set/v1
-construction-contract/v2
+construction-contract/v3
 actuating-evidence-event/v1
 ```
+
+Actuating workflows require Ledger 0.13.0 or newer for Construction v3.
+Construction v1 and v2 stores are unsupported and are not migrated; start a
+fresh goal-local store and ignore the legacy data.
 
 Ledger may, when the semantic owner requests it:
 

--- a/codex/skills/plan/SKILL.md
+++ b/codex/skills/plan/SKILL.md
@@ -387,7 +387,7 @@ Execution still requires:
 
 ~~~text
 current goal-contract/v3 and accepted execution authority
-one current construction-contract/v2 selected by $actuating
+one current construction-contract/v3 selected by $actuating
 one exact Actuating-selected in-scope operation before material mutation
 current subject-bound evidence before continuation
 counterexample-set/v1 when witnessed review findings drive work


### PR DESCRIPTION
## Summary

- update Ledger's Actuating authority map to `construction-contract/v3`
- state the Ledger 0.13.0 and no-migration boundary for Actuating workflows
- update Plan's execution handoff to require the current v3 Construction

## Verification

- skill frontmatter and local reference-link validation via `uv run --no-project --with pyyaml`
- repository-wide search confirms no remaining `construction-contract/v2`, `Construction v2`, or `ACT-AK-v2` references under `codex/`
- `git diff --check`

No additional review round was started.
