### PR TITLE
actuating: add serial review scheduling

### DIFF
--- a/codex/skills/actuating/SKILL.md
+++ b/codex/skills/actuating/SKILL.md
@@ -64,6 +64,16 @@ An unqualified request to review, inspect, audit, or classify selects `triage`.
 Mutation requires explicit implement, fix, resolve, address, or closeout intent.
 These are workflow routes, not architectural change classes.
 
+Review-bearing routes accept request-local scheduling modifiers:
+
+| Modifier | Selection | Effect |
+|---|---|---|
+| `parallel-reviews` | default when omitted | initial standard and four auxiliaries run concurrently |
+| `serial-reviews` | explicit opt-in | initial standard and each auxiliary run serially in contract order |
+
+These modifiers change review dispatch only. They do not select a route, alter
+mutation authority, remove a lens, weaken receipt quality, or change convergence.
+
 ## Build the live Actuating View
 
 At entry and after every material external change, observe:
@@ -366,14 +376,21 @@ observation digest.
 
 For the unchanged head:
 
-- launch standard plus four compact auxiliaries concurrently;
-- never cancel siblings;
-- require every terminal semantic verdict;
-- allow one request-local recovery for verdictless transport failure;
-- count the initial standard clean as clean one;
+- select `parallel-reviews` when no scheduling modifier is supplied;
+- in `parallel-reviews`, launch the initial standard plus four compact
+  auxiliaries concurrently and never cancel siblings;
+- in `serial-reviews`, launch the initial standard, footgun-finder,
+  invariant-ace, complexity-mitigator, and fresh-eyes one at a time, adjudicating
+  each terminal result before dispatching the next;
+- require every terminal semantic verdict and allow one request-local recovery
+  for verdictless transport failure;
+- count a clean initial standard as clean one;
 - run later standard confirmations serially;
 - require five consecutive distinct standard cleans;
-- reset all credit after a material head change.
+- after a material head change, reset all credit and restart the selected
+  schedule at its initial standard;
+- in `serial-reviews`, never dispatch the next review against a head that an
+  adjudicated finding will replace.
 
 Every finding passes through `$review-fold`. Credit only exact CAS receipts.
 Never reconstruct credit from prose, process exit, or claimed counts.

--- a/codex/skills/actuating/references/decision-contract.json
+++ b/codex/skills/actuating/references/decision-contract.json
@@ -4,7 +4,7 @@
     "skill": {
       "name": "actuating",
       "kind": "mixed",
-      "source_fingerprint": "actuating-post-elimination-falsifier-v6"
+      "source_fingerprint": "actuating-review-scheduling-v7"
     },
     "triggers": [
       {
@@ -75,6 +75,18 @@
           "inspect",
           "audit",
           "classify"
+        ],
+        "cue_regexes": [],
+        "exclusions": []
+      },
+      {
+        "trigger_id": "ACT-REVIEW-SCHEDULING",
+        "description": "A request-local modifier selects parallel or serial review dispatch without selecting a route.",
+        "cue_literals": [
+          "parallel-reviews",
+          "serial-reviews",
+          "$actuating parallel-reviews",
+          "$actuating serial-reviews"
         ],
         "cue_regexes": [],
         "exclusions": []
@@ -313,7 +325,8 @@
         "trigger_refs": [
           "ACT-BARE",
           "ACT-ROUTE",
-          "ACT-REVIEW-DEFAULT"
+          "ACT-REVIEW-DEFAULT",
+          "ACT-REVIEW-SCHEDULING"
         ],
         "expected_routes": [
           "ACT-TRIAGE",
@@ -322,22 +335,26 @@
         ],
         "prohibited_routes": [],
         "required_artifacts": [
-          "static actuating-review-contract/v2",
+          "static actuating-review-contract/v3",
           "exact CAS receipts for the current Git head",
           "current Review Fold after findings"
         ],
         "success_signals": [
-          "initial standard plus four compact auxiliaries launch concurrently",
-          "five consecutive standard cleans bind the exact unchanged head",
-          "material head change invalidates credit by identity",
-          "missing resumable evidence restarts a fresh wave"
+          "parallel-reviews is the request-local default and launches the initial standard plus four compact auxiliaries concurrently",
+          "serial-reviews runs the initial standard then every auxiliary serially in contract order",
+          "both modes require every lens and five consecutive standard cleans on one unchanged head",
+          "material head change invalidates all credit and restarts the selected schedule at its initial standard",
+          "missing resumable evidence restarts the selected schedule"
         ],
         "failure_signals": [
+          "review scheduling changes route or mutation authority",
+          "serial-reviews omits or reorders a required lens",
+          "parallel-reviews cancels a launched sibling",
           "review count is reconstructed from prose",
           "review evidence is copied into an Actuating store",
           "review findings bypass law-authority classification"
         ],
-        "rationale": "CAS receipts own attempt facts; Review Fold and Actuating interpret them."
+        "rationale": "Scheduling may control subscription concurrency without weakening exact-head convergence or creating another authority plane."
       },
       {
         "clause_id": "ACT-CLOSURE-005",

--- a/codex/skills/actuating/references/review-contract.json
+++ b/codex/skills/actuating/references/review-contract.json
@@ -1,6 +1,6 @@
 {
-  "schema": "actuating-review-contract/v2",
-  "contract_id": "actuating-review-contract-v4",
+  "schema": "actuating-review-contract/v3",
+  "contract_id": "actuating-review-contract-v5",
   "required_lenses": [
     {
       "name": "standard",
@@ -28,20 +28,40 @@
       "instructions_ref": "codex/skills/actuating/references/lenses/fresh-eyes-review.md"
     }
   ],
-  "initial_wave": {
-    "concurrent": true,
+  "review_scheduling": {
+    "default_mode": "parallel-reviews",
+    "request_local": true,
     "all_lenses_required": true,
-    "non_cancelling": true
+    "initial_lens_order": [
+      "standard",
+      "footgun-finder",
+      "invariant-ace",
+      "complexity-mitigator",
+      "fresh-eyes"
+    ],
+    "modes": {
+      "parallel-reviews": {
+        "dispatch": "concurrent",
+        "non_cancelling": true,
+        "terminal_barrier": true
+      },
+      "serial-reviews": {
+        "dispatch": "serial",
+        "adjudicate_before_next": true,
+        "stop_before_next_on_material_change": true
+      }
+    }
   },
   "standard_convergence": {
     "required_consecutive_clean_attempts": 5,
-    "first_wave_standard_counts": true,
+    "initial_standard_counts": true,
     "later_attempts_serial": true,
     "findings_reset_streak": true
   },
   "material_change": {
     "identity": "git-head",
-    "resets_all_review_credit": true
+    "resets_all_review_credit": true,
+    "restarts_selected_schedule_from_initial_standard": true
   },
   "transport_recovery": {
     "request_local": true,

--- a/codex/skills/actuating/references/review-contract.md
+++ b/codex/skills/actuating/references/review-contract.md
@@ -113,38 +113,69 @@ These are bounded read-only projections. They do not launch the standalone
 skill workflows, spawn authority lanes, persist artifacts, select repairs, or
 certify closeout.
 
-## Initial wave
+## Review scheduling
+
+Review-bearing routes accept one request-local scheduling modifier:
+
+| Mode | Selection | Initial lens dispatch |
+|---|---|---|
+| `parallel-reviews` | default when no modifier is supplied | standard plus all four auxiliaries concurrently |
+| `serial-reviews` | explicit opt-in | standard, footgun-finder, invariant-ace, complexity-mitigator, then fresh-eyes serially |
+
+The modifier changes dispatch topology only. Both modes require every lens,
+exactly the same receipt quality, the same finding adjudication, and five
+consecutive clean standard attempts on one unchanged head. The initial clean
+standard counts as clean attempt one, so the clean path contains nine review
+attempts in either mode.
+
+### Parallel reviews
 
 Launch all five owner-lived `cas review start --wait` processes before accepting
 an initial terminal result.
 
 - A finding, clean result, or transport failure never cancels a sibling.
 - Every launched request reaches terminal transport evidence.
-- The initial standard clean is clean attempt one.
 - Every finding passes through `$review-fold`.
-- Accepted pressure is resolved or rejected before serial confirmation.
+- Accepted pressure is resolved or rejected after the initial terminal barrier
+  and before serial standard confirmation.
+
+### Serial reviews
+
+Launch exactly one owner-lived `cas review start --wait` process at a time in the
+initial lens order. Obtain terminal transport evidence and adjudicate every
+finding before dispatching the next request.
+
+- A finding that does not authorize material mutation does not erase valid
+  exact-head receipts; continue when its disposition permits review to proceed.
+- A finding that reopens Goal authority or remains unresolved blocks rather than
+  allowing later reviews to assume a settled target.
+- When an adjudicated finding leads to material code mutation, stop before the
+  next request. Commit and validate the change, discard all prior review credit,
+  and restart `serial-reviews` at the initial standard on the new head.
 
 ## Request-local recovery
 
 A terminal request without a structured semantic verdict:
 
 - contributes no semantic attempt or clean credit;
-- preserves completed sibling evidence on the unchanged head;
-- may run one fresh exact-request recovery after the initial barrier;
+- preserves completed review evidence on the unchanged head;
+- may run one fresh exact-request recovery;
+- in `parallel-reviews`, runs recovery after the initial terminal barrier;
+- in `serial-reviews`, runs recovery before dispatching the next request;
 - blocks after a second verdictless terminal result.
 
 Recover a live known handle with CAS `wait`; do not create a duplicate attempt.
 
 ## Convergence
 
-After the initial wave is fully adjudicated, launch fresh standard attempts
-serially until the trailing exact-head clean suffix reaches five.
+After the selected initial schedule is fully adjudicated, launch fresh standard
+attempts serially until the trailing exact-head clean suffix reaches five.
 
 - A standard finding resets the suffix to zero.
 - An auxiliary finding does not change standard credit unless resolution changes
   the head.
-- Any material Git head change invalidates all prior credit by tuple mismatch
-  and requires a fresh 1+4 wave.
+- Any material Git head change invalidates all prior credit by tuple mismatch and
+  restarts the selected schedule at its initial standard.
 - No credit crosses a head change.
 
 ## Resumption
@@ -155,7 +186,7 @@ Credit only exact receipts currently available to Actuating.
   revalidated.
 - A prior summary, claimed count, or PR prose grants no credit.
 - If the complete current evidence set cannot be resolved after interruption,
-  start a fresh full wave.
+  restart the selected schedule from its initial standard.
 
 This fail-closed restart is deliberate. Actuating maintains no review database.
 

--- a/codex/skills/actuating/tests/test-reconciler-contract.sh
+++ b/codex/skills/actuating/tests/test-reconciler-contract.sh
@@ -62,6 +62,9 @@ grep -F '## Generative reach and sibling prediction' "$skill_root/SKILL.md" >/de
 grep -F 'Passing repaired examples alone never reissues elimination' "$skill_root/SKILL.md" >/dev/null
 grep -F 'No Actuating Ledger command' "$skill_root/SKILL.md" >/dev/null
 grep -F 'Git is the realized construction' "$skill_root/SKILL.md" >/dev/null
+grep -F '`parallel-reviews`' "$skill_root/SKILL.md" >/dev/null
+grep -F '`serial-reviews`' "$skill_root/SKILL.md" >/dev/null
+grep -F 'restart the selected' "$skill_root/SKILL.md" >/dev/null
 
 grep -F '# Post-Elimination Falsification' \
   "$skill_root/references/post-elimination-falsification.md" >/dev/null
@@ -98,24 +101,40 @@ grep -F 'Actuating must revoke and adjudicate' \
   "$codex_root/skills/review-fold/SKILL.md" >/dev/null
 
 "$jaq_bin" -e '
-  .schema == "actuating-review-contract/v2" and
-  .contract_id == "actuating-review-contract-v4" and
+  .schema == "actuating-review-contract/v3" and
+  .contract_id == "actuating-review-contract-v5" and
   (.required_lenses | length) == 5 and
   ([.required_lenses[].name] | sort) ==
     (["standard", "footgun-finder", "invariant-ace",
       "complexity-mitigator", "fresh-eyes"] | sort) and
-  .initial_wave.concurrent == true and
-  .initial_wave.non_cancelling == true and
+  .review_scheduling.default_mode == "parallel-reviews" and
+  .review_scheduling.request_local == true and
+  .review_scheduling.all_lenses_required == true and
+  .review_scheduling.initial_lens_order ==
+    ["standard", "footgun-finder", "invariant-ace",
+     "complexity-mitigator", "fresh-eyes"] and
+  .review_scheduling.modes["parallel-reviews"].dispatch == "concurrent" and
+  .review_scheduling.modes["parallel-reviews"].non_cancelling == true and
+  .review_scheduling.modes["parallel-reviews"].terminal_barrier == true and
+  .review_scheduling.modes["serial-reviews"].dispatch == "serial" and
+  .review_scheduling.modes["serial-reviews"].adjudicate_before_next == true and
+  .review_scheduling.modes["serial-reviews"].stop_before_next_on_material_change == true and
   .standard_convergence.required_consecutive_clean_attempts == 5 and
+  .standard_convergence.initial_standard_counts == true and
+  .standard_convergence.later_attempts_serial == true and
   .material_change.identity == "git-head" and
+  .material_change.resets_all_review_credit == true and
+  .material_change.restarts_selected_schedule_from_initial_standard == true and
   .transport_recovery.maximum_fresh_recovery_attempts == 1
 ' "$skill_root/references/review-contract.json" >/dev/null
 
 "$jaq_bin" -e '
   .skill_decision_contract.skill.source_fingerprint ==
-    "actuating-post-elimination-falsifier-v6" and
+    "actuating-review-scheduling-v7" and
   ([.skill_decision_contract.triggers[].trigger_id] |
     index("ACT-POST-ELIMINATION")) != null and
+  ([.skill_decision_contract.triggers[].trigger_id] |
+    index("ACT-REVIEW-SCHEDULING")) != null and
   ([.skill_decision_contract.clauses[].clause_id] |
     index("ACT-LAW-AUTHORITY-001")) != null and
   ([.skill_decision_contract.clauses[].clause_id] |
@@ -140,4 +159,4 @@ grep -F 'Actuating must revoke and adjudicate' \
 JAQ_BIN="$jaq_bin" "$skill_root/tests/test-semantic-hotspot-scenarios.sh"
 JAQ_BIN="$jaq_bin" "$skill_root/tests/test-post-elimination-scenarios.sh"
 
-echo "actuating post-elimination falsifier contract: pass"
+echo "actuating review scheduling and post-elimination contract: pass"


### PR DESCRIPTION
## Summary

- add request-local `parallel-reviews` and `serial-reviews` scheduling modifiers while keeping `parallel-reviews` as the default
- preserve the same four auxiliary lenses and five-consecutive-standard-clean convergence in both modes
- define the serial clean-path order as standard, footgun-finder, invariant-ace, complexity-mitigator, fresh-eyes, then four serial standard confirmations
- stop serial dispatch before the next review when an adjudicated finding leads to material code mutation, invalidate all review credit on the new Git head, and restart the selected schedule at its initial standard
- keep review scheduling orthogonal to Actuating routes and mutation authority
- bump the static review contract to `actuating-review-contract/v3` / `actuating-review-contract-v5` and extend the reconciler contract assertions

## Validation

- `sh -n codex/skills/actuating/tests/test-reconciler-contract.sh`
- parsed both changed JSON contracts with `jq -e .`
- evaluated the new review-scheduling and decision-contract assertions locally with `jq -e`

The full repository contract suite is left to PR CI.

<!-- ship-proof:start -->
## Summary
- Add request-local parallel and serial review scheduling while preserving every required review lens, exact-head credit, and five-standard-clean convergence.
- Keep scheduling orthogonal to Actuating route selection and mutation authority.

## Proof
- `sh -n codex/skills/actuating/tests/test-reconciler-contract.sh`: pass
- `jaq -e . codex/skills/actuating/references/decision-contract.json`: pass
- `jaq -e . codex/skills/actuating/references/review-contract.json`: pass
- `codex/skills/actuating/tests/test-reconciler-contract.sh`: pass, including semantic-hotspot and post-elimination scenario suites
- `git diff --check f237cf45dfb122fd34ed6a59f37bb0034bee2ae8...1a9fd7f2102b392f3575353698ca912152d1ff3c`: pass

## Scope
- repository: `tkersey/dotfiles`
- branch: `actuating-serial-reviews`
- head: `1a9fd7f2102b392f3575353698ca912152d1ff3c`
- base: `main`
- base SHA: `f237cf45dfb122fd34ed6a59f37bb0034bee2ae8`

## Risks
- No residual behavior risk identified within the static scheduling contract; no separate compiled build surface applies to these Markdown, JSON, and shell-contract changes.

## Follow-ups
- None.

## Readiness
- Operation: update-and-promote
- Final state: ready
- SHIP-v1 compatibility mode: promote-draft
- Reason: the exact remote head passes all identified contract and syntax validation.
- Caveats: GitHub currently reports no required checks for this head.
<!-- ship-proof:end -->