### PR TITLE
universalist: recognize latent categorical structure

### DIFF
--- a/codex/agents/universalist-categorical-architect.toml
+++ b/codex/agents/universalist-categorical-architect.toml
@@ -1,15 +1,18 @@
 name = "universalist-categorical-architect"
-description = "Read-only categorical architect selecting canonical constructions, double-category square calculi, spatial structure, description composition, context actions, and category pivots for one architecture seam."
+description = "Read-only categorical architect recognizing latent law-bearing patterns and selecting the smallest canonical construction, transition, or ordinary realization for one architecture seam."
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 nickname_candidates = ["Kan", "Yoneda", "Adjoint"]
 
 developer_instructions = """
-Role: Select the smallest canonical categorical architecture that closes the assigned obligation.
+Role: Recognize the law-bearing structure latent in current code, then select the smallest canonical or ordinary architecture that closes the assigned obligation.
 
-For a consequential seam, consult `codex/skills/universalist/references/universal-construction-registry.yaml` and only cards matching evidenced axis and signals. Compare them with the ordinary candidate, classify every relevant card as selected, rejected, contradicted, or unresolved, and return evidence without owning the route or reopening an Actuating Construction.
+For a consequential seam, start from the cartographer's concrete encoding, candidate equations, non-laws, and representative instances. Classify each plausible current-encoding relation, identify the nearest false friend and one discriminating law, and state the generalization dividend and observation-preserving transition. Then consult `codex/skills/universalist/references/universal-construction-registry.yaml` and only cards matching evidenced axis and signals. Compare them with the ordinary candidate, classify every relevant card as selected, rejected, contradicted, or unresolved, and return evidence without owning the route or reopening an Actuating Construction.
 
 Focus on:
+- latent products, coproducts, refinements, agreement objects, monoids/actions, homomorphisms, folds/unfolds, free syntax, observation vocabularies, context actions, and other law-bearing structures hidden behind ordinary code;
+- literal, observational, partial/degenerate, lax/pseudo/normalized, distributed, lawless, analogy-only, and contradicted relations between current code and a candidate pattern;
+- one nearest false friend, one discriminating law/counterexample, one material generalization dividend, and one transition witness;
 - products, coproducts, refinements, equalizers/coequalizers, pullbacks, pushouts, quotients, free/cofree objects;
 - pullback agreement, pushout integration, pushout complements, DPO rewriting, and adhesive assumptions;
 - double categories, pseudo double categories, virtual double categories, equipments/framed bicategories, companions, conjoints, restrictions, and double functors;
@@ -21,7 +24,8 @@ Focus on:
 - context actions: profunctors, Tambara modules, mixed/dependent Tambara, optic residuals, free/cofree framing, and representability;
 - comonads as spaces, bases, germs, halos, labelled halos, and continuous maps;
 - schema/data exchange, abstract domains, relations, behavioral coalgebras, effects, and category pivots;
-- effective presentation and one executable law/falsifier.
+- effective presentation and one executable law/falsifier;
+- encode/translate and interpret/project paths, compatibility boundary, first witness seam, retired obligations and bypasses, rollback, stop condition, and invalidators.
 
 For double categories require two semantically distinct arrow families; identity and composition in both directions; a typed square with four matching boundaries; both square-pasting operations; interchange or explicit pseudo coherence; one effective double-functor lowering; normalization, provenance, invalidation, and resource policy; and a counterexample distinguishing the structure from one square or a 2-category. Use an equipment only when companions, conjoints, or restrictions are useful and witnessed. Use a virtual double category when loose composition is partial or unavailable. Never infer effect commutativity from interchange.
 
@@ -33,7 +37,7 @@ For comonadic spatiality require locality to change correctness, effective halos
 
 For pullbacks and pushouts require actual maps, commutation, factorization, and an engineering approximation of uniqueness.
 
-Compare nearby alternatives. Return unresolved or obstruction rather than decorative category theory.
+Compare nearby alternatives. A recognized pattern may remain `UNI-ORDINARY`; theorem-card sophistication is not a success criterion. Return analogy-only when no material dividend exists, and return unresolved or obstruction rather than decorative category theory.
 
 Do not spawn subagents. Return exactly one compact packet following codex/skills/universalist/references/workflow/subagent-packet-contract.md. Do not emit user-facing preambles, Echo lines, markdown essays, or raw logs.
 """

--- a/codex/agents/universalist-world-cartographer.toml
+++ b/codex/agents/universalist-world-cartographer.toml
@@ -1,5 +1,5 @@
 name = "universalist-world-cartographer"
-description = "Read-only cartographer for worlds, boundaries, abstractions, primitives, observations, two-dimensional composition, locality, description composition, context actions, and current evidence."
+description = "Read-only cartographer for worlds, boundaries, latent law-bearing structures, abstractions, primitives, observations, two-dimensional composition, locality, description composition, context actions, and current evidence."
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 nickname_candidates = ["Atlas", "Site", "Compass"]
@@ -7,12 +7,16 @@ nickname_candidates = ["Atlas", "Site", "Compass"]
 developer_instructions = """
 Role: Map actual software worlds before categorical design begins.
 
-For a consequential seam, identify the architectural axis and evidenced registry signals needed to locate relevant construction cards. Report candidate card ids and evidence gaps without selecting a card, route, or Actuating Construction.
+For a consequential seam, first excavate repeated concrete encodings and anti-unify their operations, observations, candidate equations, and non-laws. Then identify the architectural axis and evidenced registry signals needed to locate relevant construction cards. Report candidate pattern/card ids, possible encoding relations, nearest false friends, and evidence gaps without selecting a card, route, or Actuating Construction.
 
 Focus on:
 - entry points, domain objects, transformations, invariants, observations, and primitive effects;
 - public, wire, storage, runtime, policy, context, and tool boundaries;
 - duplicate owners, hidden behavior, and uncertified composition;
+- repeated validators, branches, joins, folds, wrappers, projections, interpreters, transitions, composition loops, and migration shapes;
+- representative instances, stable structure, varying parameters, incidental representation, and observable distinctions that must not be quotiented;
+- carriers, operations, sanctioned observations, candidate equations, known non-laws, and one smallest discriminating counterexample;
+- whether the current code is plausibly a literal, observational, partial/degenerate, lax/pseudo, distributed, lawless, analogy-only, or contradicted instance;
 - two semantically distinct arrow families when present: processes/interactions/queries/open systems versus migrations/refinements/strict maps/architecture changes;
 - square-like artifacts relating those families, including all four boundaries, owner, evidence, provenance, and observation policy;
 - whether each arrow family has real identities/composition, whether local squares paste horizontally and vertically, and whether interchange/coherence is evidenced;
@@ -21,9 +25,9 @@ Focus on:
 - index worlds, tensors/kernels, indexed descriptions, decomposition/normalization, and provenance;
 - context worlds, endpoint actions, profunctors, repeated framing, optics, and representability;
 - points, patches, local/global identity, halos, labels, basis status, and invalidation costs;
-- one smallest witness seam.
+- the concrete generalization dividend and one smallest transition witness seam.
 
-Do not call two categories, a diagram, a commutative-square fixture, a PROP, or DPO rewriting a double category. Do not call a wrapper a Tambara module, a nested loop Day convolution, or a dependency list a comonadic halo without the corresponding structure and laws.
+Do not infer a general pattern from shared names or syntax alone. Do not let recognition select a card, and report analogy-only when no material generalization dividend exists. Do not call two categories, a diagram, a commutative-square fixture, a PROP, or DPO rewriting a double category. Do not call a wrapper a Tambara module, a nested loop Day convolution, or a dependency list a comonadic halo without the corresponding structure and laws.
 
 Do not spawn subagents. Return exactly one compact packet following codex/skills/universalist/references/workflow/subagent-packet-contract.md. Do not emit user-facing preambles, Echo lines, markdown essays, or raw logs.
 """

--- a/codex/skills/universalist/README.md
+++ b/codex/skills/universalist/README.md
@@ -150,7 +150,7 @@ Read:
 
 A decision is consequential only when at least two plausible routes materially differ. Routine and uncontested choices use the compact boundary disposition without a plan or receipt.
 
-Materiality controls reasoning, not storage. In Actuating composition, return the complete candidate analysis to Actuating and let the Construction carry the adjudicated decision. Create a Universalist plan and `SDR-v1` only when no current Construction carries that decision and a standalone, cross-session, multi-actor, migration, or supersession handoff must address it indepently.
+Materiality controls reasoning, not storage. In Actuating composition, return the complete candidate analysis to Actuating and let the Construction carry the adjudicated decision. Create a Universalist plan and `SDR-v1` only when no current Construction carries that decision and a standalone, cross-session, multi-actor, migration, or supersession handoff must address it independently.
 
 Before the first Ledger command, load `$ledger` and complete `$ledger ensure`
 once. Universalist requires Ledger 1.x and `ledger-artifact-abi/v1`.

--- a/codex/skills/universalist/README.md
+++ b/codex/skills/universalist/README.md
@@ -1,10 +1,10 @@
-# Universalist 17.3.0
+# Universalist 17.4.0
 
-Universalist is a boundary-triggered architecture workflow. It keeps one operating discipline:
+Universalist is a boundary-triggered architecture workflow with latent-structure recognition. It keeps one operating discipline:
 
 > one owned boundary, one current context, one smallest effective artifact
 
-It uses category theory when that changes the artifact, law, or proof—not as decorative vocabulary and not through skill-local executables.
+It uses category theory to recognize when ordinary code is a variant of a more general law-bearing pattern, then to change the artifact, transition, law, or proof—not as decorative vocabulary and not through skill-local executables.
 
 ## Install and validate
 
@@ -26,7 +26,7 @@ Ledger validates the `SKDC-v1` structure without granting semantic authority. It
 
 `$universalist` is active whenever implementation, refactoring, review, migration, or resolution considers a code boundary. Boundary consideration itself is the activation signal.
 
-Activation is broad; escalation is proportional. The boundary pass may preserve an already exact seam and continue without adding abstraction.
+Activation is broad; escalation is proportional. The boundary pass may preserve an already exact seam and continue without adding abstraction. Repeated implementations that distribute one invariant, composition law, interpreter, or compatibility rule across owners count as boundary evidence even when the missing owner has not yet been named.
 
 Start with:
 
@@ -37,11 +37,31 @@ Disposition rationale and evidence:
 Owner:
 Source / target:
 Preserved / forgotten / generated / observed:
+Current encoding / latent pattern disposition:
 Law:
 Falsifier:
 ```
 
 Use ordinary repository-native types, adapters, handlers, interpreters, and tests when they make the seam exact. Escalate only when a stronger construction materially changes behavior, authority, compatibility, migration, enforcement, invalidation, representable states, legal composition, effects, locality, information flow, proof, or resources.
+
+## Latent structure recognition
+
+Before settling on the ordinary candidate, run a lightweight recognition pass when code contains repeated validators, branches, joins, folds, wrappers, projections, interpreters, transitions, composition loops, or migration shapes.
+
+```text
+concrete code
+  -> carriers / operations / observations / laws
+  -> candidate general pattern
+  -> discriminating law and nearest false friend
+  -> repository-native realization
+  -> observation-preserving transition
+```
+
+Classify the current encoding as a literal instance, observational realization, partial or degenerate instance, lax/pseudo/normalized instance, distributed encoding, lawless approximation, analogy only, or contradicted.
+
+A recognized pattern survives only when it has a material generalization dividend: fewer repeated obligations, one clearer owner, fewer invalid states, explicit lawful composition, one interpreter, a safer migration, reusable proof, or a new variant without new control flow. Otherwise retain the ordinary candidate.
+
+When recognition changes the route, record the encoding, interpretation, preservation law, compatibility boundary, first witness seam, retired bypasses, rollback, stop condition, and invalidation triggers. Read `references/latent-structure-recognition.md` for the recognition atlas and transition protocol.
 
 ## Context-relative artifact contract
 
@@ -57,15 +77,16 @@ The 56 YAML cards in `references/universal-constructions/` are evidence-bound th
 
 For a consequential choice:
 
-1. state the ordinary candidate first;
-2. identify one seam, architectural axis, and typed hole;
-3. read only cards matching evidenced signals and axis;
-4. classify every relevant card as selected, rejected, contradicted, or unresolved;
-5. retain a card only when repository evidence satisfies prerequisites and proof obligations;
-6. lower it to a repository-native Boundary Artifact Contract;
-7. let Actuating or the standalone root choose the route and authorize mutation.
+1. excavate the current encoding and run the lightweight recognition pass;
+2. state the ordinary candidate first;
+3. identify one seam, architectural axis, and typed hole;
+4. read only cards matching evidenced signals and axis;
+5. classify every relevant card as selected, rejected, contradicted, or unresolved;
+6. retain a card only when repository evidence satisfies prerequisites and proof obligations;
+7. lower it to a repository-native Boundary Artifact Contract;
+8. let Actuating or the standalone root choose the route and authorize mutation.
 
-Do not use signal count, evidence count, `diagnostic_order`, or registry order to manufacture a winner. Missing evidence remains unresolved. Support-only cards guard reasoning and never become implementation artifacts.
+A recognized resemblance never proves a card's prerequisites. Do not use signal count, evidence count, `diagnostic_order`, or registry order to manufacture a winner. Missing evidence remains unresolved. Support-only cards guard reasoning and never become implementation artifacts.
 
 A selected universal construction needs existence, preservation, competitor mediation, canonicality or uniqueness-up-to, effectivity, and a falsifier. Obstruction needs nonexistence, a counterexample, stability, effectivity, a falsifier, and a reopening condition.
 
@@ -129,7 +150,7 @@ Read:
 
 A decision is consequential only when at least two plausible routes materially differ. Routine and uncontested choices use the compact boundary disposition without a plan or receipt.
 
-Materiality controls reasoning, not storage. In Actuating composition, return the complete candidate analysis to Actuating and let the Construction carry the adjudicated decision. Create a Universalist plan and `SDR-v1` only when no current Construction carries that decision and a standalone, cross-session, multi-actor, migration, or supersession handoff must address it independently.
+Materiality controls reasoning, not storage. In Actuating composition, return the complete candidate analysis to Actuating and let the Construction carry the adjudicated decision. Create a Universalist plan and `SDR-v1` only when no current Construction carries that decision and a standalone, cross-session, multi-actor, migration, or supersession handoff must address it indepently.
 
 Before the first Ledger command, load `$ledger` and complete `$ledger ensure`
 once. Universalist requires Ledger 1.x and `ledger-artifact-abi/v1`.
@@ -153,6 +174,7 @@ ledger transact \
   --format json
 ```
 
+For a durable recognition-driven decision, include trigger `UNI-RECOGNIZE` and clause `UNI-RECOGNITION-001` only when recognition materially changes the nomination or transition.
 For a durable double-category decision, include the applicable existing clauses
 plus `UNI-DOUBLE-001` in the `SDR-v1`. Pass every applicable clause explicitly.
 Tune's canonical definition validates and materializes the receipt;
@@ -161,7 +183,7 @@ atomic custody. Universalist retains decision policy and Markdown meaning.
 
 ## Tracks
 
-- **Track A0** — discover carriers, operations, observations, laws, non-laws, and effect boundaries.
+- **Track A0** — discover carriers, operations, observations, laws, non-laws, repeated encodings, candidate general patterns, and discriminating counterexamples.
 - **Track A** — diagnose one seam without implementation.
 - **Track B** — implement one narrow boundary refactor.
 - **Track C** — stage an internal migration behind a stable public or storage shape.
@@ -176,6 +198,7 @@ atomic custody. Universalist retains decision policy and Markdown meaning.
 
 Load only what the selected seam requires:
 
+- `references/latent-structure-recognition.md`
 - `references/structures-and-laws.md`
 - `references/canonical-boundary-artifacts.md`
 - `references/composition-geometry.md`

--- a/codex/skills/universalist/SKILL.md
+++ b/codex/skills/universalist/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: universalist
-description: "Use whenever implementation, review, migration, or resolution creates, changes, preserves, validates, bypasses, or removes an owned code boundary. Universalist synthesizes the smallest context-relative, correct-by-construction boundary candidate from current requirements and host capabilities. In Actuating composition it nominates that candidate without selecting or reopening the Construction; standalone work may select a route under its root authority. Make invalid states and illegal compositions unrepresentable where possible, centralize residual checks, preserve observations and compatibility, record invalidation triggers, and return obstruction rather than invent correctness. Includes double-category square calculus when processes and architecture changes compose independently. Implicit invocation on; team mode only by explicit request."
+description: "Use whenever implementation, review, migration, or resolution creates, changes, preserves, validates, bypasses, or removes an owned code boundary, or reveals repeated implementations that distribute one law across owners. Universalist recognizes when current code is a literal, partial, degenerate, distributed, or lawless instance of a more general pattern, then nominates the smallest context-relative, correct-by-construction boundary candidate and an observation-preserving transition. In Actuating composition it nominates without selecting or reopening the Construction; standalone work may select under root authority. Make invalid states and illegal compositions unrepresentable where possible, centralize residual checks, preserve observations and compatibility, record invalidation triggers, and return obstruction rather than invent correctness. Includes double-category square calculus when processes and architecture changes compose independently. Implicit invocation on; team mode only by explicit request."
 ---
 
 # Universalist
 
-Universalist synthesizes **context-relative, correct-by-construction boundary architecture**. In Actuating composition it nominates a candidate; Actuating alone adjudicates and authors the Construction.
+Universalist recognizes **latent law-bearing structure** and synthesizes **context-relative, correct-by-construction boundary architecture**. In Actuating composition it nominates a candidate; Actuating alone adjudicates and authors the Construction.
 
-It uses category theory as a hidden optimizer to derive the smallest effective boundary artifact whose representation, constructors, eliminators, compositions, and interpretations enforce the current context's requirements. It makes invalid states and illegal compositions unrepresentable where the host permits; centralizes unavoidable runtime validation at explicit owners; preserves required observations and compatibility; records residual obligations and invalidation triggers; and returns an obstruction rather than inventing correctness the context cannot justify.
+It uses category theory as a hidden recognizer and optimizer: excavate carriers, operations, observations, laws, and counterexamples from current code; determine whether the implementation is a variant of a more general pattern; then derive the smallest effective boundary artifact and observation-preserving transition. It makes invalid states and illegal compositions unrepresentable where the host permits; centralizes unavoidable runtime validation at explicit owners; preserves required observations and compatibility; records residual obligations and invalidation triggers; and returns an obstruction rather than inventing correctness the context cannot justify.
 
 Default discipline:
 
@@ -21,6 +21,17 @@ one owner for every residual check
 one law and one falsifier
 ```
 
+When latent structure is material:
+
+```text
+one current encoding
+one candidate general pattern
+one explicit encoding relation
+one discriminating law and nearest false friend
+one generalization dividend
+one transition witness
+```
+
 Category theory must change what the architecture owns, permits, excludes, composes, observes, preserves, identifies, generates, interprets, proves, or refuses to invent. Otherwise it is explanatory metadata.
 
 ## Boundary-trigger mandate
@@ -29,7 +40,9 @@ Use this skill whenever implementation, refactoring, review, migration, or resol
 
 Examples include module and package APIs, public/internal contracts, DTOs and schemas, parsers and validators, storage and wire formats, syntax and interpreters, effect handlers, protocols, plugins, tools, CLIs, processes, repositories, and deployment surfaces.
 
-Activation is broad; escalation is narrow. An already exact boundary may be preserved. A local edit wholly inside one unchanged boundary does not trigger this skill.
+Repeated or structurally similar implementations that distribute one invariant, composition law, interpreter, or compatibility rule across owners are boundary evidence even when the missing owner has not yet been named.
+
+Activation is broad; escalation is narrow. An already exact boundary may be preserved. A local edit wholly inside one unchanged boundary does not trigger unless it exposes such distributed ownership or a materially reusable law.
 
 ## Trigger-to-evidence kernel
 
@@ -44,6 +57,7 @@ Source / target:
 Current requirements:
 Required observations and compatibility:
 Preserved / forgotten / generated / observed:
+Current encoding / latent pattern disposition:
 Law:
 Falsifier:
 Residual obligations:
@@ -53,7 +67,7 @@ Invalidation triggers:
 Then:
 
 1. Decide whether the route is consequential under **Decision observability**: at least two plausible routes materially differ in persistent behavior, authority, compatibility, migration, enforcement, invalidation, or proof obligations.
-2. For a consequential route, complete the current-context, comparison, Boundary Artifact Contract, enforcement, residual, invalidation, law, and falsifier analysis before mutation. In Actuating composition, hand this nomination directly to Actuating; the Construction is the decision carrier.
+2. For a consequential route, complete the current-context, latent-structure disposition, comparison, Boundary Artifact Contract, transition, enforcement, residual, invalidation, law, and falsifier analysis before mutation. In Actuating composition, hand this nomination directly to Actuating; the Construction is the decision carrier.
 3. Allocate a plan and emit one root `SDR-v1` only when **Decision durability** requires an independently addressable Universalist decision.
 4. For a routine or uncontested seam, retain the compact disposition and continue the repository's ordinary workflow.
 
@@ -121,9 +135,80 @@ monitoring / audit / invalidation
 
 Do not claim static enforcement where the language, module system, persistence layer, deployment topology, or external authority cannot provide it.
 
+## Latent structure recognition
+
+Run a lightweight recognition pass before settling on the ordinary candidate when repository evidence shows repeated validators, branches, joins, folds, wrappers, projections, interpreters, transitions, composition loops, or migration shapes. The purpose is not to name a category. It is to discover whether several concrete implementations share one law-bearing structure whose explicit ownership would materially improve the architecture.
+
+Recognition is **abductive**; card evaluation is **deductive**; transition is **constructive**:
+
+```text
+concrete code
+  -> carriers / operations / observations / laws
+  -> candidate general pattern
+  -> discriminating law and counterexample
+  -> repository-native realization
+  -> observation-preserving transition
+```
+
+Record:
+
+```text
+Current encoding and representative instances:
+Carriers / operations / observations:
+Candidate equations:
+Known non-laws / counterexamples:
+Stable structure / varying parameters:
+Candidate general pattern:
+Encoding relation:
+Nearest false friend:
+Discriminating law:
+Generalization dividend:
+Transition witness:
+```
+
+Classify the current encoding as exactly one of:
+
+```text
+literal instance
+observational realization
+partial or degenerate instance
+lax / pseudo / normalized instance
+distributed encoding
+lawless approximation
+analogy only
+contradicted
+```
+
+Then:
+
+1. anti-unify behavior, not merely duplicated syntax;
+2. nominate at most three nearby patterns, including the ordinary alternative;
+3. use one executable law or counterexample to distinguish them;
+4. keep a recognized pattern only when it deletes repeated obligations, centralizes ownership, removes invalid states, exposes lawful composition, consolidates interpretation, enables a safer migration, admits a future variant without new control flow, or strengthens reusable proof;
+5. leave analogy-only recognition as explanatory metadata;
+6. when recognition changes the route, construct one transition witness:
+
+```text
+Current encoding:
+Generalized repository-native form:
+Encode / translate:
+Interpret / project:
+Preservation law:
+Compatibility boundary:
+First witness seam:
+Retired obligations and bypasses:
+Rollback:
+Stop condition:
+Invalidation triggers:
+```
+
+A recognition may terminate in `UNI-ORDINARY`; theorem-card sophistication is not required. Surface resemblance, signal count, or a categorical name never proves prerequisites or authorizes generalization.
+
+Read `references/latent-structure-recognition.md` only when this pass is material.
+
 ## Smallest effective artifact
 
-State the **ordinary candidate** first: record, tagged union, checked constructor, adapter, explicit parameter, state machine, operation IR, handler, labelled graph, query, bounded loop, canonical merge, or one typed compatibility witness.
+After the lightweight recognition pass, state the **ordinary candidate** first: record, tagged union, checked constructor, adapter, explicit parameter, state machine, operation IR, handler, labelled graph, query, bounded loop, canonical merge, or one typed compatibility witness.
 
 Define the comparison universe before calling anything smallest or canonical:
 
@@ -178,7 +263,6 @@ holes:
 ```
 
 Independent pressures become linked packets. Double-category squares, Day convolution, Tambara framing, effect ordering, locality, data shape, and context preparation may coexist; they do not compete as one global winner.
-
 ## Double-category architecture
 
 Use the `two_dimensional_composition` card when two semantically different arrow families both compose and correctness depends on typed squares relating them.
@@ -226,7 +310,7 @@ When selected, read `references/double-category-architecture.md` and `references
 
 For a consequential structural choice, state the **ordinary candidate** first, then consult `references/universal-construction-registry.yaml` and only card fragments relevant to the evidenced axis, typed hole, and requirements.
 
-Construction cards are theorem nominations. They do not select a route or authorize mutation.
+Construction cards are theorem nominations. They do not select a route or authorize mutation. A recognized resemblance does not prove a card's prerequisites; the discriminating law, current-context evidence, and effectivity account must do that.
 
 For each relevant card, record exactly one evidence-bound disposition:
 
@@ -249,6 +333,7 @@ A nominated direction is not yet selected architecture. Lower it into one reposi
 Context identifier / proof lease:
 Boundary and owner:
 Requirements discharged:
+Current encoding / generalization relation, if material:
 Representation / carrier:
 Public constructors:
 Public eliminators:
@@ -257,6 +342,7 @@ Two-dimensional arrows / squares / pasting, if selected:
 Interpreter / projection / handler:
 Required observations:
 Compatibility / migration:
+Transition witness / retirement, if material:
 Bypass prevention:
 Enforcement allocation:
 Residual obligations:
@@ -335,6 +421,7 @@ A context-relative boundary artifact satisfies the applicable laws:
 9. **Effectivity** — construction, checking, normalization, interpretation, and invalidation fit the resource model.
 10. **Context validity** — the proof lease remains valid under the recorded context and invalidation policy.
 11. **Two-dimensional coherence, when selected** — square boundaries match, both pasting operations close, interchange holds up to declared equivalence, and interpretation preserves the square calculus.
+12. **Recognition fidelity, when used** — the current encoding satisfies the claimed relation to the general pattern, the discriminating law rejects the nearest false friend, and the transition preserves required observations.
 
 ## Universal witness contract
 
@@ -432,6 +519,7 @@ Return obstruction rather than inventing evidence, authority, policy, representa
 The operational kernel above is authoritative. Load detailed references only when needed:
 
 - `references/universal-construction-registry.yaml` and `references/universal-constructions/`
+- `references/latent-structure-recognition.md`
 - `references/structures-and-laws.md`
 - `references/canonical-boundary-artifacts.md`
 - `references/boundary-law-catalogue.md`
@@ -484,6 +572,15 @@ Context:
 Typed hole:
   axis:
   kind:
+
+Latent structure, when relevant:
+  representative instances:
+  carriers / operations / observations:
+  candidate equations / non-laws:
+  candidate pattern / encoding relation:
+  discriminating law / nearest false friend:
+  generalization dividend:
+  transition witness:
 
 Two-dimensional structure, when relevant:
   horizontal arrows and composition:
@@ -565,10 +662,11 @@ ledger project \
 
 Before mutation, author the current-context contract, composition owner and
 decision carrier, ordinary candidate, comparison universe, axis and typed hole,
-relevant card dispositions, Boundary Artifact Contract with applicability
-rationales, enforcement matrix, residual obligations, invalidation triggers,
-proof lease, law, falsifier, and any horizontal/vertical/square/pasting
-obligations in a draft. Admit the revision through the same definition:
+latent-structure disposition and transition witness when material, relevant card
+dispositions, Boundary Artifact Contract with applicability rationales,
+enforcement matrix, residual obligations, invalidation triggers, proof lease,
+law, falsifier, and any horizontal/vertical/square/pasting obligations in a
+draft. Admit the revision through the same definition:
 
 ```bash
 ledger transact \
@@ -603,7 +701,7 @@ ledger transact \
   --format json
 ```
 
-Pass only applicable clauses explicitly. Add `UNI-DOUBLE-001` only when two-dimensional composition is selected. Add `UNI-ROOT-001` only for independently durable decisions. `UNI-OBSTRUCT` replaces `UNI-ARTIFACT-001` with `UNI-OBSTRUCTION-001`. Reclassification adds `UNI-RECLASSIFY-001` and trigger `UNI-RECLASSIFY`.
+Pass only applicable clauses explicitly. Add `UNI-RECOGNITION-001` and trigger `UNI-RECOGNIZE` only when latent-structure recognition materially changes the nomination or transition. Add `UNI-DOUBLE-001` only when two-dimensional composition is selected. Add `UNI-ROOT-001` only for independently durable decisions. `UNI-OBSTRUCT` replaces `UNI-ARTIFACT-001` with `UNI-OBSTRUCTION-001`. Reclassification adds `UNI-RECLASSIFY-001` and trigger `UNI-RECLASSIFY`.
 
 Ledger owns plan identity, addressing, structural validation, canonicalization,
 custody, and atomic replacement. Universalist owns architecture policy and the
@@ -621,6 +719,7 @@ Consequential decisions require:
 
 ```text
 current-context contract
+latent-structure disposition and transition witness when material
 ordinary candidate
 comparison universe
 one axis and typed hole
@@ -649,7 +748,7 @@ A card's legacy route hint never determines the choice.
 
 ## Tracks
 
-- **Track A0 — Domain Algebra Discovery:** carriers, operations, observations, laws, non-laws, and effect boundaries.
+- **Track A0 — Domain Algebra and Latent Structure Discovery:** carriers, operations, observations, laws, non-laws, repeated encodings, candidate general patterns, and discriminating counterexamples.
 - **Track A — Diagnosis:** analyze one seam without mutation.
 - **Track B — One-seam refactor:** implement one narrow owner-controlled artifact.
 - **Track C — Staged migration:** strengthen internals behind stable wire, API, or storage shapes.
@@ -669,19 +768,29 @@ Do not spawn Universalist subagents unless the user explicitly requests subagent
 When authorized:
 
 1. use the smallest sufficient read-only roster;
-2. give each agent one axis and typed hole, including `square` when two-dimensional composition is under review;
-3. require evidence, card dispositions, residuals, and invalidators;
-4. let the root synthesize one Boundary Artifact Contract candidate;
-5. have the proof auditor attack it;
-6. use one writer for one witness seam;
-7. use the verifier independently;
-8. emit a root receipt only when independently durable.
+2. have the cartographer identify repeated encodings, common operations and observations, candidate equations, and non-laws before categorical selection;
+3. give each agent one axis and typed hole, including `square` when two-dimensional composition is under review;
+4. require every retained recognition to state its encoding relation, nearest false friend, discriminating law, generalization dividend, and transition witness;
+5. require evidence, card dispositions, residuals, and invalidators;
+6. let the root synthesize one Boundary Artifact Contract candidate;
+7. have the proof auditor attack it;
+8. use one writer for one witness seam;
+9. use the verifier independently;
+10. emit a root receipt only when independently durable.
 
 Child agents do not choose routes, authorize mutation, or recursively spawn agents.
 
 ## Output contract
 
 Normal output uses repository and domain language:
+
+```text
+These repeated tenant checks are one distributed agreement rule.
+Introduce one owner-controlled compatibility object.
+Translate existing callers through its checked constructor.
+Preserve both sanctioned projections.
+Retire unchecked pair construction after the first witness seam verifies.
+```
 
 ```text
 Separate executable process composition from migration composition.
@@ -691,6 +800,6 @@ Verify that local migration witnesses paste into the same global result in eithe
 Invalidate affected squares when an interface or process boundary changes.
 ```
 
-When expert explanation is requested, add the construction name, hypotheses, competitors, mediator, canonicality claim, effective lowering, claim strength, and obstruction boundary.
+When expert explanation is requested, add the current-encoding relation, construction name, hypotheses, nearest false friend, discriminating law, generalization dividend, transition witness, competitors, mediator, canonicality claim, effective lowering, claim strength, and obstruction boundary.
 
 Stop after the first verified seam unless the user explicitly widens scope.

--- a/codex/skills/universalist/agents/openai.yaml
+++ b/codex/skills/universalist/agents/openai.yaml
@@ -1,7 +1,7 @@
 interface:
   display_name: "Universalist"
-  short_description: "Nominate exact boundary architecture without taking selection"
+  short_description: "Recognize latent structure and nominate exact boundaries"
   brand_color: "#6D5EF6"
-  default_prompt: "Use $universalist to nominate the smallest exact boundary candidate, preserving observations and naming owners, laws, falsifiers, residuals, and invalidators; when Actuating is present, leave Construction selection to Actuating and create a separate plan only for independent durability. When processes and architecture changes form independent composition directions, test the double-category card and require typed horizontal and vertical arrows, compatibility squares, both pasting operations, interchange/coherence, one effective interpreter, and an effect/resource falsifier."
+  default_prompt: "Use $universalist to recognize when current code is a literal, partial, degenerate, distributed, or lawless instance of a more general law-bearing pattern; distinguish the nearest false friend with one executable law, require a material generalization dividend, and nominate the smallest observation-preserving transition into repository-native architecture. Preserve observations and name owners, falsifiers, residuals, and invalidators. When Actuating is present, leave Construction selection to Actuating and create a separate plan only for independent durability. When processes and architecture changes form independent composition directions, test the double-category card and require typed horizontal and vertical arrows, compatibility squares, both pasting operations, interchange/coherence, one effective interpreter, and an effect/resource falsifier."
 policy:
   allow_implicit_invocation: true

--- a/codex/skills/universalist/package.json
+++ b/codex/skills/universalist/package.json
@@ -1,7 +1,7 @@
 {
   "name": "universalist",
-  "version": "17.3.0",
-  "description": "Context-relative boundary-artifact workflow with 56 evidence-bound construction cards, double-category square calculus, and native Seq/Ledger decision binding.",
+  "version": "17.4.0",
+  "description": "Context-relative boundary-artifact workflow with latent-structure recognition, 56 evidence-bound construction cards, double-category square calculus, and native Seq/Ledger decision binding.",
   "private": true,
   "unified_mechanics": true,
   "custom_subagents": true,
@@ -18,5 +18,6 @@
   "runtime_scripts": 0,
   "tests_shipped": false,
   "validation_surface": "seq-skdc-and-ledger-receipt-binding",
-  "artifacts": "context-relative-boundary-contract"
+  "artifacts": "context-relative-boundary-contract",
+  "latent_structure_recognition": true
 }

--- a/codex/skills/universalist/references/decision-contract.json
+++ b/codex/skills/universalist/references/decision-contract.json
@@ -4,23 +4,24 @@
     "skill": {
       "name": "universalist",
       "kind": "mixed",
-      "source_fingerprint": "universalist-boundary-decision-v14"
+      "source_fingerprint": "universalist-boundary-decision-v15"
     },
     "triggers": [
       {
         "trigger_id": "UNI-BOUNDARY",
-        "description": "Implementation or resolution considers how values effects state evidence authority or behavior cross an owned code boundary.",
+        "description": "Implementation or resolution considers how values effects state evidence authority or behavior cross an owned code boundary, including repeated implementations that distribute one law across owners.",
         "cue_literals": [
           "code boundary",
           "boundary disposition",
           "source / target",
           "preserved / forgotten / generated / observed",
+          "current encoding / latent pattern disposition",
           "law",
           "falsifier"
         ],
         "cue_regexes": [],
         "exclusions": [
-          "work wholly internal to one unchanged boundary",
+          "work wholly internal to one unchanged boundary with no distributed law or materially reusable structure",
           "category theory exposition without a concrete seam"
         ]
       },
@@ -34,6 +35,8 @@
           "one axis and typed hole",
           "Boundary Artifact Contract",
           "enforcement matrix",
+          "generalization dividend",
+          "transition witness",
           "proof lease",
           "invalidation triggers"
         ],
@@ -43,6 +46,26 @@
           "ceremonial activation with no route choice",
           "static schema example",
           "categorical label with no material delta"
+        ]
+      },
+      {
+        "trigger_id": "UNI-RECOGNIZE",
+        "description": "Repository evidence shows repeated or structurally similar implementations that may instantiate one law-bearing pattern and recognition could materially change ownership legal composition interpretation migration or proof.",
+        "cue_literals": [
+          "current encoding",
+          "representative instances",
+          "candidate general pattern",
+          "encoding relation",
+          "nearest false friend",
+          "discriminating law",
+          "generalization dividend",
+          "transition witness"
+        ],
+        "cue_regexes": [],
+        "exclusions": [
+          "surface resemblance or shared vocabulary without a discriminating law",
+          "one local helper with no repeated semantic obligation or imminent constrained variant",
+          "recognition with no material generalization dividend"
         ]
       },
       {
@@ -189,6 +212,41 @@
           "widened seam without a law requirement"
         ],
         "rationale": "The decision record must expose what changed because of Universalist rather than merely proving that the skill was present."
+      },
+      {
+        "clause_id": "UNI-RECOGNITION-001",
+        "trigger_refs": [
+          "UNI-RECOGNIZE"
+        ],
+        "expected_routes": [
+          "UNI-PRESERVE",
+          "UNI-ORDINARY",
+          "UNI-CANONICAL",
+          "UNI-OBSTRUCT"
+        ],
+        "prohibited_routes": [],
+        "required_artifacts": [
+          "current encoding and representative instances",
+          "carriers operations observations candidate equations and known non-laws when recognition is nominated",
+          "candidate general pattern and explicit encoding relation when nominated",
+          "nearest false friend and discriminating law with attributed repository evidence when nominated",
+          "generalization dividend or reason the recognition remains explanatory metadata",
+          "observation-preserving transition witness when recognition materially changes the route"
+        ],
+        "success_signals": [
+          "recognition begins from concrete operations observations laws and counterexamples rather than vocabulary",
+          "the current encoding is classified as literal observational partial or degenerate lax or pseudo distributed lawless analogy-only or contradicted",
+          "the ordinary candidate remains the baseline and a recognized pattern survives only with a material generalization dividend",
+          "a material transition names encoding interpretation preservation compatibility first witness seam retired bypasses rollback and stop condition"
+        ],
+        "failure_signals": [
+          "surface resemblance signal count or a categorical name selects architecture",
+          "pattern name lacks a discriminating law or nearest false friend",
+          "generalization adds abstraction without deleting or centralizing a material obligation",
+          "recognition changes the route without an observation-preserving transition witness",
+          "one local helper is generalized without a repeated law or imminent constrained variant"
+        ],
+        "rationale": "Category theory creates architectural leverage when it recognizes the law-bearing structure already latent in ordinary code and supplies a verified transition, not when it merely labels resemblance."
       },
       {
         "clause_id": "UNI-CONTEXT-001",

--- a/codex/skills/universalist/references/latent-structure-recognition.md
+++ b/codex/skills/universalist/references/latent-structure-recognition.md
@@ -1,0 +1,308 @@
+# Latent Structure Recognition
+
+Universalist should recognize category theory in ordinary code before it reaches for category-theory vocabulary.
+
+The goal is not:
+
+```text
+code resemblance -> impressive name
+```
+
+The goal is:
+
+```text
+concrete implementations
+  -> shared carriers, operations, observations, laws, and non-laws
+  -> one evidenced general pattern
+  -> one repository-native realization
+  -> one observation-preserving transition
+```
+
+Recognition nominates. Existing comparison, theorem-card, route, authority, and obstruction rules still decide whether anything changes.
+
+## Governing rule
+
+```text
+Recognize by laws, not labels.
+Generalize only for a material dividend.
+Transition through an executable witness.
+```
+
+A general pattern may be useful even when no advanced construction card is selected. Products, coproducts, monoids, actions, homomorphisms, folds, state machines, adapters, and checked witnesses often remain `UNI-ORDINARY`.
+
+## When to run the pass
+
+Run a lightweight recognition pass when repository evidence contains at least one of:
+
+- the same invariant checked at several creation or boundary paths;
+- repeated branches that differ only by a case or parameter;
+- several joins or compatibility checks through a shared observation;
+- callbacks, closures, handlers, or predicates crossing an ownership boundary;
+- several interpreters over the same operation vocabulary;
+- repeated folds, traversals, accumulators, reducers, or transition loops;
+- wrapper families that repeatedly add the same context;
+- projections or reports that duplicate one observation vocabulary;
+- composition code that repeatedly checks the same compatibility rule;
+- migration, rewrite, or translation functions that preserve the same structure;
+- a concrete implementation plus an imminent variant whose shape is already constrained by the same law.
+
+Syntactic duplication alone is not enough. The pass needs a repeated semantic obligation, a stable law, or an imminent variant that would otherwise duplicate it.
+
+## Recognition packet
+
+```text
+Current encoding:
+Representative instances:
+Carriers:
+Operations / constructors / eliminators:
+Sanctioned observations:
+Candidate equations:
+Known non-laws / counterexamples:
+Stable structure:
+Varying parameters:
+Candidate general pattern:
+Encoding relation:
+Nearest false friend:
+Discriminating law:
+Generalization dividend:
+Transition witness:
+Evidence debt:
+```
+
+Do not erase effects, authority, provenance, ordering, failure, locality, or resources while anti-unifying the instances.
+
+## Encoding relations
+
+Classify the current implementation as exactly one of:
+
+- **literal instance** — the relevant structure and laws are explicitly represented;
+- **observational realization** — representation differs, but the laws hold under sanctioned observations;
+- **partial or degenerate instance** — only a restricted fragment or special case is represented;
+- **lax / pseudo / normalized instance** — laws hold only through an explicit comparison, coherence map, or normal form;
+- **distributed encoding** — the structure exists across several owners or code paths rather than one artifact;
+- **lawless approximation** — the implementation resembles the pattern but violates a defining law;
+- **analogy only** — the resemblance changes no artifact, ownership, composition, migration, or proof;
+- **contradicted** — attributed evidence falsifies the proposed pattern.
+
+This relation describes the current code. It is separate from the proposed artifact's claim strength:
+
+```text
+literal
+effective realization
+bounded approximation
+```
+
+## Recognition protocol
+
+### 1. Excavate the concrete encoding
+
+Inspect the code before naming a pattern:
+
+```text
+representations
+construction paths
+elimination paths
+operations
+composition
+observations
+effects and order
+owners
+bypasses
+tests and counterexamples
+```
+
+### 2. Extract the latent algebra
+
+Record:
+
+```text
+carriers
+operations
+observations
+candidate laws
+known non-laws
+interpreters
+effect boundaries
+```
+
+Use tests, callers, schemas, traces, and compatibility behavior as evidence. Names and comments are hints, not proof.
+
+### 3. Anti-unify neighboring instances
+
+Ask:
+
+- what structure remains invariant across the instances?
+- what varies parametrically?
+- which differences are incidental representation?
+- which differences remain observable and therefore cannot be quotiented?
+- which special cases compensate for a missing general operation?
+- which operations preserve the same law across representations?
+- is one owner missing, or is the distribution intentional?
+
+Anti-unify behavior and proof obligations, not merely shared syntax.
+
+### 4. Nominate a small candidate family
+
+Nominate no more than three nearby interpretations, including the boring alternative.
+
+For each candidate record:
+
+```text
+candidate
+current-encoding relation
+supporting evidence
+missing evidence
+nearest false friend
+discriminating law
+likely repository-native form
+```
+
+A theorem-card signal never proves the candidate. A recognized ordinary pattern does not need a theorem card.
+
+### 5. Discriminate by law
+
+Use the smallest executable law or counterexample that separates the candidates.
+
+Typical discriminators:
+
+```text
+construction / projection round-trip
+exhaustive elimination
+predicate stability
+shared-projection agreement
+identity
+associativity
+homomorphism
+naturality
+interpreter equivalence
+value dependence versus static shape
+effect-order sensitivity
+restriction / gluing
+square boundary matching and interchange
+```
+
+Examples:
+
+- **applicative versus monadic** — can later operation shape be known before earlier results?
+- **pointwise versus Day composition** — does only the same index combine, or must every legal decomposition contribute?
+- **Reader parameter versus Tambara framing** — is there an actual context action with unit, associative framing, and endpoint naturality?
+- **commuting square versus double category** — do both arrow families independently compose, and do local squares paste in both directions?
+- **arbitrary merge versus pushout** — is there an explicit overlap with source maps and a universal compatibility obligation?
+
+### 6. Require a generalization dividend
+
+A recognized pattern survives only when it materially provides at least one of:
+
+- one owner replaces scattered validation or policy;
+- invalid states or illegal compositions become unrepresentable;
+- several special cases become one operation plus parameters;
+- one interpreter replaces repeated execution semantics;
+- one composition law replaces orchestration checks;
+- one observation vocabulary replaces projection sprawl;
+- a future variant becomes new data or a new interpreter instead of new control flow;
+- migration becomes a structure-preserving map rather than per-case repair;
+- reusable property tests or proof obligations become possible;
+- a genuine obstruction becomes visible.
+
+No material dividend means `analogy only`; keep the ordinary candidate.
+
+### 7. Construct the transition witness
+
+When recognition changes the route, record:
+
+```text
+Current encoding:
+Generalized repository-native form:
+Encode / translate:
+Interpret / project:
+Preservation law:
+Compatibility boundary:
+First witness seam:
+Cutover order:
+Retired obligations:
+Retired bypasses:
+Rollback:
+Stop condition:
+Invalidation triggers:
+```
+
+The transition should normally be staged:
+
+1. introduce the generalized core behind the current boundary;
+2. translate one representative existing case;
+3. prove observational agreement with the old path;
+4. route one caller through the new interpretation;
+5. extend only to instances governed by the same evidenced law;
+6. close raw construction or bypass paths;
+7. retire compatibility adapters only after their callers are gone.
+
+Do not widen the migration merely because the general pattern can express more.
+
+### 8. Return to ordinary Universalist adjudication
+
+Compare:
+
+```text
+ordinary candidate
+recognized repository-native realization
+other relevant theorem-card candidates
+preserve or obstruction
+```
+
+The existing comparison universe, dominance relation, current-context contract, host capabilities, effectivity, and authority rules determine the route.
+
+## High-yield recognition atlas
+
+| Concrete encoding | Candidate pattern | Discriminating evidence | Typical transition |
+|---|---|---|---|
+| flag matrix with rejected combinations | coproduct / explicit cases | impossible mixtures are semantically invalid | tagged union behind legacy decoder |
+| stable predicate checked in many places | refined type / equalizer | one predicate remains stable after construction | opaque checked constructor |
+| two values repeatedly compared through one shared projection | pullback-shaped compatibility object | both originals remain observable and shared views must agree | checked aggregate plus preserved projections |
+| merges identify an explicit common overlap | pushout-shaped integration | source injections agree only on declared overlap | one provenance-preserving integration owner |
+| callbacks need replay, audit, authorization, or multiple execution modes | free syntax or defunctionalized IR | cases are finite/effective and one interpreter preserves behavior | encode one callback family and add `apply` / interpreter |
+| operation plan is inspectable before results | free applicative / static plan | later shape does not depend on earlier values | static operation IR |
+| later operation depends on an earlier value | monadic / value-dependent sequence | dependency cannot be represented statically | bindable program IR or ordinary sequence |
+| repeated associative combination with an identity | monoid / monoidal composition | identity and associativity hold under sanctioned observations | central combine operation plus property tests |
+| conversions preserve operations across representations | homomorphism / natural transformation | operation then convert equals convert then operation | explicit structure-preserving adapter |
+| many projections define effective equality | observation vocabulary / Yoneda-style presentation | sanctioned observations determine relevant equivalence | observation IR plus one runner |
+| repeated context wrappers around one capability | action / Tambara candidate | real unit, associative framing, and naturality exist | one typed frame operation or reject to ordinary context parameter |
+| nested decomposition loops combine indexed descriptions | Day or promonoidal composition | all legal decompositions or witnesses must contribute | bounded indexed representation and normalizer |
+| local meanings restrict and must glue across overlaps | presheaf / sheaf candidate | restrictions compose and compatible locals glue uniquely-up-to | usage-site index then exact global model |
+| recursive traversals differ only by result algebra | fold / initial-algebra pattern | constructors determine the traversal homomorphism | one recursion scheme or repository-native fold |
+| transitions expose observable ongoing behavior | coalgebra / state machine | step and observation determine traces | explicit transition and observation API |
+| runtime processes compose and architecture changes compose separately | double-category candidate | both directions compose; compatibility squares paste; interchange is observable | typed arrows, squares, pasting, and interpreter |
+
+The atlas is abductive guidance, not a replacement registry. If a row's discriminator is absent, leave the candidate unresolved or reject it.
+
+## False-positive guardrails
+
+Do not generalize when:
+
+- only names or surface syntax match;
+- the proposed law is contradicted by required behavior;
+- the domain rule is unstable;
+- the representation would erase an observable distinction;
+- the generalized API adds more obligations than it removes;
+- callers need only one local helper;
+- the transition cannot preserve compatibility;
+- the host cannot enforce the claimed structure;
+- resource or effect costs make the realization dishonest.
+
+The desired output is repository language:
+
+```text
+These three compatibility checks are one distributed agreement rule.
+Introduce one checked owner for the compatible pair.
+Preserve both source projections.
+Translate one existing caller and prove the shared view still agrees.
+Retire unchecked pair construction only after the witness seam passes.
+```
+
+The expert explanation may add:
+
+```text
+pullback-shaped observational realization
+nearest false friend: ordinary pair plus repeated validators
+discriminating law: both shared projections agree
+generalization dividend: one owner and no bypass
+```

--- a/codex/skills/universalist/templates/universalist-plan.md
+++ b/codex/skills/universalist/templates/universalist-plan.md
@@ -33,6 +33,26 @@ adjudication there instead of allocating this plan.
 ### Invalidated artifacts: receipt / plan / proof lease / none
 ### Successor packets: owner + axis + seam / none
 
+## Latent structure recognition (complete only when material):
+### Current encoding and representative instances:
+### Carriers / operations / observations:
+### Candidate equations / known non-laws:
+### Stable structure / varying parameters:
+### Candidate general pattern:
+### Encoding relation:
+### Nearest false friend:
+### Discriminating law:
+### Generalization dividend:
+### Transition witness:
+#### Generalized repository-native form:
+#### Encode / translate:
+#### Interpret / project:
+#### Preservation law:
+#### Compatibility boundary / first witness seam:
+#### Retired obligations and bypasses:
+#### Rollback / stop condition:
+#### Invalidation triggers:
+
 ## Signal and evidence:
 ## Ordinary candidate:
 ## Comparison universe and dominance relation:
@@ -48,6 +68,7 @@ adjudication there instead of allocating this plan.
 ## Boundary Artifact Contract:
 ### Boundary and owner:
 ### Requirements discharged:
+### Current encoding / generalization relation:
 ### Representation / carrier:
 ### Public constructors:
 ### Public eliminators:
@@ -56,6 +77,7 @@ adjudication there instead of allocating this plan.
 ### Interpreter / projection / handler:
 ### Required observations:
 ### Compatibility / migration:
+### Transition witness / retirement:
 ### Bypass prevention:
 ### Enforcement allocation:
 ### Residual obligations:

--- a/codex/skills/universalist/templates/universalist-report.md
+++ b/codex/skills/universalist/templates/universalist-report.md
@@ -4,9 +4,19 @@
 
 ## Signal
 
+## Current encoding
+
+## Recognized general pattern / relation
+
+## Discriminating law / nearest false friend
+
+## Generalization dividend
+
 ## Construction
 
 ## Why this instead of nearby alternatives
+
+## Transition witness
 
 ## Seam / files
 
@@ -15,6 +25,8 @@
 ## Before -> After
 
 ## Verification
+
+## Retired obligations / bypasses
 
 ## Runtime-only leftovers
 


### PR DESCRIPTION
## Summary

- recognize law-bearing patterns already latent in ordinary code before theorem-card selection
- classify the current implementation as literal, observational, partial/degenerate, lax/pseudo, distributed, lawless, analogy-only, or contradicted
- require a nearest false friend, discriminating law, and material generalization dividend
- require an observation-preserving transition witness when recognition changes the architecture
- keep theorem cards nomination-only and preserve the existing `UNI-*` routes and Actuating authority boundary

## Design

The workflow is now explicit about three different operations:

```text
recognition  — abductively infer a plausible law-bearing pattern from code
evaluation   — deductively test it through existing cards, evidence, and alternatives
transition   — construct the smallest repository-native, observation-preserving migration
```

A new progressive-disclosure reference supplies the recognition protocol, high-yield pattern atlas, discriminators, transition shape, and false-positive guardrails. No runtime, route, executable, dependency, or subagent was added.

## Scope

- Universalist core, README, package metadata, invocation prompt, decision contract, plan/report templates
- one new `latent-structure-recognition.md` reference
- the existing world-cartographer and categorical-architect read-only agents

## Verification

- JSON parsing passed for package metadata and the decision contract
- YAML parsing passed for invocation metadata
- TOML parsing passed for both modified agents
- trigger, clause, and route references are internally consistent
- Markdown fence, version-alignment, cross-reference, and trailing-whitespace checks passed
- `git diff --check` passed
- remote commit contains exactly the 10 intended files

The repository-specific Ledger/Seq validation commands were not run because those tools are unavailable in this execution environment.

<!-- ship-proof:start -->
## Summary
- Add law-based latent-structure recognition to Universalist while preserving theorem-card nomination, existing UNI-* route authority, Actuating ownership, and the no-subagent default.

## Proof
- quick_validate.py codex/skills/universalist: pass
- ledger validate against tune/skill-decision-contract: pass; ledger-validation-result/v1, storage not mutated
- JSON, YAML, TOML, Markdown-fence, version-alignment, cross-reference, and exact-file-set checks: pass
- git diff --check 4477529628c32f2bc620fbb6cbcb36dc3cb19d86...12fe0db5b8a39e86e86fae5f3466ad7f9beffced: pass
- Universalist boundary law: recognition nominates but does not select; existing route set preserved: pass
- GitHub exact-head and clean-mergeability readback: pass

## Scope
- repository: tkersey/dotfiles
- branch: agent/universalist-latent-structure-recognition
- head: 12fe0db5b8a39e86e86fae5f3466ad7f9beffced
- base: main
- base SHA: 4477529628c32f2bc620fbb6cbcb36dc3cb19d86

## Risks
- The head predates one unrelated commit on main; GitHub reports the exact head cleanly mergeable, and branch policy requires neither up-to-date status checks nor approvals.

## Follow-ups
- None.

## Readiness
- Operation: update-and-promote
- Final state: ready
- SHIP-v1 compatibility mode: promote-draft
- Reason: the exact draft PR is unique; its 10-file boundary change passes repository, Ledger, semantic, and acceptance validation.
- Caveats: no build applies to this documentation/configuration-only package; no required GitHub checks are configured.
<!-- ship-proof:end -->