### PR TITLE
Use the canonical Codex skills directory

### DIFF
--- a/links.conf
+++ b/links.conf
@@ -16,7 +16,6 @@ $HOME/Library/Mobile Documents/com~apple~CloudDocs/ai/codex/sessions:$HOME/.code
 codex/AGENTS.md:$HOME/.codex/AGENTS.md
 codex/config.toml:$HOME/.codex/config.toml
 codex/agents:$HOME/.codex/agents
-codex/skills:$HOME/.codex/skills
 codex/skills:$HOME/.agents/skills
 
 # OpenCode


### PR DESCRIPTION
## What changed

- Stop linking `codex/skills` into `~/.codex/skills`.
- Keep `~/.agents/skills` as the sole user-local Codex skill projection.

## Why

Current Codex documentation defines `$HOME/.agents/skills` as the user-scoped local skill location. The dotfiles configuration projected the same tree into both the current location and the older Codex-specific location, creating redundant discovery roots.

Reference: https://developers.openai.com/codex/skills#where-codex-loads-local-skills

## Impact

Fresh dotfiles installations now create only the canonical user-scoped skill link. Because the existing installer creates links but does not reconcile removed entries, an already-present `~/.codex/skills` link must be removed once when applying this change.

## Validation

- Compared `main...agent/canonical-skills-directory`.
- Confirmed the diff contains exactly one deletion in `links.conf` and no other file changes.

<!-- ship-proof:start -->
## Summary
- Remove the redundant legacy Codex skill projection while preserving the official user-scoped $HOME/.agents/skills symlink.

## Proof
- Official OpenAI documentation for local skill locations: USER is $HOME/.agents/skills; symlinked skill folders are supported: pass
- git diff --check c842b3df5cd9e07fb021b5e3296ddd6a7a09a460...150f29daeac3c4e1c2a21ee5615501c16b8ddf76: pass
- links.conf parsing and exact-file-set checks: pass; exactly one deletion and no unrelated changes
- Installer semantics: current manifest entries are linked; removed destinations are not reconciled: pass
- Universalist boundary law: exactly one documented user projection; legacy branch entry absent: pass
- GitHub exact-head and clean-mergeability readback: pass

## Scope
- repository: tkersey/dotfiles
- branch: agent/canonical-skills-directory
- head: 150f29daeac3c4e1c2a21ee5615501c16b8ddf76
- base: main
- base SHA: c842b3df5cd9e07fb021b5e3296ddd6a7a09a460

## Risks
- The head predates later unrelated commits on main; GitHub reports the exact head cleanly mergeable, and branch policy requires neither up-to-date status checks nor approvals.
- Existing installations retain any legacy $HOME/.codex/skills link until it is removed separately; both projections currently exist on this machine.

## Follow-ups
- When applying the dotfiles change on an existing machine, remove the legacy $HOME/.codex/skills link separately. No repository work remains.

## Readiness
- Operation: update-and-promote
- Final state: ready
- SHIP-v1 compatibility mode: promote-draft
- Reason: the exact draft PR is unique; its one-line boundary change matches current official documentation and passes scope, manifest, installer, and acceptance validation.
- Caveats: no build applies to this manifest-only change; no required GitHub checks are configured.
<!-- ship-proof:end -->