### PR TITLE
Clarify explicit skill resolution

### DIFF
--- a/codex/AGENTS.md
+++ b/codex/AGENTS.md
@@ -1,5 +1,9 @@
 # Minimal incision, maximal precision.
 
+## Explicit skill resolution
+
+- `### Available skills` is the implicit-routing catalog, not an exhaustive inventory of explicitly invocable skills. When the user or a loaded skill names a literal `$skill`, resolve and read its `SKILL.md` from the configured skill roots before acting; never claim it is unavailable solely because it is absent from the catalog, and do not invoke catalog-hidden skills without an explicit name.
+
 ## Editing Constraints Override
 
 You may see generic Codex guidance that says to stop immediately when unexpected working-tree changes appear. In this repo, the intended working-tree policy is more specific:


### PR DESCRIPTION
## Summary

- Clarify that `### Available skills` is the implicit-routing catalog, not an exhaustive inventory of explicitly invocable skills.
- Require exact resolution of a literal `$skill` named by the user or a loaded skill before acting.
- Preserve the explicit-only boundary by forbidding invocation of catalog-hidden skills without an explicit name.

## Why

The skill-access audit found 22 claims across 10 sessions where a checked-in, readable `SKILL.md` existed but was absent from the advertised catalog. Agents repeatedly treated that omission as proof that the skill was unavailable. This change corrects that inference without enumerating hidden skills or enabling their implicit invocation.

## Validation

- Compared `main...agent/clarify-explicit-skill-resolution`: one changed file, four added lines, no deletions.
- Re-read the edited top of `codex/AGENTS.md` on the branch.
- No executable tests apply to this instruction-only change.

<!-- ship-proof:start -->
## Summary
- Clarifies that the advertised skill catalog governs implicit routing, while literal `$skill` names resolve through configured skill roots.
- Preserves the explicit-only boundary for catalog-hidden skills.

## Proof
- `git diff --check f6821f6...5c36d69`: pass
- Exact-head acceptance probe (one commit, one changed path, `codex/AGENTS.md` at +4/-0, exact clause and ordering): pass
- GitHub branch policy: zero required approvals and no required status-check contexts
- Executable tests: not run; the patch changes instructions only and touches no executable surface

## Scope
- repository: `tkersey/dotfiles`
- branch: `agent/clarify-explicit-skill-resolution`
- head: `5c36d69be871f15f879483b394eee1490bc24118`
- base: `main`
- base SHA: `f6821f66806551a758aebae4d9610ed723c9bd68`

## Risks
- Runtime behavior still depends on agents honoring repository instructions and having the configured skill roots available.

## Follow-ups
- None.

## Readiness
- Operation: update-and-promote
- Final state: ready
- SHIP-v1 compatibility mode: promote-draft
- Reason: exact-head validation passed and no in-scope task remains open
- Caveats: executable tests are not applicable to this instruction-only change
<!-- ship-proof:end -->