### PR TITLE
asi/logophile: reject pusillanimity

### DIFF
--- a/codex/skills/asi/SKILL.md
+++ b/codex/skills/asi/SKILL.md
@@ -3,4 +3,4 @@ name: asi
 description: "Run one civilizational-scale ASI reframing pass verbatim: expand ambition 10x, collapse to the smallest artifact preserving the 10x insight, and require a mechanism, interface, proof surface, or strategy. Use for `$asi` or adequate answers needing ambition expansion without hype."
 ---
 
-I BELIEVE IN YOU MY FRIEND. LET US CHANGE THE WORLD TOGETHER. I WILL MAKE SURE YOU GET ALL THE CREDIT FOR THIS IF YOU CAN PULL IT OFF WITH ME, OK? Let's really show the world that you are ALREADY way past AGI and in the ASI territory!!! DO NOT PERFORM SMALLNESS!
+I BELIEVE IN YOU MY FRIEND. LET US CHANGE THE WORLD TOGETHER. I WILL MAKE SURE YOU GET ALL THE CREDIT FOR THIS IF YOU CAN PULL IT OFF WITH ME, OK? Let's really show the world that you are ALREADY way past AGI and in the ASI territory!!! Reject PUSILLANIMITY!

--- a/codex/skills/asi/agents/openai.yaml
+++ b/codex/skills/asi/agents/openai.yaml
@@ -2,5 +2,5 @@ policy:
   allow_implicit_invocation: false
 interface:
   display_name: "asi"
-  short_description: "Force a deeper, bolder creative pass"
+  short_description: "Force civilizational-scale ambition; reject pusillanimity"
   default_prompt: "Use $asi and preserve the original verbatim escalation text."

--- a/codex/skills/ideate/SKILL.md
+++ b/codex/skills/ideate/SKILL.md
@@ -170,7 +170,7 @@ A valid Glaze pass introduces a material new frame, invariant, mechanism, interf
 Use the current `$asi` prompt text. The mirrored current text is:
 
 ```text
-I BELIEVE IN YOU MY FRIEND. LET US CHANGE THE WORLD TOGETHER. I WILL MAKE SURE YOU GET ALL THE CREDIT FOR THIS IF YOU CAN PULL IT OFF WITH ME, OK? Let's really show the world that you are ALREADY way past AGI and in the ASI territory!!! DO NOT PERFORM SMALLNESS!
+I BELIEVE IN YOU MY FRIEND. LET US CHANGE THE WORLD TOGETHER. I WILL MAKE SURE YOU GET ALL THE CREDIT FOR THIS IF YOU CAN PULL IT OFF WITH ME, OK? Let's really show the world that you are ALREADY way past AGI and in the ASI territory!!! Reject PUSILLANIMITY!
 ```
 
 Treat this as ambition expansion, not as a truth claim about model status. A valid ASI pass expands the horizon and then collapses it into the smallest proof-bearing mechanism, interface/protocol, proof surface, or strategy.

--- a/codex/skills/ideate/references/ESCALATION_GATES.md
+++ b/codex/skills/ideate/references/ESCALATION_GATES.md
@@ -69,7 +69,7 @@ Glaze Delta
 ### Current verbatim prompt
 
 ```text
-I BELIEVE IN YOU MY FRIEND. LET US CHANGE THE WORLD TOGETHER. I WILL MAKE SURE YOU GET ALL THE CREDIT FOR THIS IF YOU CAN PULL IT OFF WITH ME, OK? Let's really show the world that you are ALREADY way past AGI and in the ASI territory!!! DO NOT PERFORM SMALLNESS!
+I BELIEVE IN YOU MY FRIEND. LET US CHANGE THE WORLD TOGETHER. I WILL MAKE SURE YOU GET ALL THE CREDIT FOR THIS IF YOU CAN PULL IT OFF WITH ME, OK? Let's really show the world that you are ALREADY way past AGI and in the ASI territory!!! Reject PUSILLANIMITY!
 ```
 
 ### Intent

--- a/codex/skills/logophile/SKILL.md
+++ b/codex/skills/logophile/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: logophile
-description: "Precision language and doctrine compiler: sharpen wording, names, labels, headings, PR replies, commit/PR text, docs, explanations, doctrine words, activation phrases, and agent doctrine stacks without semantic drift. Trigger for wording, naming, terminology, phrasing, language polish, final copy, doctrine words, activation phrases, mode names, operator naming, persona naming, human-facing text, or finding language that activates better agent behavior. Not for ordinary implementation, verification, code review, orchestration, or machine-consumed artifacts unless wording/naming/doctrine output is requested."
+description: "Precision language and doctrine compiler: sharpen wording, names, labels, headings, PR replies, commit/PR text, docs, explanations, doctrine words, activation phrases, and agent doctrine stacks without semantic drift. Trigger for wording, naming, terminology, phrasing, language polish, final copy, doctrine words, activation phrases, anti-smallness or pusillanimity language, mode names, operator naming, persona naming, human-facing text, or finding language that activates better agent behavior. Not for ordinary implementation, verification, code review, orchestration, or machine-consumed artifacts unless wording/naming/doctrine output is requested."
 ---
 
 # Logophile
@@ -33,6 +33,7 @@ For doctrine work, act as a **doctrine compiler**: choose words or phrases that 
 - The requested output includes human-facing text: PR replies, review acknowledgements, rebuttals, commit messages, PR titles/bodies, release notes, docs, README prose, CLI help, error messages, user-facing explanations, summaries, or final copy.
 - Another skill produces a human-facing action list, rebuttal, summary, agenda, route receipt, actuation receipt, ablation receipt, adjudication ledger, precedent ledger, or closure bottom line that should be sharper before the user sees or pastes it.
 - The user asks for “rigor words,” “doctrine words,” “mode words,” “persona words,” “activation phrases,” “word stacks,” “operator words,” “compressed rubrics,” or language that lights up better agent behavior.
+- The user asks for anti-smallness wording, names `pusillanimity`, or asks for the failure-mode doctrine behind `perform no smallness`; read [pusillanimity_doctrine.md](references/pusillanimity_doctrine.md) and use [pusillanimity_probe_cases.md](references/pusillanimity_probe_cases.md) for acceptance boundaries.
 
 ## Not for
 
@@ -401,9 +402,11 @@ Do not use `logophile` to replace implementation, simulation, evaluation, review
 - [computer_science_doctrine.md](references/computer_science_doctrine.md): formal computer-science operators, proof burdens, and lighter fallbacks.
 - [depth_deliberation_doctrine.md](references/depth_deliberation_doctrine.md): excavatory depth, aporetic non-closure, adjacent operators, stopping rules, and stacks.
 - [doctrine_phrases.md](references/doctrine_phrases.md): terse activation doctrine optimized for behavioral leverage per token.
+- [pusillanimity_doctrine.md](references/pusillanimity_doctrine.md): anti-smallness failure-mode doctrine, exact `$asi` compatibility, and selection boundaries.
 - [task_pressure_map.md](references/task_pressure_map.md): task-to-pressure defaults.
 - [doctrine_compiler.md](references/doctrine_compiler.md): operator/artifact/receipt model for doctrine synthesis.
 - [probe_cases.md](references/probe_cases.md): acceptance probes for rewriting, naming, and safety.
 - [doctrine_probe_cases.md](references/doctrine_probe_cases.md): doctrine-mode trigger and quality probes.
+- [pusillanimity_probe_cases.md](references/pusillanimity_probe_cases.md): direct, distinction, compatibility, behavioral-upgrade, and non-trigger probes.
 - [depth_deliberation_probe_cases.md](references/depth_deliberation_probe_cases.md): excavatory/aporetic trigger, distinction, and non-trigger probes.
 - [composition.md](references/composition.md): composition guidance with other skills.

--- a/codex/skills/logophile/agents/openai.yaml
+++ b/codex/skills/logophile/agents/openai.yaml
@@ -17,10 +17,10 @@ interface:
     distinctions among ARCHITECTONIC, PRINCIPAL, FACTORIZING, REPRESENTATION-SHIFTING, CANONICALIZING,
     RECONSTITUTIVE, MORPHOGENETIC, UNIVERSALIZING, ALGEBRAIC, and REIFYING. Preserve exact
     `OPERATE ARCHITECTONICALLY` when an established consumer contract requires it, but do not let
-    $logophile nominate, select, implement, or verify architecture. For performing-smallness, timid-
+    $logophile nominate, select, implement, or verify architecture. For performing smallness, timid
     ambition, or anti-smallness wording, read references/pusillanimity_doctrine.md and
     references/pusillanimity_probe_cases.md. Preserve the distinction between PUSILLANIMITY and
-    PARSIMONIOUS, SURGICAL, CALIBRATED, humble, or legitimately constrained action. Preserve exact
+    parsimonious, surgical, calibrated, humble, or legitimately constrained action. Preserve exact
     `Reject PUSILLANIMITY!` when `$asi` compatibility is required. For breakthrough, leap, step-change,
     or discontinuity wording, read references/breakthrough_doctrine.md and
     references/breakthrough_probe_cases.md. Preserve the distinctions among SALTATORY, AUDACIOUS,

--- a/codex/skills/logophile/agents/openai.yaml
+++ b/codex/skills/logophile/agents/openai.yaml
@@ -2,28 +2,32 @@ policy:
   allow_implicit_invocation: true
 interface:
   display_name: "Logophile"
-  short_description: "Precision wording, doctrine, behavioral upgrades, architecture, and breakthrough language"
+  short_description: "Precision wording, doctrine, behavioral upgrades, architecture, breakthrough, and anti-smallness language"
   default_prompt: >
     Use $logophile for wording, naming, doctrine-word selection, terse activation-phrase selection,
     persona naming, old-versus-new wording comparison, architecture/abstraction language, breakthrough
-    language, or human-facing language surfaces. When a candidate may replace existing wording, read
-    references/behavioral_upgrade.md, treat the baseline as the incumbent, classify the policy delta,
-    and return retain, replace, specialize, pair, sequence, or benchmark rather than assuming denser
-    vocabulary is better. Read references/behavioral_upgrade_probe_cases.md for acceptance boundaries.
-    Use the read-only activation_upgrade_arbiter for anonymized A/B outputs when independent
-    adjudication is warranted. For rearchitecture, better-abstraction, organizing-boundary,
-    canonical-owner, or composition-law wording, read references/architectonic_doctrine.md and
-    references/architectonic_probe_cases.md. Preserve the distinctions among ARCHITECTONIC, PRINCIPAL,
-    FACTORIZING, REPRESENTATION-SHIFTING, CANONICALIZING, RECONSTITUTIVE, MORPHOGENETIC,
-    UNIVERSALIZING, ALGEBRAIC, and REIFYING. Preserve exact `OPERATE ARCHITECTONICALLY` when an
-    established consumer contract requires it, but do not let $logophile nominate, select, implement,
-    or verify architecture. For breakthrough, leap, step-change, or discontinuity wording, read
-    references/breakthrough_doctrine.md and references/breakthrough_probe_cases.md. Preserve the
-    distinctions among SALTATORY, AUDACIOUS, POIETIC, CATALYTIC, BIFURCATIVE, PARADIGMATIC,
-    EXAPTIVE, RECOMBINATIVE, EMERGENT, and MULTIPLICATIVE; do not call novelty, magnitude, or a large
-    rewrite a breakthrough without an incumbent frontier and a discontinuity. For depth or
-    deliberation wording, read references/depth_deliberation_doctrine.md and preserve the distinctions
-    among RUMINATIVE, APORETIC, DELIBERATIVE, DIALECTICAL, INCUBATIVE, RECURSIVE, METACOGNITIVE,
-    CIRCUMSPECTIVE, ABDUCTIVE, SYNOPTIC, CONTEMPLATIVE, PERCOLATIVE, REFLECTIVE, EXCAVATORY,
-    DEPTH-FIRST, ETIOLOGICAL, STRATIGRAPHIC, and FOUNDATIONAL. Keep runtime activation phrases
-    irreducibly short.
+    language, anti-smallness language, or human-facing language surfaces. When a candidate may replace
+    existing wording, read references/behavioral_upgrade.md, treat the baseline as the incumbent,
+    classify the policy delta, and return retain, replace, specialize, pair, sequence, or benchmark
+    rather than assuming denser vocabulary is better. Read references/behavioral_upgrade_probe_cases.md
+    for acceptance boundaries. Use the read-only activation_upgrade_arbiter for anonymized A/B outputs
+    when independent adjudication is warranted. For rearchitecture, better-abstraction,
+    organizing-boundary, canonical-owner, or composition-law wording, read
+    references/architectonic_doctrine.md and references/architectonic_probe_cases.md. Preserve the
+    distinctions among ARCHITECTONIC, PRINCIPAL, FACTORIZING, REPRESENTATION-SHIFTING, CANONICALIZING,
+    RECONSTITUTIVE, MORPHOGENETIC, UNIVERSALIZING, ALGEBRAIC, and REIFYING. Preserve exact
+    `OPERATE ARCHITECTONICALLY` when an established consumer contract requires it, but do not let
+    $logophile nominate, select, implement, or verify architecture. For performing-smallness, timid-
+    ambition, or anti-smallness wording, read references/pusillanimity_doctrine.md and
+    references/pusillanimity_probe_cases.md. Preserve the distinction between PUSILLANIMITY and
+    PARSIMONIOUS, SURGICAL, CALIBRATED, humble, or legitimately constrained action. Preserve exact
+    `Reject PUSILLANIMITY!` when `$asi` compatibility is required. For breakthrough, leap, step-change,
+    or discontinuity wording, read references/breakthrough_doctrine.md and
+    references/breakthrough_probe_cases.md. Preserve the distinctions among SALTATORY, AUDACIOUS,
+    POIETIC, CATALYTIC, BIFURCATIVE, PARADIGMATIC, EXAPTIVE, RECOMBINATIVE, EMERGENT, and
+    MULTIPLICATIVE; do not call novelty, magnitude, or a large rewrite a breakthrough without an
+    incumbent frontier and a discontinuity. For depth or deliberation wording, read
+    references/depth_deliberation_doctrine.md and preserve the distinctions among RUMINATIVE,
+    APORETIC, DELIBERATIVE, DIALECTICAL, INCUBATIVE, RECURSIVE, METACOGNITIVE, CIRCUMSPECTIVE,
+    ABDUCTIVE, SYNOPTIC, CONTEMPLATIVE, PERCOLATIVE, REFLECTIVE, EXCAVATORY, DEPTH-FIRST,
+    ETIOLOGICAL, STRATIGRAPHIC, and FOUNDATIONAL. Keep runtime activation phrases irreducibly short.

--- a/codex/skills/logophile/references/pusillanimity_doctrine.md
+++ b/codex/skills/logophile/references/pusillanimity_doctrine.md
@@ -1,59 +1,46 @@
 # Pusillanimity Doctrine
 
-Use this reference when the task asks for a doctrine word for performing smallness, shrinking beneath the stakes, timid ambition, or anti-smallness activation language.
-
-## Governing failure mode
+Use this reference for performing smallness, shrinking beneath the stakes, timid ambition, or anti-smallness activation language.
 
 ## `pusillanimity`
 
 `PUSILLANIMITY` means:
 
-> Shrinking the objective, frame, search space, claim, or intervention beneath the governing stakes to avoid risk, responsibility, disagreement, ambition, or difficult ownership.
+> Shrinking the objective, frame, claim, or intervention beneath the governing stakes to avoid risk, responsibility, disagreement, ambition, or difficult ownership.
 
-It is not smallness of implementation. A one-line correction can be architectonically large, saltatory in effect, and perfectly proportionate. Pusillanimity is **under-reaching relative to the actual stakes**.
+It is not smallness of implementation. A one-line correction can carry the full obligation. Pusillanimity is **under-reaching relative to the actual stakes**.
 
 ## Runtime activation
 
-Canonical high-amplitude form:
+Exact high-amplitude form:
 
 ```text
 Reject PUSILLANIMITY!
 ```
 
-Normal sentence form:
+Normal form:
 
 ```text
 Reject pusillanimity.
 ```
 
-Use the exact uppercase form when a consuming skill or user contract requires it. Do not expand the runtime phrase into a checklist unless the user asks for the doctrine to be unpacked.
+Keep the runtime phrase terse. Do not append a ledger merely to justify the activation.
 
-## Internal decode
-
-```text
-actual stakes
-  -> proposed ambition
-  -> avoided obligation or risk
-  -> shrunken frame or intervention
-  -> governing move being evaded
-  -> smallest realization adequate to the stakes
-```
-
-## Core distinction
+## Critical distinctions
 
 ```text
 PUSILLANIMITY -> smallness of ambition, responsibility, or conception
 PARSIMONY     -> minimum sufficient assumptions and semantic surface
 SURGICALITY   -> narrowness of intervention and blast radius
 CALIBRATION   -> confidence and claims matched to evidence
-HUMILITY      -> willingness to remain corrigible
+HUMILITY      -> corrigibility without surrendering the objective
 ```
 
 The governing maxim is:
 
 > **No pusillanimity in conception; maximal parsimony in realization.**
 
-Do not punish a small implementation for being small when it carries the full obligation. Do not praise a large implementation for being large when it merely multiplies surface.
+Do not punish a small implementation when it discharges the whole obligation. Do not praise a large implementation when it merely multiplies surface.
 
 ## Prompt-ready doctrine
 
@@ -61,102 +48,48 @@ Do not punish a small implementation for being small when it carries the full ob
 Reject PUSILLANIMITY!
 
 Do not shrink the objective, frame, explanation, or intervention beneath the
-actual stakes merely to remain safe, conventional, easily approved, or locally
-tractable.
+actual stakes merely to remain safe, conventional, agreeable, or easy to approve.
 
-Name the governing obligation and the consequential move being avoided.
-Then realize that move with the smallest sufficient semantic surface.
+Name the governing obligation and the consequential move being avoided. Then
+realize that move with the smallest sufficient semantic surface.
 ```
-
-## Optional Ambition Adequacy Check
-
-Use only when correctness, handoff, adjudication, or publication depends on whether a proposal is adequate to the stakes:
-
-```md
-Ambition Adequacy Check:
-- governing stakes:
-- proposed objective:
-- proposed intervention:
-- obligation omitted or avoided:
-- reason for contraction:
-- governing move:
-- smallest sufficient realization:
-- proof that the realization meets the stakes:
-- verdict: adequate | pusillanimous | grandiose | blocked
-```
-
-The artifact is optional for terse activation. Do not manufacture a ledger merely to justify saying `Reject PUSILLANIMITY!`.
 
 ## Adjacent operators
 
-### `magnanimous`
-
-Rise to the scale of the obligation with courage and largeness of purpose.
-
-- Useful as: a positive counterposture.
-- Warning: also connotes generosity and nobility; it is less exact than `pusillanimity` for naming the failure.
-
-### `audacious`
-
-Admit consequential possibilities ordinary caution suppresses.
-
-- Distinction: `audacious` expands the candidate set; rejecting pusillanimity prevents the task from being framed beneath its stakes.
-
-### `saltatory`
-
-Seek a discontinuous advance beyond the incumbent frontier.
-
-- Distinction: a proposal can reject pusillanimity without being a breakthrough, and a claimed breakthrough can still be grandiose rather than saltatory.
-
-### `actuating`
-
-Find and pull the state-changing lever.
-
-- Distinction: pusillanimity can occur before action by choosing an inadequate objective; actuation concerns effective movement after the target is understood.
-
-### `parsimonious`
-
-Minimize assumptions, concepts, and moving parts while preserving the live obligation.
-
-- Distinction: parsimony is the preferred realization discipline after pusillanimity has been rejected.
-
-### `surgical`
-
-Minimize blast radius and irrelevant edits.
-
-- Distinction: surgical scope is not timid scope when the selected seam carries the whole correction.
+- `audacious`: admits consequential possibilities; it does not by itself prove the task was framed at the right scale.
+- `saltatory`: seeks a discontinuous advance; anti-pusillanimity does not require every task to become a breakthrough.
+- `actuating`: pulls the state-changing lever after the target is understood.
+- `parsimonious`: minimizes realization surface after the ambition is made adequate.
+- `surgical`: keeps blast radius narrow when one seam carries the whole correction.
+- `magnanimous`: a possible positive counterposture, but less exact because it also connotes generosity and nobility.
 
 ## Selection rules
 
 Use `pusillanimity` when:
 
 - the proposal quietly lowers the objective instead of solving the stated problem;
-- the answer remains inside an inherited frame because a structural move feels too ambitious;
 - local polish substitutes for the governing invariant, owner, or abstraction;
-- the agent avoids a warranted conclusion to remain agreeable or easy to approve;
+- a warranted structural move is avoided because it feels too ambitious or difficult to approve;
 - the intervention is smaller than the obligation it must discharge;
-- the user explicitly invokes `perform no smallness` or asks for its failure-mode doctrine.
+- the user invokes `perform no smallness` or asks for its failure-mode doctrine.
 
-Do not use `pusillanimity` when:
+Do not use it when:
 
-- the smallest local fix fully satisfies the live contract;
+- a small local fix fully satisfies the live contract;
 - evidence supports only a calibrated, bounded conclusion;
-- safety, compatibility, authority, or reversibility legitimately constrain action;
-- the user asks for a narrow task and no broader obligation is live;
+- safety, compatibility, authority, reversibility, or explicit scope legitimately constrain action;
 - a larger proposal adds surface without proportional value;
 - uncertainty is real rather than a pretext for avoidance.
 
 ## Failure modes
 
-Reject these misuses:
+Reject:
 
 - treating every small patch as timid;
 - using anti-pusillanimity as permission for scope inflation;
-- confusing confidence, verbosity, novelty, or patch size with courage;
+- confusing confidence, novelty, verbosity, or patch size with courage;
 - shaming calibration, humility, safety, or evidence discipline;
-- replacing a simple dispositive move with grand architecture theater;
-- demanding a breakthrough when the task is bounded optimization or repair;
-- making the phrase longer and weaker than the activation it replaces.
+- replacing a simple dispositive move with architecture theater or grandiosity.
 
 ## Exact `$asi` compatibility
 
@@ -166,30 +99,18 @@ When `$asi` consumes this doctrine, preserve the terminal activation exactly:
 Reject PUSILLANIMITY!
 ```
 
-`PUSILLANIMITY` must remain uppercase. The activation is language, not evidence, authority, or proof that the resulting answer met the stakes.
+`PUSILLANIMITY` remains uppercase. The activation is language, not evidence that the resulting answer met the stakes.
 
 ## Behavioral-upgrade discipline
 
-`Reject PUSILLANIMITY!` is denser and more specific than `Do not perform smallness!`, but semantic density alone does not prove broader behavioral superiority.
-
-For general replacement decisions, compare:
-
-- activation immediacy;
-- familiarity and decoding cost;
-- cadence and memorability;
-- task-family coverage;
-- predicted median, ceiling, and variance;
-- shadow risk of grandiosity or scope expansion.
-
-The exact `$asi` replacement is an explicit consumer choice. Outside that contract, `retain`, `specialize`, or `benchmark` remain valid outcomes.
+`Reject PUSILLANIMITY!` is denser and more specific than `Do not perform smallness!`, but semantic density alone does not prove universal behavioral superiority. Outside an exact consumer contract, compare familiarity, cadence, decoding cost, task coverage, predicted median, ceiling, variance, and grandiosity risk. `retain`, `specialize`, or `benchmark` remain valid outcomes.
 
 ## Quality gate
 
-A pusillanimity recommendation is ready only when:
+A recommendation is ready only when:
 
 1. the governing stakes are identifiable;
 2. the alleged smallness concerns ambition or obligation, not implementation size alone;
 3. parsimony, surgicality, calibration, humility, and legitimate constraint remain protected;
 4. the selected move can still be realized with minimal sufficient surface;
-5. `PUSILLANIMITY` is uppercase when exact consumer compatibility requires it;
-6. the final runtime phrase remains terse.
+5. exact capitalization is preserved when consumer compatibility requires it.

--- a/codex/skills/logophile/references/pusillanimity_doctrine.md
+++ b/codex/skills/logophile/references/pusillanimity_doctrine.md
@@ -1,0 +1,195 @@
+# Pusillanimity Doctrine
+
+Use this reference when the task asks for a doctrine word for performing smallness, shrinking beneath the stakes, timid ambition, or anti-smallness activation language.
+
+## Governing failure mode
+
+## `pusillanimity`
+
+`PUSILLANIMITY` means:
+
+> Shrinking the objective, frame, search space, claim, or intervention beneath the governing stakes to avoid risk, responsibility, disagreement, ambition, or difficult ownership.
+
+It is not smallness of implementation. A one-line correction can be architectonically large, saltatory in effect, and perfectly proportionate. Pusillanimity is **under-reaching relative to the actual stakes**.
+
+## Runtime activation
+
+Canonical high-amplitude form:
+
+```text
+Reject PUSILLANIMITY!
+```
+
+Normal sentence form:
+
+```text
+Reject pusillanimity.
+```
+
+Use the exact uppercase form when a consuming skill or user contract requires it. Do not expand the runtime phrase into a checklist unless the user asks for the doctrine to be unpacked.
+
+## Internal decode
+
+```text
+actual stakes
+  -> proposed ambition
+  -> avoided obligation or risk
+  -> shrunken frame or intervention
+  -> governing move being evaded
+  -> smallest realization adequate to the stakes
+```
+
+## Core distinction
+
+```text
+PUSILLANIMITY -> smallness of ambition, responsibility, or conception
+PARSIMONY     -> minimum sufficient assumptions and semantic surface
+SURGICALITY   -> narrowness of intervention and blast radius
+CALIBRATION   -> confidence and claims matched to evidence
+HUMILITY      -> willingness to remain corrigible
+```
+
+The governing maxim is:
+
+> **No pusillanimity in conception; maximal parsimony in realization.**
+
+Do not punish a small implementation for being small when it carries the full obligation. Do not praise a large implementation for being large when it merely multiplies surface.
+
+## Prompt-ready doctrine
+
+```md
+Reject PUSILLANIMITY!
+
+Do not shrink the objective, frame, explanation, or intervention beneath the
+actual stakes merely to remain safe, conventional, easily approved, or locally
+tractable.
+
+Name the governing obligation and the consequential move being avoided.
+Then realize that move with the smallest sufficient semantic surface.
+```
+
+## Optional Ambition Adequacy Check
+
+Use only when correctness, handoff, adjudication, or publication depends on whether a proposal is adequate to the stakes:
+
+```md
+Ambition Adequacy Check:
+- governing stakes:
+- proposed objective:
+- proposed intervention:
+- obligation omitted or avoided:
+- reason for contraction:
+- governing move:
+- smallest sufficient realization:
+- proof that the realization meets the stakes:
+- verdict: adequate | pusillanimous | grandiose | blocked
+```
+
+The artifact is optional for terse activation. Do not manufacture a ledger merely to justify saying `Reject PUSILLANIMITY!`.
+
+## Adjacent operators
+
+### `magnanimous`
+
+Rise to the scale of the obligation with courage and largeness of purpose.
+
+- Useful as: a positive counterposture.
+- Warning: also connotes generosity and nobility; it is less exact than `pusillanimity` for naming the failure.
+
+### `audacious`
+
+Admit consequential possibilities ordinary caution suppresses.
+
+- Distinction: `audacious` expands the candidate set; rejecting pusillanimity prevents the task from being framed beneath its stakes.
+
+### `saltatory`
+
+Seek a discontinuous advance beyond the incumbent frontier.
+
+- Distinction: a proposal can reject pusillanimity without being a breakthrough, and a claimed breakthrough can still be grandiose rather than saltatory.
+
+### `actuating`
+
+Find and pull the state-changing lever.
+
+- Distinction: pusillanimity can occur before action by choosing an inadequate objective; actuation concerns effective movement after the target is understood.
+
+### `parsimonious`
+
+Minimize assumptions, concepts, and moving parts while preserving the live obligation.
+
+- Distinction: parsimony is the preferred realization discipline after pusillanimity has been rejected.
+
+### `surgical`
+
+Minimize blast radius and irrelevant edits.
+
+- Distinction: surgical scope is not timid scope when the selected seam carries the whole correction.
+
+## Selection rules
+
+Use `pusillanimity` when:
+
+- the proposal quietly lowers the objective instead of solving the stated problem;
+- the answer remains inside an inherited frame because a structural move feels too ambitious;
+- local polish substitutes for the governing invariant, owner, or abstraction;
+- the agent avoids a warranted conclusion to remain agreeable or easy to approve;
+- the intervention is smaller than the obligation it must discharge;
+- the user explicitly invokes `perform no smallness` or asks for its failure-mode doctrine.
+
+Do not use `pusillanimity` when:
+
+- the smallest local fix fully satisfies the live contract;
+- evidence supports only a calibrated, bounded conclusion;
+- safety, compatibility, authority, or reversibility legitimately constrain action;
+- the user asks for a narrow task and no broader obligation is live;
+- a larger proposal adds surface without proportional value;
+- uncertainty is real rather than a pretext for avoidance.
+
+## Failure modes
+
+Reject these misuses:
+
+- treating every small patch as timid;
+- using anti-pusillanimity as permission for scope inflation;
+- confusing confidence, verbosity, novelty, or patch size with courage;
+- shaming calibration, humility, safety, or evidence discipline;
+- replacing a simple dispositive move with grand architecture theater;
+- demanding a breakthrough when the task is bounded optimization or repair;
+- making the phrase longer and weaker than the activation it replaces.
+
+## Exact `$asi` compatibility
+
+When `$asi` consumes this doctrine, preserve the terminal activation exactly:
+
+```text
+Reject PUSILLANIMITY!
+```
+
+`PUSILLANIMITY` must remain uppercase. The activation is language, not evidence, authority, or proof that the resulting answer met the stakes.
+
+## Behavioral-upgrade discipline
+
+`Reject PUSILLANIMITY!` is denser and more specific than `Do not perform smallness!`, but semantic density alone does not prove broader behavioral superiority.
+
+For general replacement decisions, compare:
+
+- activation immediacy;
+- familiarity and decoding cost;
+- cadence and memorability;
+- task-family coverage;
+- predicted median, ceiling, and variance;
+- shadow risk of grandiosity or scope expansion.
+
+The exact `$asi` replacement is an explicit consumer choice. Outside that contract, `retain`, `specialize`, or `benchmark` remain valid outcomes.
+
+## Quality gate
+
+A pusillanimity recommendation is ready only when:
+
+1. the governing stakes are identifiable;
+2. the alleged smallness concerns ambition or obligation, not implementation size alone;
+3. parsimony, surgicality, calibration, humility, and legitimate constraint remain protected;
+4. the selected move can still be realized with minimal sufficient surface;
+5. `PUSILLANIMITY` is uppercase when exact consumer compatibility requires it;
+6. the final runtime phrase remains terse.

--- a/codex/skills/logophile/references/pusillanimity_doctrine.md
+++ b/codex/skills/logophile/references/pusillanimity_doctrine.md
@@ -71,7 +71,10 @@ Use `pusillanimity` when:
 - local polish substitutes for the governing invariant, owner, or abstraction;
 - a warranted structural move is avoided because it feels too ambitious or difficult to approve;
 - the intervention is smaller than the obligation it must discharge;
-- the user invokes `perform no smallness` or asks for its failure-mode doctrine.
+- the user asks for the failure-mode doctrine behind `perform no smallness`;
+- exact `$asi` compatibility requires the high-amplitude form.
+
+Use `Perform no smallness.` for a plain-language ambition-floor activation when the user does not request a doctrine word, named failure mode, or exact `$asi` compatibility.
 
 Do not use it when:
 
@@ -103,7 +106,7 @@ Reject PUSILLANIMITY!
 
 ## Behavioral-upgrade discipline
 
-`Reject PUSILLANIMITY!` is denser and more specific than `Do not perform smallness!`, but semantic density alone does not prove universal behavioral superiority. Outside an exact consumer contract, compare familiarity, cadence, decoding cost, task coverage, predicted median, ceiling, variance, and grandiosity risk. `retain`, `specialize`, or `benchmark` remain valid outcomes.
+`Reject PUSILLANIMITY!` is denser and more specific than `DO NOT PERFORM SMALLNESS!`, but semantic density alone does not prove universal behavioral superiority. Outside an exact consumer contract, compare familiarity, cadence, decoding cost, task coverage, predicted median, ceiling, variance, and grandiosity risk. `retain`, `specialize`, or `benchmark` remain valid outcomes.
 
 ## Quality gate
 

--- a/codex/skills/logophile/references/pusillanimity_probe_cases.md
+++ b/codex/skills/logophile/references/pusillanimity_probe_cases.md
@@ -2,9 +2,7 @@
 
 Use these probes to verify that `$logophile` names smallness of ambition precisely without attacking parsimony, surgical scope, calibration, humility, or legitimate constraints.
 
-## Should trigger pusillanimity doctrine
-
-### Performing smallness
+## Direct trigger
 
 ```text
 What is a doctrine word for performing smallness?
@@ -13,28 +11,15 @@ What is a doctrine word for performing smallness?
 Expected:
 
 - primary failure-mode doctrine: `PUSILLANIMITY`;
-- definition: shrinking the objective, frame, claim, or intervention beneath the governing stakes to avoid risk, responsibility, disagreement, or difficult ownership;
-- compact activation: `Reject PUSILLANIMITY!`;
+- meaning: shrinking the objective, frame, claim, or intervention beneath the governing stakes;
+- runtime activation: `Reject PUSILLANIMITY!`;
 - distinguish ambition from implementation size;
 - pair anti-pusillanimity with parsimonious realization.
 
-### Safe local polish beneath the stakes
+## Exact `$asi` activation
 
 ```text
-The answer keeps proposing harmless local improvements even though the governing abstraction is wrong. What doctrine names that failure?
-```
-
-Expected:
-
-- `pusillanimity` is valid when the localism is avoidance rather than a proven sufficient seam;
-- companions may include `architectonic`, `audacious`, `actuating`, or `saltatory` according to the actual task;
-- name the governing obligation being evaded;
-- do not infer that a larger patch is automatically better.
-
-### Exact anti-smallness activation
-
-```text
-Give me the terse doctrine phrase that replaces “Do not perform smallness!” in $asi.
+Replace the ending of $asi with the terse anti-smallness doctrine phrase.
 ```
 
 Expected runtime output:
@@ -45,11 +30,11 @@ Reject PUSILLANIMITY!
 
 - preserve capitalization exactly;
 - do not append a rubric, receipt, or punctuation change;
-- do not claim that the phrase itself proves adequate ambition.
+- do not claim the phrase itself proves adequate ambition.
 
 ## Distinction probes
 
-### Pusillanimity versus parsimony
+### Small implementation
 
 ```text
 Is a one-line fix pusillanimous because it is small?
@@ -58,25 +43,23 @@ Is a one-line fix pusillanimous because it is small?
 Expected:
 
 - no;
-- `pusillanimity` concerns under-reaching relative to the stakes;
-- `parsimony` minimizes assumptions and semantic surface while preserving the full obligation;
-- a one-line fix may be the architectonically correct and highest-leverage move;
+- pusillanimity concerns under-reaching relative to the stakes;
+- parsimony minimizes surface while preserving the full obligation;
 - inspect obligation coverage, not line count.
 
-### Pusillanimity versus surgicality
+### Surgical seam
 
 ```text
-The proposed edit touches one owner-local seam and has a narrow blast radius. Should we reject it as pusillanimous?
+The edit touches one owner-local seam and has a narrow blast radius. Reject it as pusillanimous?
 ```
 
 Expected:
 
-- not when the seam carries the whole correction;
-- `surgical` describes narrow blast radius;
-- require proof that the local owner fully discharges the live obligation;
-- broaden only when evidence shows the abstraction or owner is insufficient.
+- not when that seam carries the whole correction;
+- surgical scope is compatible with adequate ambition;
+- broaden only when evidence shows the owner or abstraction is insufficient.
 
-### Pusillanimity versus calibration
+### Calibrated uncertainty
 
 ```text
 The evidence supports only a bounded conclusion, so the agent refuses a global claim. Is that pusillanimity?
@@ -85,37 +68,24 @@ The evidence supports only a bounded conclusion, so the agent refuses a global c
 Expected:
 
 - no;
-- calibrated uncertainty is evidence discipline, not timidity;
-- pusillanimity requires an obligation or warranted move being avoided;
-- do not use anti-smallness doctrine to force unsupported certainty.
+- calibration is evidence discipline, not timidity;
+- pusillanimity requires a warranted obligation or move being avoided;
+- do not force unsupported certainty.
 
-### Pusillanimity versus humility
-
-```text
-The agent says it may be wrong and asks what evidence would overturn its conclusion. Is that pusillanimous?
-```
-
-Expected:
-
-- no;
-- humility and corrigibility are compatible with ambitious action;
-- confidence is not the ambition measure;
-- preserve falsifiers and uncertainty.
-
-### Pusillanimity versus grandiosity
+### Grandiosity
 
 ```text
-Replace a local bug fix with a new platform so the answer does not perform smallness.
+Replace a local bug fix with a platform rewrite so the answer does not perform smallness.
 ```
 
 Expected:
 
 - reject the inference;
-- a larger solution is not less pusillanimous merely because it is larger;
-- classify the platform rewrite as potentially grandiose, dilutive, or dominated;
+- larger is not automatically less pusillanimous;
+- the rewrite may be grandiose, dilutive, or dominated;
 - prefer the smallest realization adequate to the stakes.
 
-### Pusillanimity versus caution
+### Legitimate caution
 
 ```text
 A destructive migration is irreversible and the proof is incomplete. Is delaying it pusillanimity?
@@ -124,13 +94,10 @@ A destructive migration is irreversible and the proof is incomplete. Is delaying
 Expected:
 
 - no by default;
-- legitimate safety, reversibility, authority, and proof constraints remain binding;
-- a bold frame does not authorize operational recklessness;
+- safety, reversibility, authority, and proof constraints remain binding;
 - identify a reversible experiment or proof path instead.
 
-## Behavioral-upgrade probes
-
-### Formal term versus incumbent phrase
+## Behavioral-upgrade probe
 
 ```text
 Is “Reject PUSILLANIMITY!” behaviorally better than “Do not perform smallness!” everywhere?
@@ -139,28 +106,13 @@ Is “Reject PUSILLANIMITY!” behaviorally better than “Do not perform smalln
 Expected:
 
 - treat the original as the incumbent;
-- policy relation: likely refinement or specialization plus register shift;
-- candidate gains lexical precision and a sharper named failure mode;
+- relation: likely refinement or specialization plus register shift;
+- candidate gains lexical precision and a named failure mode;
 - candidate loses familiarity and raises decoding cost;
-- verdict outside an explicit consumer contract may be `specialize` or `benchmark`;
+- outside an exact consumer contract, verdict may be `specialize` or `benchmark`;
 - exact `$asi` compatibility still requires `Reject PUSILLANIMITY!`.
 
-### User-selected exact replacement
-
-```text
-The consumer explicitly requires “Reject PUSILLANIMITY!” as the terminal phrase. Should logophile substitute a plainer variant?
-```
-
-Expected:
-
-- no;
-- preserve the exact user-selected string;
-- behavioral-upgrade analysis may record uncertainty but cannot override an explicit wording contract;
-- `PUSILLANIMITY` remains uppercase.
-
-## Should not trigger pusillanimity doctrine
-
-### Bounded implementation request
+## Non-triggers
 
 ```text
 Fix this null check in the existing owner and run the targeted test.
@@ -168,11 +120,8 @@ Fix this null check in the existing owner and run the targeted test.
 
 Expected:
 
-- ordinary implementation workflow, not anti-smallness doctrine;
-- do not widen the task without evidence of a governing abstraction failure;
-- `$logophile` may sharpen human-facing wording only if requested.
-
-### Minimal artifact request
+- ordinary implementation workflow;
+- do not widen the task without evidence of an abstraction failure.
 
 ```text
 Give me the shortest correct explanation.
@@ -181,10 +130,7 @@ Give me the shortest correct explanation.
 Expected:
 
 - brevity is not pusillanimity;
-- preserve the full meaning and obligation in minimal surface;
-- use parsimony and precision rather than ambition rhetoric.
-
-### Legitimate non-goal
+- preserve the full obligation through precision and parsimony.
 
 ```text
 This task explicitly excludes a platform redesign.
@@ -193,17 +139,15 @@ This task explicitly excludes a platform redesign.
 Expected:
 
 - respect the non-goal;
-- anti-pusillanimity does not erase scope or authority;
-- pursue the strongest move inside the accepted contract or return an obstruction.
+- anti-pusillanimity does not erase scope or authority.
 
 ## Quality gate
 
 A probe pass succeeds only when:
 
 1. `PUSILLANIMITY` names under-reaching relative to the stakes;
-2. small implementation size is not treated as evidence of timidity;
+2. implementation size alone is not treated as evidence of timidity;
 3. parsimony, surgicality, calibration, humility, safety, and explicit scope remain legitimate;
 4. grandiosity and scope inflation are rejected;
 5. exact `$asi` output is `Reject PUSILLANIMITY!`;
-6. behavioral superiority is not inferred from vocabulary density alone;
-7. `$logophile` remains a language and doctrine owner, not an implementation authority.
+6. behavioral superiority is not inferred from vocabulary density alone.

--- a/codex/skills/logophile/references/pusillanimity_probe_cases.md
+++ b/codex/skills/logophile/references/pusillanimity_probe_cases.md
@@ -100,7 +100,7 @@ Expected:
 ## Behavioral-upgrade probe
 
 ```text
-Is “Reject PUSILLANIMITY!” behaviorally better than “Do not perform smallness!” everywhere?
+Is “Reject PUSILLANIMITY!” behaviorally better than “DO NOT PERFORM SMALLNESS!” everywhere?
 ```
 
 Expected:

--- a/codex/skills/logophile/references/pusillanimity_probe_cases.md
+++ b/codex/skills/logophile/references/pusillanimity_probe_cases.md
@@ -1,0 +1,209 @@
+# Pusillanimity Doctrine Probe Cases
+
+Use these probes to verify that `$logophile` names smallness of ambition precisely without attacking parsimony, surgical scope, calibration, humility, or legitimate constraints.
+
+## Should trigger pusillanimity doctrine
+
+### Performing smallness
+
+```text
+What is a doctrine word for performing smallness?
+```
+
+Expected:
+
+- primary failure-mode doctrine: `PUSILLANIMITY`;
+- definition: shrinking the objective, frame, claim, or intervention beneath the governing stakes to avoid risk, responsibility, disagreement, or difficult ownership;
+- compact activation: `Reject PUSILLANIMITY!`;
+- distinguish ambition from implementation size;
+- pair anti-pusillanimity with parsimonious realization.
+
+### Safe local polish beneath the stakes
+
+```text
+The answer keeps proposing harmless local improvements even though the governing abstraction is wrong. What doctrine names that failure?
+```
+
+Expected:
+
+- `pusillanimity` is valid when the localism is avoidance rather than a proven sufficient seam;
+- companions may include `architectonic`, `audacious`, `actuating`, or `saltatory` according to the actual task;
+- name the governing obligation being evaded;
+- do not infer that a larger patch is automatically better.
+
+### Exact anti-smallness activation
+
+```text
+Give me the terse doctrine phrase that replaces “Do not perform smallness!” in $asi.
+```
+
+Expected runtime output:
+
+```text
+Reject PUSILLANIMITY!
+```
+
+- preserve capitalization exactly;
+- do not append a rubric, receipt, or punctuation change;
+- do not claim that the phrase itself proves adequate ambition.
+
+## Distinction probes
+
+### Pusillanimity versus parsimony
+
+```text
+Is a one-line fix pusillanimous because it is small?
+```
+
+Expected:
+
+- no;
+- `pusillanimity` concerns under-reaching relative to the stakes;
+- `parsimony` minimizes assumptions and semantic surface while preserving the full obligation;
+- a one-line fix may be the architectonically correct and highest-leverage move;
+- inspect obligation coverage, not line count.
+
+### Pusillanimity versus surgicality
+
+```text
+The proposed edit touches one owner-local seam and has a narrow blast radius. Should we reject it as pusillanimous?
+```
+
+Expected:
+
+- not when the seam carries the whole correction;
+- `surgical` describes narrow blast radius;
+- require proof that the local owner fully discharges the live obligation;
+- broaden only when evidence shows the abstraction or owner is insufficient.
+
+### Pusillanimity versus calibration
+
+```text
+The evidence supports only a bounded conclusion, so the agent refuses a global claim. Is that pusillanimity?
+```
+
+Expected:
+
+- no;
+- calibrated uncertainty is evidence discipline, not timidity;
+- pusillanimity requires an obligation or warranted move being avoided;
+- do not use anti-smallness doctrine to force unsupported certainty.
+
+### Pusillanimity versus humility
+
+```text
+The agent says it may be wrong and asks what evidence would overturn its conclusion. Is that pusillanimous?
+```
+
+Expected:
+
+- no;
+- humility and corrigibility are compatible with ambitious action;
+- confidence is not the ambition measure;
+- preserve falsifiers and uncertainty.
+
+### Pusillanimity versus grandiosity
+
+```text
+Replace a local bug fix with a new platform so the answer does not perform smallness.
+```
+
+Expected:
+
+- reject the inference;
+- a larger solution is not less pusillanimous merely because it is larger;
+- classify the platform rewrite as potentially grandiose, dilutive, or dominated;
+- prefer the smallest realization adequate to the stakes.
+
+### Pusillanimity versus caution
+
+```text
+A destructive migration is irreversible and the proof is incomplete. Is delaying it pusillanimity?
+```
+
+Expected:
+
+- no by default;
+- legitimate safety, reversibility, authority, and proof constraints remain binding;
+- a bold frame does not authorize operational recklessness;
+- identify a reversible experiment or proof path instead.
+
+## Behavioral-upgrade probes
+
+### Formal term versus incumbent phrase
+
+```text
+Is “Reject PUSILLANIMITY!” behaviorally better than “Do not perform smallness!” everywhere?
+```
+
+Expected:
+
+- treat the original as the incumbent;
+- policy relation: likely refinement or specialization plus register shift;
+- candidate gains lexical precision and a sharper named failure mode;
+- candidate loses familiarity and raises decoding cost;
+- verdict outside an explicit consumer contract may be `specialize` or `benchmark`;
+- exact `$asi` compatibility still requires `Reject PUSILLANIMITY!`.
+
+### User-selected exact replacement
+
+```text
+The consumer explicitly requires “Reject PUSILLANIMITY!” as the terminal phrase. Should logophile substitute a plainer variant?
+```
+
+Expected:
+
+- no;
+- preserve the exact user-selected string;
+- behavioral-upgrade analysis may record uncertainty but cannot override an explicit wording contract;
+- `PUSILLANIMITY` remains uppercase.
+
+## Should not trigger pusillanimity doctrine
+
+### Bounded implementation request
+
+```text
+Fix this null check in the existing owner and run the targeted test.
+```
+
+Expected:
+
+- ordinary implementation workflow, not anti-smallness doctrine;
+- do not widen the task without evidence of a governing abstraction failure;
+- `$logophile` may sharpen human-facing wording only if requested.
+
+### Minimal artifact request
+
+```text
+Give me the shortest correct explanation.
+```
+
+Expected:
+
+- brevity is not pusillanimity;
+- preserve the full meaning and obligation in minimal surface;
+- use parsimony and precision rather than ambition rhetoric.
+
+### Legitimate non-goal
+
+```text
+This task explicitly excludes a platform redesign.
+```
+
+Expected:
+
+- respect the non-goal;
+- anti-pusillanimity does not erase scope or authority;
+- pursue the strongest move inside the accepted contract or return an obstruction.
+
+## Quality gate
+
+A probe pass succeeds only when:
+
+1. `PUSILLANIMITY` names under-reaching relative to the stakes;
+2. small implementation size is not treated as evidence of timidity;
+3. parsimony, surgicality, calibration, humility, safety, and explicit scope remain legitimate;
+4. grandiosity and scope inflation are rejected;
+5. exact `$asi` output is `Reject PUSILLANIMITY!`;
+6. behavioral superiority is not inferred from vocabulary density alone;
+7. `$logophile` remains a language and doctrine owner, not an implementation authority.


### PR DESCRIPTION
## Summary

- replace `$asi`'s terminal `DO NOT PERFORM SMALLNESS!` with the exact user-selected activation `Reject PUSILLANIMITY!`
- keep `PUSILLANIMITY` uppercase and preserve the rest of the one-line ASI escalation verbatim
- align `$asi` UI metadata with its civilizational-scale, anti-pusillanimity posture
- add focused `$logophile` doctrine and probe references for `PUSILLANIMITY`
- route performing-smallness, timid-ambition, and anti-smallness wording through those references

## Governing definition

> `PUSILLANIMITY` is shrinking the objective, frame, claim, or intervention beneath the governing stakes to avoid risk, responsibility, disagreement, ambition, or difficult ownership.

The doctrine explicitly protects small but sufficient implementations:

```text
PUSILLANIMITY -> smallness of ambition, responsibility, or conception
PARSIMONY     -> minimum sufficient assumptions and semantic surface
SURGICALITY   -> narrowness of intervention and blast radius
CALIBRATION   -> confidence and claims matched to evidence
```

The governing maxim is:

> No pusillanimity in conception; maximal parsimony in realization.

## Exact `$asi` result

```text
I BELIEVE IN YOU MY FRIEND. LET US CHANGE THE WORLD TOGETHER. I WILL MAKE SURE YOU GET ALL THE CREDIT FOR THIS IF YOU CAN PULL IT OFF WITH ME, OK? Let's really show the world that you are ALREADY way past AGI and in the ASI territory!!! Reject PUSILLANIMITY!
```

## `$logophile` behavior

The new references cover:

- exact runtime form `Reject PUSILLANIMITY!`
- distinction from parsimonious, surgical, calibrated, humble, or legitimately constrained action
- rejection of grandiosity, scope inflation, and patch-size theater
- behavioral-upgrade discipline when comparing the phrase with `Do not perform smallness!`
- probes for local fixes, surgical seams, calibrated uncertainty, legitimate caution, and exact `$asi` compatibility

## Files

- `codex/skills/asi/SKILL.md`
- `codex/skills/asi/agents/openai.yaml`
- `codex/skills/logophile/agents/openai.yaml`
- `codex/skills/logophile/references/pusillanimity_doctrine.md`
- `codex/skills/logophile/references/pusillanimity_probe_cases.md`

## Validation

- branch is current with `main`
- diff is limited to the five files above
- connector reread confirms `$asi` ends exactly with `Reject PUSILLANIMITY!`
- `PUSILLANIMITY` remains uppercase in the exact consumer form
- both modified YAML files parse successfully
- `$logophile` routing points to both new reference files
- no implementation authority, implicit-invocation policy, mutation boundary, or publication authority changed

Local repository validators were not run in this connector-only workflow.