### PR TITLE
negative-ledger: keep route gating lightweight

### DIFF
--- a/codex/skills/negative-ledger/FULL_CONTRACT.md
+++ b/codex/skills/negative-ledger/FULL_CONTRACT.md
@@ -1,0 +1,351 @@
+---
+name: negative-ledger
+description: "Implicitly invoke when implementation, debugging, review, or validation encounters a witnessed failed/no-effect attempt, benchmark or test regression, revert, repeated same-cluster retry, abandoned strategy, or asks what has already been tried. Project the route gate before repeating a route; transact only inspectable decision-shaping negative evidence through the passive Negative Evidence definition; reopen only after proved applicability changes; selectively admit complete projections to Codex memory."
+metadata:
+  version: "8.1.0"
+---
+
+# Negative Ledger
+
+## Mission
+
+Prune semantic search space without turning stale failures into permanent dogma.
+
+The structural boundary is the passive definition:
+
+```text
+${CODEX_HOME:-$HOME/.codex}/skills/negative-ledger/definitions/ledger/negative-evidence-protocol.json
+```
+
+The selected definition exclusively addresses the canonical store at
+`.ledger/negative-ledger/events.jsonl`, and every operation or projection is
+explicit.
+
+The memory-admission channel is:
+
+```text
+~/.codex/memories/extensions/negative-ledger/notes/*.md
+```
+
+`$negative-ledger` owns the meaning and lifecycle of current negative-evidence
+state. Ledger structurally replays the declared protocol and projects that
+state without acquiring its semantic authority. `memory-note` transports an
+immutable projection to Phase 2. Phase 2 decides whether to compile a route
+constraint, routing trigger, or reusable memory skill.
+
+Never use memory notes as the operational route gate. For accepted admission, load `$memory-source-notes` before invoking `run_memory_note_tool`.
+
+## Trigger Cues
+
+- `$negative-ledger`;
+- failed attempts, no-effect attempts, reverts, benchmark or test regressions;
+- repeated semantic routes or same-cluster retries;
+- strategy pivots that abandon a concrete route future work might repeat;
+- "what have we already tried?";
+- "do not retry this route";
+- route reopening after artifact-state changes;
+- fixed-point or review-governor negative evidence;
+- memory admission of an active/stale/reopened/superseded `NEG-*` projection.
+
+## Activation Policy
+
+Activation is broad; capture is narrow.
+
+Invoke this skill implicitly when current work may change route selection because a concrete route failed, had no effect, regressed a signal, was reverted, was rejected by current proof/review evidence, or is about to be retried under the same cluster. Do not wait for the user to literally name `$negative-ledger`.
+
+Before selecting a route that resembles a prior failure, project the canonical
+`route-gate`. A recalled `$learnings` row may trigger this check, but it cannot
+block directly.
+
+After a material strategy pivot, regression-confirmed revert, or closeout that leaves a failed route likely to recur, evaluate capture. A transient red test, syntax error, first incomplete implementation, or discarded local typo is `no-op` unless it exposes a durable failed hypothesis that changes future routing.
+
+Retain exactly one internal disposition for each material activation:
+
+```text
+mapped       current ledger checked; no write required
+captured     witnessed negative evidence appended
+transitioned existing NEG record changed lifecycle state
+no-op        activation evaluated; evidence was not durable or route-shaping
+blocked      ledger unavailable/invalid or active exact/applicable exclusion matched
+```
+
+A material closeout with no failed-route semantics does not activate this
+source. Do not query, doctor, or capture merely to manufacture a no-op receipt.
+
+## Canonical Store and CLI
+
+Before the first Ledger command in this workflow, load `$ledger` and complete
+`$ledger ensure` once. Require Ledger major version 1 and
+`ledger-artifact-abi/v1`:
+
+```bash
+ledger version
+ledger capabilities --format json
+```
+
+Set the canonical definition once:
+
+```bash
+negative_ledger_definition="$(realpath "${CODEX_HOME:-$HOME/.codex}/skills/negative-ledger/definitions/ledger/negative-evidence-protocol.json")"
+```
+
+Use only:
+
+```text
+ledger definition check --definition DEFINITION
+ledger transact --definition DEFINITION --operation capture|promote|transition|bind-existing --repo REPO
+ledger project --definition DEFINITION --projection current-records|route-gate|memory-note --repo REPO
+ledger doctor --definition DEFINITION --repo REPO
+```
+
+`ledger project --projection memory-note` is the authoritative source payload
+for memory admission. Never reconstruct it from a summary projection.
+
+Bind a pre-cutover current-format store exactly once before ordinary reads or
+writes. This validates every existing row and records the selected definition
+digest without rewriting the event log:
+
+```bash
+ledger transact \
+  --definition "$negative_ledger_definition" \
+  --operation bind-existing \
+  --repo "<repo-root>" \
+  --format json
+```
+
+## Valid Statuses
+
+```text
+capture_candidate
+need-evidence
+unknown
+active
+accepted_risk
+stale
+reopened
+superseded
+```
+
+Only `active` can block, and only when witness evidence exists, exclusion scope is valid, applicability still matches the current artifact state, and the route/cluster match is exact enough for the declared scope.
+
+Fuzzy or lexical overlap is suggest-only.
+
+## Route-Gate Workflow
+
+For review-driven repair, apply the owner boundary in
+[counterexample-construction-integration.md](references/counterexample-construction-integration.md).
+
+1. Identify `repository_id`, immutable `artifact_state_id`, human-readable `artifact_state_label`, route, cluster, declared scope, target signal, and changed surface.
+2. Run:
+
+   ```bash
+   ledger project \
+     --definition "$negative_ledger_definition" \
+     --projection route-gate \
+     --repo "<repo-root>" \
+     --param "artifact=<artifact-state-id>" \
+     --param "identity=<declared-scope-identity>" \
+     --format json
+   ```
+
+3. Interpret exit codes: `0` no active exact exclusion, `2` active exact/applicable exclusion, `3` ledger unavailable or invalid.
+4. Pass the identity selected by the record's declared exact, route, route-family, cluster, authority-model, distinction-pattern, or proof-pattern scope.
+5. Treat fuzzy candidates as search hints only.
+6. Re-check current applicability before route suppression.
+7. Resolve symbolic Git refs before the call, pass the immutable identity as `artifact`, and retain the human-readable source as `artifact_state_label` in capture data.
+
+## Capture Workflow
+
+Capture only when a failure changes future routing: witnessed no-effect attempt, local/global regression, unsound route, complexity disproportionate to value, revert with concrete rationale, repeated proof-wound pattern, or a strategy pivot whose abandoned route would otherwise be retried.
+
+Append only through:
+
+```bash
+ledger transact \
+  --definition "$negative_ledger_definition" \
+  --operation capture \
+  --repo "<repo-root>" \
+  --input capture=capture.json \
+  --format json
+```
+
+Captures without adequate witness evidence must become `need-evidence` or `capture_candidate`, never active exclusions.
+
+`capture.json` contains one `record` object, including its requested initial
+`status`. An active capture requires an explicit supported scope and its
+identity, an immutable artifact identity, structured source references,
+applicability conditions, a narrow exclusion rule, and identified reopening
+criteria. Select `need-evidence` before transaction when those structural
+requirements are incomplete; never assert `active` in prose after Ledger
+rejects it.
+
+Every transition to `active`, including promotion, reactivation, and
+reopening, requires the transition proof plus the complete replacement record,
+whose `status` is `active`. Use the dedicated operation so the event atomically
+replaces the reducer's retained record:
+
+```bash
+ledger transact \
+  --definition "$negative_ledger_definition" \
+  --operation promote \
+  --repo "<repo-root>" \
+  --input promotion=promotion.json \
+  --format json
+```
+
+## Lifecycle Transitions
+
+Use append-only status events. Every transition requires a JSON proof packet with a reason and structured source references:
+
+```json
+{
+  "neg_id": "NEG-000001",
+  "from": "active",
+  "to": "accepted_risk",
+  "reason": "The prior evidence was accepted as a bounded risk.",
+  "criterion_ids": [],
+  "criterion_changes": [],
+  "source_refs": [
+    {"kind": "review", "ref": "PR 123 acceptance"}
+  ]
+}
+```
+
+```bash
+ledger transact \
+  --definition "$negative_ledger_definition" \
+  --operation transition \
+  --repo "<repo-root>" \
+  --input transition=transition.json \
+  --format json
+```
+
+Reopening requires a proved before/after change for an identified criterion already present on the record:
+
+```json
+{
+  "neg_id": "NEG-000001",
+  "from": "stale",
+  "to": "reopened",
+  "reason": "The implementation and representative fixture changed.",
+  "criterion_ids": ["artifact-or-fixture-changed"],
+  "criterion_changes": [
+    {
+      "criterion_id": "artifact-or-fixture-changed",
+      "before": "commit abc123 with fixture v1",
+      "after": "commit def456 with fixture v2"
+    }
+  ],
+  "source_refs": [
+    {"kind": "git", "ref": "commit:def456"},
+    {"kind": "test", "ref": "zig build test-ledger --summary all"}
+  ]
+}
+```
+
+```bash
+ledger transact \
+  --definition "$negative_ledger_definition" \
+  --operation transition \
+  --repo "<repo-root>" \
+  --input transition=reopen-proof.json \
+  --format json
+```
+
+Ledger rejects illegal edges, promotion without a complete active record,
+unknown criteria, and unchanged before/after claims before append.
+
+Never rewrite old events.
+
+## Memory Admission Gate
+
+A negative-ledger source note is allowed only when:
+
+1. a canonical `NEG-*` record exists;
+2. definition-bound `ledger doctor` passes;
+3. `ledger project --projection memory-note --param id=NEG-ID` returns a complete current projection;
+4. projection includes witness, applicability, narrow exclusion, and reopening criteria when status is active;
+5. the record is likely to matter in future related work;
+6. the note embeds the full bounded projection, stable repository identity, event-chain fingerprint, projection fingerprint, and any prior projection link.
+
+Do not admit prose-only negative-evidence claims, unpromoted `learnings` hits,
+partial `current-records` output, every `need-evidence` candidate, or stale
+history with no future routing value.
+
+## Admission Workflow
+
+After the source owner accepts admission for a capture or lifecycle transition,
+load `$memory-source-notes` and use the validated Negative Ledger adapter:
+
+```bash
+uv run codex/skills/memory-source-notes/scripts/negative_ledger_memory_note.py \
+  admit \
+  --id NEG-000001 \
+  --kind ledger-projection
+```
+
+For a status transition:
+
+```bash
+uv run codex/skills/memory-source-notes/scripts/negative_ledger_memory_note.py \
+  admit \
+  --id NEG-000001 \
+  --kind ledger-status-transition
+```
+
+The adapter runs the definition-bound doctor, obtains the source-owned
+projection, rejects incomplete projections, preserves the deterministic
+projection payload bytes, and invokes `memory-note` idempotently. It transports
+an accepted source decision; it does not decide recurrence, utility, or route
+applicability.
+
+If the definition projection is unavailable, preserve the canonical Ledger transaction and report:
+
+```text
+memory-note: not-attempted: ledger projection unavailable
+```
+
+Do not reconstruct an authoritative projection from memory or prose.
+
+## Proof Lines
+
+Canonical write:
+
+```text
+ledger-capture: neg_id=NEG-... status=active
+ledger-status: neg_id=NEG-... status=stale
+ledger-capture: not-attempted: evidence not durable enough
+```
+
+Memory admission:
+
+```text
+memory-note: id=MSN-... extension=negative-ledger kind=ledger-projection status=created
+memory-note: not-attempted: ledger projection unavailable
+memory-note: not-attempted: source admission gate not met
+memory-note: not-attempted: cli unavailable
+```
+
+Report both layers separately.
+
+## Learnings Relationship
+
+The learning source is historical candidate evidence, not the route-exclusion
+store. Legacy `.ledger/learnings/learnings.jsonl` and `.learnings.jsonl` are
+read only during migration. Verify current applicability and promote
+qualifying evidence through the definition's `capture` transaction.
+
+## Guardrails
+
+- Do not record vibes as negative evidence.
+- Do not convert one failed implementation into a broad strategy ban.
+- Do not block from fuzzy matches.
+- Do not use stale benchmarks without current applicability reasoning.
+- Do not treat absence of a ledger entry as novelty proof.
+- Do not bypass Ledger or hand-edit persistent-adapter records.
+- Do not let memory notes outrank the repo-local ledger.
+- Do not write compiled memory directly.
+- Do not publish incomplete projections to Phase 2.
+- Do not capture every transient test failure merely because implicit activation occurred.
+- Do not bypass failed `route-gate`, `memory-note`, or doctor projections; those boundaries must fail closed.
+- Do not invoke a sibling source merely because Negative Ledger activated.

--- a/codex/skills/negative-ledger/SKILL.md
+++ b/codex/skills/negative-ledger/SKILL.md
@@ -1,351 +1,85 @@
 ---
 name: negative-ledger
-description: "Implicitly invoke when implementation, debugging, review, or validation encounters a witnessed failed/no-effect attempt, benchmark or test regression, revert, repeated same-cluster retry, abandoned strategy, or asks what has already been tried. Project the route gate before repeating a route; transact only inspectable decision-shaping negative evidence through the passive Negative Evidence definition; reopen only after proved applicability changes; selectively admit complete projections to Codex memory."
+description: "Implicitly invoke when implementation, debugging, review, or validation encounters a witnessed failed or no-effect attempt, regression, revert, repeated same-cluster retry, abandoned strategy, or asks what has already been tried. Project the canonical route gate before repeating a route; capture only inspectable decision-shaping negative evidence; reopen only after proved applicability changes."
 metadata:
   version: "8.1.0"
 ---
-
 # Negative Ledger
 
 ## Mission
 
 Prune semantic search space without turning stale failures into permanent dogma.
 
-The structural boundary is the passive definition:
+Activation is broad. Capture and blocking are narrow.
+
+## Always-live route gate
+
+Before selecting a route that resembles a prior failure:
+
+1. Bind immutable current artifact identity and the proposed route, family,
+   cluster, authority model, distinction pattern, or proof pattern.
+2. Project the canonical `route-gate`.
+3. Block only on an `active`, witnessed, exact-enough, currently applicable
+   exclusion.
+4. Treat fuzzy or lexical overlap as a search hint, never a block.
+5. Recheck applicability whenever artifact state or governing criteria changed.
+
+A recalled `$learnings` row may trigger the check but cannot block directly.
+
+## Capture gate
+
+Capture only when the observed failure changes future route selection:
 
 ```text
-${CODEX_HOME:-$HOME/.codex}/skills/negative-ledger/definitions/ledger/negative-evidence-protocol.json
+witnessed no-effect attempt
+local or global regression
+unsound route
+complexity disproportionate to value
+revert with concrete rationale
+repeated proof-wound pattern
+abandoned strategy likely to recur
 ```
 
-The selected definition exclusively addresses the canonical store at
-`.ledger/negative-ledger/events.jsonl`, and every operation or projection is
-explicit.
+A transient red test, typo, or first incomplete implementation is normally a
+no-op.
 
-The memory-admission channel is:
+Retain one disposition:
 
 ```text
-~/.codex/memories/extensions/negative-ledger/notes/*.md
+mapped | captured | transitioned | no-op | blocked
 ```
 
-`$negative-ledger` owns the meaning and lifecycle of current negative-evidence
-state. Ledger structurally replays the declared protocol and projects that
-state without acquiring its semantic authority. `memory-note` transports an
-immutable projection to Phase 2. Phase 2 decides whether to compile a route
-constraint, routing trigger, or reusable memory skill.
+Only `active` can block. Incomplete evidence becomes `need-evidence` or
+`capture_candidate`, never an asserted exclusion.
 
-Never use memory notes as the operational route gate. For accepted admission, load `$memory-source-notes` before invoking `run_memory_note_tool`.
+## Lifecycle law
 
-## Trigger Cues
+Reopening or reactivation requires a proved before/after change for a criterion
+already owned by the record. Append lifecycle events; never rewrite history.
+Keep `accepted_risk`, `stale`, `reopened`, and `superseded` distinct from
+`active`.
 
-- `$negative-ledger`;
-- failed attempts, no-effect attempts, reverts, benchmark or test regressions;
-- repeated semantic routes or same-cluster retries;
-- strategy pivots that abandon a concrete route future work might repeat;
-- "what have we already tried?";
-- "do not retry this route";
-- route reopening after artifact-state changes;
-- fixed-point or review-governor negative evidence;
-- memory admission of an active/stale/reopened/superseded `NEG-*` projection.
+## Conditional disclosure
 
-## Activation Policy
+The complete pre-split contract is preserved byte-for-byte in
+[FULL_CONTRACT.md](FULL_CONTRACT.md). Do not load it for an ordinary route-gate
+projection or no-op capture decision.
 
-Activation is broad; capture is narrow.
+Load it only for:
 
-Invoke this skill implicitly when current work may change route selection because a concrete route failed, had no effect, regressed a signal, was reverted, was rejected by current proof/review evidence, or is about to be retried under the same cluster. Do not wait for the user to literally name `$negative-ledger`.
+- exact definition, doctor, bind, route-gate, capture, promote, or transition
+  commands;
+- status schemas, scope identities, witness packets, and reopening JSON;
+- review/Construction integration;
+- memory-admission adapters, projection completeness, and supersession;
+- an unported edge route.
 
-Before selecting a route that resembles a prior failure, project the canonical
-`route-gate`. A recalled `$learnings` row may trigger this check, but it cannot
-block directly.
-
-After a material strategy pivot, regression-confirmed revert, or closeout that leaves a failed route likely to recur, evaluate capture. A transient red test, syntax error, first incomplete implementation, or discarded local typo is `no-op` unless it exposes a durable failed hypothesis that changes future routing.
-
-Retain exactly one internal disposition for each material activation:
-
-```text
-mapped       current ledger checked; no write required
-captured     witnessed negative evidence appended
-transitioned existing NEG record changed lifecycle state
-no-op        activation evaluated; evidence was not durable or route-shaping
-blocked      ledger unavailable/invalid or active exact/applicable exclusion matched
-```
-
-A material closeout with no failed-route semantics does not activate this
-source. Do not query, doctor, or capture merely to manufacture a no-op receipt.
-
-## Canonical Store and CLI
-
-Before the first Ledger command in this workflow, load `$ledger` and complete
-`$ledger ensure` once. Require Ledger major version 1 and
-`ledger-artifact-abi/v1`:
-
-```bash
-ledger version
-ledger capabilities --format json
-```
-
-Set the canonical definition once:
-
-```bash
-negative_ledger_definition="$(realpath "${CODEX_HOME:-$HOME/.codex}/skills/negative-ledger/definitions/ledger/negative-evidence-protocol.json")"
-```
-
-Use only:
-
-```text
-ledger definition check --definition DEFINITION
-ledger transact --definition DEFINITION --operation capture|promote|transition|bind-existing --repo REPO
-ledger project --definition DEFINITION --projection current-records|route-gate|memory-note --repo REPO
-ledger doctor --definition DEFINITION --repo REPO
-```
-
-`ledger project --projection memory-note` is the authoritative source payload
-for memory admission. Never reconstruct it from a summary projection.
-
-Bind a pre-cutover current-format store exactly once before ordinary reads or
-writes. This validates every existing row and records the selected definition
-digest without rewriting the event log:
-
-```bash
-ledger transact \
-  --definition "$negative_ledger_definition" \
-  --operation bind-existing \
-  --repo "<repo-root>" \
-  --format json
-```
-
-## Valid Statuses
-
-```text
-capture_candidate
-need-evidence
-unknown
-active
-accepted_risk
-stale
-reopened
-superseded
-```
-
-Only `active` can block, and only when witness evidence exists, exclusion scope is valid, applicability still matches the current artifact state, and the route/cluster match is exact enough for the declared scope.
-
-Fuzzy or lexical overlap is suggest-only.
-
-## Route-Gate Workflow
-
-For review-driven repair, apply the owner boundary in
-[counterexample-construction-integration.md](references/counterexample-construction-integration.md).
-
-1. Identify `repository_id`, immutable `artifact_state_id`, human-readable `artifact_state_label`, route, cluster, declared scope, target signal, and changed surface.
-2. Run:
-
-   ```bash
-   ledger project \
-     --definition "$negative_ledger_definition" \
-     --projection route-gate \
-     --repo "<repo-root>" \
-     --param "artifact=<artifact-state-id>" \
-     --param "identity=<declared-scope-identity>" \
-     --format json
-   ```
-
-3. Interpret exit codes: `0` no active exact exclusion, `2` active exact/applicable exclusion, `3` ledger unavailable or invalid.
-4. Pass the identity selected by the record's declared exact, route, route-family, cluster, authority-model, distinction-pattern, or proof-pattern scope.
-5. Treat fuzzy candidates as search hints only.
-6. Re-check current applicability before route suppression.
-7. Resolve symbolic Git refs before the call, pass the immutable identity as `artifact`, and retain the human-readable source as `artifact_state_label` in capture data.
-
-## Capture Workflow
-
-Capture only when a failure changes future routing: witnessed no-effect attempt, local/global regression, unsound route, complexity disproportionate to value, revert with concrete rationale, repeated proof-wound pattern, or a strategy pivot whose abandoned route would otherwise be retried.
-
-Append only through:
-
-```bash
-ledger transact \
-  --definition "$negative_ledger_definition" \
-  --operation capture \
-  --repo "<repo-root>" \
-  --input capture=capture.json \
-  --format json
-```
-
-Captures without adequate witness evidence must become `need-evidence` or `capture_candidate`, never active exclusions.
-
-`capture.json` contains one `record` object, including its requested initial
-`status`. An active capture requires an explicit supported scope and its
-identity, an immutable artifact identity, structured source references,
-applicability conditions, a narrow exclusion rule, and identified reopening
-criteria. Select `need-evidence` before transaction when those structural
-requirements are incomplete; never assert `active` in prose after Ledger
-rejects it.
-
-Every transition to `active`, including promotion, reactivation, and
-reopening, requires the transition proof plus the complete replacement record,
-whose `status` is `active`. Use the dedicated operation so the event atomically
-replaces the reducer's retained record:
-
-```bash
-ledger transact \
-  --definition "$negative_ledger_definition" \
-  --operation promote \
-  --repo "<repo-root>" \
-  --input promotion=promotion.json \
-  --format json
-```
-
-## Lifecycle Transitions
-
-Use append-only status events. Every transition requires a JSON proof packet with a reason and structured source references:
-
-```json
-{
-  "neg_id": "NEG-000001",
-  "from": "active",
-  "to": "accepted_risk",
-  "reason": "The prior evidence was accepted as a bounded risk.",
-  "criterion_ids": [],
-  "criterion_changes": [],
-  "source_refs": [
-    {"kind": "review", "ref": "PR 123 acceptance"}
-  ]
-}
-```
-
-```bash
-ledger transact \
-  --definition "$negative_ledger_definition" \
-  --operation transition \
-  --repo "<repo-root>" \
-  --input transition=transition.json \
-  --format json
-```
-
-Reopening requires a proved before/after change for an identified criterion already present on the record:
-
-```json
-{
-  "neg_id": "NEG-000001",
-  "from": "stale",
-  "to": "reopened",
-  "reason": "The implementation and representative fixture changed.",
-  "criterion_ids": ["artifact-or-fixture-changed"],
-  "criterion_changes": [
-    {
-      "criterion_id": "artifact-or-fixture-changed",
-      "before": "commit abc123 with fixture v1",
-      "after": "commit def456 with fixture v2"
-    }
-  ],
-  "source_refs": [
-    {"kind": "git", "ref": "commit:def456"},
-    {"kind": "test", "ref": "zig build test-ledger --summary all"}
-  ]
-}
-```
-
-```bash
-ledger transact \
-  --definition "$negative_ledger_definition" \
-  --operation transition \
-  --repo "<repo-root>" \
-  --input transition=reopen-proof.json \
-  --format json
-```
-
-Ledger rejects illegal edges, promotion without a complete active record,
-unknown criteria, and unchanged before/after claims before append.
-
-Never rewrite old events.
-
-## Memory Admission Gate
-
-A negative-ledger source note is allowed only when:
-
-1. a canonical `NEG-*` record exists;
-2. definition-bound `ledger doctor` passes;
-3. `ledger project --projection memory-note --param id=NEG-ID` returns a complete current projection;
-4. projection includes witness, applicability, narrow exclusion, and reopening criteria when status is active;
-5. the record is likely to matter in future related work;
-6. the note embeds the full bounded projection, stable repository identity, event-chain fingerprint, projection fingerprint, and any prior projection link.
-
-Do not admit prose-only negative-evidence claims, unpromoted `learnings` hits,
-partial `current-records` output, every `need-evidence` candidate, or stale
-history with no future routing value.
-
-## Admission Workflow
-
-After the source owner accepts admission for a capture or lifecycle transition,
-load `$memory-source-notes` and use the validated Negative Ledger adapter:
-
-```bash
-uv run codex/skills/memory-source-notes/scripts/negative_ledger_memory_note.py \
-  admit \
-  --id NEG-000001 \
-  --kind ledger-projection
-```
-
-For a status transition:
-
-```bash
-uv run codex/skills/memory-source-notes/scripts/negative_ledger_memory_note.py \
-  admit \
-  --id NEG-000001 \
-  --kind ledger-status-transition
-```
-
-The adapter runs the definition-bound doctor, obtains the source-owned
-projection, rejects incomplete projections, preserves the deterministic
-projection payload bytes, and invokes `memory-note` idempotently. It transports
-an accepted source decision; it does not decide recurrence, utility, or route
-applicability.
-
-If the definition projection is unavailable, preserve the canonical Ledger transaction and report:
-
-```text
-memory-note: not-attempted: ledger projection unavailable
-```
-
-Do not reconstruct an authoritative projection from memory or prose.
-
-## Proof Lines
-
-Canonical write:
-
-```text
-ledger-capture: neg_id=NEG-... status=active
-ledger-status: neg_id=NEG-... status=stale
-ledger-capture: not-attempted: evidence not durable enough
-```
-
-Memory admission:
-
-```text
-memory-note: id=MSN-... extension=negative-ledger kind=ledger-projection status=created
-memory-note: not-attempted: ledger projection unavailable
-memory-note: not-attempted: source admission gate not met
-memory-note: not-attempted: cli unavailable
-```
-
-Report both layers separately.
-
-## Learnings Relationship
-
-The learning source is historical candidate evidence, not the route-exclusion
-store. Legacy `.ledger/learnings/learnings.jsonl` and `.learnings.jsonl` are
-read only during migration. Verify current applicability and promote
-qualifying evidence through the definition's `capture` transaction.
+Its frontmatter is archived source, not a second skill definition.
 
 ## Guardrails
 
-- Do not record vibes as negative evidence.
-- Do not convert one failed implementation into a broad strategy ban.
-- Do not block from fuzzy matches.
-- Do not use stale benchmarks without current applicability reasoning.
-- Do not treat absence of a ledger entry as novelty proof.
-- Do not bypass Ledger or hand-edit persistent-adapter records.
-- Do not let memory notes outrank the repo-local ledger.
-- Do not write compiled memory directly.
-- Do not publish incomplete projections to Phase 2.
-- Do not capture every transient test failure merely because implicit activation occurred.
-- Do not bypass failed `route-gate`, `memory-note`, or doctor projections; those boundaries must fail closed.
-- Do not invoke a sibling source merely because Negative Ledger activated.
+- Do not activate merely to manufacture a no-op at unrelated closeout.
+- Do not turn missing evidence into a durable prohibition.
+- Do not use fuzzy matching as route authority.
+- Do not hand-edit the event store or compiled memory.
+- Do not let stale exclusions block changed artifact states.


### PR DESCRIPTION
## What changed

- Preserve the complete pre-split `$negative-ledger` contract byte-for-byte in `FULL_CONTRACT.md`.
- Keep the exact/applicable route gate, capture threshold, lifecycle law, and non-dogma guardrails always loaded.
- Load exact Ledger commands, schemas, reopening packets, review integration, and memory-admission mechanics only when those routes are active.

## Why

The implicit route check should be cheap. It previously loaded every capture, transition, recovery, and memory transport detail before determining whether a current route was actually excluded.

## Impact

Repeated-route prevention stays immediate and fail-closed without making every activation pay for lifecycle and persistence machinery.

## Validation

- Original `SKILL.md` blob preserved unchanged as `FULL_CONTRACT.md`.
- New kernel is 87 lines.
- Change is isolated to `codex/skills/negative-ledger`.