### PR TITLE
Prefer jaq over jq when installed

### DIFF
--- a/codex/AGENTS.md
+++ b/codex/AGENTS.md
@@ -56,6 +56,10 @@ You may see generic Codex guidance that says to stop immediately when unexpected
 - Do not create or reuse `.venv*` for skill-only tooling. Do not `uv pip install` external packages for skills unless the user explicitly requests a persistent dependency.
 - For projects that intentionally manage Python dependencies, keep `pyproject.toml`/`uv.lock` authoritative with `uv sync` or `uv lock` plus `uv sync`.
 
+### JSON
+
+- Use `jaq` instead of `jq` when `jaq` is installed; fall back to `jq` when it is not.
+
 ### Learnings and memory-source lifecycle
 
 - Treat `.ledger/*` stores as canonical repo-local source evidence. Mutate them


### PR DESCRIPTION
## Summary

- add a `JSON` subsection under `Tooling standards` in `codex/AGENTS.md`
- direct agents to use `jaq` when it is installed and fall back to `jq` otherwise

## Why

`jaq` should be the preferred JSON query and transformation CLI when the environment already provides it, while retaining `jq` as the zero-setup fallback.

## Validation

- reviewed the branch diff against `main`
- confirmed the PR changes only `codex/AGENTS.md` with four added lines

<!-- ship-proof:start -->
## Summary
- Add an explicit JSON tooling policy: use `jaq` when installed and fall back to `jq` otherwise.

## Proof
- `git diff --check 5e48789..30d72d0`: pass
- exact changed-path and `+4/-0` scope assertion: pass
- unique `### JSON` section and policy-rule assertion: pass
- build/lint/tests/language-specific: not-run (documentation-only change; no applicable repository lane)
- acceptance: pass

## Scope
- repository: tkersey/dotfiles
- branch: agent/prefer-jaq-over-jq
- head: 30d72d0b066ac1fbfce8cb3ea65978f69973733a
- base: main
- base SHA: 5e48789a7d578006ca41aede1636f622869947dc

## Risks
- Runtime command selection still depends on whether `jaq` is available on PATH.

## Follow-ups
- None.

## Readiness
- Operation: update-and-promote
- Final state: ready
- SHIP-v1 compatibility mode: promote-draft
- Reason: the exact documentation-only head passed scoped validation.
- Caveats: executable suites were not run because no executable files changed and no applicable repository lane was found.
<!-- ship-proof:end -->