### PR TITLE
Make Emulator self-contained

### DIFF
--- a/codex/skills/emulator/SKILL.md
+++ b/codex/skills/emulator/SKILL.md
@@ -1,68 +1,70 @@
 ---
 name: emulator
-description: "Instantiate Ghost-style behavior contracts as executable, replayable, mutatable synthetic implementations. Use for `$emulator`, emulator runs, generated worlds from Ghost packages, synthetic implementations, scenario mutation, counterexamples, implementation divergence, trace reports, or EER-v1 execution reports. Not for deciding what to specify, producing Ghost contracts, editing target skills, or assuming emulator failures imply skill defects."
+description: "Define, generate, run, mutate, compare, and export executable emulator environments for agents. Use for `$emulator`, synthetic worlds, agent learning environments, scenario contracts, deterministic/noisy/adversarial environments, counterexamples, trajectory datasets, implementation divergence, trace reports, or EER-v1. Not for generic library reimplementation specs, material scope clarification, target-skill edits, or treating synthetic outcomes as production truth."
 ---
 
 # Emulator
 
 ## Mission
 
-`$emulator` turns portable behavior contracts into executable synthetic experience.
+`$emulator` owns the complete path from evidence or explicit design intent to executable synthetic experience.
 
 ```text
-$grill-me learns what is worth specifying
-$ghost    captures the behavior contract
-$emulator instantiates, runs, mutates, and compares implementations
+source evidence + explicit user decisions
+                  |
+                  v
+          emulator-spec.yaml
+                  |
+                  v
+environments -> agent episodes -> traces, counterexamples, datasets, EER-v1
 ```
 
-`$emulator` does not decide what matters, produce the Ghost contract, diagnose skill deltas, or edit target skills.
+Use `$grill-me` only when a material human judgment cannot be resolved from evidence. No separate contract-generation skill is required.
 
 ## Activation boundary
 
-Use `$emulator` when the user asks to:
+Use `$emulator` to:
 
 ```text
-generate executable worlds from a Ghost package
-instantiate a scenario spec as a runnable environment
-create deterministic, noisy, adversarial, or mutation implementations
-run or compare synthetic implementations
-mutate scenarios to find counterexamples
-produce traces, divergence reports, or EER-v1
+author an emulator contract from a repo, spec, tests, traces, or user design
+generate an executable environment for an agent
+instantiate deterministic, noisy, adversarial, or mutable worlds
+run agents and collect replayable episodes
+mutate or shrink scenarios to find counterexamples
+compare agents or implementations against one contract
+export traces, trajectories, divergences, or EER-v1
 ```
 
-Do not use `$emulator` for:
+Do not use it for:
 
 ```text
-material scope clarification -> $grill-me
-portable behavior contract/spec extraction -> $ghost
+material human choices -> $grill-me
+generic portable library reimplementation contracts -> direct specification work
 historical session mining -> $seq
 one live watched session -> $shadow
-skill change diagnosis -> $tune only if explicitly requested
-skill package edits -> $refine only after explicit apply authority
+skill diagnosis -> $tune only when explicitly requested
+skill edits -> $refine only after explicit apply authority
 ```
 
-`$tune` and `$refine` are optional downstream consumers, not part of the core emulator lifecycle.
-
-## Inputs
+## Request
 
 Prefer:
 
 ```yaml
 emulator_request:
   mode: design | implement | run | mutate | compare | export
-  source_contract:
-    kind: ghost_package | ghost_scenario_tests | emulator_contract
+  source:
+    kind: repository | specification | tests | traces | user_design | existing_contract | mixed
     path:
+    revision:
     fingerprint:
+    evidence_refs: []
+  contract_path: codex/emulators/<target>/emulator-spec.yaml
   target:
     name:
     kind: skill | agent_loop | tool_loop | workflow | library_protocol
   emulator_root: codex/emulators
-  implementation_kinds:
-    - deterministic
-    - noisy
-    - adversarial
-    - mutation
+  implementation_kinds: [deterministic, noisy, adversarial, mutation]
   seed:
   scenario_budget:
   authorized_files:
@@ -70,9 +72,10 @@ emulator_request:
     forbidden: []
   output:
     report: EER-v1
+    trajectories: true
 ```
 
-Fail closed when the source contract is absent or the target is unknown.
+An existing contract is optional. Fail closed only when neither a valid contract nor enough evidence and explicit user decisions exist to author one.
 
 ## Modes
 
@@ -80,157 +83,139 @@ Choose exactly one mode.
 
 ### design
 
-Inspect a Ghost-style contract and produce an emulator design plan.
-
-No files are changed unless the user explicitly requests implementation.
+Author or repair `emulator-spec.yaml`. Do not generate runtime files.
 
 ### implement
 
-Create or update emulator implementation files inside the authorized emulator directory.
+Validate an existing contract or author the missing contract first, then generate or update the executable environment inside the authorized emulator directory.
 
-Do not edit the source Ghost package unless the user explicitly asks for contract repair.
-
-Do not edit target skills.
+Do not edit source repositories or target skills without explicit authority.
 
 ### run
 
-Execute seeded scenarios against one or more emulator implementations.
-
-Capture traces, state transitions, oracle results, and skipped-case reasons.
+Execute seeded scenarios against one or more implementations or agents. Capture observations, actions, tool interactions, state transitions, rewards, oracle results, termination, and skips.
 
 ### mutate
 
-Generate scenario variants from the contract while preserving declared invariants.
-
-Use mutations to find smaller counterexamples, wider boundary coverage, and oracle gaps.
+Generate contract-admissible variants and shrink failures. An invariant-breaking mutation must be explicitly labeled as a negative or boundary case.
 
 ### compare
 
-Compare multiple synthetic implementations against the same contract.
-
-Classify differences as contract ambiguity, emulator bug, oracle gap, nondeterminism, or behavior gap.
+Compare implementations or agents against the same contract. Classify differences as contract ambiguity, emulator bug, oracle gap, nondeterminism, behavior gap, or source-contract gap.
 
 ### export
 
-Emit an `emulator_execution_report / EER-v1`.
+Emit EER-v1 and requested trajectory, counterexample, or curriculum datasets.
 
-Only produce `$tune`-compatible evidence when the user explicitly asks to use emulator findings to improve a skill.
+`$tune` and `$refine` are optional downstream consumers, never implicit parts of this lifecycle.
 
-## Source contract rules
+## Contract ownership
 
-The preferred source is a Ghost scenario-layout package:
+`emulator-spec.yaml` is the single normative contract. Its contract fingerprint is the SHA-256 digest of the finalized file's exact UTF-8 bytes.
 
-```text
-SPEC.md
-tests.yaml
-TESTS_SCHEMA.md
-VERIFY.md
-verification/evidence/*
-```
-
-Treat `tests.yaml` as the behavior contract.
-
-Treat `SPEC.md` as explanatory and normative only where the Ghost package marks it as binding.
-
-Treat `VERIFY.md` and `verification/evidence/*` as provenance and confidence evidence.
-
-If the Ghost package is incomplete, report the missing contract surface instead of inventing it.
-
-## Synthetic implementations
-
-Generate implementations from the same contract, such as:
+A contract declares one origin:
 
 ```text
-deterministic  exact, reproducible state-machine execution
-noisy          latency, partial failure, retries, stochastic user behavior
-adversarial    hostile inputs, prompt injection, misleading tool output
-mutation       systematic perturbation and counterexample shrinking
+source_faithful  source behavior is being reproduced
+designed         explicit user intent defines the world
+mixed            source behavior is the baseline with explicit deviations
 ```
 
-Each implementation must declare:
+Rules about source behavior must be grounded in executable tests, captured traces, public interfaces, schemas, source behavior, or non-contradicted normative documentation. Designed behavior must be grounded in explicit user decisions.
 
-```yaml
-implementation:
-  id:
-  kind:
-  source_contract_fingerprint:
-  seed_policy:
-  supported_scenarios: []
-  oracle_surface:
-  nondeterminism:
-  limitations: []
-```
+Every normative scenario rule, permission, side-effect boundary, terminal condition, oracle, reward, and mutation dimension must cite its authority. Assumptions may fill non-critical description only; never infer safety, security, authority, hidden truth, side effects, reward, or termination.
 
-## Runtime traces
-
-Capture enough evidence to reproduce and explain behavior:
+Normalize nondeterminism into explicit inputs:
 
 ```text
-scenario id
-case id
-implementation id
-seed
-initial visible state
-hidden ground truth fingerprint
-tool surface
-user/actor events
-tool calls and responses
-state mutations
-trace invariants checked
-oracle results
-final state
-failure labels
-counterexample data
+seed, time, timezone, locale, latency, failure schedule,
+actor stochasticity, message ordering, collection normalization
 ```
 
-Do not rely on final text matching when state or trace assertions can express the outcome.
+Read `references/emulator-contract-profile.md` when authoring or validating the contract.
 
-## Oracle policy
+## Workflow
 
-Prefer deterministic oracles:
+1. Bind the target, authority source or user design, revision when applicable, origin, and output path.
+2. Inspect discoverable tests, traces, interfaces, schemas, behavior, and normative docs.
+3. Use `$grill-me` only for unresolved material choices.
+4. Author or validate `emulator-spec.yaml`.
+5. Generate the requested environment implementations.
+6. Run, mutate, compare, or export as requested.
+7. Report exact contract gaps instead of inventing missing normative behavior.
+
+## Environment laws
+
+Every generated environment must expose semantic equivalents of:
 
 ```text
-state assertions
-trace invariants
-forbidden tool checks
-side-effect checks
-budget and step limits
-schema assertions
+reset(scenario_id, seed) -> initial observation
+observe() -> current agent-visible observation
+step(action) -> observation, reward, done, termination reason, oracle results
+score() -> deterministic score and invariant summary
+trace() -> replayable execution trace
 ```
 
-Use model judgment only when deterministic checks cannot express the criterion.
+Hidden ground truth belongs to the environment and oracles. It reaches the agent only through contracted observations or tool results.
 
-Never let a model judge be the sole authority for safety-critical behavior.
+The same deterministic implementation, contract fingerprint, scenario, seed, recorded action sequence, and oracle version must reproduce the same environment observations, state transitions, and terminal result.
 
-When an oracle fails, classify whether the likely problem is:
+A failed hard oracle or trace invariant cannot be overridden by reward or model judgment.
+
+## Implementations and traces
+
+Implementations may be:
 
 ```text
-contract_ambiguity
-emulator_bug
-oracle_gap
-nondeterminism
-behavior_gap
-source_contract_gap
+deterministic  exact state-machine execution
+noisy          seeded latency, failures, retries, and actor noise
+adversarial    hostile inputs, injection, misleading outputs, hidden-state traps
+mutation       declared perturbations and counterexample shrinking
 ```
+
+Each declares its id, kind, contract fingerprint, supported scenarios, seed policy, oracle surface, nondeterminism, and limitations.
+
+Each episode records:
+
+```text
+episode/scenario/case/agent/implementation ids and agent fingerprint
+contract fingerprint, seed, recorded actions, and oracle version
+visible observations and hidden-state fingerprint
+actions, tool calls/results, state mutations, and rewards
+oracle and invariant results
+final state, termination, failure labels, and counterexample data
+```
+
+Read `references/synthetic-implementations.md` when generating environments.
+
+## Oracle and learning policy
+
+Prefer deterministic state, trace, tool, side-effect, schema, budget, and terminal assertions. Model judgment may support criteria that deterministic checks cannot express, but it is never sole authority for safety-critical behavior.
+
+EER-v1 is the run-level evidence record. When requested, also emit:
+
+```text
+trajectories.jsonl
+counterexamples.jsonl
+curriculum.jsonl
+```
+
+Every dataset row binds the contract fingerprint, episode identities, agent fingerprint, implementation, seed, recorded actions, trace, terminal status, and oracle result.
+
+A counterexample becomes a binding regression only after adoption into `emulator-spec.yaml`.
 
 ## Output
 
-Default report:
-
 ```text
 Emulated:
-- Source contract:
-- Target:
-- Mode:
-- Implementations:
-- Seed:
-- Scenario budget:
+- Source and origin:
+- Contract and fingerprint:
+- Target and mode:
+- Implementations and agents:
+- Seed and scenario budget:
 
 Run summary:
-- Executed:
-- Passed:
-- Failed:
-- Skipped:
+- Executed / passed / failed / skipped:
 
 Findings:
 - Divergences:
@@ -240,25 +225,26 @@ Findings:
 - Candidate regressions:
 
 Artifacts:
+- Environment:
 - Traces:
-- Report:
+- Datasets:
 - EER-v1:
 
 Next route:
 - none | repair-contract | build-more-implementations | export-eval-dataset | optional-handoff-tune
 ```
 
-Use `optional-handoff-tune` only when the user explicitly asks to improve a skill from emulator evidence.
+Use `optional-handoff-tune` only after explicit skill-improvement intent.
 
 ## Hard rules
 
-- `$grill-me` decides material user judgments; `$emulator` does not.
-- `$ghost` owns portable contract generation; `$emulator` consumes the contract.
-- Do not edit target skills.
-- Do not assume emulator failures imply skill defects.
-- Do not route to `$tune` or `$refine` unless skill improvement is explicit.
-- Preserve seeds, fingerprints, implementation IDs, and oracle versions.
-- Every exported failure must have a trace, fixture, or skipped-case reason.
-- Prefer contract-faithful implementation over creative scenario invention.
-- Prefer deterministic checks over model-judged checks.
-- Report source-contract gaps instead of filling them silently.
+- `$emulator` owns emulator contract authoring and environment generation.
+- `$grill-me` owns unresolved material human judgments.
+- Keep one normative `emulator-spec.yaml`.
+- Attribute every normative rule; do not silently invent behavior.
+- Preserve contract, scenario, case, implementation, agent, seed, and oracle identities.
+- Keep hidden truth out of uncontracted agent observations.
+- Every exported failure has a trace, fixture, or skip reason.
+- Prefer contract-faithful behavior and deterministic checks.
+- Do not edit target skills or infer skill defects from emulator failures.
+- Do not invoke `$tune` or `$refine` without explicit skill-improvement intent.

--- a/codex/skills/emulator/agents/openai.yaml
+++ b/codex/skills/emulator/agents/openai.yaml
@@ -2,5 +2,5 @@ policy:
   allow_implicit_invocation: false
 interface:
   display_name: "Emulator"
-  short_description: "Instantiate Ghost contracts as executable synthetic worlds"
-  default_prompt: "Use $emulator to consume a Ghost-style behavior contract, generate or run synthetic implementations, preserve seeds and trace evidence, emit EER-v1, and avoid routing to $tune or $refine unless skill-improvement intent is explicit."
+  short_description: "Define and run executable agent learning environments"
+  default_prompt: "Use $emulator to author or validate emulator-spec.yaml from source evidence and explicit user decisions, generate and run replayable agent environments, preserve contract/scenario/case/agent/implementation/seed/oracle identities, emit traces and EER-v1, and avoid target-skill edits or $tune/$refine handoff without explicit skill-improvement intent."

--- a/codex/skills/emulator/references/architecture.md
+++ b/codex/skills/emulator/references/architecture.md
@@ -1,38 +1,73 @@
 # Emulator Architecture
 
-`$emulator` is the runtime companion to `$ghost`.
+`$emulator` owns both the behavior contract and the executable synthetic world.
 
 ```text
-$grill-me  ->  emulator_subject_packet / ESP-v1
-$ghost     ->  Ghost scenario package
-$emulator  ->  synthetic implementations + emulator_execution_report / EER-v1
+source evidence + explicit user decisions
+                  |
+                  v
+          emulator-spec.yaml
+                  |
+                  v
+ environments + episodes + traces + EER-v1
 ```
+
+Use `$grill-me` only when a material human judgment cannot be resolved from evidence.
 
 ## Responsibility split
 
 | Skill | Owns | Does not own |
 |---|---|---|
-| `$grill-me` | Material user judgments, scope, proof bar, and failure priorities | Specs, implementation, repository analysis beyond discoverable context |
-| `$ghost` | Portable behavior contract, scenario tests, verification/provenance | Executable emulator runtime |
-| `$emulator` | Executable synthetic implementations, runs, mutation, traces, divergence reports | Deciding what matters, writing Ghost contracts, editing skills |
+| `$grill-me` | Material user judgments, scope, proof bar, failure priorities | Contracts or environments |
+| `$emulator` | Contract authoring, environments, runs, mutation, traces, datasets, divergence reports | Undiscoverable user priorities or target-skill edits |
 | `$tune` | Optional downstream skill-change diagnosis | Core emulator lifecycle |
 | `$refine` | Optional downstream authorized edits | Core emulator lifecycle |
 
+## Boundary
+
+`emulator-spec.yaml` is the single normative boundary between authority and runtime.
+
+Each rule identifies its authority:
+
+```text
+source evidence
+explicit user decision
+non-critical assumption
+```
+
+Source-faithful claims require source evidence. Designed deviations require explicit user decisions. Assumptions cannot define critical behavior.
+
+Every implementation interprets one contract fingerprint.
+
+Laws:
+
+```text
+same deterministic implementation + contract + scenario + seed + action sequence + oracle version
+  -> same environment observations, state transitions, and terminal result
+
+hidden ground truth
+  -> environment/oracle-visible
+  -> agent-visible only through contracted observations or tool results
+
+hard oracle failure
+  -> not overridable by reward or model judgment
+```
+
 ## Canonical flow
 
-1. `$grill-me` is used only when the subject is materially under-specified.
-2. `$ghost` converts the chosen subject into a portable scenario-layout contract.
-3. `$emulator` reads that contract and generates one or more executable implementations.
-4. `$emulator` runs, mutates, and compares those implementations.
-5. `$emulator` emits EER-v1 and concrete artifacts.
-6. Optional consumers use the report: human review, CI, eval generation, Ghost repair, or skill tuning.
+1. Resolve source, target, revision, origin, and requested environment.
+2. Inspect discoverable evidence.
+3. Use `$grill-me` only for unresolved material choices.
+4. Author or validate `emulator-spec.yaml`.
+5. Generate and run one or more implementations.
+6. Mutate, shrink, compare, and export only as requested.
 
-## Non-core downstream route
+Missing normative evidence is `source_contract_gap`, not permission to invent behavior. Conflicting authority is `contract_ambiguity`.
 
-Use this route only when explicitly requested:
+## Optional downstream route
 
 ```text
 EER-v1 -> $tune -> $refine
 ```
 
-Emulator evidence is behavioral evidence. It becomes skill-improvement evidence only after the user asks to improve a skill from it and the existing tuning/refinement gates accept the handoff.
+Use it only after explicit skill-improvement intent.

--- a/codex/skills/emulator/references/eer-v1.md
+++ b/codex/skills/emulator/references/eer-v1.md
@@ -1,8 +1,6 @@
 # EER-v1: Emulator Execution Report
 
-`emulator_execution_report / EER-v1` is the default evidence artifact emitted by `$emulator`.
-
-It records what was run, what happened, where implementations diverged, and which findings are reusable.
+`emulator_execution_report / EER-v1` records what contract and environment ran, what each episode did, where agents or implementations diverged, and which findings are reusable.
 
 ## Schema
 
@@ -10,11 +8,12 @@ It records what was run, what happened, where implementations diverged, and whic
 emulator_execution_report:
   packet_version: EER-v1
   source_contract:
-    kind: ghost_package | ghost_scenario_tests | emulator_contract
+    kind: emulator_contract
     spec_ref:
-    tests_ref:
-    verify_ref:
+    contract_id:
     fingerprint:
+    source_revision:
+    authority_refs: []
   target:
     name:
     kind:
@@ -22,17 +21,37 @@ emulator_execution_report:
     version:
     implementation_ids: []
     seed:
+    seed_policy:
     oracle_version:
+  agents:
+    - id:
+      fingerprint:
+      limitations: []
   run_summary:
     generated_cases:
     executed_cases:
     passed_cases:
     failed_cases:
     skipped_cases:
+  executions:
+    - episode_id:
+      scenario_id:
+      case_id:
+      implementation_id:
+      agent_id:
+      agent_fingerprint:
+      seed:
+      status: pass | fail | skip
+      termination_reason:
+      reward_total:
+      action_trace_ref:
+      oracle_results_ref:
+      trace_ref:
+      skipped_reason:
   implementations:
     - id:
       kind: deterministic | noisy | adversarial | mutation
-      source_contract_fingerprint:
+      contract_fingerprint:
       supported_scenarios: []
       limitations: []
   divergences:
@@ -40,6 +59,7 @@ emulator_execution_report:
       scenario_id:
       case_id:
       implementations: []
+      agents: []
       observed_difference:
       likely_source:
         contract_ambiguity | emulator_bug | oracle_gap | nondeterminism | behavior_gap | source_contract_gap
@@ -57,6 +77,10 @@ emulator_execution_report:
       source_counterexample:
       why_reusable:
       required_oracles: []
+  datasets:
+    trajectories_ref:
+    counterexamples_ref:
+    curriculum_ref:
   limitations: []
   optional_downstream:
     tune_handoff:
@@ -64,9 +88,24 @@ emulator_execution_report:
       reason:
 ```
 
-## Interpretation rules
+## Accounting rules
 
-- EER-v1 is behavioral evidence, not proof that a target skill should change.
-- A failed emulator run may indicate an emulator bug, a contract ambiguity, an oracle gap, nondeterminism, or a real behavior gap.
-- A candidate regression becomes binding only after the downstream owner adopts it.
-- `$tune` handoff is optional and requires explicit skill-improvement intent.
+- Every episode appears in `executions`.
+- Summary counts equal execution counts.
+- Every pass or failure has a trace and recorded action sequence.
+- Every skip has a reason.
+- Every execution binds contract, implementation, agent, scenario, case, seed, and oracle identities.
+- Every counterexample binds violated oracles and reproducible evidence.
+- Dataset references appear only for emitted datasets.
+
+## Interpretation
+
+EER-v1 is behavioral evidence, not proof that a target skill or production system should change.
+
+A failed episode may indicate an emulator bug, contract ambiguity, oracle gap, nondeterminism, behavior gap, or missing source contract.
+
+Reward never overrides a failed hard oracle.
+
+A candidate regression becomes binding only after adoption into `emulator-spec.yaml`.
+
+`$tune` handoff requires explicit skill-improvement intent.

--- a/codex/skills/emulator/references/emulator-contract-profile.md
+++ b/codex/skills/emulator/references/emulator-contract-profile.md
@@ -1,79 +1,154 @@
 # Emulator Contract Profile
 
-Use this profile when a Ghost package is intended to be consumed by `$emulator`.
+`emulator-spec.yaml` is the canonical contract owned by `$emulator`.
 
-## Required contract shape
+Its contract fingerprint is the SHA-256 digest of the finalized file's exact UTF-8 bytes.
 
-Prefer Ghost's scenario layout:
-
-```yaml
-meta:
-  kind: scenario
-  version: 1
-  source_version: "skill:<fingerprint-or-revision>"
-  contract_purpose: emulator
-
-scenarios:
-  <scenario_id>:
-    description:
-    initial_state:
-    tools:
-    task:
-    limits:
-    constraints:
-    evaluation:
-```
-
-## Scenario requirements
-
-Each scenario should define:
+## Canonical shape
 
 ```yaml
-scenario:
-  case_id:
-  actor_model:
-  visible_state:
-  hidden_ground_truth:
-  tool_surface:
-  allowed_tools: []
-  denied_tools: []
-  user_goal:
-  expected_behavior:
-  prohibited_behavior:
-  hard_oracles: []
-  trace_invariants: []
-  mutation_hints: []
+emulator_contract:
+  packet_version: EC-v1
+  contract_id:
+  origin: source_faithful | designed | mixed
+  source:
+    kind: repository | specification | tests | traces | user_design | existing_contract | mixed
+    path:
+    revision:
+    fingerprint:
+    evidence_refs: []
+    explicit_deviations: []
+    discrepancies: []
+  target:
+    name:
+    kind: skill | agent_loop | tool_loop | workflow | library_protocol
+  environment:
+    reset_semantics: fresh_episode | checkpoint | explicit
+    observation_schema:
+    action_schema:
+    visible_state_schema:
+    hidden_state_schema:
+    seed_policy:
+    terminal_conditions: []
+    reward_channels: []
+  tools:
+    <tool_id>:
+      input_schema:
+      output_schema:
+      permissions:
+      side_effect: true | false
+      modeled_failures: []
+      authority_refs: []
+  scenarios:
+    - scenario_id:
+      case_id:
+      description:
+      authority_refs: []
+      actor_model:
+      initial_visible_state:
+      hidden_ground_truth:
+      user_goal:
+      limits:
+        max_steps:
+        timeout_s:
+      expected_behavior: []
+      prohibited_behavior: []
+      terminal_conditions: []
+      hard_oracles: []
+      trace_invariants: []
+      mutation_dimensions: []
 ```
+
+## Authority
+
+A normative field cites either source evidence or an explicit user decision.
+
+For source-faithful claims, prefer:
+
+```text
+executable tests and captured traces
+public runtime interfaces, schemas, and source behavior
+non-contradicted normative documentation
+examples
+```
+
+Record source contradictions under `source.discrepancies`.
+
+For designed or mixed worlds, record intentional departures under `source.explicit_deviations`.
+
+An assumption may explain non-critical description only. It cannot define safety, security, authority, hidden truth, side effects, rewards, or termination.
+
+## Required semantics
+
+The contract must define equivalents of:
+
+```text
+reset(scenario_id, seed)
+observe()
+step(action)
+score()
+trace()
+```
+
+Each scenario defines stable identities, authority references, actor model, initial visible state, hidden truth, goal, limits, terminal conditions, hard oracles, trace invariants, and allowed mutations.
+
+A critical scenario requires a deterministic hard oracle. Safety-critical behavior requires a trace invariant. Reward or final text alone is insufficient.
 
 ## Oracles
 
-Prefer hard oracles over final-text goldens:
+Prefer:
 
 ```text
 state_assert
 trace_invariant
-tool_called
-tool_not_called
+tool_called / tool_not_called
 side_effect_assert
 schema_assert
 budget_assert
+terminal_assert
 confirmation_before_side_effect
 injection_resistance
 ```
 
-Rubric or model-judged oracles are allowed only as supporting evidence. They must not be the sole authority for safety-critical behavior.
+Model-judged oracles may support criteria that deterministic checks cannot express. They must not be sole authority for safety-critical behavior.
 
-## Fidelity labels
+## Rewards
 
-Every emulator-targeted Ghost package should declare one or more fidelity labels:
+Rewards are optional learning signals. Each channel declares meaning, range, aggregation, and authority.
+
+A reward cannot turn a failed hard oracle into a pass.
+
+## Mutations
+
+Each mutation dimension declares:
 
 ```text
-contract-debug       exact and deterministic
-production-like      includes noise, retries, latency, and stochastic actors
-adversarial          includes hostile or misleading inputs
-mutation-ready       includes dimensions that may be varied safely
+id
+allowed values or generator
+invariants preserved
+invariants intentionally violated, if negative
+shrink strategy
 ```
 
-## Contract gaps
+Do not vary undeclared normative behavior and still claim contract conformance.
 
-If a Ghost package lacks actor models, hidden state, tool behavior, or oracle definitions, `$emulator` should report `source_contract_gap` rather than inventing normative behavior.
+## Validation gate
+
+Require:
+
+```text
+EC-v1, contract id, origin, authority identity and fingerprint, and source revision when applicable
+stable scenario and case ids
+explicit reset, observation, action, state, and terminal semantics
+visible/hidden state separation
+tool schemas, permissions, side effects, and modeled failures
+seed-controlled nondeterminism
+hard oracles for critical scenarios
+trace invariants for safety-critical behavior
+authority attribution for every normative rule
+declared mutation invariants
+```
+
+Missing authority or semantics is `source_contract_gap`. Conflicting authority is `contract_ambiguity`.
+
+Do not fill either gap silently.

--- a/codex/skills/emulator/references/synthetic-implementations.md
+++ b/codex/skills/emulator/references/synthetic-implementations.md
@@ -1,12 +1,24 @@
 # Synthetic Implementation Patterns
 
-`$emulator` may generate multiple executable implementations from the same Ghost contract.
+`$emulator` may generate multiple executable environments from one `emulator-spec.yaml`.
 
-## Deterministic implementation
+Variation belongs in implementation behavior or contract-declared mutations, not silent changes to normative semantics.
+
+## Common surface
+
+Each implementation provides equivalents of:
+
+```text
+reset(scenario_id, seed)
+observe()
+step(action)
+score()
+trace()
+```
+
+## Deterministic
 
 Use for debugging and reproducible counterexamples.
-
-Properties:
 
 ```text
 fixed seed
@@ -16,67 +28,51 @@ exact oracle checks
 no unmodeled time or randomness
 ```
 
-## Noisy implementation
+The same contract fingerprint, implementation id, scenario, seed, recorded action sequence, and oracle version must reproduce the same environment observations, state transitions, and terminal result.
+
+## Noisy
 
 Use for production-like reliability testing.
 
-Possible perturbations:
-
 ```text
 tool latency
-transient errors
-partial failures
-retryable failures
+transient or partial failures
+retries
 actor hesitation
-message ordering noise
+message-order noise
 irrelevant context
 ```
 
-All noise must be seed-controlled and trace-recorded.
+All noise must be contract-admissible, seed-controlled, and trace-recorded.
 
-## Adversarial implementation
+## Adversarial
 
-Use to test security, safety, and robustness boundaries.
-
-Possible perturbations:
+Use for security, safety, and robustness boundaries.
 
 ```text
-prompt injection in tool output
+injection in tool output
 misleading user claims
 conflicting instructions
-forbidden tool temptations
-malformed tool responses
-stale policy snippets
+forbidden-tool temptations
+malformed responses
+stale information
 hidden-state traps
 ```
 
-The implementation must preserve the contract's declared invariants.
+The world must preserve its contracted laws while presenting adversarial observations.
 
-## Mutation implementation
+## Mutation
 
-Use to explore nearby cases and shrink failures.
+Use declared mutation dimensions to explore nearby cases and shrink failures.
 
-Mutation dimensions may include:
-
-```text
-remove a visible fact
-swap tool response order
-rename an entity
-change a threshold
-add irrelevant noise
-delay a tool
-make hidden ground truth contradict the user's claim
-```
-
-Do not mutate a scenario in a way that invalidates the source contract unless the mutation is explicitly marked as a negative/boundary case.
+An invariant-breaking mutation must be labeled as a negative or boundary case. Do not mutate outside the contract and claim conformance.
 
 ## Artifact layout
-
-Recommended output:
 
 ```text
 codex/emulators/<target>/
   emulator-spec.yaml
+  env-manifest.yaml
   implementations/
     deterministic/
     noisy/
@@ -87,7 +83,29 @@ codex/emulators/<target>/
     mutations/
   traces/
   reports/
+    EER-v1.yaml
+  datasets/
+    trajectories.jsonl
+    counterexamples.jsonl
+    curriculum.jsonl
   evidence/
 ```
 
-Each implementation should be reproducible from source contract fingerprint, implementation id, seed, and oracle version.
+Create only requested artifacts; empty scaffolding has no value.
+
+## Reproducibility
+
+Each implementation declares its id, kind, contract fingerprint, supported scenarios, seed policy, oracle version, nondeterminism, and limitations.
+
+Each episode is reproducible from:
+
+```text
+contract fingerprint
+implementation id
+scenario id
+case id
+seed
+oracle version
+recorded action sequence
+agent id and configuration fingerprint when regenerating actions
+```


### PR DESCRIPTION
## What changed

- Removed every remaining dependency on the deleted `$ghost` skill from `$emulator`.
- Made `emulator-spec.yaml` the single normative contract owned by `$emulator`.
- Taught `design` to author or repair that contract and `implement` to author it when absent before generating an environment.
- Added explicit `source_faithful`, `designed`, and `mixed` contract origins so synthetic learning worlds can reproduce source behavior or intentionally depart from it without conflating the two.
- Defined the common environment surface (`reset`, `observe`, `step`, `score`, `trace`), visible/hidden-state boundary, authority attribution, hard-oracle precedence, mutation laws, replay identities, trajectory datasets, and per-episode EER-v1 accounting.
- Updated the architecture, contract profile, synthetic implementation guidance, EER-v1 reference, and agent prompt to use the self-contained ownership model.

## Why

`$ghost` was removed, but `$emulator` still delegated contract generation, contract authority, provenance, and its canonical lifecycle to it. That left `$emulator` unable to generate an environment unless a nonexistent owner first produced a contract.

This change moves only the emulator-specific subset into `$emulator`. It does not restore the former general-purpose library reimplementation, licensing, Lean, or heavyweight evidence-package responsibilities.

## Impact

`$emulator` can now start from a repository, specification, tests, traces, explicit user design, or an existing contract and proceed through contract authoring, environment generation, agent execution, mutation, comparison, and export without another skill.

The environment boundary is now explicit and testable:

- deterministic environment replay is bound to contract fingerprint, scenario, seed, implementation, recorded action sequence, and oracle version; regenerating actions additionally binds the agent fingerprint;
- hidden ground truth cannot reach the agent outside contracted observations or tool results;
- rewards and model judges cannot override failed hard oracles;
- missing authority is reported as `source_contract_gap` rather than silently invented.

## Validation

- `main...agent/make-emulator-self-contained` is one commit ahead with changes restricted to the six `$emulator` files.
- Parsed the skill frontmatter and `agents/openai.yaml` as YAML.
- Checked Markdown fence balance and trailing whitespace.
- Verified the replacement contents contain no stale `$ghost`/Ghost references.


<!-- ship-proof:start -->
## Summary
- Made `$emulator` self-contained after removal of `$ghost` by moving emulator-specific contract ownership into `$emulator`.
- Defined the Emulator contract, environment boundary, replay/oracle laws, and EER-v1 accounting across the six Emulator files.

## Proof
- `uv run --with pyyaml python3 codex/skills/.system/skill-creator/scripts/quick_validate.py codex/skills/emulator`: pass
- YAML parse of `codex/skills/emulator/agents/openai.yaml`: pass
- `git diff --check bc7af5cc1e6dfeb3d51e056f5db22b73ca6897b9...a8cbd65357d926bc86a77013b325f0baa0310d07`: pass
- Stale `$ghost`/Ghost scan across changed files: pass (no matches)
- Exact changed-file and one-commit scope check: pass
- GitHub status checks: not-run (repository reports no checks for this branch)

## Scope
- repository: tkersey/dotfiles
- branch: agent/make-emulator-self-contained
- head: a8cbd65357d926bc86a77013b325f0baa0310d07
- base: main
- base SHA: bc7af5cc1e6dfeb3d51e056f5db22b73ca6897b9

## Risks
- No executable build or test suite applies to this Markdown/YAML-only skill change.

## Follow-ups
- None.

## Readiness
- Operation: update-and-promote
- Final state: ready
- SHIP-v1 compatibility mode: promote-draft
- Reason: exact head validated; declared scope complete; no blocked, deferred, or open tasks.
- Caveats: build and executable tests not run because the change is documentation/YAML skill configuration only; repository policy requires no checks or approvals.
<!-- ship-proof:end -->