### PR TITLE
Make Refine select the weakest valid intervention

### DIFF
--- a/codex/skills/refine/SKILL.md
+++ b/codex/skills/refine/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: refine
-description: "Own and apply bounded, evidence-backed optimization of an existing Codex skill. Use after `$tune` supplies STE-v1/SDC-v2 or a complete REFINE-SKILL-v3 brief; inspect the target package, select one smallest intervention, edit only authorized files, preserve stable decision-contract IDs, and retain the named behavioral `$seq` observation query. Not for broad historical diagnosis or system-managed skill optimization."
+description: "Own and apply bounded, evidence-backed optimization of an existing Codex skill. Use after `$tune` supplies STE-v1/SDC-v2 or a complete REFINE-SKILL-v3 brief; inspect the target package, select the weakest valid intervention supportable by current evidence, realize it with the smallest authorized diff, preserve stable decision-contract IDs, and retain the named behavioral `$seq` observation query. Not for broad historical diagnosis or system-managed skill optimization."
 ---
 
 # Refine
@@ -18,6 +18,15 @@ $refine owns package optimization and editing
 Do not delegate optimization to a system-managed `skill-optimizer`.
 
 `$refine` may use read-only evidence/modeling subagents supplied by the parent, but root owns all skill-package edits.
+
+Keep two optimization questions separate:
+
+```text
+semantic selection   -> weakest valid intervention supportable by evidence
+physical realization -> smallest authorized diff
+```
+
+A short edit can impose a strong, overfitted policy. A longer edit can preserve more lawful future behavior. Never use physical size as a proxy for semantic generality.
 
 ## Activation boundary
 
@@ -53,7 +62,7 @@ regression
 
 Inspect the target package against an already supplied brief.
 
-Return the smallest viable intervention and outcome-observation plan.
+Return the weakest viable intervention and outcome-observation plan.
 
 No edits.
 
@@ -61,11 +70,11 @@ No edits.
 
 Default when explicit edit authority and a complete brief exist.
 
-Inspect, select one intervention, edit, and retain the outcome-observation query.
+Inspect, select one weakest valid intervention, realize it minimally, and retain the outcome-observation query.
 
 ### regression
 
-Repair a previously observed skill failure and install the smallest reproducible guard.
+Repair a previously observed skill failure and install the weakest reproducible guard that excludes the witnessed failure class without unnecessarily constraining neighboring valid behavior.
 
 ## Required input
 
@@ -118,6 +127,8 @@ refine_brief:
     evidence_limits: []
 ```
 
+`smallest_change_hint` is advisory about physical implementation cost. It does not establish semantic weakness and cannot select the intervention.
+
 Fail closed when the brief does not identify an expected delta and authorized surface.
 
 ## Package inspection
@@ -132,6 +143,8 @@ brief-authorized references/
 brief-authorized scripts/
 brief-authorized assets/
 ```
+
+Read `references/weakness-selection.md` whenever candidate interventions differ in semantic scope, a short edit would introduce a broad rule, or a regression guard risks overfitting one episode.
 
 Check the worktree before mutation.
 
@@ -155,6 +168,7 @@ reference/resource placement
 metadata/default prompt
 decision observability
 duplication/deletion
+semantic specificity and future-behavior extension
 ```
 
 Do not optimize for prose elegance alone.
@@ -189,16 +203,41 @@ SKILL.md rule
 
 Do not combine unrelated improvements into one refinement.
 
-## Selection standard
+## Weakness-first selection standard
 
-Choose the smallest route that can plausibly produce the expected delta.
+Select by semantic weakness, then realize by physical minimality.
 
-Compare candidate interventions in this order:
+A candidate intervention is valid only when all hold:
+
+- it produces the expected delta on the supplied evidence;
+- it preserves protected contracts and known valid near-miss behavior;
+- it stays inside the authorized package and intervention budget;
+- it introduces no known contradiction, prohibited route, or unowned authority;
+- its claimed effect remains observable through the named outcome query.
+
+For a valid candidate `c`, let `E(c)` denote the future target-skill decision episodes still permitted by `c`, restricted by the protected contracts and available evidence. The paper defines weakness by extension cardinality, but `$refine` usually cannot enumerate all future episodes and must not fabricate a numeric weakness score. It therefore uses set-inclusion dominance as a conservative proof rule: candidate `a` is **provably weaker** than candidate `b` when `E(b)` is a proper subset of `E(a)`. Everything `b` permits remains permitted by `a`, while `a` avoids at least one additional restriction.
+
+Among valid candidates, reject a semantically stronger candidate when a provably weaker valid candidate exists. When neither extension contains the other, preserve the candidates as incomparable unless bounded evidence or an explicit domain prior discriminates them; do not claim a globally weakest candidate. Never infer weakness from prose length, diff size, file count, clause count, or the route list order.
+
+When exact extensions cannot be enumerated, use these operational tests:
+
+- bind the rule to the witnessed trigger, clause, route, phase, or owner rather than a broader category;
+- preserve behavior the evidence does not require changing;
+- test protected near misses and counterexamples, not only the triggering episode;
+- prefer a causal condition at the owning decision point over a blanket downstream prohibition;
+- avoid exact wording, sequencing, or artifact requirements when a weaker outcome relation suffices;
+- treat `always`, `never`, unconditional activation, and global bans as strong hypotheses requiring explicit evidence;
+- identify incomparable candidates instead of manufacturing a total order;
+- use an evidenced domain prior when future episodes are not plausibly uniform, and state that prior in the receipt.
+
+The cited weakness result is conditional on a finite representational language, a well-defined extension, and a uniform task distribution. `$refine` uses it as a semantic-dominance discipline, not as proof that future skill invocations are uniformly distributed or that unenumerated extension sizes are known. See `references/weakness-selection.md`.
+
+After semantic selection, use physical cost only to realize the selected rule or break a genuine semantic tie:
 
 ```text
-1. no edit
+1. no edit, when the current package already satisfies the brief or no mutation is justified within the supplied evidence and authority
 2. delete or consolidate
-3. clarify existing trigger/rule/route
+3. clarify an existing trigger, rule, route, or stop condition
 4. repair an existing artifact or operational surface
 5. add one narrowly scoped reference
 6. add a substantive operation
@@ -230,7 +269,7 @@ When no contract exists:
 
 - Edit only allowed files.
 - Preserve unrelated user changes.
-- Prefer surgical replacements.
+- Prefer surgical replacements after semantic selection.
 - Keep `SKILL.md` under 500 lines.
 - Move schemas and long examples to references/assets.
 - Keep frontmatter minimal and valid.
@@ -251,7 +290,7 @@ expected future behavior
 reproduction query
 ```
 
-The intervention should address the observed skill failure, not merely change wording.
+The intervention should address the observed skill failure, not merely change wording. Constrain the witnessed failure class; do not install a broader ban unless the evidence and protected contracts require it.
 
 Examples:
 
@@ -305,6 +344,13 @@ skill_refinement_receipt:
     to:
   selected_route:
   alternatives_rejected: []
+  selection_basis:
+    validity_gate:
+    semantic_weakness:
+    stronger_candidates_rejected: []
+    incomparable_candidates: []
+    domain_prior:
+    physical_tie_breaker:
   files_inspected: []
   files_changed: []
   clauses_changed: []
@@ -321,6 +367,8 @@ skill_refinement_receipt:
     within_boundary: yes | no
     expected_delta_addressed: yes | no
 ```
+
+Keep `selection_basis` compact. A single-candidate refinement may state why that candidate is valid and why no broader rule is required; do not invent ceremonial alternatives.
 
 ## Optional read-only subagents
 
@@ -349,6 +397,12 @@ Refined:
 - Expected delta:
 - Selected route:
 
+Selection:
+- Weakness basis:
+- Stronger candidates rejected:
+- Incomparables / domain prior:
+- Physical tie-breaker:
+
 Changed:
 - Files:
 - Clauses:
@@ -371,7 +425,8 @@ Residual uncertainty:
 - Root owns all edits.
 - No complete brief, no mutation.
 - One dominant intervention per refinement.
-- Minimal diff.
+- Select the weakest valid intervention; use the smallest diff only after semantic selection.
+- Do not equate short prose, few lines, or broad universal rules with semantic weakness.
 - Preserve unrelated work.
 - Preserve stable contract IDs.
 - No observability artifact without a concrete need.

--- a/codex/skills/refine/agents/openai.yaml
+++ b/codex/skills/refine/agents/openai.yaml
@@ -2,5 +2,5 @@ policy:
   allow_implicit_invocation: false
 interface:
   display_name: "Refine"
-  short_description: "User-owned evidence-backed skill optimizer"
-  default_prompt: "Use $refine as the user-owned skill optimizer: consume a complete tune brief, select one smallest intervention, edit only authorized files, preserve contract IDs, and retain the bounded outcome-observation query."
+  short_description: "User-owned weakness-first skill optimizer"
+  default_prompt: "Use $refine as the user-owned skill optimizer: consume a complete tune brief, select the weakest valid intervention supportable by evidence without treating edit size as semantic generality, preserve incomparability when dominance is not established, realize the choice with the smallest authorized diff, preserve contract IDs, and retain the bounded outcome-observation query."

--- a/codex/skills/refine/references/decision-contract.json
+++ b/codex/skills/refine/references/decision-contract.json
@@ -4,7 +4,7 @@
     "skill": {
       "name": "refine",
       "kind": "mixed",
-      "source_fingerprint": "generated-with-corrected-dropin"
+      "source_fingerprint": "generated-with-weakness-first-selection-v1"
     },
     "triggers": [
       {
@@ -120,10 +120,11 @@
         "required_artifacts": [
           "expected delta",
           "allowed files",
-          "outcome observation"
+          "outcome observation",
+          "selection basis"
         ],
         "success_signals": [
-          "one dominant intervention",
+          "one dominant weakest valid intervention",
           "SRR-v1"
         ],
         "failure_signals": [
@@ -131,6 +132,37 @@
           "unrelated package rewrite"
         ],
         "rationale": "A complete brief authorizes one bounded user-owned refinement."
+      },
+      {
+        "clause_id": "REFINE-SELECTION-001",
+        "trigger_refs": [
+          "REFINE-BRIEF-READY",
+          "REFINE-REGRESSION"
+        ],
+        "expected_routes": [
+          "REFINE-NO-CHANGE",
+          "REFINE-TRIGGER",
+          "REFINE-DECISION",
+          "REFINE-SURFACE",
+          "REFINE-CONSOLIDATE"
+        ],
+        "prohibited_routes": [],
+        "required_artifacts": [
+          "weakness comparison, recorded incomparability, or single-candidate justification",
+          "physical tie-breaker when candidates are semantically equivalent"
+        ],
+        "success_signals": [
+          "weakest valid intervention supportable by current evidence",
+          "incomparability preserved when dominance is not established",
+          "shortest diff used only after semantic selection"
+        ],
+        "failure_signals": [
+          "description length used as a generalization proxy",
+          "unnecessarily specific rule",
+          "unreported incomparable candidates",
+          "unsupported extension-cardinality claim"
+        ],
+        "rationale": "Refine selects the least specific intervention that satisfies the expected delta and protected contracts, then minimizes its physical realization."
       },
       {
         "clause_id": "REFINE-BOUNDARY-001",
@@ -174,12 +206,14 @@
           "reproduction query"
         ],
         "success_signals": [
+          "weakest reproducible guard",
           "expected future behavior is observable"
         ],
         "failure_signals": [
-          "wording-only regression"
+          "wording-only regression",
+          "blanket guard overfitting one episode"
         ],
-        "rationale": "Regression work must bind to observable skill behavior."
+        "rationale": "Regression work must bind to observable skill behavior and constrain no more than the witnessed failure class requires."
       }
     ],
     "instrumentation": {

--- a/codex/skills/refine/references/refinement-receipt.md
+++ b/codex/skills/refine/references/refinement-receipt.md
@@ -8,10 +8,16 @@ It binds:
 - gap signature;
 - expected delta;
 - selected and rejected intervention routes;
+- the validity and semantic-weakness basis for selection, including whether weakness was proved by dominance or remained incomparable;
+- stronger and genuinely incomparable candidates;
+- any evidenced domain prior;
+- the physical-minimality tie-breaker used only after semantic selection;
 - files and clauses changed;
 - metadata disposition;
 - current outcome evidence;
 - future outcome-observation query;
 - residual uncertainty.
+
+`selection_basis` may be compact. It must distinguish semantic weakness from prose length, diff size, file count, and clause count. A single-candidate refinement may record a validity and no-broader-rule justification instead of inventing alternatives.
 
 It is not a claim that future production sessions have already improved.

--- a/codex/skills/refine/references/weakness-selection.md
+++ b/codex/skills/refine/references/weakness-selection.md
@@ -1,0 +1,156 @@
+# Weakness-first intervention selection
+
+This reference adapts Michael Timothy Bennett's *The Optimal Choice of Hypothesis Is the Weakest, Not the Shortest*, arXiv:2301.12987v4 (2024), to `$refine`'s intervention-selection problem:
+
+- https://arxiv.org/abs/2301.12987
+- https://arxiv.org/pdf/2301.12987v4
+
+The paper's operative razor is:
+
+> Explanations should be no more specific than necessary.
+
+`$refine` applies the same discipline to skill changes: an intervention should impose no more policy than the evidenced expected delta requires.
+
+## Translation into skill refinement
+
+| Paper concept | `$refine` analogue |
+|---|---|
+| child task | supplied decision episodes, failure evidence, and brief |
+| unknown parent task | future invocation family containing those observed cases |
+| hypothesis | candidate intervention and the rule it installs |
+| valid model | candidate satisfying the expected delta, protected contracts, and authority boundary |
+| extension | future decision episodes still compatible with the changed skill |
+| weaker hypothesis | valid candidate with a larger compatible-behavior extension |
+| description length | prose length, diff size, file count, clause count, or implementation cost |
+
+The central separation is:
+
+```text
+semantic weakness != physical smallness
+```
+
+A one-line `always` rule can be semantically strong because it forbids many future behaviors. A multi-file alignment edit can be semantically weak when it expresses one narrowly conditioned rule consistently across `SKILL.md`, its decision contract, and metadata.
+
+## Validity before weakness
+
+Weakness never authorizes permissiveness that violates the brief.
+
+A candidate enters comparison only when it:
+
+1. produces the expected delta on supplied evidence;
+2. preserves protected contracts and known valid near misses;
+3. stays inside the authorized files and intervention budget;
+4. introduces no known prohibited route, contradiction, or authority transfer;
+5. leaves the claimed effect observable.
+
+An invalid candidate is not rescued by being weak, short, elegant, or cheap.
+
+## Semantic dominance
+
+For candidate `c`, let `E(c)` be the future target-skill episodes still permitted by `c` after applying protected contracts and known evidence. The paper measures weakness as the cardinality `|E(c)|`. `$refine` generally cannot enumerate that set, so it must not invent a scalar weakness score. Instead it uses inclusion as a conservative dominance proof.
+
+Candidate `a` is **provably weaker** than candidate `b` when:
+
+```text
+E(b) is a proper subset of E(a)
+```
+
+In words: every future behavior allowed by `b` is also allowed by `a`, while `a` avoids at least one restriction introduced by `b`.
+
+When both are valid, `b` is dominated unless evidence supplies a material prior against the additional behavior preserved by `a`. If neither extension contains the other, the candidates remain incomparable; description length cannot break that semantic incomparability.
+
+## Decision procedure
+
+1. Generate only plausible interventions inside the brief's boundary.
+2. Reject candidates that fail validity.
+3. State the rule each survivor adds, removes, or narrows.
+4. Ask what future cases each rule newly forbids or requires.
+5. Eliminate candidates that are strictly more specific without buying required correctness.
+6. Record genuinely incomparable candidates rather than forcing a false ranking.
+7. When evidence shows a nonuniform future distribution, use that domain prior explicitly.
+8. Only after semantic selection, minimize the physical realization or use cost to break a semantic tie.
+
+Do not manufacture multiple candidates for ceremony. A single candidate is sufficient when the receipt states why it is valid and why no broader rule is required.
+
+## Practical weakness probes
+
+Use these questions when exact extensions cannot be enumerated:
+
+- Is the change scoped to the witnessed trigger, clause, route, phase, or owner?
+- What behavior outside the witnessed class does it newly forbid?
+- Is each new restriction required by evidence or a protected contract?
+- Could a causal condition replace a blanket downstream guard?
+- Could an outcome relation replace exact wording, ordering, or artifact shape?
+- Does a short sentence conceal a global `always`, `never`, or unconditional activation rule?
+- Were valid near misses tested alongside the triggering episode?
+- Does the target skill's vocabulary make the relevant distinction representable?
+
+If the last answer is no, report a representation gap. Do not claim to have found the weakest candidate inside a vocabulary that cannot express the needed distinction.
+
+## Examples
+
+### Missed activation
+
+Observed: one review-closeout prompt failed to activate a skill.
+
+Semantically stronger response:
+
+```text
+Always activate for every review.
+```
+
+Weaker valid response:
+
+```text
+Activate when review-closeout cues and the required decision surface are both present; preserve explicit non-trigger cases.
+```
+
+The second rule corrects the witnessed class while preserving more legitimate review behavior.
+
+### Incomplete apply authority
+
+Observed: mutation occurred with an incomplete expected delta.
+
+Semantically stronger response:
+
+```text
+Never edit unless a Tune packet exists.
+```
+
+Weaker valid response:
+
+```text
+Block when the expected delta or authorized file boundary is missing; retain the explicit current-turn-defect route when those fields are complete.
+```
+
+The second rule excludes the failure without deleting an already lawful route.
+
+### Ceremonial activation
+
+Observed: repeated activation produced no decision delta.
+
+Semantically stronger response:
+
+```text
+Disable the skill outside explicit invocation.
+```
+
+Weaker valid response:
+
+```text
+Stop with no action when no consequential clause, route, proof, or lifecycle state changes.
+```
+
+The second rule removes ceremony while preserving useful implicit cases.
+
+## Assumption guard
+
+Bennett's formal result depends on an enactive formalism, a finite implementable language, well-defined extensions, and a uniform distribution over tasks. Real skill invocations are not known to satisfy those assumptions.
+
+Therefore `$refine` does **not** claim that weakness maximization is formally optimal for Codex skill packages. It imports three narrower disciplines:
+
+1. description length is not semantic generality;
+2. unnecessary specificity is a generalization liability;
+3. semantic dominance should precede physical-cost minimization.
+
+When a well-supported domain prior favors a more specific candidate, select it and record the prior. When candidates are incomparable, preserve the incomparability and use the brief's evidence, protected contracts, reversibility, and outcome observation rather than pretending the theorem supplies a total order.


### PR DESCRIPTION
## Summary

- incorporate Michael Timothy Bennett’s weakness-over-description-length result into `$refine`
- separate semantic selection from physical realization: choose the weakest valid intervention, then minimize its authorized diff
- use extension dominance as a conservative comparison rule and preserve incomparability when dominance is not established
- align the Refine decision contract, SRR-v1 documentation, and agent prompt

## Why

`$refine` previously selected the “smallest intervention,” conflating implementation size with semantic generality. [*The Optimal Choice of Hypothesis Is the Weakest, Not the Shortest*](https://arxiv.org/pdf/2301.12987v4) argues that weakness concerns the extension of a hypothesis rather than its description length.

This change operationalizes that distinction for skill refinement:

```text
semantic selection   -> weakest valid intervention supportable by evidence
physical realization -> smallest authorized diff
```

## Semantics and safeguards

- validity, protected contracts, authority, and observability remain hard gates
- `$refine` does not fabricate extension-cardinality scores for unenumerated future episodes
- set inclusion is used only as a conservative dominance proof
- genuinely incomparable candidates remain explicit rather than being ranked by diff size
- an evidenced nonuniform domain prior may justify a more specific candidate and must be recorded
- the paper’s finite-language, well-defined-extension, and uniform-distribution assumptions are explicit; the skill does not claim a formal optimality theorem for Codex skills

## Changed surfaces

- `codex/skills/refine/SKILL.md`
- `codex/skills/refine/agents/openai.yaml`
- `codex/skills/refine/references/decision-contract.json`
- `codex/skills/refine/references/refinement-receipt.md`
- `codex/skills/refine/references/weakness-selection.md`

## Validation

- parsed `SKILL.md` frontmatter and `agents/openai.yaml` as YAML
- parsed `decision-contract.json` as JSON
- verified unique trigger, route, and clause IDs
- verified trigger/route reference integrity and expected/prohibited route disjointness
- verified remote Git blob identities against the validated local package
- verified `SKILL.md` remains below 500 lines and its description below 1,024 characters

`ledger validate` was not available in this runtime, so the decision contract received equivalent structural checks but not execution through the repository’s native Ledger binary.

<!-- ship-proof:start -->
## Summary
- Make Refine select the weakest valid intervention supportable by evidence, then realize that selection with the smallest authorized diff.
- Preserve semantic incomparability when extension dominance is not established.

## Proof
- `git diff origin/main...HEAD --check`: pass
- YAML and JSON parsing plus decision-contract ID/reference integrity: pass
- `ledger validate --definition codex/skills/tune/definitions/ledger/skill-decision-contract.json --input contract=codex/skills/refine/references/decision-contract.json --format json`: pass
- Boundary law inspection: pass — semantic selection precedes physical minimization; no diff-size proxy resolves semantic incomparability.

## Scope
- repository: tkersey/dotfiles
- branch: agent/refine-weakness-first
- head: fd9e368cd4dfdd1feb6693baaeb31509c31ed950
- base: main
- base SHA: 3b69cfda7561bbd2407bdbc21440034f5af6bb20

## Risks
- The behavioral effect remains to be observed in future live Refine decisions; this PR does not claim retrospective outcome improvement.

## Follow-ups
- None.

## Readiness
- Operation: update-and-promote
- Final state: ready
- SHIP-v1 compatibility mode: promote-draft
- Reason: exact committed head is validated, task scope is complete, and no blocker, deferral, or open implementation remains.
- Caveats: no repository build or test suite applies to this documentation-and-contract-only change.
<!-- ship-proof:end -->