### PR TITLE
Teach CAS skills version-neutral compatibility

### DIFF
--- a/codex/skills/actuating/SKILL.md
+++ b/codex/skills/actuating/SKILL.md
@@ -432,7 +432,7 @@ Before binding or dispatching closure-grade review, require:
 cas app-server preflight --cwd <repo> --profile review \
   --app-server-transport managed-ws --json
 
-cas_codex_0146_structured_review_v1=true
+cas_structured_review_v1=true
 cas_workflow_bound_owner_lived_review_v1=true
 ~~~
 

--- a/codex/skills/cas/SKILL.md
+++ b/codex/skills/cas/SKILL.md
@@ -16,7 +16,7 @@ CAS owns route execution and facts it directly observes. It does not decide
 Goal semantics, review credit, finding truth, repairs, mutation, publication,
 closure, what an automation ought to do, or whether its result is correct.
 
-Require installed CAS `0.4.1` or newer. There is no standalone automation
+Require installed CAS `0.5.0` or newer. There is no standalone automation
 product, compatibility skill, or legacy command route.
 
 ## Native surface
@@ -61,23 +61,24 @@ Use these profiles:
 | release conformance and the complete feature surface | `full` |
 
 Require `status == "compatible"`, the intended resolved Codex path, contract
-ID `codex-app-server-0.146.0`, no missing required methods or handlers, and all
-required selected-profile probes passed. `degraded` is not compatible proof for
-a required route behavior.
+ID `codex-app-server-capabilities-v1`, no missing required methods or handlers,
+and all required selected-profile probes passed. Codex version and release
+channel are diagnostic only. `degraded` is not compatible proof for a required
+route behavior.
 
 For review and session inquiry, also require the preflight receipt's
 `transport.selected == "managed-ws"`; a compatible stdio receipt is not
-equivalent proof. CAS 0.4.1 review runs this gate internally before starting
+equivalent proof. CAS 0.5.0 review runs this gate internally before starting
 and reports the realized connection as `selectedTransport == "websocket"`.
 Session inquiry additionally receives `--transport managed-ws` on execution.
 
 Compile-time capabilities report what CAS implements. They do not prove that
 the resolved runtime implements it. For review, require both the compatible
 `review` preflight and
-`cas_capabilities.features.cas_codex_0146_structured_review_v1 == true`.
+`cas_capabilities.features.cas_structured_review_v1 == true`.
 
 See [codex_app_server_contract.md](references/codex_app_server_contract.md) and
-[codex-0146-feature-matrix.md](references/codex-0146-feature-matrix.md).
+[codex-app-server-capability-matrix.md](references/codex-app-server-capability-matrix.md).
 
 ## Route guidance
 

--- a/codex/skills/cas/references/codex-app-server-capability-matrix.md
+++ b/codex/skills/cas/references/codex-app-server-capability-matrix.md
@@ -1,4 +1,4 @@
-# Codex 0.146 feature matrix
+# Codex app-server capability matrix
 
 | Surface | CAS behavior | Required proof |
 |---|---|---|
@@ -15,7 +15,7 @@
 | Plugin attribution | Preserve `pluginId` and `scriptPath` as attribution only | schema and item fixtures |
 | Executor skills/resources | Lossless listing/read with source path or URI identity | `full` probe |
 | Plugins/apps | Preserve refetch, workspace-publish capability, enabled/disabled/read-only metadata | schema fixtures |
-| Managed config | Preserve all 0.146 `ConfigRequirements`; session-static defaults are not hot-reloaded | schema fixtures |
+| Managed config | Preserve all admitted `ConfigRequirements`; session-static defaults are not hot-reloaded | schema fixtures |
 | External import | Bounded detect/import and provider-attributed record history in isolated state | `full` probe |
 | Account plan | Preserve `ent26` and unknown plan values as data | account tests |
 | Additive payloads | Preserve raw metadata; reject unknown control flow explicitly | contract mutation tests |

--- a/codex/skills/cas/references/codex_app_server_contract.md
+++ b/codex/skills/cas/references/codex_app_server_contract.md
@@ -1,8 +1,9 @@
-# Codex app-server 0.146 contract
+# Codex app-server capability contract
 
-Treat the installed `codex` executable as the runtime schema source. CAS 0.4.1
-compares its compact `codex-app-server-0.146.0` baseline with both generated
-bundles and the selected live behavioral probes.
+Treat the installed `codex` executable as the runtime schema source. CAS 0.5.0
+compares its compact `codex-app-server-capabilities-v1` contract with both
+generated bundles and the selected live behavioral probes. The contract names
+required capabilities, not a Codex release.
 
 ## Schema and preflight
 
@@ -21,7 +22,6 @@ compatibility predicate.
 
 A compatible profile requires:
 
-- the stable version floor and no unapproved prerelease;
 - every baseline client method, server request, and notification;
 - compatible required fields, scalar kinds, nullability, discriminators, and
   control-flow enums;
@@ -39,7 +39,7 @@ unsupported-item result.
   bounded overload behavior.
 - `review`: core plus structured review.
 - `session-inquiry`: core plus paginated and ephemeral fork/anchor behavior.
-- `full`: all required 0.146 features, including pinning, executor skills and
+- `full`: all declared features, including pinning, executor skills and
   resources, external import history, review, and inquiry.
 
 An explicit external endpoint must earn its own runtime and behavioral proof;

--- a/codex/skills/cas/references/review-proof-boundary.md
+++ b/codex/skills/cas/references/review-proof-boundary.md
@@ -9,11 +9,11 @@ cas capabilities --json
 ```
 
 The preflight must be compatible for the exact resolved runtime. The capability
-receipt must report `cas_codex_0146_structured_review_v1: true` and, for a
+receipt must report `cas_structured_review_v1: true` and, for a
 workflow-bound start, `cas_workflow_bound_owner_lived_review_v1: true`.
 Require `transport.selected == "managed-ws"`; review's native runtime gate
 does not accept stdio compatibility as equivalent proof.
-CAS 0.4.1 executes that gate internally before `review/start` and reports the
+CAS 0.5.0 executes that gate internally before `review/start` and reports the
 realized connection in its receipt as `selectedTransport == "websocket"`;
 `cas review` intentionally exposes no caller transport flag.
 


### PR DESCRIPTION
Updates CAS and Actuating to consume the CAS 0.5 capability contract instead of requiring Codex 0.146 identities.

- requires `codex-app-server-capabilities-v1`
- treats Codex version/release channel as diagnostic
- requires `cas_structured_review_v1`
- renames the feature matrix around capabilities

Validation:
- `quick_validate.py codex/skills/cas`
- `quick_validate.py codex/skills/actuating`