### PR TITLE
actuating: isolate the authority kernel

### DIFF
--- a/codex/skills/actuating/FULL_CONTRACT.md
+++ b/codex/skills/actuating/FULL_CONTRACT.md
@@ -1,0 +1,558 @@
+---
+name: actuating
+description: "Turn accepted intent and review evidence into correct-by-construction software through Goal Contracts, Counterexample Sets, Construction Contracts, and an Evidence Ledger. Use bare $actuating for implementation, Ship publication, and review convergence; use explicit implement, triage, remediation-plan, or review-closeout for their bounded routes. Begin every architecture or abstraction decision with OPERATE ARCHITECTONICALLY, use $first-principles to establish the incumbent-independent Construction basis before $universalist nomination, and integrate one bounded $metanoetic pass when an initial high-regret nomination, accepted findings, causal recurrence, or cumulative review-path accretion makes abstraction change live. Before fresh review after repair, fold the cumulative changeset and review-induced delta so pointwise minimal repairs cannot compose into a dominated final Construction. Actuating alone selects the Construction and next action; Ledger is non-executing and Ship alone owns public effects."
+---
+
+# Actuating
+
+Turn accepted intent into a lawful construction, directly orchestrated effects,
+independent falsification, and an evidence-backed closure judgment.
+
+## Authority kernel
+
+Use exactly four authoritative per-goal artifact families:
+
+1. `goal-contract/v3` — accepted semantics, authority, scope, compatibility,
+   laws, and acceptance, compiled by `$goal-contract`.
+2. `counterexample-set/v1` — classified witnessed falsifications, authored by
+   `$review-fold`.
+3. `construction-contract/v3` — the selected architecture, compared candidate
+   families, factor surfaces, supersession, proof obligations, preserved
+   observations, and retirements, authored by `$actuating` after an
+   Actuating-bound `$first-principles` basis, a `$universalist` nomination, and,
+   when required, one `$reduce` challenge.
+4. `actuating-evidence-event/v1` — append-only observations whose event bodies
+   retain their domain owners.
+
+The Goal Contract is the sole semantic-authority artifact. The Counterexample
+Set is the sole classified-bug artifact. The Construction Contract is the sole
+architecture-selection artifact. The Evidence Ledger is the sole mutable
+per-goal truth. Read [artifact-kernel.md](references/artifact-kernel.md).
+
+Plans, CAS receipts, Ship receipts, verifier output, work graphs, and Ledger
+projections are supporting evidence or discardable structural aids. An
+Actuating-authored closure receipt is a semantic report, not another authority
+family.
+
+## Owner boundary
+
+Actuating owns:
+
+- correct-by-construction implementation;
+- evaluation of current Counterexample classes against the current Construction;
+- initial and successor Construction selection;
+- repository-effect and review orchestration;
+- the clean committed Git subject used by local proof;
+- review-path accretion evaluation and pathwise-minimality disposition;
+- construction and ownership of the static Review Contract;
+- semantic evaluation of CAS owner facts and review credit;
+- the next legal action;
+- application of the closure theorem and authorship of its semantic receipt.
+
+`$review-fold` classifies witnessed facts before Actuating selects a repair.
+`$first-principles` establishes the admissible premise basis without revising
+the Goal. `$universalist` lowers the admissible derivation and nominates the
+essential boundary shape. When abstraction change is live, `$metanoetic`
+performs one bounded generative escalation and Universalist lowers every
+material result. `$reduce` may challenge nominated factors through congruent
+quotients, ablations, and recomposition. `$complexity-mitigator` may supply one
+read-only local normal-form preflight when review accretion is realization-only.
+
+The composition order is:
+
+~~~text
+activate
+-> axiomatize once or retain the current basis
+-> nominate
+-> metanoetic once when triggered
+-> lower
+-> challenge once
+-> adjudicate
+~~~
+
+Actuating alone performs adjudication. No supporting skill, review prose, plan,
+or Reduction Certificate selects a Construction, Repair Disposition, Review
+Accretion Disposition, operation, next action, or closure.
+
+Ledger may materialize, canonicalize, validate, append, replay, and emit
+requested disposable structural projections. Ledger never executes repository
+changes, invokes Git, evaluates CAS facts or review credit, interprets Ship,
+selects a repair or Construction, grants mutation, chooses the next action, or
+emits or authors semantic closure.
+
+Before the first Ledger command, load `$ledger` and complete `$ledger ensure`
+once. Require Ledger 1.x with `ledger-artifact-abi/v1`, Seq 1.x with
+`seq-observation-abi/v1`, and successful checks for every selected passive
+definition. Apply the same gate when entering from a standalone Goal Contract
+or Review Fold handoff. Construction v1 and v2 are unsupported; start a fresh
+v3 goal-local Evidence store rather than treating legacy data as current
+authority.
+
+`$ship` is the sole owner of public PR or tracker effects and Ship-owned
+publication evidence. Actuating supplies a current `ready-to-ship` proof and
+records Ship's returned receipt; it never performs the public effect or authors
+a substitute publication receipt itself.
+
+## Public modes
+
+| Intent | Route | Mutation | Terminal result |
+|---|---|---:|---|
+| Bare `$actuating` or `/goal $actuating` | implement -> Ship -> review-closeout | Authority-bound | `complete` |
+| `$actuating implement` | implementation only | Authority-bound | Local `complete` |
+| `$actuating triage` | acquire and classify review | Forbidden | Counterexample Set and report |
+| `$actuating remediation-plan` | propose a successor Construction | Forbidden | Non-executable Construction Contract |
+| `$actuating review-closeout` | repair, ablate, Ship when required, and re-review | Authority-bound | `complete` |
+
+An unqualified request to review, inspect, audit, or classify selects `triage`.
+Require explicit implement, fix, resolve, address, or closeout intent before
+mutation.
+
+## Architectonic decision gate
+
+At the beginning of every process that selects, preserves, changes, or ablates
+architecture or abstraction, and before Universalist nomination, state exactly:
+
+~~~text
+OPERATE ARCHITECTONICALLY
+~~~
+
+This is an activation instruction, not evidence, authority, or a receipt.
+
+## Axiomatic Construction gate
+
+Before the first Universalist nomination for each materially new candidate
+universe, invoke `$first-principles` with the current Goal fixed as the
+irreducible outcome and sole semantic authority. Bracket inherited repository
+abstractions, conventions, analogies, owner boundaries, rationale, and alleged
+constraints. Do not reopen Goal outcomes, laws, scope, compatibility,
+authority, acceptance, or proof posture.
+
+Inspect the incumbent only to establish observed facts, external obligations,
+and host enforcement capabilities. Freeze the incumbent-independent derivation
+before incumbent comparison, then record:
+
+~~~text
+Axiomatic Construction Basis
+Goal axioms:
+Observed facts:
+Necessary constraints:
+Chosen objectives:
+Irreducible postulates:
+Definitions:
+Derived claims:
+Rejected inherited premises:
+Governing invariants and causal mechanisms:
+Incumbent-independent derivation:
+Incumbent comparison:
+Basis status: sufficient | underdetermined | inconsistent | blocked
+Invalidators:
+Falsifier:
+~~~
+
+The basis is an ephemeral proof lease over exact Goal, fact, constraint, and
+host-capability inputs. It is not a fifth authority artifact and adds no
+Construction field. It expires at session end, compaction, or execution-context
+handoff and is never reconstructed from a materialized Construction. Within one
+uninterrupted run, a premise-neutral clean commit change may retain the basis
+while all inputs and invalidators remain current. Any later run or premise
+change re-axiomatizes before nomination or affected mutation.
+
+A `sufficient` basis admits nomination. `underdetermined` preserves every
+materially incomparable derivation and blocks if Goal law, observation, or
+dominance cannot distinguish them. `inconsistent` or `blocked` stops.
+`$first-principles` may expose a Goal conflict or missing authority, but it
+cannot rewrite the Goal, classify Counterexamples, select a Construction,
+grant mutation, or author a durable decision.
+
+Before authoring a successor Goal, project `goal-carry-forward-context` from the
+canonical Evidence store. Treat its retained Goal artifact as current and
+derive supporting references only from retained classes whose status is
+`accepted`, `blocked`, or `follow-up`. Never guess references, reconstruct the
+Goal from an older artifact, or read the event log directly. An unavailable or
+incomplete projection is an owner-side obstruction.
+
+When accepted or blocked Counterexamples remain unresolved, or a revision
+brings a `follow-up` class within scope, the successor Goal cites every Set
+carrying those classes. `$review-fold` then authors a successor Set that cites
+the successor Goal, preserves lineage, evaluates the predecessor Construction,
+and dispositions every carried class. No affected mutation or successor
+Construction selection occurs before that carry-forward is complete.
+
+## Metanoetic escalation
+
+For an initial Construction with no classified findings, invoke `$metanoetic`
+exactly once after the first Universalist nomination and before candidate
+adjudication when the nomination is high-regret or difficult to reverse,
+remains a coherent but merely adequate local optimum, and a materially
+different Construction is plausible. Initial implementation, architecture, or
+consequence alone is not a trigger.
+
+After `$review-fold` classifies findings, invoke `$metanoetic` exactly once when
+an accepted class:
+
+- makes `architecture-repair` or `ablation-repair` live;
+- challenges representation, owner, admitted domain, equivalence,
+  normalization, or information retention;
+- triggers causal recurrence; or
+- would add a validator, correlation, cache, bypass, compatibility branch, or
+  path-dependent recovery to reconstruct forgotten information;
+
+or when Review Accretion establishes material path dependence, accumulated
+semantic machinery, obsolete residue, proof accretion, inadequate ordinary
+normalization, or pathwise domination pressure.
+
+Record:
+
+~~~text
+Architectonic Escalation
+Trigger: initial-high-regret | accepted-class-abstraction | causal-recurrence | review-path-accretion
+Abstraction pressure:
+Metanoetic result: material-reframe | no-material-reframe | blocked
+Material frame, invariant, mechanism, or artifact:
+Universalist reclassification: retain | split | escalate | obstruct
+Candidate-family delta:
+Falsifier:
+~~~
+
+Compile material results into existing candidate comparison, factor surfaces,
+supersession, proof obligations, and falsifiers. Metanoetic neither classifies,
+nominates, selects, authorizes, nor closes. Do not repeat it for an unchanged
+decision surface.
+
+## Committed Git subject
+
+The durable Actuating subject is one clean Git commit target. Dirty index,
+worktree, untracked, and ignored state is provisional implementation state and
+never an Evidence subject.
+
+For Git, derive the subject exactly as:
+
+~~~text
+subject_digest = sha256(
+  "actuating-git-subject/v1" || 0x00 ||
+  repository_id || 0x00 ||
+  commit_oid || 0x00 ||
+  tree_oid
+)
+~~~
+
+Where:
+
+- `commit_oid = git rev-parse --verify HEAD^{commit}`;
+- `tree_oid = git rev-parse --verify HEAD^{tree}`;
+- `git status --porcelain=v2 --untracked-files=all --ignore-submodules=none`
+  is empty;
+- branch attachment is excluded from semantic identity;
+- ignored files are excluded because they are not candidates for the committed
+  artifact.
+
+Ledger stores and compares this opaque digest. It never invokes Git or derives
+the tuple. Ship separately binds repository, base and head refs, exact OIDs,
+and live publication readback.
+
+## Construction procedure
+
+1. Compile accepted source with `$goal-contract`. Require the canonical artifact,
+   non-null `artifact_id`, and applicable Goal registration event.
+2. Enter the Architectonic decision gate. Establish or retain the Axiomatic
+   Construction Basis. Apply Universalist at every changed or preserved
+   boundary. Complete one Metanoetic pass and re-lowering when a live trigger
+   exists.
+3. Compile exactly four candidate families in canonical order:
+   `realization-preserve`, `admitted-domain-restriction`,
+   `representation-or-owner-strengthening`, and `ablation-normalization`.
+   Factor every independent mandatory repair into one common obligation core;
+   vary only the disputed family delta. Give each candidate a factor inventory
+   and falsifier, mark at least one genuinely incumbent-independent, and select
+   exactly one.
+4. Challenge the nominated candidate once with `$reduce` when it adds or
+   preserves an independent semantic owner, parallel representation, bypass,
+   compatibility branch, semantic mechanism, or apparently dominated residue.
+   Record:
+
+   ~~~text
+   Repair Disposition
+   Law:
+   Owner:
+   Reduction: not-required | minimal | dominated | incomparable | essential-shape-gap | blocked
+   Route: delete | consolidate | edit | add
+   Why not smaller:
+   Falsifier:
+   ~~~
+
+   Choose the least additive lawful route. `add` explains why `delete`,
+   `consolidate`, and `edit` are insufficient.
+5. Adjudicate basis, nomination, escalation, and challenge. Select the smallest
+   non-dominated Construction satisfying every Goal law, make invalid states
+   unrepresentable where feasible, and name exact proof and retirement
+   obligations. Partition every predecessor and successor factor as preserved,
+   retired, introduced, or replaced.
+6. Materialize and register the selected Construction through Ledger. Only the
+   returned canonical artifact and appended registration event make it current.
+7. Require the repository to be at the exact clean committed subject before
+   preparing an operation.
+8. For each edit:
+
+   ~~~text
+   clean parent subject
+   -> prepare exact operation
+   -> one-seam-operator creates one provisional diff
+   -> Actuating inspects the complete diff and changed paths
+   -> Actuating commits exactly that operation
+   -> require one-parent clean successor
+   -> derive successor subject
+   -> record-effect parent -> successor
+   -> verify and falsify on the successor commit
+   ~~~
+
+   `one-seam-operator` never stages, commits, amends, pushes, or publishes.
+   Actuating rejects unrelated dirty state before preparation. The successor
+   commit has exactly one parent equal to the prepared parent, a nonempty commit
+   path set exactly equal to the selected operation, only allowed paths, and a
+   clean checkout. `effect_recorded` advances directly from the parent subject
+   in `pre_effect_subject_digest` to the successor subject in the event envelope.
+9. Run inspect, verifier, falsifier, and retirement operations only on an exact
+   clean commit. Require the checkout and subject to remain unchanged afterward.
+   Record immutable outputs through [evidence-ledger.md](references/evidence-ledger.md).
+10. Re-evaluate all current artifacts and observations. Select the next
+    operation, Ship handoff, review action, closure judgment, or blocker.
+
+The one-operation law is:
+
+~~~text
+select -> prepare -> effect -> commit -> record -> observe -> evaluate -> select or close
+~~~
+
+No stage may smuggle a second repository effect. A document, operation
+envelope, validator pass, Ledger append, review result, or Construction never
+grants mutation by itself. Mutation requires accepted authority, a current
+Construction, an exact clean committed subject, and an in-scope operation.
+
+## Goal-causal lineage
+
+Subject freshness and causal decision lineage are independent. A clean commit,
+publication, or other material subject change makes subject-bound proof,
+operations, review bindings, and review credit stale. It does not erase prior
+Construction decisions or Counterexample history for the same `goal_id`.
+
+Only the first Construction in the authoritative v3 lineage may use
+`mode: initial` with no predecessor. Every later Construction names the exact
+current Construction as its sole predecessor, including after a successor Goal
+or clean subject rebind.
+
+Before accepting a new Counterexample Set, resolve prior Sets for the Goal.
+When a stable class recurs, require the new Set to name the most recent Set
+carrying it. Missing lineage blocks and does not make the class novel.
+
+## Counterexample and causal recurrence procedure
+
+Every witnessed bug, failing test, incident, compatibility failure, or review
+finding passes through `$review-fold`. Actuating then determines whether each
+accepted class is:
+
+- a realization defect;
+- an architecture defect requiring a successor Construction;
+- an ablation defect requiring dominated-residue removal; or
+- blocked by missing authority or evidence.
+
+Re-establish the current-run basis before choosing an affected repair. If a
+finding falsifies a premise or makes architecture/ablation live, re-axiomatize,
+run the bounded Metanoetic pass, lower through Universalist, and compare the
+successor candidates before selecting an operation.
+
+The causal recurrence gate triggers when one accepted class recurs after repair
+or two accepted classes across subject revisions share an evidenced missing
+observation, authority, correlation, or Construction factor. Similar files,
+prose, diff size, or timing do not establish shared cause.
+
+Record:
+
+~~~text
+Causal Recurrence Disposition
+Evidence and class refs:
+Shared cause:
+Current Construction factor:
+Candidate comparison: realization preserve / admitted-domain restriction / representation strengthening / ablation normalization
+Disposition: instance-specific | architecture-repair | ablation-repair | blocked
+Why another local repair is sufficient or forbidden:
+Proof:
+Falsifier:
+~~~
+
+A recurring cluster makes abstraction change live and invalidates the prior
+candidate universe. `instance-specific` requires non-example separation proof.
+Otherwise select architecture/ablation repair or block. Do not add another
+validator that recreates information the representation repeatedly forgets.
+
+## Review accretion
+
+A sequence of pointwise least-additive repairs may compose into a globally
+dominated realization. After every review-driven mutation epoch and before the
+next Ship handoff or fresh review, apply the
+[Review Accretion Gate](references/review-accretion.md). Apply it again before
+final closeout when mutation occurred after the last disposition.
+
+Bind the exact delivery baseline, review-entry committed subject, and current
+committed subject. Keep the review-entry anchor across campaigns, publication
+epochs, review-credit resets, subject rebinding, and successor Constructions for
+the same closeout objective. Fold the complete delivery and review-induced
+commit deltas, Construction and Counterexample lineage, and cumulative
+production, semantic, proof, and comprehension surfaces. Line count, file
+count, elapsed time, and repair count force inspection only.
+
+First derive the ordinary cumulative normal form. Use one read-only
+`$complexity-mitigator` Micro Preflight when the architecture and factor
+inventory remain sufficient. When representation, owner, admitted domain,
+equivalence, information retention, or boundary may be insufficient, retain or
+re-establish the basis and require Universalist to nominate the ordinary
+repository-native normal form.
+
+When the fold establishes material path dependence, accumulated semantic
+machinery, obsolete residue, proof accretion, inadequate ordinary
+normalization, or pathwise domination, run Metanoetic with
+`Trigger: review-path-accretion`, lower the result, challenge it once with
+Reduce, and adjudicate.
+
+Select exactly one disposition: `preserve`, `realization-normalization`,
+`ablation-repair`, `architecture-repair`, or `blocked`. Any material repair
+creates a new committed review subject and resets all review credit. Compile
+material results into existing Construction factors, supersession, proof
+obligations, and retirements. Add no artifact family, mutable control state,
+review lens, or Ledger/Seq/CAS accretion command.
+
+## Review convergence
+
+`$first-principles`, Review Accretion, and Metanoetic are Construction-selection
+passes, not review lenses. Preserve the static topology of standard plus the
+existing four auxiliaries.
+
+Before binding or dispatching closure-grade review, require:
+
+~~~bash
+cas app-server preflight --cwd <repo> --profile review \
+  --app-server-transport managed-ws --json
+
+cas_codex_0146_structured_review_v1=true
+cas_workflow_bound_owner_lived_review_v1=true
+~~~
+
+The first receipt must be `compatible` for the exact resolved Codex runtime,
+contract, and `managed-ws` transport with every required probe passed. The two
+features come from `cas capabilities --json`. Any missing runtime or compiled
+capability proof blocks before request binding or `review/start`.
+
+Bind standard plus four auxiliary requests before dispatch. Launch the initial
+1+4 wave as five concurrent owner-lived:
+
+~~~text
+cas review start --wait --timeout-ms 2700000
+~~~
+
+processes, one per request, and retain each process through a structured
+terminal receipt or explicit terminal owner failure. Do not split a
+workflow-bound attempt into detached `start` and unrelated `wait`. Never cancel
+a sibling because another request finds a defect or loses transport.
+
+A verdictless terminal failure earns zero credit and reruns only that request
+once on the same committed subject with a fresh attempt. Preserve completed
+siblings and standard clean credit on the unchanged subject. Count the initial
+wave's standard clean as attempt one, run four later standard attempts
+serially, and require five consecutive distinct standard cleans. Any committed
+subject change resets all review credit and requires a fresh 1+4 wave.
+
+Publication-bearing review uses Ship-confirmed remote identity. For a current
+PR, use `SHIP-v1`; for a new adoption route, record a read-only
+`SHIP-OBSERVATION-v1` pre-review publication observation before binding or
+dispatching the campaign. Map the exact published target to
+`cas review --base <immutable-base-sha>` and require every receipt's
+`baseSha`, `headSha`, and target fingerprint to equal Ship readback. Never use
+`--uncommitted` for a published PR. `--commit HEAD` is sufficient only when one
+commit is the complete bound PR delta.
+
+Actuating evaluates CAS owner receipts and review credit. Ledger may record
+receipt references and project structural history, but never dispatches CAS or
+translates CAS fields into semantic verdicts.
+
+## Publication and closure
+
+Bare mode and publication-bearing review closeout hand a current
+`ready-to-ship` proof to `$ship`. Ship either pushes the exact clean verified
+commit and creates or updates its PR, returning `SHIP-v1`, or read-only adopts
+an exact already-public subject that has no truthful current PR tuple, returning
+`SHIP-ADOPTION-v1`. Both routes exact-match the repository, base/head refs and
+OIDs, complete actuation binding, and route-specific live readback. Actuating
+must not substitute its own live-readback record.
+
+Ship evidence precedes review. For a new campaign, a later
+`SHIP-ADOPTION-v1` does not reset review credit merely because the adoption
+receipt was recorded later when it ratifies the exact `SHIP-OBSERVATION-v1`
+digest that Actuating recorded before the credited campaign. The observation, adoption, and every credited CAS
+receipt must exact-match the repository, canonical head ref, base/head tuple,
+subject, current default-branch state, Goal, Construction, and review contract
+through the observation's `review_binding`. That binding is the exact named
+Goal/Construction/subject/review-contract projection of Ship's validated
+actuation binding; it is not a second authority.
+The final adoption carries its own current actuation binding. The
+`publication-review-events` projection exposes exact ordered publication and
+campaign event rows without interpreting them. Evidence Ledger
+order from the recorded Ship observation to campaign binding proves causality;
+never compare provider and Ledger wall clocks. Otherwise the review credit is
+stale. The reducer admits exactly one campaign-start occurrence for the current
+Goal, Construction, subject, and Review Contract and binds every request to
+that occurrence. The pre-review observation proves the exact reviewed bytes
+were public before that occurrence; ratification exact-matches its stable tuple
+while final adoption freshly re-reads the same live default branch. Neither
+endpoint comparison nor ratification claims intermediate branch continuity.
+
+For a historical campaign that predates `SHIP-OBSERVATION-v1`, adoption may
+instead carry provider-backed publication evidence for the exact target.
+Actuating preserves review credit only when a content-addressed causal-order
+observation binds that exact provider event to the exact campaign start and
+shows the publication operation completed first. The supporting attachment is
+`actuating-publication-campaign-causality/v1`, owned and issued by Actuating
+after it validates one exact Seq observation, successful call lifecycles, and
+`publication.finalized_line < campaign.declared_line`. Matching endpoints, an
+arbitrary older event, or a comparison between independent wall clocks is not
+such proof. This attachment does not alter CAS receipts or create a new
+authority artifact.
+A non-null adopted release also requires its provider to match the branch
+readback provider,
+its repository to match the adopted repository, its state to be published and
+non-draft, its resolved tag
+target to equal the subject head, and its uniquely named assets to have equal
+cardinality and exact set equality with the complete live provider inventory.
+Release assets added after review are separate publication
+evidence and do not rewrite review time.
+
+Apply [closure.md](references/closure.md) only to current artifacts and
+observations. Actuating authors `actuating-closure-receipt/v1`; Ledger neither
+emits the verdict nor authors the receipt. `$proof-patch` may render a complete
+result but cannot decide it. Complete delivery handoff before source-memory
+evaluation; memory admission cannot delay, invalidate, or roll back closure.
+
+The Axiomatic Construction gate applies prospectively when selecting a new or
+successor Construction. A non-selecting route may consume a valid pre-feature
+v3 Construction lacking basis provenance, record that provenance as
+unavailable, and award it no basis proof. Any resulting mutation or selection
+requires fresh axiomatization and a successor Construction.
+
+## Fail closed
+
+Always block on stale or missing authority, Goal, Construction, or clean
+committed subject; unrelated dirty state before operation preparation; a
+successor commit whose parent, changed paths, scope, or cleanliness does not
+exactly realize the selected edit; a prospective material selection with a
+missing, stale, inconsistent, blocked, or unresolvedly underdetermined basis;
+an incumbent-independent marker without a frozen derivation and Universalist
+lowering; unresolved accepted or blocked Counterexamples; undispositioned
+material review accretion; incomplete proof or retirement; missing lineage; a
+public effect outside Ship; or any supporting skill, Ledger, or executor taking
+Actuating's semantic authority.
+
+For `final-closeout` `complete`, also block on stale or missing publication
+identity, CAS tuple mismatch, unresolved request-local recovery, fewer than five
+current-published-subject standard cleans, or missing required Ship evidence
+(`SHIP-v1` or `SHIP-ADOPTION-v1`).
+`ready-to-ship` requires neither publication nor review evidence.
+`local-implementation` `complete` requires neither and rejects them as
+inapplicable.

--- a/codex/skills/actuating/SKILL.md
+++ b/codex/skills/actuating/SKILL.md
@@ -1,558 +1,100 @@
 ---
 name: actuating
-description: "Turn accepted intent and review evidence into correct-by-construction software through Goal Contracts, Counterexample Sets, Construction Contracts, and an Evidence Ledger. Use bare $actuating for implementation, Ship publication, and review convergence; use explicit implement, triage, remediation-plan, or review-closeout for their bounded routes. Begin every architecture or abstraction decision with OPERATE ARCHITECTONICALLY, use $first-principles to establish the incumbent-independent Construction basis before $universalist nomination, and integrate one bounded $metanoetic pass when an initial high-regret nomination, accepted findings, causal recurrence, or cumulative review-path accretion makes abstraction change live. Before fresh review after repair, fold the cumulative changeset and review-induced delta so pointwise minimal repairs cannot compose into a dominated final Construction. Actuating alone selects the Construction and next action; Ledger is non-executing and Ship alone owns public effects."
+description: "Turn accepted intent and classified review evidence into correct-by-construction software through Goal Contracts, Counterexample Sets, Construction Contracts, and an Evidence Ledger. Use bare $actuating for implementation, publication, and review convergence; use explicit implement, triage, remediation-plan, or review-closeout for bounded routes. Actuating alone selects the Construction and next action; Ledger is non-executing and Ship alone owns public effects."
 ---
-
 # Actuating
 
-Turn accepted intent into a lawful construction, directly orchestrated effects,
-independent falsification, and an evidence-backed closure judgment.
+## Mission
+
+Turn accepted intent into one lawful Construction, one directly owned operation
+at a time, with independent falsification and evidence-backed closure.
 
 ## Authority kernel
 
-Use exactly four authoritative per-goal artifact families:
-
-1. `goal-contract/v3` — accepted semantics, authority, scope, compatibility,
-   laws, and acceptance, compiled by `$goal-contract`.
-2. `counterexample-set/v1` — classified witnessed falsifications, authored by
-   `$review-fold`.
-3. `construction-contract/v3` — the selected architecture, compared candidate
-   families, factor surfaces, supersession, proof obligations, preserved
-   observations, and retirements, authored by `$actuating` after an
-   Actuating-bound `$first-principles` basis, a `$universalist` nomination, and,
-   when required, one `$reduce` challenge.
-4. `actuating-evidence-event/v1` — append-only observations whose event bodies
-   retain their domain owners.
-
-The Goal Contract is the sole semantic-authority artifact. The Counterexample
-Set is the sole classified-bug artifact. The Construction Contract is the sole
-architecture-selection artifact. The Evidence Ledger is the sole mutable
-per-goal truth. Read [artifact-kernel.md](references/artifact-kernel.md).
-
-Plans, CAS receipts, Ship receipts, verifier output, work graphs, and Ledger
-projections are supporting evidence or discardable structural aids. An
-Actuating-authored closure receipt is a semantic report, not another authority
-family.
-
-## Owner boundary
-
-Actuating owns:
-
-- correct-by-construction implementation;
-- evaluation of current Counterexample classes against the current Construction;
-- initial and successor Construction selection;
-- repository-effect and review orchestration;
-- the clean committed Git subject used by local proof;
-- review-path accretion evaluation and pathwise-minimality disposition;
-- construction and ownership of the static Review Contract;
-- semantic evaluation of CAS owner facts and review credit;
-- the next legal action;
-- application of the closure theorem and authorship of its semantic receipt.
-
-`$review-fold` classifies witnessed facts before Actuating selects a repair.
-`$first-principles` establishes the admissible premise basis without revising
-the Goal. `$universalist` lowers the admissible derivation and nominates the
-essential boundary shape. When abstraction change is live, `$metanoetic`
-performs one bounded generative escalation and Universalist lowers every
-material result. `$reduce` may challenge nominated factors through congruent
-quotients, ablations, and recomposition. `$complexity-mitigator` may supply one
-read-only local normal-form preflight when review accretion is realization-only.
-
-The composition order is:
-
-~~~text
-activate
--> axiomatize once or retain the current basis
--> nominate
--> metanoetic once when triggered
--> lower
--> challenge once
--> adjudicate
-~~~
-
-Actuating alone performs adjudication. No supporting skill, review prose, plan,
-or Reduction Certificate selects a Construction, Repair Disposition, Review
-Accretion Disposition, operation, next action, or closure.
-
-Ledger may materialize, canonicalize, validate, append, replay, and emit
-requested disposable structural projections. Ledger never executes repository
-changes, invokes Git, evaluates CAS facts or review credit, interprets Ship,
-selects a repair or Construction, grants mutation, chooses the next action, or
-emits or authors semantic closure.
-
-Before the first Ledger command, load `$ledger` and complete `$ledger ensure`
-once. Require Ledger 1.x with `ledger-artifact-abi/v1`, Seq 1.x with
-`seq-observation-abi/v1`, and successful checks for every selected passive
-definition. Apply the same gate when entering from a standalone Goal Contract
-or Review Fold handoff. Construction v1 and v2 are unsupported; start a fresh
-v3 goal-local Evidence store rather than treating legacy data as current
-authority.
-
-`$ship` is the sole owner of public PR or tracker effects and Ship-owned
-publication evidence. Actuating supplies a current `ready-to-ship` proof and
-records Ship's returned receipt; it never performs the public effect or authors
-a substitute publication receipt itself.
-
-## Public modes
-
-| Intent | Route | Mutation | Terminal result |
-|---|---|---:|---|
-| Bare `$actuating` or `/goal $actuating` | implement -> Ship -> review-closeout | Authority-bound | `complete` |
-| `$actuating implement` | implementation only | Authority-bound | Local `complete` |
-| `$actuating triage` | acquire and classify review | Forbidden | Counterexample Set and report |
-| `$actuating remediation-plan` | propose a successor Construction | Forbidden | Non-executable Construction Contract |
-| `$actuating review-closeout` | repair, ablate, Ship when required, and re-review | Authority-bound | `complete` |
-
-An unqualified request to review, inspect, audit, or classify selects `triage`.
-Require explicit implement, fix, resolve, address, or closeout intent before
-mutation.
-
-## Architectonic decision gate
-
-At the beginning of every process that selects, preserves, changes, or ablates
-architecture or abstraction, and before Universalist nomination, state exactly:
-
-~~~text
-OPERATE ARCHITECTONICALLY
-~~~
-
-This is an activation instruction, not evidence, authority, or a receipt.
-
-## Axiomatic Construction gate
-
-Before the first Universalist nomination for each materially new candidate
-universe, invoke `$first-principles` with the current Goal fixed as the
-irreducible outcome and sole semantic authority. Bracket inherited repository
-abstractions, conventions, analogies, owner boundaries, rationale, and alleged
-constraints. Do not reopen Goal outcomes, laws, scope, compatibility,
-authority, acceptance, or proof posture.
-
-Inspect the incumbent only to establish observed facts, external obligations,
-and host enforcement capabilities. Freeze the incumbent-independent derivation
-before incumbent comparison, then record:
-
-~~~text
-Axiomatic Construction Basis
-Goal axioms:
-Observed facts:
-Necessary constraints:
-Chosen objectives:
-Irreducible postulates:
-Definitions:
-Derived claims:
-Rejected inherited premises:
-Governing invariants and causal mechanisms:
-Incumbent-independent derivation:
-Incumbent comparison:
-Basis status: sufficient | underdetermined | inconsistent | blocked
-Invalidators:
-Falsifier:
-~~~
-
-The basis is an ephemeral proof lease over exact Goal, fact, constraint, and
-host-capability inputs. It is not a fifth authority artifact and adds no
-Construction field. It expires at session end, compaction, or execution-context
-handoff and is never reconstructed from a materialized Construction. Within one
-uninterrupted run, a premise-neutral clean commit change may retain the basis
-while all inputs and invalidators remain current. Any later run or premise
-change re-axiomatizes before nomination or affected mutation.
-
-A `sufficient` basis admits nomination. `underdetermined` preserves every
-materially incomparable derivation and blocks if Goal law, observation, or
-dominance cannot distinguish them. `inconsistent` or `blocked` stops.
-`$first-principles` may expose a Goal conflict or missing authority, but it
-cannot rewrite the Goal, classify Counterexamples, select a Construction,
-grant mutation, or author a durable decision.
-
-Before authoring a successor Goal, project `goal-carry-forward-context` from the
-canonical Evidence store. Treat its retained Goal artifact as current and
-derive supporting references only from retained classes whose status is
-`accepted`, `blocked`, or `follow-up`. Never guess references, reconstruct the
-Goal from an older artifact, or read the event log directly. An unavailable or
-incomplete projection is an owner-side obstruction.
-
-When accepted or blocked Counterexamples remain unresolved, or a revision
-brings a `follow-up` class within scope, the successor Goal cites every Set
-carrying those classes. `$review-fold` then authors a successor Set that cites
-the successor Goal, preserves lineage, evaluates the predecessor Construction,
-and dispositions every carried class. No affected mutation or successor
-Construction selection occurs before that carry-forward is complete.
-
-## Metanoetic escalation
-
-For an initial Construction with no classified findings, invoke `$metanoetic`
-exactly once after the first Universalist nomination and before candidate
-adjudication when the nomination is high-regret or difficult to reverse,
-remains a coherent but merely adequate local optimum, and a materially
-different Construction is plausible. Initial implementation, architecture, or
-consequence alone is not a trigger.
-
-After `$review-fold` classifies findings, invoke `$metanoetic` exactly once when
-an accepted class:
-
-- makes `architecture-repair` or `ablation-repair` live;
-- challenges representation, owner, admitted domain, equivalence,
-  normalization, or information retention;
-- triggers causal recurrence; or
-- would add a validator, correlation, cache, bypass, compatibility branch, or
-  path-dependent recovery to reconstruct forgotten information;
-
-or when Review Accretion establishes material path dependence, accumulated
-semantic machinery, obsolete residue, proof accretion, inadequate ordinary
-normalization, or pathwise domination pressure.
-
-Record:
-
-~~~text
-Architectonic Escalation
-Trigger: initial-high-regret | accepted-class-abstraction | causal-recurrence | review-path-accretion
-Abstraction pressure:
-Metanoetic result: material-reframe | no-material-reframe | blocked
-Material frame, invariant, mechanism, or artifact:
-Universalist reclassification: retain | split | escalate | obstruct
-Candidate-family delta:
-Falsifier:
-~~~
-
-Compile material results into existing candidate comparison, factor surfaces,
-supersession, proof obligations, and falsifiers. Metanoetic neither classifies,
-nominates, selects, authorizes, nor closes. Do not repeat it for an unchanged
-decision surface.
-
-## Committed Git subject
-
-The durable Actuating subject is one clean Git commit target. Dirty index,
-worktree, untracked, and ignored state is provisional implementation state and
-never an Evidence subject.
-
-For Git, derive the subject exactly as:
-
-~~~text
-subject_digest = sha256(
-  "actuating-git-subject/v1" || 0x00 ||
-  repository_id || 0x00 ||
-  commit_oid || 0x00 ||
-  tree_oid
-)
-~~~
-
-Where:
-
-- `commit_oid = git rev-parse --verify HEAD^{commit}`;
-- `tree_oid = git rev-parse --verify HEAD^{tree}`;
-- `git status --porcelain=v2 --untracked-files=all --ignore-submodules=none`
-  is empty;
-- branch attachment is excluded from semantic identity;
-- ignored files are excluded because they are not candidates for the committed
-  artifact.
-
-Ledger stores and compares this opaque digest. It never invokes Git or derives
-the tuple. Ship separately binds repository, base and head refs, exact OIDs,
-and live publication readback.
-
-## Construction procedure
-
-1. Compile accepted source with `$goal-contract`. Require the canonical artifact,
-   non-null `artifact_id`, and applicable Goal registration event.
-2. Enter the Architectonic decision gate. Establish or retain the Axiomatic
-   Construction Basis. Apply Universalist at every changed or preserved
-   boundary. Complete one Metanoetic pass and re-lowering when a live trigger
-   exists.
-3. Compile exactly four candidate families in canonical order:
-   `realization-preserve`, `admitted-domain-restriction`,
-   `representation-or-owner-strengthening`, and `ablation-normalization`.
-   Factor every independent mandatory repair into one common obligation core;
-   vary only the disputed family delta. Give each candidate a factor inventory
-   and falsifier, mark at least one genuinely incumbent-independent, and select
-   exactly one.
-4. Challenge the nominated candidate once with `$reduce` when it adds or
-   preserves an independent semantic owner, parallel representation, bypass,
-   compatibility branch, semantic mechanism, or apparently dominated residue.
-   Record:
-
-   ~~~text
-   Repair Disposition
-   Law:
-   Owner:
-   Reduction: not-required | minimal | dominated | incomparable | essential-shape-gap | blocked
-   Route: delete | consolidate | edit | add
-   Why not smaller:
-   Falsifier:
-   ~~~
-
-   Choose the least additive lawful route. `add` explains why `delete`,
-   `consolidate`, and `edit` are insufficient.
-5. Adjudicate basis, nomination, escalation, and challenge. Select the smallest
-   non-dominated Construction satisfying every Goal law, make invalid states
-   unrepresentable where feasible, and name exact proof and retirement
-   obligations. Partition every predecessor and successor factor as preserved,
-   retired, introduced, or replaced.
-6. Materialize and register the selected Construction through Ledger. Only the
-   returned canonical artifact and appended registration event make it current.
-7. Require the repository to be at the exact clean committed subject before
-   preparing an operation.
-8. For each edit:
-
-   ~~~text
-   clean parent subject
-   -> prepare exact operation
-   -> one-seam-operator creates one provisional diff
-   -> Actuating inspects the complete diff and changed paths
-   -> Actuating commits exactly that operation
-   -> require one-parent clean successor
-   -> derive successor subject
-   -> record-effect parent -> successor
-   -> verify and falsify on the successor commit
-   ~~~
-
-   `one-seam-operator` never stages, commits, amends, pushes, or publishes.
-   Actuating rejects unrelated dirty state before preparation. The successor
-   commit has exactly one parent equal to the prepared parent, a nonempty commit
-   path set exactly equal to the selected operation, only allowed paths, and a
-   clean checkout. `effect_recorded` advances directly from the parent subject
-   in `pre_effect_subject_digest` to the successor subject in the event envelope.
-9. Run inspect, verifier, falsifier, and retirement operations only on an exact
-   clean commit. Require the checkout and subject to remain unchanged afterward.
-   Record immutable outputs through [evidence-ledger.md](references/evidence-ledger.md).
-10. Re-evaluate all current artifacts and observations. Select the next
-    operation, Ship handoff, review action, closure judgment, or blocker.
-
-The one-operation law is:
-
-~~~text
-select -> prepare -> effect -> commit -> record -> observe -> evaluate -> select or close
-~~~
-
-No stage may smuggle a second repository effect. A document, operation
-envelope, validator pass, Ledger append, review result, or Construction never
-grants mutation by itself. Mutation requires accepted authority, a current
-Construction, an exact clean committed subject, and an in-scope operation.
-
-## Goal-causal lineage
-
-Subject freshness and causal decision lineage are independent. A clean commit,
-publication, or other material subject change makes subject-bound proof,
-operations, review bindings, and review credit stale. It does not erase prior
-Construction decisions or Counterexample history for the same `goal_id`.
-
-Only the first Construction in the authoritative v3 lineage may use
-`mode: initial` with no predecessor. Every later Construction names the exact
-current Construction as its sole predecessor, including after a successor Goal
-or clean subject rebind.
-
-Before accepting a new Counterexample Set, resolve prior Sets for the Goal.
-When a stable class recurs, require the new Set to name the most recent Set
-carrying it. Missing lineage blocks and does not make the class novel.
-
-## Counterexample and causal recurrence procedure
-
-Every witnessed bug, failing test, incident, compatibility failure, or review
-finding passes through `$review-fold`. Actuating then determines whether each
-accepted class is:
-
-- a realization defect;
-- an architecture defect requiring a successor Construction;
-- an ablation defect requiring dominated-residue removal; or
-- blocked by missing authority or evidence.
-
-Re-establish the current-run basis before choosing an affected repair. If a
-finding falsifies a premise or makes architecture/ablation live, re-axiomatize,
-run the bounded Metanoetic pass, lower through Universalist, and compare the
-successor candidates before selecting an operation.
-
-The causal recurrence gate triggers when one accepted class recurs after repair
-or two accepted classes across subject revisions share an evidenced missing
-observation, authority, correlation, or Construction factor. Similar files,
-prose, diff size, or timing do not establish shared cause.
-
-Record:
-
-~~~text
-Causal Recurrence Disposition
-Evidence and class refs:
-Shared cause:
-Current Construction factor:
-Candidate comparison: realization preserve / admitted-domain restriction / representation strengthening / ablation normalization
-Disposition: instance-specific | architecture-repair | ablation-repair | blocked
-Why another local repair is sufficient or forbidden:
-Proof:
-Falsifier:
-~~~
-
-A recurring cluster makes abstraction change live and invalidates the prior
-candidate universe. `instance-specific` requires non-example separation proof.
-Otherwise select architecture/ablation repair or block. Do not add another
-validator that recreates information the representation repeatedly forgets.
-
-## Review accretion
-
-A sequence of pointwise least-additive repairs may compose into a globally
-dominated realization. After every review-driven mutation epoch and before the
-next Ship handoff or fresh review, apply the
-[Review Accretion Gate](references/review-accretion.md). Apply it again before
-final closeout when mutation occurred after the last disposition.
-
-Bind the exact delivery baseline, review-entry committed subject, and current
-committed subject. Keep the review-entry anchor across campaigns, publication
-epochs, review-credit resets, subject rebinding, and successor Constructions for
-the same closeout objective. Fold the complete delivery and review-induced
-commit deltas, Construction and Counterexample lineage, and cumulative
-production, semantic, proof, and comprehension surfaces. Line count, file
-count, elapsed time, and repair count force inspection only.
-
-First derive the ordinary cumulative normal form. Use one read-only
-`$complexity-mitigator` Micro Preflight when the architecture and factor
-inventory remain sufficient. When representation, owner, admitted domain,
-equivalence, information retention, or boundary may be insufficient, retain or
-re-establish the basis and require Universalist to nominate the ordinary
-repository-native normal form.
-
-When the fold establishes material path dependence, accumulated semantic
-machinery, obsolete residue, proof accretion, inadequate ordinary
-normalization, or pathwise domination, run Metanoetic with
-`Trigger: review-path-accretion`, lower the result, challenge it once with
-Reduce, and adjudicate.
-
-Select exactly one disposition: `preserve`, `realization-normalization`,
-`ablation-repair`, `architecture-repair`, or `blocked`. Any material repair
-creates a new committed review subject and resets all review credit. Compile
-material results into existing Construction factors, supersession, proof
-obligations, and retirements. Add no artifact family, mutable control state,
-review lens, or Ledger/Seq/CAS accretion command.
-
-## Review convergence
-
-`$first-principles`, Review Accretion, and Metanoetic are Construction-selection
-passes, not review lenses. Preserve the static topology of standard plus the
-existing four auxiliaries.
-
-Before binding or dispatching closure-grade review, require:
-
-~~~bash
-cas app-server preflight --cwd <repo> --profile review \
-  --app-server-transport managed-ws --json
-
-cas_codex_0146_structured_review_v1=true
-cas_workflow_bound_owner_lived_review_v1=true
-~~~
-
-The first receipt must be `compatible` for the exact resolved Codex runtime,
-contract, and `managed-ws` transport with every required probe passed. The two
-features come from `cas capabilities --json`. Any missing runtime or compiled
-capability proof blocks before request binding or `review/start`.
-
-Bind standard plus four auxiliary requests before dispatch. Launch the initial
-1+4 wave as five concurrent owner-lived:
-
-~~~text
-cas review start --wait --timeout-ms 2700000
-~~~
-
-processes, one per request, and retain each process through a structured
-terminal receipt or explicit terminal owner failure. Do not split a
-workflow-bound attempt into detached `start` and unrelated `wait`. Never cancel
-a sibling because another request finds a defect or loses transport.
-
-A verdictless terminal failure earns zero credit and reruns only that request
-once on the same committed subject with a fresh attempt. Preserve completed
-siblings and standard clean credit on the unchanged subject. Count the initial
-wave's standard clean as attempt one, run four later standard attempts
-serially, and require five consecutive distinct standard cleans. Any committed
-subject change resets all review credit and requires a fresh 1+4 wave.
-
-Publication-bearing review uses Ship-confirmed remote identity. For a current
-PR, use `SHIP-v1`; for a new adoption route, record a read-only
-`SHIP-OBSERVATION-v1` pre-review publication observation before binding or
-dispatching the campaign. Map the exact published target to
-`cas review --base <immutable-base-sha>` and require every receipt's
-`baseSha`, `headSha`, and target fingerprint to equal Ship readback. Never use
-`--uncommitted` for a published PR. `--commit HEAD` is sufficient only when one
-commit is the complete bound PR delta.
-
-Actuating evaluates CAS owner receipts and review credit. Ledger may record
-receipt references and project structural history, but never dispatches CAS or
-translates CAS fields into semantic verdicts.
-
-## Publication and closure
-
-Bare mode and publication-bearing review closeout hand a current
-`ready-to-ship` proof to `$ship`. Ship either pushes the exact clean verified
-commit and creates or updates its PR, returning `SHIP-v1`, or read-only adopts
-an exact already-public subject that has no truthful current PR tuple, returning
-`SHIP-ADOPTION-v1`. Both routes exact-match the repository, base/head refs and
-OIDs, complete actuation binding, and route-specific live readback. Actuating
-must not substitute its own live-readback record.
-
-Ship evidence precedes review. For a new campaign, a later
-`SHIP-ADOPTION-v1` does not reset review credit merely because the adoption
-receipt was recorded later when it ratifies the exact `SHIP-OBSERVATION-v1`
-digest that Actuating recorded before the credited campaign. The observation, adoption, and every credited CAS
-receipt must exact-match the repository, canonical head ref, base/head tuple,
-subject, current default-branch state, Goal, Construction, and review contract
-through the observation's `review_binding`. That binding is the exact named
-Goal/Construction/subject/review-contract projection of Ship's validated
-actuation binding; it is not a second authority.
-The final adoption carries its own current actuation binding. The
-`publication-review-events` projection exposes exact ordered publication and
-campaign event rows without interpreting them. Evidence Ledger
-order from the recorded Ship observation to campaign binding proves causality;
-never compare provider and Ledger wall clocks. Otherwise the review credit is
-stale. The reducer admits exactly one campaign-start occurrence for the current
-Goal, Construction, subject, and Review Contract and binds every request to
-that occurrence. The pre-review observation proves the exact reviewed bytes
-were public before that occurrence; ratification exact-matches its stable tuple
-while final adoption freshly re-reads the same live default branch. Neither
-endpoint comparison nor ratification claims intermediate branch continuity.
-
-For a historical campaign that predates `SHIP-OBSERVATION-v1`, adoption may
-instead carry provider-backed publication evidence for the exact target.
-Actuating preserves review credit only when a content-addressed causal-order
-observation binds that exact provider event to the exact campaign start and
-shows the publication operation completed first. The supporting attachment is
-`actuating-publication-campaign-causality/v1`, owned and issued by Actuating
-after it validates one exact Seq observation, successful call lifecycles, and
-`publication.finalized_line < campaign.declared_line`. Matching endpoints, an
-arbitrary older event, or a comparison between independent wall clocks is not
-such proof. This attachment does not alter CAS receipts or create a new
-authority artifact.
-A non-null adopted release also requires its provider to match the branch
-readback provider,
-its repository to match the adopted repository, its state to be published and
-non-draft, its resolved tag
-target to equal the subject head, and its uniquely named assets to have equal
-cardinality and exact set equality with the complete live provider inventory.
-Release assets added after review are separate publication
-evidence and do not rewrite review time.
-
-Apply [closure.md](references/closure.md) only to current artifacts and
-observations. Actuating authors `actuating-closure-receipt/v1`; Ledger neither
-emits the verdict nor authors the receipt. `$proof-patch` may render a complete
-result but cannot decide it. Complete delivery handoff before source-memory
-evaluation; memory admission cannot delay, invalidate, or roll back closure.
-
-The Axiomatic Construction gate applies prospectively when selecting a new or
-successor Construction. A non-selecting route may consume a valid pre-feature
-v3 Construction lacking basis provenance, record that provenance as
-unavailable, and award it no basis proof. Any resulting mutation or selection
-requires fresh axiomatization and a successor Construction.
-
-## Fail closed
-
-Always block on stale or missing authority, Goal, Construction, or clean
-committed subject; unrelated dirty state before operation preparation; a
-successor commit whose parent, changed paths, scope, or cleanliness does not
-exactly realize the selected edit; a prospective material selection with a
-missing, stale, inconsistent, blocked, or unresolvedly underdetermined basis;
-an incumbent-independent marker without a frozen derivation and Universalist
-lowering; unresolved accepted or blocked Counterexamples; undispositioned
-material review accretion; incomplete proof or retirement; missing lineage; a
-public effect outside Ship; or any supporting skill, Ledger, or executor taking
-Actuating's semantic authority.
-
-For `final-closeout` `complete`, also block on stale or missing publication
-identity, CAS tuple mismatch, unresolved request-local recovery, fewer than five
-current-published-subject standard cleans, or missing required Ship evidence
-(`SHIP-v1` or `SHIP-ADOPTION-v1`).
-`ready-to-ship` requires neither publication nor review evidence.
-`local-implementation` `complete` requires neither and rejects them as
-inapplicable.
+Use exactly four authoritative per-goal families:
+
+```text
+goal-contract/v3          accepted semantics, authority, scope, laws, proof bar
+counterexample-set/v1     classified witnessed falsifications
+construction-contract/v3 selected architecture, owners, obligations, retirements
+evidence-ledger           current observations bound to the exact subject
+```
+
+Supporting views, plans, work graphs, review receipts, and proof summaries do not
+become peer authority.
+
+## Routes
+
+Choose exactly one current route:
+
+```text
+implement          realize the current Construction
+triage             classify new pressure before mutation
+remediation-plan   select a successor Construction without editing
+review-closeout    converge review, publication, and final closure
+```
+
+Bare `$actuating` may traverse the routes required by the accepted goal. An
+explicit bounded route must not silently widen itself.
+
+## Common loop
+
+1. Bind the current Goal, Construction, subject identity, evidence head, and
+   applicable Counterexample Sets.
+2. Recompute the current frontier; cached plans or node state do not authorize
+   continuation.
+3. When architecture or abstraction is live:
+   - **OPERATE ARCHITECTONICALLY**;
+   - use `$first-principles` to establish the incumbent-independent basis;
+   - obtain a bounded `$universalist` nomination;
+   - use one bounded `$metanoetic` pass only for a high-regret initial
+     nomination, causal recurrence, accepted structural findings, or cumulative
+     review-path accretion.
+4. Actuating selects exactly one current Construction and one bounded operation.
+5. Execute through the owning implementation surface.
+6. Record current evidence, classify any new falsifier through `$review-fold`,
+   and fold the cumulative changeset before fresh review.
+7. Replace the Construction rather than stacking local repairs when accepted
+   findings share an owner, law, or cause.
+8. Close only from current subject-bound proof; otherwise continue, regress,
+   block, or ask for the missing authority.
+
+Before fresh review after repair, evaluate the whole cumulative delta. Pointwise
+small fixes must not compose into a dominated final Construction.
+
+## Public effects and closure
+
+`$ship` alone creates or updates public publication state. Actuating decides
+whether the current goal is ready to hand to Ship and whether returned
+publication evidence satisfies the Goal.
+
+Local implementation completion is not final closeout. Review convergence,
+required publication, retirements, and residual blockers remain route-specific.
+
+## Conditional disclosure
+
+The complete pre-split contract is preserved byte-for-byte in
+[FULL_CONTRACT.md](FULL_CONTRACT.md). Do not load it for a bounded ordinary
+implementation operation.
+
+Load it when exact detail is required for:
+
+- artifact schemas, identities, Ledger definitions, or transaction commands;
+- Construction candidate comparison and supersession;
+- WorkGraph compilation or multi-owner decomposition;
+- CAS review topology, clean-streak accounting, or recovery;
+- cumulative review-delta folding and refactor-kernel triggers;
+- Ship handoffs, adoption, publication evidence, or closure receipts;
+- an unported edge route.
+
+Its frontmatter is archived source, not a second skill definition.
+
+## Guardrails
+
+- No mutation without current Goal authority and a selected Construction.
+- No raw review comment becomes work before `$review-fold` classifies it.
+- No helper, plan, graph, reviewer, or subagent selects the next action.
+- No passing command, queued review, or successful publication mutation proves
+  goal closure by itself.
+- Prefer deletion, owner repair, and shared-cause correction over wound-specific
+  accretion.


### PR DESCRIPTION
## What changed

- Preserve the complete pre-split `$actuating` contract byte-for-byte in `FULL_CONTRACT.md`.
- Keep only the four authoritative artifact families, route selection, architectonic sequence, one-operation loop, publication boundary, and closure laws always loaded.
- Load exact schemas, Ledger commands, WorkGraph mechanics, CAS review topology, cumulative-delta detail, Ship adoption, and closure receipts only when those routes are active.

## Why

`$actuating` contained common implementation control, every specialist route, and every artifact/transport detail in one kernel. That made a bounded implementation operation pay for review-closeout, publication, and recovery machinery.

## Impact

The common control loop remains complete and authority-preserving. All existing detailed doctrine remains intact on demand.

## Validation

- Original `SKILL.md` blob preserved unchanged as `FULL_CONTRACT.md`.
- New kernel is 100 lines.
- Change is isolated to `codex/skills/actuating`.