### PR TITLE
Make $land reconcile and resolve review threads before merge

### DIFF
--- a/codex/skills/land/SKILL.md
+++ b/codex/skills/land/SKILL.md
@@ -1,24 +1,37 @@
 ---
 name: land
-description: "Safely finish an explicitly selected GitHub PR: bind exact repository/base/head identity, close review blockers, verify required checks, merge or wait for queue/auto-merge completion, prove live MERGED state, and then clean remote/local branches and associated worktrees. Use only for explicit `$land` or unmistakable merge/land intent. Do not use merely to watch CI, close an unmerged PR, delete a branch, sync local state, or open/update a PR."
+description: "Safely finish an explicitly selected GitHub PR: reconcile every unresolved review thread, bind each successor head as a fresh landing epoch, verify merge admission, merge the exact approved head or wait for queue/auto-merge completion, prove live MERGED state, and then clean remote/local branches and associated worktrees. Use only for explicit `$land` or unmistakable merge/land intent. Do not use merely to watch CI, close an unmerged PR, delete a branch, sync local state, or open/update a PR."
 ---
 
 # Land
 
 ## Purpose
 
-Land one explicitly selected pull request as a fail-closed transaction.
+Finish one explicitly selected pull request as a proof-preserving landing
+protocol.
 
-Core rule:
+Core laws:
 
 ```text
+An unresolved review thread means merge not ready, not workflow terminal.
+Every unresolved review thread must reach a justified disposition before merge.
+Thread resolution records proof; it never creates proof.
 Mutation success is not landing success.
-Do not clean branches or worktrees until live GitHub state proves the intended PR is MERGED.
 ```
 
-`$ship` owns PR creation, proof publication, and draft-to-ready promotion. `$land`
-consumes live state and may consume SHIP-v1 as a hint, but copied receipts are
-never authoritative for merge readiness.
+`$land` owns end-to-end completion: review-thread inventory, review closure,
+fresh merge admission, exact-head merge, live terminal readback, and cleanup.
+It does not duplicate semantic owners:
+
+- `$review-fold` classifies a concern's authority and current applicability;
+- `$actuating review-closeout` repairs accepted current concerns, with its direct
+  owner-local repair path available for an isolated mistake;
+- `$ship` publishes a validated successor head;
+- `$land` proves the resulting disposition, resolves the GitHub thread, and
+  restarts landing against the successor head.
+
+Copied receipts and thread metadata are never authoritative for current merge
+readiness.
 
 ## Activation boundary
 
@@ -36,7 +49,7 @@ The skill is side-effecting and must remain explicit-invocation only.
 
 ## Input
 
-Establish one immutable target before any mutation:
+Bind one immutable landing epoch before any mutation:
 
 ```yaml
 land_input:
@@ -56,43 +69,121 @@ land_input:
     associated_worktrees: yes | no
 ```
 
-Resolve the repository and PR explicitly. Never infer an irreversible target
-from a branch name alone. Require the live repository, PR number, base ref, head
-repository, head ref, and head OID to match the target. Record the base OID as a
-preflight fact; merge queues may legitimately advance the base before the PR
-lands.
+Never infer an irreversible target from a branch name alone. Require the live
+repository, PR number, base ref, head repository, head ref, and head OID to match
+the epoch. Record the base OID as an observation; a merge queue may legitimately
+advance the base before the PR lands.
 
 ## State model
 
-Choose exactly one mode:
+Choose exactly one route:
 
 ```text
+reconcile-reviews
+rebind-successor-head
 merge-now
 queue-and-wait
 auto-merge-and-wait
 cleanup-only
-blocked
+obstructed
 ```
 
-- `merge-now`: every gate passes and the repository permits immediate merge.
-- `queue-and-wait`: every admission gate passes and repository policy requires a merge queue.
-- `auto-merge-and-wait`: every admission gate passes and explicit repository/user policy selects auto-merge.
-- `cleanup-only`: the exact PR is already merged and only post-merge cleanup remains.
-- `blocked`: target identity, evidence, policy, or authority is incomplete or inconsistent.
+- `reconcile-reviews`: merge is not ready, but review closure can progress.
+- `rebind-successor-head`: a repair or authorized branch update published a new
+  head; supersede the old epoch and rebuild all evidence.
+- `merge-now`: every admission gate passes and immediate merge is permitted.
+- `queue-and-wait`: every queue-admission gate passes; submit and wait for live
+  merged state.
+- `auto-merge-and-wait`: every admission gate passes and explicit policy selects
+  auto-merge; enable it and wait for live merged state.
+- `cleanup-only`: the exact PR/head is already merged.
+- `obstructed`: no safe authorized successor action exists.
 
-A draft PR, closed-unmerged PR, conflicting PR, changed head, active requested
-changes, incomplete review inventory, missing approval, or non-green required
-check is `blocked`. Do not silently reopen, promote, update, override, or retarget.
+A repairable review concern is never `obstructed` before repair is attempted.
+Reserve obstruction for missing mutation authority, an undecidable user-owned
+requirement, required reviewer clarification, an unrepairable conflict, invalid
+or unavailable evidence, or a repair whose strongest relevant validation fails.
 
-## Freshness invariant
+## Landing epochs
 
-Every push, branch update, review-thread resolution, approval change, or other
-material PR mutation invalidates all cached landing evidence.
+A landing epoch is immutable in repository/PR/base/head identity. Any push,
+branch update, review repair, or other head mutation supersedes the current
+epoch rather than retargeting it.
 
-After the final mutation, rebuild one fresh snapshot containing:
+After `$ship` publishes successor head `H[n+1]`:
+
+```text
+close epoch H[n] as superseded
+bind H[n+1] as a new immutable target
+discard every admission observation from H[n]
+fetch the complete review inventory again
+run complete fresh preflight
+```
+
+Do not carry approvals, checks, mergeability, thread counts, or resolution proof
+across a head change without fresh current-head evidence.
+
+## Review reconciliation
+
+Every unresolved review thread is owned work for `$land`, not merely a reason to
+stop. Land must drive every unresolved thread to a justified resolution before
+merge or prove an exact obstruction.
+
+For each unresolved thread:
+
+1. Fetch enough of the complete conversation to understand the concern. A bare
+   thread ID, latest-comment excerpt, `isOutdated`, or status count is
+   insufficient.
+2. Preserve the concern as a witness and ask `$review-fold` for law authority and
+   current applicability when the disposition is not mechanically evident.
+3. Choose exactly one disposition:
+
+   ```text
+   fixed-and-evidenced
+   already-satisfied-and-evidenced
+   obsolete-and-evidenced
+   reviewer-withdrawn
+   nonblocking-by-authority
+   needs-authority
+   needs-reviewer-clarification
+   repair-failed
+   ```
+
+4. For a current accepted concern that is directly repairable, do not return
+   terminal obstruction. Use the smallest authorized repair path:
+
+   ```text
+   patch -> validate -> publish successor head -> prove current-head discharge
+   ```
+
+   Then enter `rebind-successor-head` and restart complete preflight.
+5. Resolve the GitHub thread only after the disposition is evidenced at the
+   current head and live resolution readback succeeds.
+6. Refetch every review-thread page after each resolution batch and require zero
+   unresolved threads before merge admission.
+
+`fixed-and-evidenced` requires a successor head distinct from the head on which
+the current defect was observed. Use `already-satisfied-and-evidenced` when the
+current head already falsifies the concern. `isOutdated` alone never proves
+obsolescence.
+
+A generic continuation instruction such as "continue", "finish it", or "do your
+job" is not reviewer withdrawal, defect invalidation, new-requirement adoption,
+or permission to dismiss a current substantive concern.
+
+Never bulk-resolve from bare thread IDs. Batch execution is permitted only after
+each thread is bound to an individual evidence-bearing disposition. Preserve a
+current substantive concern at an unchanged head; do not resolve or merge it.
+
+See [landing-protocol.md](references/landing-protocol.md).
+
+## Merge admission
+
+After review reconciliation is complete, rebuild one current-head snapshot with:
 
 - exact target identity and `headRefOid`;
-- complete paginated review-thread inventory;
+- complete paginated review-thread inventory and unresolved thread IDs;
+- per-thread reconciliation records for every thread resolved by this landing;
 - structured review decision, latest reviews, and review requests;
 - final required-check buckets;
 - conflict, branch-freshness, merge-method, queue, and repository-policy state.
@@ -103,34 +194,16 @@ Run the pure evaluator:
 uv run python3 codex/skills/land/scripts/evaluate_preflight.py <snapshot.json>
 ```
 
-Proceed only when its route matches the intended mode. See
-[references/landing-protocol.md](references/landing-protocol.md).
-
-## Review gate
-
-Fetch every review-thread page. Require the collected node count to equal
-`totalCount`, the final `hasNextPage` to be false, and every page to report the
-same expected head OID. API failure, missing counts, duplicate/partial pages, or
-head drift blocks landing.
-
-Every unresolved thread requires one explicit disposition:
+Interpret its result:
 
 ```text
-fixed-and-evidenced
-obsolete-and-explicitly-withdrawn
-resolve-only-with-user-authorization
-still-blocking
-needs-reviewer-clarification
+exit 0 / verdict pass      merge admission is ready
+exit 3 / verdict continue  follow the returned nonterminal route
+exit 2 / verdict block     preserve state and report the exact obstruction
 ```
 
-Do not equate `isOutdated` with resolved. Resolve a GitHub thread only when the
-concern is objectively fixed or explicitly withdrawn; ambiguous design concerns,
-questions, and reviewer-owned blockers remain open. After any resolution,
-rebuild the complete inventory.
-
-Use structured `reviewDecision`, `latestReviews`, and `reviewRequests` before
-interpreting free-form top-level comments. An explicit unresolved human blocker
-still blocks even when GitHub's normalized review decision appears permissive.
+`REVIEW_THREADS_UNRESOLVED` routes to `reconcile-reviews`; it is never by itself
+a terminal workflow result.
 
 ## Required-check gate
 
@@ -140,28 +213,34 @@ final snapshot with `name`, `state`, `bucket`, and `link`.
 For required checks:
 
 - `pass` is accepted;
-- `fail`, `pending`, or `cancel` blocks;
-- `skipping` blocks unless repository policy explicitly accepts that required context as skipped;
-- an empty required-check set is accepted only after proving repository policy requires none.
+- `fail`, `pending`, or `cancel` obstructs merge admission;
+- `skipping` obstructs unless live repository policy explicitly accepts it;
+- an empty required-check set is accepted only after proving policy requires
+  none.
 
 Never interpret command exit zero alone as green.
 
 ## Merge mutation
 
-Immediately before mutation, recapture the exact live `headRefOid`. Pass that
-same OID to the merge command's exact-head guard.
+Immediately before mutation, repeat the complete current-head review sweep and
+merge-admission readback, then recapture `headRefOid`. Pass that same OID to the
+merge command's exact-head guard.
 
 - Never bundle cleanup into the merge command; do not use `--delete-branch`.
-- Never use `--admin` unless the user explicitly authorizes a named protection bypass after seeing the exact blocked rule.
-- Keep the merge method aligned with repository policy.
-- A queue or auto-merge submission is nonterminal. Continue monitoring until live state is actually merged.
+- Ordinary `$land` never performs an administrator protection bypass.
+- Keep the merge method aligned with live repository policy.
+- Queue and auto-merge submission are nonterminal; continue until live state is
+  actually merged.
+- A merge queue does not require the source branch to be current merely because
+  direct strict merging would; derive branch freshness from the selected route
+  and live policy.
 
-If the head OID changes, the merge must fail or stop. Do not retarget the attempt
-to the new head automatically.
+If the head changes, stop the mutation, supersede the epoch, and restart against
+the newly authorized head. Never retarget an in-flight merge attempt.
 
 ## Landing postcondition
 
-Before reporting success or cleaning anything, read live PR state and prove:
+Before reporting success or cleaning anything, prove from live state:
 
 ```text
 repository and PR still match the target
@@ -171,13 +250,12 @@ mergeCommit OID is non-null
 landed head OID == expected head OID
 ```
 
-For queue and auto-merge modes, wait through all nonterminal states. A successful
-submission, enabled auto-merge request, or queue admission is not a completed
-landing.
+A successful command, queue admission, or enabled auto-merge request is not a
+completed landing.
 
 ## Cleanup transaction
 
-Cleanup is post-merge and independently reported. A cleanup blocker does not
+Cleanup is post-merge and independently reported. A cleanup obstruction does not
 undo a successful merge; it produces a degraded cleanup result.
 
 Order:
@@ -205,46 +283,57 @@ For every associated worktree:
 
 - require its `HEAD` and branch ref to equal the landed head OID;
 - require a clean tracked and untracked status;
-- preserve and report locked worktrees, inaccessible paths, head drift, unique commits, or dirty state;
-- never use `git worktree remove --force` and never delete the directory with `rm -rf`;
-- if it is the primary worktree, switch it to the base branch and fast-forward rather than removing it;
-- if it is a linked worktree, move the running shell outside that path, run `git worktree remove -- <path>`, and verify the record disappeared;
-- prune only stale administrative metadata after path-safe removal and then refetch the full worktree inventory.
+- preserve and report locked worktrees, inaccessible paths, head drift, unique
+  commits, or dirty state;
+- never use `git worktree remove --force` and never delete the directory with
+  `rm -rf`;
+- switch the primary worktree to the base branch and fast-forward it rather than
+  removing it;
+- move the running shell outside a linked worktree, run
+  `git worktree remove -- <path>`, and verify the record disappeared;
+- prune only stale administrative metadata after path-safe removal and refetch
+  the complete worktree inventory.
 
-All associated worktrees must be removed or switched away from the head branch
-before deleting the local branch. See the exact algorithm in
-[references/landing-protocol.md](references/landing-protocol.md).
+All associated worktrees must be removed or switched away before deleting the
+local branch.
 
 ### Branches
 
-Delete the remote branch only when the live remote ref still equals the landed
-head OID and the head repository is the intended deletion target. Delete the
-local branch only when its ref still equals the landed head OID, no worktree is associated with it, and the current worktree is on the updated base branch.
-If requested cleanup observes that the exact local or remote branch ref is
-already absent, report `already-absent` as a successful no-op; never claim that
-the landing workflow deleted it.
+Delete the remote branch only when its live ref still equals the landed head OID
+and the head repository is the intended deletion target. Delete the local branch
+only when its ref still equals the landed head OID, no worktree is associated,
+and the current worktree is on the updated base branch.
 
-Under squash merge, a force branch deletion may be necessary because the landed
-commit is not an ancestor of the squash commit. Use it only after the OID and
-worktree proofs above; never inherit an implicit force-delete from `gh pr merge`.
+If an exact requested ref is already absent, report `already-absent` as a
+successful no-op; never claim that this landing deleted it.
+
+Under squash or rebase merge, local branch deletion may require force because the
+landed commit is rewritten. Use it only after exact-OID and worktree proof; never
+inherit implicit force deletion from `gh pr merge`.
 
 ## Output
 
-Emit one `LAND-v1` record after terminal readback and cleanup. Keep merge outcome,
-remote cleanup, local cleanup, and per-worktree cleanup separate. Use
-[references/land-record.md](references/land-record.md).
+Emit one `LAND-v2` record after terminal readback and cleanup attempts. Preserve
+landing epochs, per-thread review dispositions, merge admission, postcondition,
+remote cleanup, local cleanup, per-worktree cleanup, and plural obstructions as
+separate facts. See [land-record.md](references/land-record.md).
 
 ## Guardrails
 
 - Never merge an ambiguous PR target.
-- Never reuse evidence from before the final material mutation.
+- Never treat unresolved review threads as terminal when safe repair can progress.
+- Never resolve a current substantive concern without current-head discharge
+  evidence.
+- Never resolve threads from bare IDs or generic user encouragement.
+- Never reuse evidence across a material head mutation.
 - Never merge with an unresolved or incompletely inventoried review thread.
 - Never treat canceled required checks as green.
-- Never bypass protections with `--admin` without explicit user authorization.
+- Never use `--admin` in ordinary `$land`.
 - Never report queued, auto-enabled, or command-success state as merged.
 - Never clean a branch or worktree before a live `MERGED` postcondition.
 - Never force-remove a dirty, locked, drifted, or unidentified worktree.
-- If blocked, preserve state and report the exact failed gate and next safe action.
+- If obstructed, preserve state and report every exact obstruction and next safe
+  action.
 
 ## Resources
 

--- a/codex/skills/land/agents/openai.yaml
+++ b/codex/skills/land/agents/openai.yaml
@@ -2,5 +2,5 @@ policy:
   allow_implicit_invocation: false
 interface:
   display_name: "Land"
-  short_description: "Safely merge a ready GitHub PR and clean its state"
-  default_prompt: "Use $land to verify the exact PR and head commit, merge or wait for queue completion, prove live merged state, and safely clean branches and associated worktrees."
+  short_description: "Reconcile reviews, merge the exact PR, and clean state"
+  default_prompt: "Use $land to reconcile every unresolved review thread through evidence-backed repair or disposition, bind each successor head as a fresh landing epoch, establish current exact-head merge admission, prove live merged state, and safely clean branches and associated worktrees."

--- a/codex/skills/land/references/decision-contract.json
+++ b/codex/skills/land/references/decision-contract.json
@@ -4,7 +4,7 @@
     "skill": {
       "name": "land",
       "kind": "mixed",
-      "source_fingerprint": "land-v2-exact-head-postcondition-worktree-cleanup"
+      "source_fingerprint": "land-v3-review-reconciliation-successor-epochs"
     },
     "triggers": [
       {
@@ -25,8 +25,22 @@
         ]
       },
       {
+        "trigger_id": "LAND-REVIEW-CLOSURE",
+        "description": "The selected PR has unresolved review threads, active requested changes, or explicit current review blockers that Land must reconcile before merge.",
+        "cue_literals": [
+          "unresolved review thread",
+          "requested changes",
+          "review blocker",
+          "resolveReviewThread"
+        ],
+        "cue_regexes": [],
+        "exclusions": [
+          "bare thread IDs without concern context"
+        ]
+      },
+      {
         "trigger_id": "LAND-LIVE-STATE",
-        "description": "Live PR state must be classified before an irreversible merge or cleanup action.",
+        "description": "Live PR state must be classified before any review-resolution, merge, or cleanup mutation.",
         "cue_literals": [
           "headRefOid",
           "reviewDecision",
@@ -54,8 +68,25 @@
     ],
     "routes": [
       {
+        "route_id": "LAND-RECONCILE-REVIEWS",
+        "description": "Read, classify, repair or disposition, evidence, and resolve every unresolved review thread before fresh merge admission.",
+        "aliases": [
+          "reconcile-reviews",
+          "close-reviews-and-reflight"
+        ],
+        "terminal": false
+      },
+      {
+        "route_id": "LAND-REBIND-SUCCESSOR",
+        "description": "Supersede the immutable landing epoch after a repair or authorized update publishes a successor head, then rebuild all evidence.",
+        "aliases": [
+          "rebind-successor-head"
+        ],
+        "terminal": false
+      },
+      {
         "route_id": "LAND-MERGE-NOW",
-        "description": "Merge the exact approved head immediately with an exact-head guard, then verify live merged state.",
+        "description": "Merge the exact admitted head immediately with an exact-head guard, then prove live merged state.",
         "aliases": [
           "merge-now"
         ],
@@ -63,7 +94,7 @@
       },
       {
         "route_id": "LAND-QUEUE-WAIT",
-        "description": "Admit the exact approved head to the merge queue and wait for live merged state.",
+        "description": "Admit the exact head to the merge queue without inventing direct-merge freshness, then wait for live merged state.",
         "aliases": [
           "queue-and-wait"
         ],
@@ -71,7 +102,7 @@
       },
       {
         "route_id": "LAND-AUTO-WAIT",
-        "description": "Enable explicitly authorized auto-merge for the exact approved head and wait for live merged state.",
+        "description": "Enable explicitly selected auto-merge for the exact admitted head and wait for live merged state.",
         "aliases": [
           "auto-merge-and-wait"
         ],
@@ -79,7 +110,7 @@
       },
       {
         "route_id": "LAND-CLEANUP-ONLY",
-        "description": "Skip merge mutation because the exact PR is already merged and perform guarded cleanup only.",
+        "description": "Skip merge mutation because the exact PR/head is already merged and perform guarded cleanup only.",
         "aliases": [
           "cleanup-only"
         ],
@@ -87,17 +118,19 @@
       },
       {
         "route_id": "LAND-COMPLETE",
-        "description": "Emit LAND-v1 after live merged-state proof and independently verified cleanup outcomes.",
+        "description": "Emit LAND-v2 after review closure, live merged-state proof, and independently verified cleanup outcomes.",
         "aliases": [
+          "complete",
           "merged-and-cleaned",
           "merged-with-degraded-cleanup"
         ],
         "terminal": true
       },
       {
-        "route_id": "LAND-BLOCK",
-        "description": "Preserve state because identity, evidence, policy, authority, postcondition, or cleanup safety is incomplete.",
+        "route_id": "LAND-OBSTRUCT",
+        "description": "Preserve state only after proving no safe authorized review, admission, postcondition, or cleanup transition remains.",
         "aliases": [
+          "obstructed",
           "blocked"
         ],
         "terminal": true
@@ -111,11 +144,13 @@
           "LAND-LIVE-STATE"
         ],
         "expected_routes": [
+          "LAND-RECONCILE-REVIEWS",
+          "LAND-REBIND-SUCCESSOR",
           "LAND-MERGE-NOW",
           "LAND-QUEUE-WAIT",
           "LAND-AUTO-WAIT",
           "LAND-CLEANUP-ONLY",
-          "LAND-BLOCK"
+          "LAND-OBSTRUCT"
         ],
         "prohibited_routes": [],
         "required_artifacts": [
@@ -127,17 +162,119 @@
           "expected head OID"
         ],
         "success_signals": [
-          "all live identity fields match one immutable target"
+          "all live identity fields match one immutable landing epoch"
         ],
         "failure_signals": [
           "branch-name-only targeting",
-          "changed head",
+          "changed head silently retargeted",
           "mismatched repository or PR"
         ],
-        "rationale": "Irreversible actions require an exact repository and commit target."
+        "rationale": "Irreversible actions require an exact repository and head epoch."
       },
       {
-        "clause_id": "LAND-FRESHNESS-001",
+        "clause_id": "LAND-REVIEW-PROGRESS-001",
+        "trigger_refs": [
+          "LAND-REVIEW-CLOSURE",
+          "LAND-LIVE-STATE"
+        ],
+        "expected_routes": [
+          "LAND-RECONCILE-REVIEWS",
+          "LAND-REBIND-SUCCESSOR",
+          "LAND-OBSTRUCT"
+        ],
+        "prohibited_routes": [
+          "LAND-MERGE-NOW",
+          "LAND-QUEUE-WAIT",
+          "LAND-AUTO-WAIT"
+        ],
+        "required_artifacts": [
+          "complete paginated review-thread inventory",
+          "unresolved thread IDs",
+          "full concern context",
+          "current-head applicability",
+          "law-authority classification when needed"
+        ],
+        "success_signals": [
+          "every safe unresolved concern enters repair or evidence-backed disposition",
+          "a repairable concern never produces terminal obstruction before attempted repair"
+        ],
+        "failure_signals": [
+          "unresolved thread reported as terminal merely because merge is not ready",
+          "repairable concern delegated back to the user"
+        ],
+        "rationale": "Merge admission failure is not workflow terminality while review closure can progress."
+      },
+      {
+        "clause_id": "LAND-THREAD-DISCHARGE-001",
+        "trigger_refs": [
+          "LAND-REVIEW-CLOSURE",
+          "LAND-LIVE-STATE"
+        ],
+        "expected_routes": [
+          "LAND-RECONCILE-REVIEWS",
+          "LAND-REBIND-SUCCESSOR",
+          "LAND-OBSTRUCT"
+        ],
+        "prohibited_routes": [
+          "LAND-MERGE-NOW",
+          "LAND-QUEUE-WAIT",
+          "LAND-AUTO-WAIT"
+        ],
+        "required_artifacts": [
+          "thread ID",
+          "concern reference",
+          "observed and resolved head OIDs",
+          "disposition",
+          "evidence references",
+          "live resolution readback"
+        ],
+        "success_signals": [
+          "every resolved thread has one individual evidence-bearing disposition",
+          "fixed current concern is evidenced at a successor head",
+          "final live unresolved thread set is empty before merge"
+        ],
+        "failure_signals": [
+          "bulk resolution from bare thread IDs",
+          "isOutdated treated as proof of obsolescence",
+          "current substantive concern resolved at an unchanged head",
+          "generic user continuation treated as withdrawal"
+        ],
+        "rationale": "GitHub resolution metadata records semantic discharge; it cannot manufacture it."
+      },
+      {
+        "clause_id": "LAND-SUCCESSOR-EPOCH-001",
+        "trigger_refs": [
+          "LAND-REVIEW-CLOSURE",
+          "LAND-LIVE-STATE"
+        ],
+        "expected_routes": [
+          "LAND-REBIND-SUCCESSOR",
+          "LAND-RECONCILE-REVIEWS",
+          "LAND-MERGE-NOW",
+          "LAND-QUEUE-WAIT",
+          "LAND-AUTO-WAIT",
+          "LAND-OBSTRUCT"
+        ],
+        "prohibited_routes": [],
+        "required_artifacts": [
+          "superseded head OID",
+          "successor head OID",
+          "fresh complete thread inventory",
+          "fresh structured review state",
+          "fresh required checks",
+          "fresh policy snapshot"
+        ],
+        "success_signals": [
+          "every material head mutation starts a new immutable landing epoch"
+        ],
+        "failure_signals": [
+          "admission evidence reused across a push",
+          "old epoch silently retargeted to a successor head"
+        ],
+        "rationale": "Review repair changes the object being admitted and invalidates all prior admission evidence."
+      },
+      {
+        "clause_id": "LAND-ADMISSION-001",
         "trigger_refs": [
           "LAND-LIVE-STATE"
         ],
@@ -145,24 +282,27 @@
           "LAND-MERGE-NOW",
           "LAND-QUEUE-WAIT",
           "LAND-AUTO-WAIT",
-          "LAND-BLOCK"
+          "LAND-OBSTRUCT"
         ],
         "prohibited_routes": [],
         "required_artifacts": [
-          "fresh complete thread inventory",
-          "structured reviews",
+          "zero live unresolved thread IDs",
+          "complete review reconciliation records",
+          "structured approvals",
           "terminal required-check buckets",
-          "merge policy snapshot"
+          "route-specific branch freshness",
+          "repository policy"
         ],
         "success_signals": [
-          "all evidence was rebuilt after the final material mutation"
+          "merge admission is derived from the current epoch",
+          "queue admission does not invent direct strict branch freshness"
         ],
         "failure_signals": [
-          "stale review sweep",
-          "partial pagination",
-          "canceled required check treated as green"
+          "canceled required check treated as green",
+          "behind queue candidate blocked solely by direct-merge freshness",
+          "administrator bypass selected"
         ],
-        "rationale": "A push or review mutation invalidates prior landing evidence."
+        "rationale": "Only current-head, route-correct admission evidence may authorize merge mutation."
       },
       {
         "clause_id": "LAND-MUTATION-001",
@@ -174,7 +314,7 @@
           "LAND-MERGE-NOW",
           "LAND-QUEUE-WAIT",
           "LAND-AUTO-WAIT",
-          "LAND-BLOCK"
+          "LAND-OBSTRUCT"
         ],
         "prohibited_routes": [],
         "required_artifacts": [
@@ -185,14 +325,14 @@
         "success_signals": [
           "merge command binds expected head",
           "no bundled branch deletion",
-          "no unauthorized admin bypass"
+          "no administrator bypass"
         ],
         "failure_signals": [
           "missing match-head guard",
           "delete-branch bundled into merge",
-          "implicit admin override"
+          "admin retry"
         ],
-        "rationale": "The mutation must fail rather than land a different head or bypass policy silently."
+        "rationale": "The mutation must fail rather than land a different head or negate repository policy."
       },
       {
         "clause_id": "LAND-POSTCONDITION-001",
@@ -201,7 +341,7 @@
         ],
         "expected_routes": [
           "LAND-COMPLETE",
-          "LAND-BLOCK"
+          "LAND-OBSTRUCT"
         ],
         "prohibited_routes": [],
         "required_artifacts": [
@@ -220,62 +360,39 @@
         "rationale": "Command success and queue admission are not terminal landing proof."
       },
       {
-        "clause_id": "LAND-WORKTREE-001",
-        "trigger_refs": [
-          "LAND-CLEANUP"
-        ],
-        "expected_routes": [
-          "LAND-COMPLETE",
-          "LAND-BLOCK"
-        ],
-        "prohibited_routes": [],
-        "required_artifacts": [
-          "NUL-safe worktree inventory",
-          "exact branch association",
-          "per-worktree head and cleanliness proof"
-        ],
-        "success_signals": [
-          "linked worktrees removed without force",
-          "primary worktree switched to base",
-          "no associated record remains"
-        ],
-        "failure_signals": [
-          "detached worktree deleted by OID",
-          "dirty or locked worktree forced away",
-          "directory removed with rm -rf"
-        ],
-        "rationale": "Worktrees can hold unique local state and must be cleaned before branch deletion without destructive inference."
-      },
-      {
         "clause_id": "LAND-CLEANUP-001",
         "trigger_refs": [
           "LAND-CLEANUP"
         ],
         "expected_routes": [
           "LAND-COMPLETE",
-          "LAND-BLOCK"
+          "LAND-OBSTRUCT"
         ],
         "prohibited_routes": [],
         "required_artifacts": [
           "landed head OID",
+          "NUL-safe worktree inventory",
+          "per-worktree head and cleanliness proof",
           "remote ref readback",
-          "local ref readback",
-          "final worktree inventory"
+          "local ref readback"
         ],
         "success_signals": [
+          "linked worktrees removed without force",
+          "primary worktree switched to base",
           "each cleanup surface reports an independent verified result"
         ],
         "failure_signals": [
+          "detached worktree deleted by OID",
+          "dirty or locked worktree forced away",
           "branch ref drift ignored",
-          "cleanup failure rewrites merge outcome",
-          "implicit force deletion"
+          "cleanup failure rewrites merge outcome"
         ],
-        "rationale": "Cleanup is a post-merge transaction with separate remote, local, and worktree facts."
+        "rationale": "Cleanup is a preservation-first post-merge saga with independent facts."
       }
     ],
     "instrumentation": {
       "decision_receipt": "optional",
-      "rationale": "LAND-v1 is the required operational receipt; emit SDR-v1 only when route selection needs separate tuning evidence."
+      "rationale": "LAND-v2 is the required operational receipt; emit SDR-v1 only when route selection needs separate tuning evidence."
     }
   }
 }

--- a/codex/skills/land/references/land-record.md
+++ b/codex/skills/land/references/land-record.md
@@ -1,10 +1,11 @@
 # Land Record
 
-Emit one terminal record after live merged-state readback and cleanup attempts.
+Emit one terminal record after review reconciliation, live merged-state readback,
+and cleanup attempts.
 
 ```yaml
 land_record:
-  record_version: LAND-v1
+  record_version: LAND-v2
 
   target:
     repository:
@@ -16,24 +17,56 @@ land_record:
     head_ref:
     expected_head_oid:
 
+  epochs:
+    - head_oid:
+      supersedes_head_oid:
+      reason: initial | review-repair | authorized-branch-update
+      result: superseded | admitted | merged | obstructed
+
+  review_reconciliation:
+    initial_unresolved_thread_ids: []
+    records:
+      - thread_id:
+        concern_ref:
+        observed_head_oid:
+        resolved_head_oid:
+        law_authority: entailed | strengthening | preference |
+          new-requirement | underdetermined
+        current_applicability: still-present | transformed-applicable |
+          already-excluded | not-comparable | unknown
+        disposition: fixed-and-evidenced |
+          already-satisfied-and-evidenced | obsolete-and-evidenced |
+          reviewer-withdrawn | nonblocking-by-authority
+        evidence_refs: []
+        resolution_readback: true | false
+    unresolved_after: []
+    result: complete | not-needed | obstructed
+
   decision:
-    mode: merge-now | queue-and-wait | auto-merge-and-wait | cleanup-only | blocked
-    merge_method: merge | squash | rebase | repo-policy | none
+    mode: reconcile-reviews | rebind-successor-head | merge-now |
+      queue-and-wait | auto-merge-and-wait | cleanup-only | obstructed |
+      complete
+    workflow_status: continue | ready | obstructed | terminal
+    merge_admission: ready | not-ready | not-applicable
+    merge_method: merge | squash | rebase | none
     reason:
 
   gates:
-    target_identity: pass | fail
-    review_inventory: pass | fail
-    review_decision: pass | fail
-    required_checks: pass | fail
-    conflict_free: pass | fail
-    branch_freshness: pass | fail
-    repository_policy: pass | fail
-    exact_head: pass | fail
+    target_identity: pass | fail | not-applicable
+    pr_state: pass | fail | not-applicable
+    review_inventory: pass | fail | not-applicable
+    review_reconciliation: pass | fail | not-applicable
+    review_decision: pass | fail | not-applicable
+    required_checks: pass | fail | not-applicable
+    conflict_free: pass | fail | not-applicable
+    branch_freshness: pass | fail | not-applicable
+    repository_policy: pass | fail | not-applicable
+    exact_head: pass | fail | not-applicable
 
   action:
     command:
-    result: merged | queued | auto-enabled | already-merged | blocked | failed
+    result: merged | queued | auto-enabled | already-merged |
+      obstructed | failed
     expected_head_oid:
     admin_override: false
 
@@ -48,7 +81,7 @@ land_record:
   cleanup:
     associated_worktrees:
       requested: yes | no
-      result: cleaned | partial | preserved | not-requested | blocked
+      result: cleaned | partial | preserved | not-requested | obstructed
       items:
         - path:
           kind: primary | linked | stale
@@ -56,43 +89,59 @@ land_record:
           observed_head_oid:
           dirty: yes | no | unknown
           locked: yes | no | unknown
-          action: switched-to-base | removed | pruned | preserved | not-applicable
-          result: pass | fail | blocked
+          action: switched-to-base | removed | pruned | preserved |
+            not-applicable
+          result: pass | fail | obstructed
           reason:
     remote_branch:
       requested: yes | no
       observed_oid:
-      action: deleted | already-absent | preserved | not-requested | blocked
+      action: deleted | already-absent | preserved | not-requested |
+        obstructed
       reason:
     local_branch:
       requested: yes | no
       observed_oid:
-      action: deleted | already-absent | preserved | not-requested | blocked
+      action: deleted | already-absent | preserved | not-requested |
+        obstructed
       reason:
-    overall: complete | degraded | not-requested | blocked
+    overall: complete | degraded | not-requested | obstructed
 
-  blocker:
-    gate:
-    reason:
-    next_safe_action:
+  obstructions:
+    - code:
+      gate:
+      evidence_refs: []
+      reason:
+      next_safe_action:
 ```
 
 ## Semantics
 
+- `LAND-v2` is terminal. Nonterminal preflight returns
+  `LAND-PREFLIGHT-v2` with `verdict: continue`; do not emit a final record while
+  review reconciliation or queue monitoring can still progress.
+- Every thread resolved by this landing appears exactly once in
+  `review_reconciliation.records`. Bare thread IDs, aggregate counts, and
+  `isOutdated` are not disposition evidence.
+- `fixed-and-evidenced` requires a successor head. A current substantive concern
+  cannot be reported fixed at the same head on which it was observed.
+- `review_reconciliation.result: complete` requires
+  `unresolved_after: []`, complete current-head evidence for every record, and
+  successful live resolution readback.
+- A new head appends a new epoch and supersedes the old epoch. Evidence from a
+  superseded head cannot establish current merge admission.
 - `action.result: queued` and `action.result: auto-enabled` are nonterminal. Do
-  not emit the final LAND-v1 until postcondition monitoring reaches `MERGED` or a
-  terminal blocker.
+  not emit final `LAND-v2` until monitoring reaches `MERGED` or an exact terminal
+  obstruction.
 - `action.result: merged` is valid only when the live postcondition passes. A
   successful mutation command alone is insufficient.
 - `cleanup.overall: degraded` means the PR merged but at least one requested
-  branch or worktree cleanup was preserved or blocked. A cleanup blocker does not
-  rewrite a successful merge as failed.
-- Worktree items are reported independently. Do not collapse a dirty or locked
-  worktree into a generic branch-deletion failure.
-- `already-absent` is a successful no-op only when requested cleanup proves the
-  exact local or remote branch ref was absent before mutation. It must not imply
-  that this landing attempt deleted the ref.
-- `admin_override` must remain false unless the user explicitly authorized a
-  specific bypass in the current landing attempt.
-- Copied SHIP-v1 fields may be referenced in surrounding evidence, but LAND-v1
-  target, gate, action, and postcondition fields come from fresh live state.
+  cleanup surface was preserved or obstructed. Cleanup does not rewrite a
+  successful merge as failed.
+- Worktree, remote-ref, and local-ref outcomes are independent.
+- `already-absent` is a successful no-op only after proving exact ref absence. It
+  never implies that this landing deleted the ref.
+- `admin_override` is always false. Administrator bypass is outside ordinary
+  `$land`.
+- `obstructions` is plural and lossless. Do not collapse independent review,
+  admission, postcondition, or cleanup failures into one generic blocker.

--- a/codex/skills/land/references/landing-protocol.md
+++ b/codex/skills/land/references/landing-protocol.md
@@ -1,10 +1,19 @@
 # Landing Protocol
 
-This reference defines the operational details behind `$land`. The order is
-normative: target binding, fresh evidence, guarded mutation, live postcondition,
-then cleanup.
+This reference defines the operational details behind `$land`. The normative
+order is:
 
-## 1. Bind the exact target
+```text
+bind landing epoch
+-> reconcile every review thread
+-> bind any successor head as a new epoch
+-> collect fresh merge admission
+-> guarded merge mutation
+-> live postcondition
+-> cleanup
+```
+
+## 1. Bind the exact landing epoch
 
 Use an explicit repository and PR selector for every GitHub command:
 
@@ -33,15 +42,15 @@ Reject a mismatched repository, PR number, base ref, head repository, head ref,
 or head OID. Branch names are not globally unique and are never sufficient by
 themselves.
 
-A SHIP-v1 receipt may identify the intended PR, but live GitHub state remains
+A SHIP receipt may identify the intended PR, but live GitHub state remains
 authoritative.
 
-## 2. Update policy and evidence invalidation
+## 2. Authorized branch updates
 
 Do not update or rewrite the PR branch merely because it is behind. First read
-repository policy and select the authorized update method.
+live repository policy and select the authorized route.
 
-When an update is permitted:
+When a direct branch update is required and permitted:
 
 ```bash
 gh pr update-branch "$pr" --repo "$repo"
@@ -49,9 +58,13 @@ gh pr update-branch "$pr" --repo "$repo"
 gh pr update-branch "$pr" --repo "$repo" --rebase
 ```
 
-Any push, branch update, review-thread resolution, approval change, or other
-material mutation invalidates every prior review, check, mergeability, and
-head-OID observation. Rebuild the complete snapshot after the final mutation.
+Any branch update publishes a new head. Close the current landing epoch as
+superseded and bind a successor landing epoch before further review or merge
+admission.
+
+A merge queue synthesizes and validates a merge group against the current base;
+it does not require the source branch to be updated merely because a direct
+strict merge route would require freshness.
 
 ## 3. Complete review-thread inventory
 
@@ -80,12 +93,17 @@ query(
           isOutdated
           path
           line
-          comments(last: 1) {
+          comments(first: 100) {
             totalCount
+            pageInfo {
+              hasNextPage
+              endCursor
+            }
             nodes {
               author { login }
               body
               url
+              createdAt
             }
           }
         }
@@ -103,25 +121,147 @@ gh api graphql --paginate --slurp \
   > review-pages.json
 ```
 
-Require all of the following:
+Require:
 
 ```text
 first page contains totalCount
-sum(nodes across pages) == totalCount
-last page pageInfo.hasNextPage == false
-all pages report the same headRefOid
-that headRefOid == expected head OID
+sum(thread nodes across pages) == totalCount
+last thread page hasNextPage == false
 all thread IDs are unique
-unresolved thread count == 0
+all pages report the same headRefOid
+that headRefOid == epoch head OID
+complete conversation context is available for every unresolved thread
 ```
 
-If any invariant fails, block. Do not fall back to the first 100 threads.
+If conversation pagination is needed, fetch it before disposition. The latest
+comment is an index, not necessarily the concern.
 
-For an unresolved thread, retrieve enough of the conversation to understand the
-concern before choosing its disposition. The latest comment alone is an index,
-not always sufficient evidence.
+Incomplete inventory, API failure, missing counts, duplicate IDs, or head drift
+is an obstruction. Do not fall back to the first 100 threads and do not treat
+absence caused by an API failure as zero unresolved threads.
 
-Resolve an objectively addressed or explicitly withdrawn thread with:
+## 4. Review reconciliation loop
+
+An unresolved thread blocks merge admission, but it is a nonterminal workflow
+state whenever safe resolution work remains.
+
+For every unresolved thread:
+
+1. Preserve its complete concern and source URL as a witness.
+2. Inspect the current head and determine current applicability.
+3. Use `$review-fold` when law authority or applicability is not mechanically
+   evident.
+4. Choose one disposition:
+
+   ```text
+   fixed-and-evidenced
+   already-satisfied-and-evidenced
+   obsolete-and-evidenced
+   reviewer-withdrawn
+   nonblocking-by-authority
+   needs-authority
+   needs-reviewer-clarification
+   repair-failed
+   ```
+
+5. Resolve only the first five dispositions. The final three preserve the thread
+   and produce an exact obstruction.
+
+### Directly repairable concerns
+
+A current accepted concern that is safely repairable within the authorized PR
+scope must not cause terminal obstruction before repair is attempted.
+
+Use the existing semantic owners:
+
+```text
+Review Fold classification
+-> Actuating review-closeout or isolated owner-local repair
+-> strongest relevant validation
+-> Ship publication
+-> Land current-head discharge proof
+-> Land thread resolution
+```
+
+The minimum behavioral trace is:
+
+```text
+patch -> validate -> publish successor head
+-> prove current-head discharge
+-> resolve thread
+-> complete fresh preflight
+```
+
+If repair changes the head from `H0` to `H1`:
+
+```text
+close H0 epoch as superseded
+bind H1 as the successor landing epoch
+discard every admission observation from H0
+refetch every review thread at H1
+reclassify any still-current concerns
+rebuild required checks and repository policy at H1
+```
+
+Do not automatically retarget the old epoch. The PR identity persists; the head
+identity does not.
+
+### Evidence-bearing resolution record
+
+Before resolving a thread, retain:
+
+```yaml
+review_resolution:
+  thread_id:
+  concern_ref:
+  observed_head_oid:
+  resolved_head_oid:
+  law_authority: entailed | strengthening | preference |
+    new-requirement | underdetermined
+  current_applicability: still-present | transformed-applicable |
+    already-excluded | not-comparable | unknown
+  disposition: fixed-and-evidenced | already-satisfied-and-evidenced |
+    obsolete-and-evidenced | reviewer-withdrawn | nonblocking-by-authority
+  evidence_refs: []
+  resolution_readback: true
+```
+
+Requirements:
+
+- `fixed-and-evidenced` requires `resolved_head_oid != observed_head_oid` and
+  validation or proof against `resolved_head_oid`;
+- `already-satisfied-and-evidenced` requires current-head source or test evidence
+  that the alleged defect is absent;
+- `obsolete-and-evidenced` requires objective current-head evidence; GitHub
+  `isOutdated` alone is insufficient;
+- `reviewer-withdrawn` requires the reviewer's explicit withdrawal;
+- `nonblocking-by-authority` requires the accepted Goal or public-contract basis
+  showing the requested property is not a current merge obligation;
+- every record requires live GitHub resolution readback;
+- all evidence must be current at the final epoch head.
+
+A generic continuation instruction such as "continue", "finish it", or "do your
+job" is not withdrawal, defect invalidation, or authority to dismiss a concern.
+
+### Prohibited resolution behavior
+
+Never:
+
+- resolve from bare thread IDs;
+- convert `isOutdated` directly into `obsolete`;
+- bulk-resolve before assigning an individual disposition to every thread;
+- call a current substantive defect fixed at an unchanged head;
+- modify a temporary preflight count to simulate resolution;
+- resolve a concern merely because the user asked Land to finish the PR.
+
+Batching is permitted only after every member is bound to a valid individual
+record. Review Fold may quotient duplicate witnesses into a shared semantic
+class, but every original thread must retain its own evidence binding and live
+resolution readback.
+
+### Resolution mutation
+
+For an evidenced resolvable disposition:
 
 ```bash
 gh api graphql \
@@ -129,24 +269,37 @@ gh api graphql \
   -f query='mutation($threadId:ID!){resolveReviewThread(input:{threadId:$threadId}){thread{id isResolved}}}'
 ```
 
-Then discard the old inventory and fetch every page again.
+Require the returned thread ID to match and `isResolved` to be true. Then discard
+the previous inventory and refetch every page.
 
-## 4. Structured review and blocker state
+The reconciliation loop reaches its fixed point only when:
 
-Read structured review state:
+```text
+complete current-head inventory
+unresolved thread IDs == []
+all threads resolved by this landing have complete current-head records
+no active requested changes
+no explicit unresolved material blocker
+```
+
+## 5. Structured review and approval state
+
+Read structured review state after the final resolution mutation:
 
 ```bash
 gh pr view "$pr" --repo "$repo" \
   --json reviewDecision,latestReviews,reviewRequests,comments,headRefOid
 ```
 
-Repository policy determines whether an approval is required. Active
-`CHANGES_REQUESTED`, pending required review, unanswered material questions, or
-an explicit top-level blocker prevents landing. Do not infer approval solely
-from free-form prose when `reviewDecision` and latest review states are
+Active `CHANGES_REQUESTED`, unanswered material questions, or an explicit
+current blocker routes back to `reconcile-reviews`. A required approval that is
+simply absent and cannot be supplied by Land is an obstruction with the exact
+required next action.
+
+Do not infer approval solely from free-form prose when structured review state is
 available.
 
-## 5. Required checks
+## 6. Required checks
 
 Wait, then read a separate structured terminal snapshot:
 
@@ -158,25 +311,22 @@ gh pr checks "$pr" --repo "$repo" --required \
   > required-checks.json
 ```
 
-The waiter cannot be the final proof because canceled checks are not equivalent
-to passed checks.
-
-Default policy:
+The waiter is not final proof.
 
 | Bucket | Disposition |
 |---|---|
 | `pass` | accept |
-| `fail` | block |
-| `pending` | block |
-| `cancel` | block |
-| `skipping` | block unless repository policy explicitly accepts the skipped required context |
+| `fail` | obstruct |
+| `pending` | wait, then reread |
+| `cancel` | obstruct |
+| `skipping` | obstruct unless live policy explicitly accepts the skipped required context |
 
-If no required checks are returned, prove that the base-branch policy requires
-none. An API error or unknown policy is not an empty passing set.
+If no required checks are returned, prove that current base-branch policy
+requires none. An API error or unknown policy is not an empty passing set.
 
-## 6. Preflight snapshot
+## 7. LAND-PREFLIGHT-v2 snapshot
 
-Normalize live observations into the evaluator input:
+Normalize current observations without erasing unresolved thread identities:
 
 ```json
 {
@@ -186,7 +336,7 @@ Normalize live observations into the evaluator input:
     "base_ref": "main",
     "head_repository": "owner/name",
     "head_ref": "feature",
-    "head_oid": "0123456789abcdef"
+    "head_oid": "1111111111111111111111111111111111111111"
   },
   "observed": {
     "repository": "owner/name",
@@ -196,14 +346,33 @@ Normalize live observations into the evaluator input:
     "base_ref": "main",
     "head_repository": "owner/name",
     "head_ref": "feature",
-    "head_oid": "0123456789abcdef"
+    "head_oid": "1111111111111111111111111111111111111111"
   },
   "reviews": {
     "inventory_complete": true,
-    "unresolved_threads": 0,
+    "unresolved_thread_ids": [],
     "review_decision": "APPROVED",
     "requested_changes_active": false,
-    "explicit_blockers": 0
+    "explicit_blockers": 0,
+    "reconciliation": {
+      "initial_unresolved_thread_ids": ["PRRT_thread_1"],
+      "records": [
+        {
+          "thread_id": "PRRT_thread_1",
+          "concern_ref": "https://github.com/owner/name/pull/123#discussion_r1",
+          "observed_head_oid": "0000000000000000000000000000000000000000",
+          "resolved_head_oid": "1111111111111111111111111111111111111111",
+          "law_authority": "entailed",
+          "current_applicability": "already-excluded",
+          "disposition": "fixed-and-evidenced",
+          "evidence_refs": [
+            "commit:1111111111111111111111111111111111111111",
+            "test:uv run python3 -m unittest"
+          ],
+          "resolution_readback": true
+        }
+      ]
+    }
   },
   "checks": {
     "required_expected": true,
@@ -215,6 +384,7 @@ Normalize live observations into the evaluator input:
     "delivery_mode": "immediate",
     "conflict_free": true,
     "branch_up_to_date": true,
+    "strict_freshness_required": true,
     "policy_satisfied": true,
     "method_allowed": true,
     "admin_override": false
@@ -226,7 +396,7 @@ Normalize live observations into the evaluator input:
 }
 ```
 
-`merge.delivery_mode` is one of `immediate`, `queue`, or `auto`.
+`merge.delivery_mode` is `immediate`, `queue`, or `auto`.
 
 Evaluate:
 
@@ -234,27 +404,50 @@ Evaluate:
 uv run python3 codex/skills/land/scripts/evaluate_preflight.py snapshot.json
 ```
 
-The evaluator is pure: it performs no network, Git, filesystem, merge, or cleanup
-mutation. It returns one route and an explicit blocker list.
+The evaluator is pure. It performs no network, Git, filesystem, merge, thread
+resolution, or cleanup mutation.
 
-## 7. Final exact-head recapture
+Result semantics:
 
-Immediately before the merge mutation, reread live state and recapture the head:
+```text
+verdict pass / exit 0
+  merge admission ready or cleanup-only
 
-```bash
-head_oid="$({
-  gh pr view "$pr" --repo "$repo" --json headRefOid --jq .headRefOid
-})"
+verdict continue / exit 3
+  workflow can progress through reconcile-reviews
+
+verdict block / exit 2
+  evidence or authority is unsound or unavailable; preserve state
 ```
 
+An unresolved thread ID produces `continue`, `merge_admission: not-ready`, and
+`mode: reconcile-reviews`. It does not produce terminal obstruction merely for
+being unresolved.
+
+## 8. Final current-head recapture
+
+Immediately before merge mutation:
+
+1. refetch the complete review-thread inventory;
+2. require zero unresolved IDs;
+3. reread structured review and required checks;
+4. reevaluate the current snapshot;
+5. recapture `headRefOid`:
+
+   ```bash
+   head_oid="$({
+     gh pr view "$pr" --repo "$repo" --json headRefOid --jq .headRefOid
+   })"
+   ```
+
 Require `head_oid` to equal the evaluator's expected head. If it differs, stop,
-discard every gate, and restart preflight against the newly authorized target.
+supersede the epoch, and restart complete preflight.
 
-## 8. Merge actions
+## 9. Merge actions
 
-Never pass `--delete-branch` here.
+Never pass `--delete-branch` here. Never use `--admin` in ordinary `$land`.
 
-Immediate merge, using the repository-approved method:
+Immediate merge using the repository-approved method:
 
 ```bash
 gh pr merge "$pr" --repo "$repo" \
@@ -278,12 +471,10 @@ gh pr merge "$pr" --repo "$repo" \
   --match-head-commit "$head_oid"
 ```
 
-Substitute `--merge` or `--rebase` only when repository policy selects that
-method. Never use `--admin` as a retry mechanism. An administrator bypass
-requires a new explicit user authorization naming the rule that would be
-bypassed.
+Substitute `--merge` or `--rebase` only when live repository policy selects that
+method.
 
-## 9. Wait for the terminal postcondition
+## 10. Wait for the terminal postcondition
 
 After any merge, queue, or auto-merge command, repeatedly read live PR state:
 
@@ -293,8 +484,8 @@ gh pr view "$pr" --repo "$repo" \
 ```
 
 Continue waiting while the exact PR remains open and legitimately queued or
-auto-enabled. Stop and report a blocker when it is closed without merge, removed
-from the expected flow, or its head changes.
+auto-enabled. Stop when it is closed without merge, removed from the expected
+flow, or its head changes.
 
 Landing is proven only when:
 
@@ -307,11 +498,10 @@ headRefOid == expected head OID
 
 Record the merge commit OID and timestamp before cleanup.
 
-## 10. Worktree cleanup
+## 11. Worktree cleanup
 
-Worktree cleanup precedes local branch deletion because Git refuses ordinary
-branch deletion while a worktree uses the branch, and because force deletion can
-hide unique local state.
+Worktree cleanup precedes local branch deletion because worktrees can hold unique
+local state.
 
 ### Inventory
 
@@ -319,16 +509,6 @@ From a surviving repository context:
 
 ```bash
 git worktree list --porcelain -z > worktrees.before
-```
-
-Parse NUL-delimited records. Relevant fields include:
-
-```text
-worktree <absolute-path>
-HEAD <oid>
-branch refs/heads/<branch>
-locked [reason]
-prunable <reason>
 ```
 
 Select only records whose branch field is exactly:
@@ -344,9 +524,9 @@ head OID.
 
 For each selected record:
 
-1. Require the record's `HEAD` to equal the landed head OID.
-2. Require `git rev-parse refs/heads/<head_ref>` to equal the landed head OID.
-3. Require the path to be accessible, unless the record is explicitly stale and prunable.
+1. Require the record `HEAD` to equal the landed head OID.
+2. Require `refs/heads/<head_ref>` to equal the landed head OID.
+3. Require the path to be accessible unless explicitly stale and prunable.
 4. Require no `locked` marker.
 5. Require clean tracked and untracked state:
 
@@ -354,15 +534,14 @@ For each selected record:
    git -C "$worktree_path" status --porcelain=v1 -uall
    ```
 
-6. Detect whether the running process's current directory is the worktree path or a descendant. Move to a different surviving worktree or other safe repository context before removal.
+6. Move the running process outside a linked worktree before removal.
 
-Any failed gate preserves the worktree and records an exact blocker. Never use
-`--force` to convert uncertainty into deletion.
+Any failed gate preserves the worktree and reports an exact cleanup obstruction.
+Never use `--force` to convert uncertainty into deletion.
 
 ### Primary worktree
 
-The primary worktree is not removable with `git worktree remove`. If it uses the
-head branch:
+If the primary worktree uses the head branch:
 
 ```bash
 git -C "$primary_path" fetch <base-remote> <base-ref>
@@ -370,12 +549,11 @@ git -C "$primary_path" switch <base-ref>
 git -C "$primary_path" merge --ff-only <base-remote>/<base-ref>
 ```
 
-If the switch or fast-forward fails, preserve the worktree and branch. Successful
-switching removes the association without deleting the primary checkout.
+Preserve it if switching or fast-forwarding fails.
 
 ### Linked worktree
 
-For a clean, unlocked linked worktree whose `HEAD` equals the landed head OID:
+For a clean, unlocked linked worktree at the landed head:
 
 ```bash
 cd "$safe_surviving_context"
@@ -389,32 +567,22 @@ git worktree remove --force
 rm -rf <worktree-path>
 ```
 
-After removal, refetch the inventory and prove that the exact path and branch
-association are gone.
+Refetch inventory and prove the exact association disappeared.
 
-For a stale `prunable` record whose directory is already absent, run:
+For an absent stale `prunable` path, `git worktree prune --verbose` may remove
+administrative metadata. Inventory before and after, and report every removed
+record.
 
-```bash
-git worktree prune --verbose
-```
+Completion requires no record with `branch refs/heads/<head_ref>`. Detached
+worktrees remain untouched.
 
-Then refetch and verify. Pruning is administrative cleanup, not permission to
-delete a live directory.
+## 12. Branch cleanup
 
-### Completion condition
+If an exact requested local or remote ref is already absent, record
+`already-absent` as a successful no-op. API failure or ambiguous lookup is an
+obstruction, not absence.
 
-Worktree cleanup is complete only when no inventory record contains
-`branch refs/heads/<head_ref>`. Detached worktrees remain untouched.
-
-## 11. Branch cleanup
-
-If requested cleanup observes that the exact local or remote branch ref is
-already absent, record `already-absent` as a successful no-op. Prove absence by
-querying the exact ref; an API error, inaccessible repository, or ambiguous
-lookup is `blocked`, not absence. Never report `deleted` when this landing
-attempt performed no deletion.
-
-Remote branch deletion requires:
+Remote deletion requires:
 
 ```text
 head repository is the intended repository
@@ -423,7 +591,7 @@ remote ref OID == landed head OID
 cleanup policy requests deletion
 ```
 
-Local branch deletion requires:
+Local deletion requires:
 
 ```text
 local ref OID == landed head OID
@@ -432,13 +600,14 @@ current worktree is on the updated base branch
 cleanup policy requests deletion
 ```
 
-Under squash merge, use a force delete only after those proofs:
+Under squash or rebase merge, force deletion may be necessary after those exact
+proofs:
 
 ```bash
 git branch -D -- "$head_ref"
 ```
 
-For a merge commit or rebase merge, prefer ordinary safe deletion when possible:
+For a merge commit, prefer ordinary safe deletion when possible:
 
 ```bash
 git branch -d -- "$head_ref"
@@ -446,17 +615,19 @@ git branch -d -- "$head_ref"
 
 Never rely on `gh pr merge --delete-branch` for these decisions.
 
-## 12. Final verification
+## 13. Final verification
 
 Read back:
 
 ```text
 PR remains MERGED at the expected head
+review unresolved IDs remain empty
 remote branch deletion result
 local branch deletion result
 full worktree inventory
 updated base branch OID
 ```
 
-Emit LAND-v1 even when cleanup is partially blocked. The merge result and each
-cleanup surface are independent facts.
+Emit `LAND-v2` even when cleanup is partially obstructed. Merge, review
+reconciliation, remote cleanup, local cleanup, and each worktree remain
+independent facts.

--- a/codex/skills/land/scripts/evaluate_preflight.py
+++ b/codex/skills/land/scripts/evaluate_preflight.py
@@ -9,271 +9,301 @@ import sys
 from pathlib import Path
 from typing import Any
 
-RECORD_VERSION = "LAND-PREFLIGHT-v1"
-IDENTITY_FIELDS = (
-    "repository",
-    "pr_number",
-    "base_ref",
-    "head_repository",
-    "head_ref",
-    "head_oid",
-)
-DELIVERY_ROUTES = {
-    "immediate": "merge-now",
-    "queue": "queue-and-wait",
-    "auto": "auto-merge-and-wait",
+VERSION = "LAND-PREFLIGHT-v2"
+IDENTITY = ("repository", "pr_number", "base_ref", "head_repository", "head_ref", "head_oid")
+ROUTES = {"immediate": "merge-now", "queue": "queue-and-wait", "auto": "auto-merge-and-wait"}
+DISPOSITIONS = {
+    "fixed-and-evidenced", "already-satisfied-and-evidenced",
+    "obsolete-and-evidenced", "reviewer-withdrawn", "nonblocking-by-authority",
 }
+AUTHORITIES = {"entailed", "strengthening", "preference", "new-requirement", "underdetermined"}
+APPLICABILITY = {"still-present", "transformed-applicable", "already-excluded", "not-comparable", "unknown"}
+NA_GATES = ("required_checks", "conflict_free", "branch_freshness", "repository_policy")
 
 
-def _mapping(value: Any) -> dict[str, Any]:
-    return value if isinstance(value, dict) else {}
+def issue(dst: list[dict[str, str]], code: str, detail: str) -> None:
+    dst.append({"code": code, "detail": detail})
 
 
-def _list(value: Any) -> list[Any]:
-    return value if isinstance(value, list) else []
+def gate(gates: dict[str, str], name: str, value: bool | str) -> None:
+    gates[name] = ("pass" if value else "fail") if isinstance(value, bool) else value
 
 
-def _block(blockers: list[dict[str, str]], code: str, detail: str) -> None:
-    blockers.append({"code": code, "detail": detail})
+def result(verdict: str, status: str, admission: str, mode: str, head: Any,
+           gates: dict[str, str], reasons: list[dict[str, str]],
+           blockers: list[dict[str, str]]) -> dict[str, Any]:
+    return {"land_preflight": {
+        "record_version": VERSION, "verdict": verdict, "workflow_status": status,
+        "merge_admission": admission, "mode": mode, "expected_head_oid": head,
+        "gates": gates, "reasons": reasons, "blockers": blockers,
+    }}
 
 
-def _gate(gates: dict[str, str], name: str, passed: bool) -> None:
-    gates[name] = "pass" if passed else "fail"
+def strings(value: Any, field: str, blockers: list[dict[str, str]]) -> tuple[list[str], bool]:
+    if not isinstance(value, list):
+        issue(blockers, "FIELD_LIST_INVALID", f"{field} must be a list")
+        return [], False
+    valid = True
+    out: list[str] = []
+    for i, item in enumerate(value):
+        if not isinstance(item, str) or not item:
+            valid = False
+            issue(blockers, "FIELD_LIST_ITEM_INVALID", f"{field}[{i}] must be a non-empty string")
+        else:
+            out.append(item)
+    if len(out) != len(set(out)):
+        valid = False
+        issue(blockers, "FIELD_LIST_DUPLICATE", f"{field} must contain unique values")
+    return out, valid
+
+
+def resolution_records(reviews: dict[str, Any], head: Any,
+                       blockers: list[dict[str, str]]) -> tuple[list[str], list[str]]:
+    reconciliation = reviews.get("reconciliation")
+    if not isinstance(reconciliation, dict):
+        issue(blockers, "REVIEW_RECONCILIATION_MISSING", "reviews.reconciliation must be an object")
+        return [], []
+    initial, _ = strings(
+        reconciliation.get("initial_unresolved_thread_ids"),
+        "reviews.reconciliation.initial_unresolved_thread_ids", blockers,
+    )
+    raw = reconciliation.get("records")
+    if not isinstance(raw, list):
+        issue(blockers, "REVIEW_RESOLUTION_RECORDS_INVALID", "reviews.reconciliation.records must be a list")
+        return initial, []
+
+    ids: list[str] = []
+    for i, record in enumerate(raw):
+        if not isinstance(record, dict):
+            issue(blockers, "REVIEW_RESOLUTION_RECORD_INVALID", f"resolution record {i} must be an object")
+            continue
+        tid = record.get("thread_id")
+        concern = record.get("concern_ref")
+        observed = record.get("observed_head_oid")
+        resolved = record.get("resolved_head_oid")
+        authority = record.get("law_authority")
+        applicability = record.get("current_applicability")
+        disposition = record.get("disposition")
+        evidence = record.get("evidence_refs")
+
+        if not isinstance(tid, str) or not tid:
+            issue(blockers, "REVIEW_RESOLUTION_THREAD_ID_INVALID", f"resolution record {i} requires thread_id")
+        else:
+            ids.append(tid)
+        if not isinstance(concern, str) or not concern:
+            issue(blockers, "REVIEW_RESOLUTION_CONCERN_REF_INVALID", f"thread {tid!r} requires concern_ref")
+        if not isinstance(observed, str) or not observed:
+            issue(blockers, "REVIEW_RESOLUTION_OBSERVED_HEAD_INVALID", f"thread {tid!r} requires observed_head_oid")
+        if not isinstance(resolved, str) or not resolved:
+            issue(blockers, "REVIEW_RESOLUTION_RESOLVED_HEAD_INVALID", f"thread {tid!r} requires resolved_head_oid")
+        elif resolved != head:
+            issue(blockers, "REVIEW_RESOLUTION_STALE_HEAD", f"thread {tid!r} was evidenced at {resolved!r}, not {head!r}")
+        if authority not in AUTHORITIES:
+            issue(blockers, "REVIEW_RESOLUTION_AUTHORITY_INVALID", f"thread {tid!r} has invalid law_authority {authority!r}")
+        if applicability not in APPLICABILITY:
+            issue(blockers, "REVIEW_RESOLUTION_APPLICABILITY_INVALID", f"thread {tid!r} has invalid applicability {applicability!r}")
+        if disposition not in DISPOSITIONS:
+            issue(blockers, "REVIEW_RESOLUTION_DISPOSITION_INVALID", f"thread {tid!r} has invalid disposition {disposition!r}")
+        if disposition == "fixed-and-evidenced" and observed == resolved:
+            issue(blockers, "FIXED_THREAD_HEAD_UNCHANGED", f"thread {tid!r} claims a fix without a successor head")
+        if disposition in {"fixed-and-evidenced", "already-satisfied-and-evidenced"} and applicability != "already-excluded":
+            issue(blockers, "REVIEW_RESOLUTION_APPLICABILITY_CONTRADICTION", f"thread {tid!r} is not already excluded")
+        if disposition == "obsolete-and-evidenced" and applicability not in {"already-excluded", "not-comparable"}:
+            issue(blockers, "REVIEW_RESOLUTION_APPLICABILITY_CONTRADICTION", f"thread {tid!r} is not obsolete")
+        if disposition == "nonblocking-by-authority" and authority not in {"strengthening", "preference", "new-requirement"}:
+            issue(blockers, "REVIEW_RESOLUTION_AUTHORITY_CONTRADICTION", f"thread {tid!r} cannot be nonblocking with {authority!r}")
+        if not isinstance(evidence, list) or not evidence or any(not isinstance(x, str) or not x for x in evidence):
+            issue(blockers, "REVIEW_RESOLUTION_EVIDENCE_MISSING", f"thread {tid!r} requires evidence_refs")
+        if record.get("resolution_readback") is not True:
+            issue(blockers, "REVIEW_RESOLUTION_READBACK_MISSING", f"thread {tid!r} requires live resolution readback")
+
+    if len(ids) != len(set(ids)):
+        issue(blockers, "REVIEW_RESOLUTION_RECORD_DUPLICATE", "resolution records must contain unique thread IDs")
+    return initial, ids
 
 
 def evaluate(snapshot: dict[str, Any]) -> dict[str, Any]:
     blockers: list[dict[str, str]] = []
+    reasons: list[dict[str, str]] = []
     gates: dict[str, str] = {}
-
-    expected = _mapping(snapshot.get("expected"))
-    observed = _mapping(snapshot.get("observed"))
-    reviews = _mapping(snapshot.get("reviews"))
-    checks = _mapping(snapshot.get("checks"))
-    merge = _mapping(snapshot.get("merge"))
-    policy = _mapping(snapshot.get("policy"))
+    expected = snapshot.get("expected") if isinstance(snapshot.get("expected"), dict) else {}
+    observed = snapshot.get("observed") if isinstance(snapshot.get("observed"), dict) else {}
 
     if not expected:
-        _block(blockers, "SCHEMA_EXPECTED_MISSING", "expected must be an object")
+        issue(blockers, "SCHEMA_EXPECTED_MISSING", "expected must be an object")
     if not observed:
-        _block(blockers, "SCHEMA_OBSERVED_MISSING", "observed must be an object")
-
+        issue(blockers, "SCHEMA_OBSERVED_MISSING", "observed must be an object")
     identity_ok = True
-    for field in IDENTITY_FIELDS:
-        expected_value = expected.get(field)
-        observed_value = observed.get(field)
-        if expected_value in (None, ""):
+    for field in IDENTITY:
+        want, got = expected.get(field), observed.get(field)
+        if want in (None, ""):
             identity_ok = False
-            _block(blockers, "TARGET_EXPECTED_FIELD_MISSING", f"expected.{field} is required")
-        elif observed_value in (None, ""):
+            issue(blockers, "TARGET_EXPECTED_FIELD_MISSING", f"expected.{field} is required")
+        elif got in (None, ""):
             identity_ok = False
-            _block(blockers, "TARGET_OBSERVED_FIELD_MISSING", f"observed.{field} is required")
-        elif expected_value != observed_value:
+            issue(blockers, "TARGET_OBSERVED_FIELD_MISSING", f"observed.{field} is required")
+        elif want != got:
             identity_ok = False
             code = "TARGET_HEAD_MISMATCH" if field == "head_oid" else "TARGET_IDENTITY_MISMATCH"
-            _block(
-                blockers,
-                code,
-                f"{field} expected {expected_value!r} but observed {observed_value!r}",
-            )
-    _gate(gates, "target_identity", identity_ok)
-    _gate(
-        gates,
-        "exact_head",
-        bool(expected.get("head_oid")) and expected.get("head_oid") == observed.get("head_oid"),
-    )
+            issue(blockers, code, f"{field} expected {want!r} but observed {got!r}")
+    gate(gates, "target_identity", identity_ok)
+    gate(gates, "exact_head", bool(expected.get("head_oid")) and expected.get("head_oid") == observed.get("head_oid"))
 
     state = observed.get("state")
     if state not in {"OPEN", "MERGED", "CLOSED"}:
-        _block(blockers, "PR_STATE_UNKNOWN", f"unsupported observed.state: {state!r}")
-
+        issue(blockers, "PR_STATE_UNKNOWN", f"unsupported observed.state: {state!r}")
     if state == "MERGED":
-        merged_at = observed.get("merged_at")
-        merge_commit_oid = observed.get("merge_commit_oid")
-        postcondition_ok = bool(merged_at) and bool(merge_commit_oid)
-        if not merged_at:
-            _block(blockers, "MERGED_AT_MISSING", "MERGED state requires observed.merged_at")
-        if not merge_commit_oid:
-            _block(
-                blockers,
-                "MERGE_COMMIT_MISSING",
-                "MERGED state requires observed.merge_commit_oid",
-            )
-        _gate(gates, "pr_state", postcondition_ok)
-        result_mode = "cleanup-only" if identity_ok and postcondition_ok and not blockers else "blocked"
-        return {
-            "land_preflight": {
-                "record_version": RECORD_VERSION,
-                "verdict": "pass" if result_mode == "cleanup-only" else "block",
-                "mode": result_mode,
-                "expected_head_oid": expected.get("head_oid"),
-                "gates": gates,
-                "blockers": blockers,
-            }
-        }
+        post = bool(observed.get("merged_at")) and bool(observed.get("merge_commit_oid"))
+        if not observed.get("merged_at"):
+            issue(blockers, "MERGED_AT_MISSING", "MERGED state requires observed.merged_at")
+        if not observed.get("merge_commit_oid"):
+            issue(blockers, "MERGE_COMMIT_MISSING", "MERGED state requires observed.merge_commit_oid")
+        gate(gates, "pr_state", post)
+        for name in ("review_inventory", "review_reconciliation", "review_decision", *NA_GATES):
+            gate(gates, name, "not-applicable")
+        ok = identity_ok and post and not blockers
+        return result("pass" if ok else "block", "ready" if ok else "obstructed",
+                      "not-applicable", "cleanup-only" if ok else "obstructed",
+                      expected.get("head_oid"), gates, reasons, blockers)
 
     open_ready = state == "OPEN" and observed.get("is_draft") is False
     if state == "CLOSED":
-        _block(blockers, "PR_CLOSED_UNMERGED", "closed, unmerged PRs cannot be landed")
+        issue(blockers, "PR_CLOSED_UNMERGED", "closed, unmerged PRs cannot be landed")
     elif state == "OPEN" and observed.get("is_draft") is not False:
-        _block(blockers, "PR_DRAFT", "draft PR must be promoted by an authorized workflow before landing")
-    _gate(gates, "pr_state", open_ready)
+        issue(blockers, "PR_DRAFT", "draft PR must be promoted before landing")
+    gate(gates, "pr_state", open_ready)
 
-    inventory_complete = reviews.get("inventory_complete") is True
-    unresolved_threads = reviews.get("unresolved_threads")
-    if unresolved_threads != 0:
-        _block(
-            blockers,
-            "REVIEW_THREADS_UNRESOLVED",
-            f"expected 0 unresolved threads, observed {unresolved_threads!r}",
-        )
-    if not inventory_complete:
-        _block(
-            blockers,
-            "REVIEW_INVENTORY_INCOMPLETE",
-            "complete paginated review-thread inventory is required",
-        )
-    review_inventory_ok = inventory_complete and unresolved_threads == 0
-    _gate(gates, "review_inventory", review_inventory_ok)
+    reviews = snapshot.get("reviews") if isinstance(snapshot.get("reviews"), dict) else {}
+    policy = snapshot.get("policy") if isinstance(snapshot.get("policy"), dict) else {}
+    if not reviews:
+        issue(blockers, "SCHEMA_REVIEWS_MISSING", "reviews must be an object")
+    inventory = reviews.get("inventory_complete") is True
+    if not inventory:
+        issue(blockers, "REVIEW_INVENTORY_INCOMPLETE", "complete paginated review-thread inventory is required")
+    gate(gates, "review_inventory", inventory)
 
-    requested_changes_active = reviews.get("requested_changes_active")
-    explicit_blockers = reviews.get("explicit_blockers")
-    approvals_required = policy.get("approvals_required")
-    review_decision = reviews.get("review_decision")
+    unresolved, _ = strings(reviews.get("unresolved_thread_ids"), "reviews.unresolved_thread_ids", blockers)
+    initial, recorded = resolution_records(reviews, observed.get("head_oid"), blockers)
+    explicit = reviews.get("explicit_blockers")
+    requested = reviews.get("requested_changes_active")
+    approvals = policy.get("approvals_required")
+    if not isinstance(explicit, int) or isinstance(explicit, bool) or explicit < 0:
+        issue(blockers, "EXPLICIT_BLOCKERS_INVALID", "reviews.explicit_blockers must be a non-negative integer")
+    if requested not in {True, False}:
+        issue(blockers, "REQUESTED_CHANGES_STATE_INVALID", "reviews.requested_changes_active must be true or false")
+    if approvals not in {True, False}:
+        issue(blockers, "APPROVAL_POLICY_UNKNOWN", "policy.approvals_required must be true or false")
 
-    review_decision_ok = True
-    if requested_changes_active is not False:
-        review_decision_ok = False
-        _block(
-            blockers,
-            "REQUESTED_CHANGES_ACTIVE",
-            "requested_changes_active must be explicitly false",
-        )
-    if not isinstance(explicit_blockers, int) or isinstance(explicit_blockers, bool):
-        review_decision_ok = False
-        _block(blockers, "EXPLICIT_BLOCKERS_INVALID", "explicit_blockers must be an integer")
-    elif explicit_blockers != 0:
-        review_decision_ok = False
-        _block(
-            blockers,
-            "EXPLICIT_BLOCKERS_PRESENT",
-            f"observed {explicit_blockers} explicit blocker(s)",
-        )
-    if approvals_required is not False and approvals_required is not True:
-        review_decision_ok = False
-        _block(
-            blockers,
-            "APPROVAL_POLICY_UNKNOWN",
-            "policy.approvals_required must be true or false",
-        )
-    elif approvals_required is True and review_decision != "APPROVED":
-        review_decision_ok = False
-        _block(
-            blockers,
-            "APPROVAL_MISSING",
-            f"approval required but review_decision is {review_decision!r}",
-        )
-    _gate(gates, "review_decision", review_decision_ok)
+    live, started, done = set(unresolved), set(initial), set(recorded)
+    overlap = sorted(live & done)
+    if overlap:
+        issue(blockers, "REVIEW_RESOLUTION_STATE_CONTRADICTION", f"threads are both unresolved and resolved: {overlap!r}")
+    unbound = sorted((live | done) - started)
+    if unbound:
+        issue(blockers, "REVIEW_RECONCILIATION_SCOPE_MISMATCH", f"threads are absent from initial unresolved set: {unbound!r}")
 
+    if blockers:
+        gate(gates, "review_reconciliation", False)
+        gate(gates, "review_decision", False)
+        for name in NA_GATES:
+            gate(gates, name, "not-applicable")
+        return result("block", "obstructed", "not-ready", "obstructed",
+                      expected.get("head_oid"), gates, reasons, blockers)
+
+    pending = sorted(started - (live | done))
+    needs_review = bool(live or pending or requested is True or explicit > 0)
+    if live:
+        issue(reasons, "REVIEW_THREADS_UNRESOLVED", f"{len(live)} unresolved review thread(s) require reconciliation")
+    if pending:
+        issue(reasons, "REVIEW_RECONCILIATION_INCOMPLETE", f"threads disappeared without resolution evidence: {pending!r}")
+    if requested is True:
+        issue(reasons, "REQUESTED_CHANGES_ACTIVE", "active requested changes require review reconciliation")
+    if explicit > 0:
+        issue(reasons, "EXPLICIT_BLOCKERS_PRESENT", f"observed {explicit} explicit blocker(s)")
+    gate(gates, "review_reconciliation", not needs_review)
+    gate(gates, "review_decision", requested is False and explicit == 0)
+    if needs_review:
+        for name in NA_GATES:
+            gate(gates, name, "not-applicable")
+        return result("continue", "continue", "not-ready", "reconcile-reviews",
+                      expected.get("head_oid"), gates, reasons, blockers)
+
+    if approvals is True and reviews.get("review_decision") != "APPROVED":
+        issue(blockers, "APPROVAL_MISSING", f"approval required but review_decision is {reviews.get('review_decision')!r}")
+        gate(gates, "review_decision", False)
+
+    checks = snapshot.get("checks") if isinstance(snapshot.get("checks"), dict) else {}
     required_expected = checks.get("required_expected")
-    raw_check_items = checks.get("items")
-    if not isinstance(raw_check_items, list):
-        _block(blockers, "CHECK_ITEMS_INVALID", "checks.items must be a list")
-    check_items = _list(raw_check_items)
-    if required_expected is not False and required_expected is not True:
-        _block(
-            blockers,
-            "REQUIRED_CHECK_POLICY_UNKNOWN",
-            "checks.required_expected must be true or false",
-        )
-    required_items = [item for item in check_items if isinstance(item, dict) and item.get("required") is True]
-    checks_ok = required_expected is True or required_expected is False
-    if required_expected is True and not required_items:
-        checks_ok = False
-        _block(
-            blockers,
-            "REQUIRED_CHECKS_MISSING",
-            "repository policy expects required checks but no required check items were supplied",
-        )
-
-    allow_skipping = policy.get("allow_required_skipping") is True
-    allowed_buckets = {"pass"}
-    if allow_skipping:
-        allowed_buckets.add("skipping")
-
-    for index, item in enumerate(check_items):
-        if not isinstance(item, dict):
+    allow_skip = policy.get("allow_required_skipping")
+    items = checks.get("items")
+    checks_ok = required_expected in {True, False} and allow_skip in {True, False} and isinstance(items, list)
+    if required_expected not in {True, False}:
+        issue(blockers, "REQUIRED_CHECK_POLICY_UNKNOWN", "checks.required_expected must be true or false")
+    if allow_skip not in {True, False}:
+        issue(blockers, "REQUIRED_SKIP_POLICY_UNKNOWN", "policy.allow_required_skipping must be true or false")
+    if not isinstance(items, list):
+        issue(blockers, "CHECK_ITEMS_INVALID", "checks.items must be a list")
+        items = []
+    required: list[dict[str, Any]] = []
+    for i, item in enumerate(items):
+        if not isinstance(item, dict) or item.get("required") not in {True, False}:
             checks_ok = False
-            _block(blockers, "CHECK_ITEM_INVALID", f"checks.items[{index}] must be an object")
-            continue
-        if item.get("required") is not True:
-            continue
-        name = item.get("name") or f"required-check-{index}"
+            issue(blockers, "CHECK_ITEM_INVALID", f"checks.items[{i}] is invalid")
+        elif item["required"] is True:
+            required.append(item)
+    if required_expected is True and not required:
+        checks_ok = False
+        issue(blockers, "REQUIRED_CHECKS_MISSING", "policy expects required checks but none were supplied")
+    allowed = {"pass", "skipping"} if allow_skip is True else {"pass"}
+    for i, item in enumerate(required):
         bucket = item.get("bucket")
-        if bucket not in allowed_buckets:
+        if bucket not in allowed:
             checks_ok = False
             code = "REQUIRED_CHECK_CANCELLED" if bucket == "cancel" else "REQUIRED_CHECK_NOT_GREEN"
-            _block(
-                blockers,
-                code,
-                f"required check {name!r} has bucket {bucket!r}",
-            )
-    _gate(gates, "required_checks", checks_ok)
+            issue(blockers, code, f"required check {(item.get('name') or i)!r} has bucket {bucket!r}")
+    gate(gates, "required_checks", checks_ok)
 
-    conflict_free = merge.get("conflict_free") is True
-    branch_up_to_date = merge.get("branch_up_to_date") is True
-    policy_satisfied = merge.get("policy_satisfied") is True
-    method_allowed = merge.get("method_allowed") is True
-    admin_override = merge.get("admin_override")
-
-    if not conflict_free:
-        _block(blockers, "MERGE_CONFLICT", "merge.conflict_free must be true")
-    if not branch_up_to_date:
-        _block(blockers, "BRANCH_NOT_CURRENT", "merge.branch_up_to_date must be true")
-    if not policy_satisfied:
-        _block(blockers, "REPOSITORY_POLICY_BLOCK", "merge.policy_satisfied must be true")
-    if not method_allowed:
-        _block(blockers, "MERGE_METHOD_NOT_ALLOWED", "merge.method_allowed must be true")
-    if admin_override is not False:
-        _block(
-            blockers,
-            "ADMIN_OVERRIDE_NOT_AUTHORIZED",
-            "merge.admin_override must be explicitly false for ordinary preflight",
-        )
-
-    _gate(gates, "conflict_free", conflict_free)
-    _gate(gates, "branch_freshness", branch_up_to_date)
-    _gate(
-        gates,
-        "repository_policy",
-        policy_satisfied and method_allowed and admin_override is False,
-    )
-
-    delivery_mode = merge.get("delivery_mode")
-    route = DELIVERY_ROUTES.get(delivery_mode)
+    merge = snapshot.get("merge") if isinstance(snapshot.get("merge"), dict) else {}
+    delivery = merge.get("delivery_mode")
+    route = ROUTES.get(delivery)
     if route is None:
-        _block(
-            blockers,
-            "DELIVERY_MODE_INVALID",
-            f"merge.delivery_mode must be one of {sorted(DELIVERY_ROUTES)}, observed {delivery_mode!r}",
-        )
+        issue(blockers, "DELIVERY_MODE_INVALID", f"invalid merge.delivery_mode {delivery!r}")
+    conflict = merge.get("conflict_free") is True
+    policy_ok = merge.get("policy_satisfied") is True
+    method_ok = merge.get("method_allowed") is True
+    admin = merge.get("admin_override")
+    current = merge.get("branch_up_to_date")
+    strict = merge.get("strict_freshness_required")
+    if not conflict:
+        issue(blockers, "MERGE_CONFLICT", "merge.conflict_free must be true")
+    if not policy_ok:
+        issue(blockers, "REPOSITORY_POLICY_BLOCK", "merge.policy_satisfied must be true")
+    if not method_ok:
+        issue(blockers, "MERGE_METHOD_NOT_ALLOWED", "merge.method_allowed must be true")
+    if admin is not False:
+        issue(blockers, "ADMIN_OVERRIDE_PROHIBITED", "ordinary $land never performs an administrator bypass")
+    if current not in {True, False}:
+        issue(blockers, "BRANCH_FRESHNESS_UNKNOWN", "merge.branch_up_to_date must be true or false")
+    if strict not in {True, False}:
+        issue(blockers, "STRICT_FRESHNESS_POLICY_UNKNOWN", "merge.strict_freshness_required must be true or false")
+    gate(gates, "conflict_free", conflict)
+    if delivery == "queue":
+        gate(gates, "branch_freshness", "not-applicable")
+    else:
+        freshness = strict is False or (strict is True and current is True)
+        if not freshness:
+            issue(blockers, "BRANCH_NOT_CURRENT", "strict policy requires the PR branch to be current")
+        gate(gates, "branch_freshness", freshness)
+    gate(gates, "repository_policy", policy_ok and method_ok and admin is False)
 
-    verdict = "pass" if not blockers else "block"
-    mode = route if verdict == "pass" and route is not None else "blocked"
-    return {
-        "land_preflight": {
-            "record_version": RECORD_VERSION,
-            "verdict": verdict,
-            "mode": mode,
-            "expected_head_oid": expected.get("head_oid"),
-            "gates": gates,
-            "blockers": blockers,
-        }
-    }
+    passed = not blockers
+    return result("pass" if passed else "block", "ready" if passed else "obstructed",
+                  "ready" if passed else "not-ready", route if passed and route else "obstructed",
+                  expected.get("head_oid"), gates, reasons, blockers)
 
 
-def _load(path: str) -> dict[str, Any]:
-    text = sys.stdin.read() if path == "-" else Path(path).read_text(encoding="utf-8")
-    value = json.loads(text)
+def load(path: str) -> dict[str, Any]:
+    value = json.loads(sys.stdin.read() if path == "-" else Path(path).read_text(encoding="utf-8"))
     if not isinstance(value, dict):
         raise ValueError("snapshot must be a JSON object")
     return value
@@ -283,23 +313,13 @@ def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("snapshot", nargs="?", default="-", help="JSON file, or - for stdin")
     args = parser.parse_args(argv)
-
     try:
-        result = evaluate(_load(args.snapshot))
+        out = evaluate(load(args.snapshot))
     except Exception as exc:
-        result = {
-            "land_preflight": {
-                "record_version": RECORD_VERSION,
-                "verdict": "block",
-                "mode": "blocked",
-                "expected_head_oid": None,
-                "gates": {},
-                "blockers": [{"code": "SNAPSHOT_INVALID", "detail": str(exc)}],
-            }
-        }
-
-    print(json.dumps(result, indent=2, sort_keys=True))
-    return 0 if result["land_preflight"]["verdict"] == "pass" else 2
+        out = result("block", "obstructed", "not-ready", "obstructed", None, {}, [],
+                     [{"code": "SNAPSHOT_INVALID", "detail": str(exc)}])
+    print(json.dumps(out, indent=2, sort_keys=True))
+    return {"pass": 0, "continue": 3}.get(out["land_preflight"]["verdict"], 2)
 
 
 if __name__ == "__main__":

--- a/codex/skills/land/tests/test_land.py
+++ b/codex/skills/land/tests/test_land.py
@@ -1,0 +1,193 @@
+import copy
+import importlib.util
+import json
+from pathlib import Path
+import subprocess
+import sys
+import unittest
+
+ROOT = Path(__file__).resolve().parents[1]
+SKILL = (ROOT / "SKILL.md").read_text()
+PROTOCOL = (ROOT / "references" / "landing-protocol.md").read_text()
+RECORD = (ROOT / "references" / "land-record.md").read_text()
+CONTRACT = json.loads((ROOT / "references" / "decision-contract.json").read_text())
+AGENT = (ROOT / "agents" / "openai.yaml").read_text()
+SCRIPT = ROOT / "scripts" / "evaluate_preflight.py"
+SPEC = importlib.util.spec_from_file_location("land_preflight", SCRIPT)
+assert SPEC and SPEC.loader
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+H0 = "0" * 40
+H1 = "1" * 40
+
+
+def snapshot(head=H0, delivery="immediate"):
+    return {
+        "expected": {"repository": "o/r", "pr_number": 42, "base_ref": "main", "head_repository": "o/r", "head_ref": "feature", "head_oid": head},
+        "observed": {"repository": "o/r", "pr_number": 42, "state": "OPEN", "is_draft": False, "base_ref": "main", "head_repository": "o/r", "head_ref": "feature", "head_oid": head},
+        "reviews": {"inventory_complete": True, "unresolved_thread_ids": [], "review_decision": "APPROVED", "requested_changes_active": False, "explicit_blockers": 0, "reconciliation": {"initial_unresolved_thread_ids": [], "records": []}},
+        "checks": {"required_expected": True, "items": [{"name": "tests", "required": True, "bucket": "pass"}]},
+        "merge": {"delivery_mode": delivery, "conflict_free": True, "branch_up_to_date": True, "strict_freshness_required": True, "policy_satisfied": True, "method_allowed": True, "admin_override": False},
+        "policy": {"approvals_required": True, "allow_required_skipping": False},
+    }
+
+
+def resolution(*, observed=H0, resolved=H1, authority="entailed", applicability="already-excluded", disposition="fixed-and-evidenced", tid="T1"):
+    return {"thread_id": tid, "concern_ref": "https://github.com/o/r/pull/42#discussion_r1", "observed_head_oid": observed, "resolved_head_oid": resolved, "law_authority": authority, "current_applicability": applicability, "disposition": disposition, "evidence_refs": ["proof:current-head"], "resolution_readback": True}
+
+
+def report(value):
+    return MODULE.evaluate(value)["land_preflight"]
+
+
+def codes(value, field="blockers"):
+    return {item["code"] for item in value[field]}
+
+
+class ContractTests(unittest.TestCase):
+    def test_review_closure_is_explicit_owned_work(self):
+        for phrase in ("allow_implicit_invocation: false", "reconcile every unresolved review thread"):
+            self.assertIn(phrase, AGENT)
+        for phrase in ("Every unresolved review thread", "must drive every unresolved thread"):
+            self.assertIn(phrase, SKILL)
+
+    def test_state_machine_and_order(self):
+        modes = ("reconcile-reviews", "rebind-successor-head", "merge-now", "queue-and-wait", "auto-merge-and-wait", "cleanup-only", "obstructed")
+        for mode in modes:
+            self.assertIn(mode, SKILL)
+            self.assertIn(mode, RECORD)
+        self.assertLess(SKILL.index("## Review reconciliation"), SKILL.index("## Merge admission"))
+
+    def test_resolution_cannot_erase_evidence(self):
+        self.assertNotIn("resolve-only-with-user-authorization", SKILL + PROTOCOL)
+        for phrase in ("Thread resolution records proof; it never creates proof", "bare thread IDs", "generic continuation instruction", "fixed-and-evidenced", "reviewer-withdrawn"):
+            self.assertIn(phrase, SKILL + PROTOCOL)
+
+    def test_successor_epoch_restarts_preflight(self):
+        for phrase in ("successor landing epoch", "patch -> validate -> publish successor head", "discard every admission observation", "complete fresh preflight"):
+            self.assertIn(phrase, SKILL + PROTOCOL)
+
+    def test_existing_safety_invariants_remain(self):
+        for phrase in ("--match-head-commit", "state == MERGED", "mergedAt", "mergeCommit OID", "git worktree list --porcelain -z", "git worktree remove --force", "rm -rf"):
+            self.assertIn(phrase, SKILL + PROTOCOL)
+        self.assertIn("Never use `--admin`", PROTOCOL)
+        for field in ("record_version: LAND-v2", "review_reconciliation:", "epochs:", "obstructions:", "postcondition:", "associated_worktrees:"):
+            self.assertIn(field, RECORD)
+
+    def test_decision_contract_references_exist(self):
+        contract = CONTRACT["skill_decision_contract"]
+        triggers = {x["trigger_id"] for x in contract["triggers"]}
+        routes = {x["route_id"] for x in contract["routes"]}
+        self.assertTrue({"LAND-RECONCILE-REVIEWS", "LAND-REBIND-SUCCESSOR", "LAND-OBSTRUCT"} <= routes)
+        for clause in contract["clauses"]:
+            self.assertTrue(set(clause["trigger_refs"]) <= triggers, clause["clause_id"])
+            self.assertTrue(set(clause["expected_routes"]) <= routes, clause["clause_id"])
+            self.assertTrue(set(clause["prohibited_routes"]) <= routes, clause["clause_id"])
+        self.assertLessEqual(len(SKILL.splitlines()), 500)
+
+
+class EvaluatorTests(unittest.TestCase):
+    def assert_block(self, value, code):
+        result = report(value)
+        self.assertEqual("block", result["verdict"])
+        self.assertIn(code, codes(result))
+
+    def test_immediate_ready(self):
+        value = report(snapshot())
+        self.assertEqual(("pass", "ready", "merge-now"), (value["verdict"], value["merge_admission"], value["mode"]))
+
+    def test_unresolved_thread_continues(self):
+        value = snapshot()
+        value["reviews"]["unresolved_thread_ids"] = ["T1"]
+        value["reviews"]["reconciliation"]["initial_unresolved_thread_ids"] = ["T1"]
+        result = report(value)
+        self.assertEqual(("continue", "not-ready", "reconcile-reviews"), (result["verdict"], result["merge_admission"], result["mode"]))
+        self.assertIn("REVIEW_THREADS_UNRESOLVED", codes(result, "reasons"))
+
+    def test_requested_changes_continue(self):
+        value = snapshot()
+        value["reviews"].update(requested_changes_active=True, review_decision="CHANGES_REQUESTED")
+        self.assertEqual("continue", report(value)["verdict"])
+
+    def test_successor_head_fix_reflights(self):
+        value = snapshot(H1)
+        value["reviews"]["reconciliation"] = {"initial_unresolved_thread_ids": ["T1"], "records": [resolution()]}
+        self.assertEqual("pass", report(value)["verdict"])
+
+    def test_unchanged_head_fix_is_rejected(self):
+        value = snapshot()
+        value["reviews"]["reconciliation"] = {"initial_unresolved_thread_ids": ["T1"], "records": [resolution(resolved=H0)]}
+        self.assert_block(value, "FIXED_THREAD_HEAD_UNCHANGED")
+
+    def test_disappeared_thread_requires_resolution_evidence(self):
+        value = snapshot()
+        value["reviews"]["reconciliation"]["initial_unresolved_thread_ids"] = ["T1"]
+        result = report(value)
+        self.assertEqual("continue", result["verdict"])
+        self.assertIn("REVIEW_RECONCILIATION_INCOMPLETE", codes(result, "reasons"))
+
+    def test_nonblocking_preference_can_resolve_without_head_change(self):
+        value = snapshot()
+        rec = resolution(resolved=H0, authority="preference", applicability="still-present", disposition="nonblocking-by-authority")
+        value["reviews"]["reconciliation"] = {"initial_unresolved_thread_ids": ["T1"], "records": [rec]}
+        self.assertEqual("pass", report(value)["verdict"])
+
+    def test_reconciliation_provenance_failures(self):
+        cases = []
+        unbound = snapshot(); unbound["reviews"]["unresolved_thread_ids"] = ["T1"]
+        cases.append((unbound, "REVIEW_RECONCILIATION_SCOPE_MISMATCH"))
+        overlap = snapshot(); overlap["reviews"]["unresolved_thread_ids"] = ["T1"]
+        overlap["reviews"]["reconciliation"] = {"initial_unresolved_thread_ids": ["T1"], "records": [resolution(resolved=H0, authority="preference", applicability="still-present", disposition="nonblocking-by-authority")]}
+        cases.append((overlap, "REVIEW_RESOLUTION_STATE_CONTRADICTION"))
+        entailed = snapshot(); entailed["reviews"]["reconciliation"] = {"initial_unresolved_thread_ids": ["T1"], "records": [resolution(resolved=H0, applicability="still-present", disposition="nonblocking-by-authority")]}
+        cases.append((entailed, "REVIEW_RESOLUTION_AUTHORITY_CONTRADICTION"))
+        for value, code in cases:
+            with self.subTest(code=code): self.assert_block(value, code)
+
+    def test_thread_id_shape_is_fail_closed(self):
+        invalid = snapshot(); invalid["reviews"]["unresolved_thread_ids"] = False
+        self.assert_block(invalid, "FIELD_LIST_INVALID")
+        duplicate = snapshot(); duplicate["reviews"]["unresolved_thread_ids"] = ["T1", "T1"]
+        duplicate["reviews"]["reconciliation"]["initial_unresolved_thread_ids"] = ["T1", "T1"]
+        self.assert_block(duplicate, "FIELD_LIST_DUPLICATE")
+
+    def test_checks_and_freshness_are_route_correct(self):
+        canceled = snapshot(); canceled["checks"]["items"][0]["bucket"] = "cancel"
+        self.assert_block(canceled, "REQUIRED_CHECK_CANCELLED")
+        queued = snapshot(delivery="queue"); queued["merge"]["branch_up_to_date"] = False
+        self.assertEqual(("pass", "not-applicable"), (report(queued)["verdict"], report(queued)["gates"]["branch_freshness"]))
+        strict = snapshot(); strict["merge"]["branch_up_to_date"] = False
+        self.assert_block(strict, "BRANCH_NOT_CURRENT")
+        loose = snapshot(); loose["merge"].update(branch_up_to_date=False, strict_freshness_required=False)
+        self.assertEqual("pass", report(loose)["verdict"])
+
+    def test_admin_and_head_drift_block(self):
+        admin = snapshot(); admin["merge"]["admin_override"] = True
+        self.assert_block(admin, "ADMIN_OVERRIDE_PROHIBITED")
+        drift = snapshot(); drift["observed"]["head_oid"] = H1
+        self.assert_block(drift, "TARGET_HEAD_MISMATCH")
+
+    def test_cleanup_only_needs_only_merged_identity(self):
+        value = snapshot()
+        value["observed"].update(state="MERGED", merged_at="2026-08-20T20:00:00Z", merge_commit_oid="a" * 40)
+        for field in ("reviews", "checks", "merge", "policy"): value.pop(field)
+        result = report(value)
+        self.assertEqual(("pass", "cleanup-only", "not-applicable"), (result["verdict"], result["mode"], result["merge_admission"]))
+
+    def test_skipping_requires_policy(self):
+        value = snapshot(); value["checks"]["items"][0]["bucket"] = "skipping"
+        self.assertEqual("block", report(value)["verdict"])
+        value["policy"]["allow_required_skipping"] = True
+        self.assertEqual("pass", report(value)["verdict"])
+
+    def test_cli_exit_codes(self):
+        continuing = snapshot(); continuing["reviews"]["unresolved_thread_ids"] = ["T1"]
+        continuing["reviews"]["reconciliation"]["initial_unresolved_thread_ids"] = ["T1"]
+        obstructed = snapshot(); obstructed["checks"]["items"][0]["bucket"] = "cancel"
+        def run(value):
+            return subprocess.run([sys.executable, str(SCRIPT)], input=json.dumps(value), text=True, capture_output=True).returncode
+        self.assertEqual((0, 3, 2), (run(snapshot()), run(continuing), run(obstructed)))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/codex/skills/land/tests/test_land.py
+++ b/codex/skills/land/tests/test_land.py
@@ -8,11 +8,11 @@ import unittest
 
 ROOT = Path(__file__).resolve().parents[1]
 SKILL = (ROOT / "SKILL.md").read_text()
-PROTOCOL = (ROOT / "references" / "landing-protocol.md").read_text()
-RECORD = (ROOT / "references" / "land-record.md").read_text()
-CONTRACT = json.loads((ROOT / "references" / "decision-contract.json").read_text())
-AGENT = (ROOT / "agents" / "openai.yaml").read_text()
-SCRIPT = ROOT / "scripts" / "evaluate_preflight.py"
+PROTOCOL = (ROOT / "references/landing-protocol.md").read_text()
+RECORD = (ROOT / "references/land-record.md").read_text()
+CONTRACT = json.loads((ROOT / "references/decision-contract.json").read_text())
+AGENT = (ROOT / "agents/openai.yaml").read_text()
+SCRIPT = ROOT / "scripts/evaluate_preflight.py"
 SPEC = importlib.util.spec_from_file_location("land_preflight", SCRIPT)
 assert SPEC and SPEC.loader
 MODULE = importlib.util.module_from_spec(SPEC)


### PR DESCRIPTION
## Summary

- make unresolved review threads a nonterminal reconciliation route rather than a terminal merge failure
- require per-thread concern context, authority, current-head applicability, evidence, and live readback before resolution
- prohibit bare-ID bulk resolution, generic-user-authorized dismissal, and unchanged-head claims that a substantive defect was fixed
- make repair pushes create successor landing epochs and invalidate all prior admission evidence
- separate workflow progress from merge admission in `LAND-PREFLIGHT-v2`
- make branch freshness route-specific, prohibit ordinary administrator bypass, and emit `LAND-v2`
- restore 20 focused owner-local regressions for the witnessed failure modes and adjacent safety invariants

## Why

The failure report documents both sides of one state-model defect: PR #211 stopped before a repair Land could perform, while PR #206 bulk-resolved 313 threads and merged an unchanged head that included a current valid P1. This change makes Land own every unresolved thread through repair or evidence-backed disposition without allowing GitHub resolution metadata to substitute for substantive discharge.

“Always resolves unresolved review threads” now means that Land exhausts every safe reconciliation path and resolves every thread with a justified disposition. It never merges while a live unresolved thread remains, and it never fabricates resolution for a current substantive concern.

## Validation

- `uv run python3 -m unittest discover -s codex/skills/land/tests -p 'test_*.py' -v`: 20 passed
- `uv run python3 -m py_compile codex/skills/land/scripts/evaluate_preflight.py codex/skills/land/tests/test_land.py`: pass
- malformed-snapshot fuzz: 10,000/10,000 evaluations failed closed
- decision contract: trigger/route references pass structural checks
- package checks: `SKILL.md` remains below 500 lines

<!-- ship-proof:start -->
## Summary
- Make Land reconcile unresolved review threads through evidence-bound disposition or repair, then rebuild merge admission from a successor epoch.
- Keep substantive concerns fail-closed: no bare-ID bulk resolution, unchanged-head fix claims, or ordinary administrator bypass.

## Proof
- `uv run python3 -m unittest discover -s codex/skills/land/tests -p "test_*.py" -v`: pass (20 tests)
- `uv run python3 -m py_compile codex/skills/land/scripts/evaluate_preflight.py codex/skills/land/tests/test_land.py`: pass
- deterministic malformed-snapshot fuzz: pass (10,000/10,000 failed closed)
- decision-contract trigger/route reference validation: pass
- `git diff --check origin/main...origin/agent/land-review-reconciliation`: pass

## Scope
- repository: `tkersey/dotfiles`
- branch: `agent/land-review-reconciliation`
- head: `ddd6e508b4ca3c395da96bd5dd977e1a4c77cf9b`
- base: `main`
- base SHA: `a6226d308e31780bcdbdb9b555ebf7675bb6d08e`

## Risks
- None identified after focused contract, evaluator, and fail-closed regression coverage.

## Follow-ups
- None.

## Readiness
- Operation: update-and-promote
- Final state: ready
- SHIP-v1 compatibility mode: promote-draft
- Reason: the exact head is validated with no blocked, deferred, or open task state.
- Caveats: no required status contexts are configured or reported for `main`.
<!-- ship-proof:end -->