### PR TITLE
logophile: add retopologizing adjacency doctrine

### DIFF
--- a/codex/skills/logophile/SKILL.md
+++ b/codex/skills/logophile/SKILL.md
@@ -223,6 +223,14 @@ Read [doctrine_compiler.md](references/doctrine_compiler.md),
 [task_pressure_map.md](references/task_pressure_map.md) for general doctrine
 work. Read specialized references only when their trigger is live.
 
+For explicit requests about changing what counts as adjacent, topology,
+neighborhood structure, making distant concepts local, or automobile-not-faster-
+horses moves, read
+[retopologizing_doctrine.md](references/retopologizing_doctrine.md) and
+[retopologizing_probe_cases.md](references/retopologizing_probe_cases.md). Treat
+`CHANGE WHAT COUNTS AS ADJACENT!!` as the runtime incumbent unless Behavioral
+Upgrade adjudication supports replacement.
+
 ## Behavioral upgrades
 
 When proposed wording may replace an incumbent that already steers behavior,
@@ -291,3 +299,5 @@ authorize mutation, verify, or publish.
   [metanoetic_probe_cases.md](references/metanoetic_probe_cases.md).
 - [pusillanimity_doctrine.md](references/pusillanimity_doctrine.md) and
   [pusillanimity_probe_cases.md](references/pusillanimity_probe_cases.md).
+- [retopologizing_doctrine.md](references/retopologizing_doctrine.md) and
+  [retopologizing_probe_cases.md](references/retopologizing_probe_cases.md).

--- a/codex/skills/logophile/agents/openai.yaml
+++ b/codex/skills/logophile/agents/openai.yaml
@@ -12,4 +12,7 @@ interface:
     disposition. Do not invoke for routine prose, summaries, status updates, implementation handoffs,
     final responses, or merely because text is human-facing. Read SKILL.md for the canonical routing
     gate, load only the reference family required by the current language decision, and treat `no change`
-    as a valid result.
+    as a valid result. For explicit doctrine about changing adjacency, topology, neighborhood structure,
+    or making distant concepts local, read references/retopologizing_doctrine.md and
+    references/retopologizing_probe_cases.md; preserve `CHANGE WHAT COUNTS AS ADJACENT!!` as the runtime
+    incumbent unless Behavioral Upgrade adjudication supports replacement.

--- a/codex/skills/logophile/references/retopologizing_doctrine.md
+++ b/codex/skills/logophile/references/retopologizing_doctrine.md
@@ -78,10 +78,10 @@ Canonical high-amplitude form:
 CHANGE WHAT COUNTS AS ADJACENT!!
 ```
 
-Formal sentence form:
+Formal mode:
 
 ```text
-Operate retopologizingly.
+RETOPOLOGIZING
 ```
 
 Preferred technical command:
@@ -301,7 +301,7 @@ The decisive distinction is:
 
 ```text
 SALTATORY      -> cross the existing distance
-RETOPOLOGIZING -> redefine distance-independent neighborhood
+RETOPOLOGIZING -> change the neighborhood relation that determines local reachability
 ```
 
 A saltatory move jumps the chasm. A retopologizing move discovers a principled
@@ -431,7 +431,7 @@ Candidate formalizations include:
 
 ```text
 Retopologize the search space.
-Operate retopologizingly.
+Operate in RETOPOLOGIZING mode.
 MAKE THE DISTANT LOCAL!!
 ```
 

--- a/codex/skills/logophile/references/retopologizing_doctrine.md
+++ b/codex/skills/logophile/references/retopologizing_doctrine.md
@@ -1,0 +1,492 @@
+# Retopologizing Doctrine
+
+Use this reference when the task asks to change what counts as adjacent, make the
+distant local, escape an inherited neighborhood, rewire a possibility space, or
+name the doctrine behind an automobile-not-faster-horses move.
+
+## Governing operator
+
+## `retopologizing`
+
+In this repository, `RETOPOLOGIZING` means:
+
+> Change the neighborhood structure of a problem so that previously distant
+> concepts, components, observations, or moves become locally reachable, while
+> inherited neighbors without a live structural relationship cease to count as
+> adjacent.
+
+Retopologizing does not merely search farther through the incumbent possibility
+space. It changes the local geometry that defines the next available moves.
+
+```text
+ordinary search
+  -> explore the incumbent neighbors
+
+saltatory search
+  -> cross a large incumbent distance
+
+retopologizing search
+  -> change which candidates are neighbors
+```
+
+The operational question is:
+
+```text
+What would become possible if the adjacency relation were different?
+```
+
+A retopologizing move may:
+
+- make two distant concepts adjacent through a shared invariant;
+- replace file, service, team, or domain proximity with semantic proximity;
+- turn a multi-step operation into one lawful primitive;
+- expose a direct owner-to-observer relation hidden by intermediaries;
+- connect representations through a structure-preserving translation;
+- remove false neighbors created by history, naming, or accidental colocation;
+- alter which tools, skills, abstractions, or evidence sources are considered
+  locally relevant;
+- make a previously remote solution reachable without crossing every incumbent
+  intermediate state.
+
+## Formality boundary
+
+Use `retopologizing` at the strongest level the task supports:
+
+```text
+conceptual topology
+  -> what the solver treats as locally related or reachable
+
+graph topology
+  -> vertices plus an explicit adjacency or edge relation
+
+metric structure
+  -> distances or costs over an unchanged neighborhood relation
+
+mathematical topology
+  -> a carrier plus open sets, neighborhoods, continuity, or a basis
+```
+
+Do not claim a literal topological result when the task supplies only a graph,
+metric, architecture, or conceptual search space. The doctrine remains useful,
+but the proof burden must match the actual structure.
+
+## Runtime activation
+
+Canonical high-amplitude form:
+
+```text
+CHANGE WHAT COUNTS AS ADJACENT!!
+```
+
+Formal sentence form:
+
+```text
+Operate retopologizingly.
+```
+
+Preferred technical command:
+
+```text
+Retopologize the search space.
+```
+
+Poietic companion:
+
+```text
+MAKE THE DISTANT LOCAL!!
+```
+
+The emphatic phrase is the runtime incumbent. Do not automatically replace it
+with the rarer doctrine word. `RETOPOLOGIZING` names the operator; the phrase may
+remain the stronger activation.
+
+## Internal decode
+
+```text
+incumbent objects or states
+  -> incumbent adjacency relation
+  -> false localities and excluded remote relations
+  -> structural invariant, analogy, translation, or ownership relation
+  -> edges added, removed, or reinterpreted
+  -> newly local moves
+  -> newly reachable candidates
+  -> downstream adjudication
+```
+
+## Prompt-ready doctrine
+
+```md
+Operate in RETOPOLOGIZING mode.
+
+Do not search only among candidates made adjacent by the inherited vocabulary,
+decomposition, architecture, ownership model, domain boundary, representation,
+or workflow.
+
+Rewrite the adjacency relation.
+
+Ask:
+- Which apparently distant elements share a governing invariant?
+- Which concepts become neighbors under a different representation?
+- Which components should be adjacent because they exchange one semantic
+  obligation?
+- Which distant domains are structurally analogous?
+- Which multi-step path can become one lawful primitive?
+- Which current neighbors are adjacent only through historical accident?
+- Which tools, skills, or evidence sources become local when relevance is
+  indexed by the actual obligation rather than by labels or location?
+
+Add only principled connections.
+Sever false proximities.
+Preserve authority, safety, type, and information-flow boundaries.
+Then search the new neighborhood.
+```
+
+## Adjacency Rewrite Map
+
+Do not require an artifact merely to emit the terse activation. Use this
+optional explanatory artifact when correctness, handoff, adjudication, or a
+behavioral-upgrade claim depends on the retopologizing result:
+
+```md
+Adjacency Rewrite Map:
+- task / objective:
+- incumbent space:
+- objects, states, or concepts:
+- incumbent adjacency relation:
+- incumbent metric or cost model, if any:
+- false neighbors:
+- structurally related but distant pairs:
+- governing invariant / analogy / translation:
+- edges or neighborhoods added:
+- edges or neighborhoods removed:
+- distance-only changes:
+- representation or ownership changes:
+- newly local operations:
+- newly reachable candidates:
+- preserved authority / safety boundaries:
+- possibility-space delta:
+- route delta:
+- falsifier:
+- disposition: retain | rewire | remetricize | retopologize | obstruct
+```
+
+The map is explanatory, not authority. The receiving workflow owns selection,
+mutation, proof, and closure.
+
+## Adjacent operators
+
+### `remetricizing`
+
+Change the cost or distance between states while preserving the underlying
+adjacency relation.
+
+- Governs: relative distance, effort, priority, or search cost.
+- Cash-out when needed: before/after metric or cost model.
+- Distinction: two states may become cheaper to reach without becoming direct
+  neighbors.
+
+### `rewiring`
+
+Add, remove, or redirect concrete edges in a graph, dependency network, routing
+surface, or workflow.
+
+- Governs: particular connections.
+- Cash-out when needed: edge delta and preserved graph invariants.
+- Distinction: rewiring is the concrete graph operation; retopologizing is the
+  broader change in what counts as locally connected.
+
+### `analogical`
+
+Transfer structure from one domain to another through a defensible
+correspondence.
+
+- Governs: cross-domain structural comparison.
+- Cash-out when needed: source structure, target structure, preserved relation,
+  and broken analogy.
+- Distinction: analogy proposes a relation; retopologizing makes that relation
+  part of the active neighborhood.
+
+### `recombinative`
+
+Combine existing primitives across inherited boundaries to create a capability
+none supplies alone.
+
+- Governs: novel composition.
+- Cash-out when needed: source primitives, composition law, and resulting
+  capability.
+- Distinction: recombination exploits newly adjacent elements; it does not by
+  itself justify their adjacency.
+
+### `relocalizing`
+
+Change where data, authority, computation, or an obligation is treated as
+locally available or canonically owned.
+
+- Governs: locality and ownership placement.
+- Cash-out when needed: old locus, new locus, access path, and owner proof.
+- Distinction: relocalization changes locus; retopologizing changes the broader
+  neighborhood relation.
+
+### `representation-shifting`
+
+Change the representation so formerly remote operations or invariants become
+local and natural.
+
+- Governs: representation choice.
+- Cash-out when needed: before/after representation and observation-preservation
+  proof.
+- Distinction: a representation shift is one common mechanism for
+  retopologizing.
+
+### `quotienting`
+
+Collapse distinctions with no semantic consequence into equivalence classes.
+
+- Governs: removal of distinctions.
+- Cash-out: equivalence relation and congruence proof.
+- Distinction: quotienting can make states adjacent by identifying them, but it
+  is narrower and carries a preservation burden.
+
+### `architectonic`
+
+Discover the governing abstractions, owners, boundaries, and composition laws
+of the whole relevant system.
+
+- Governs: system organization.
+- Distinction: retopologizing changes candidate locality; architectonic
+  adjudication decides whether the resulting organization should govern.
+
+### `saltatory`
+
+Seek a discontinuous advance beyond the incumbent frontier.
+
+- Governs: leap pressure.
+- Distinction: saltation crosses or escapes the current landscape;
+  retopologizing changes the landscape's neighborhood structure.
+
+### `metanoetic`
+
+Change the cognitive regime producing the answer: frame, assumptions, search
+posture, and admissible possibilities.
+
+- Governs: composite cognitive-regime change.
+- Distinction: retopologizing is one possible metanoetic operation over the
+  possibility space.
+
+### `defamiliarizing`
+
+Make the familiar strange enough that inherited assumptions and false
+proximities become visible.
+
+- Governs: de-anchoring perception.
+- Distinction: defamiliarization reveals candidate adjacency errors;
+  retopologizing rewrites them.
+
+## Core distinctions
+
+```text
+DEFAMILIARIZING -> expose inherited proximity as contingent
+ANALOGICAL      -> propose a cross-domain structural relation
+REWIRING        -> change concrete graph edges
+REMETRICIZING   -> change distances or costs
+RELOCALIZING    -> change the locus of availability or ownership
+RETOPOLOGIZING  -> change the neighborhood structure itself
+RECOMBINATIVE   -> compose the newly adjacent primitives
+ARCHITECTONIC   -> select the governing organization
+SALTATORY       -> exploit the new space to reach a new frontier
+METANOETIC      -> change the cognitive regime constructing the space
+```
+
+The decisive distinction is:
+
+```text
+SALTATORY      -> cross the existing distance
+RETOPOLOGIZING -> redefine distance-independent neighborhood
+```
+
+A saltatory move jumps the chasm. A retopologizing move discovers a principled
+connection under which the two sides are locally related.
+
+## Strong stacks
+
+### Escape an inherited local optimum
+
+```text
+DEFAMILIARIZING -> RETOPOLOGIZING -> RECOMBINATIVE -> POIETIC -> SALTATORY
+```
+
+Stop treating inherited proximity as natural, rewrite the neighborhood,
+combine the newly local primitives, create the new form, and seek the leap.
+
+### Rearchitect around semantic adjacency
+
+```text
+EXCAVATORY -> RETOPOLOGIZING -> ARCHITECTONIC -> CANONICALIZING -> RECONSTITUTIVE
+```
+
+Find the governing layer, change which obligations and owners count as local,
+select the organization, establish canonical truth, and rebuild around it.
+
+### Cross-domain invention
+
+```text
+ANALOGICAL -> RETOPOLOGIZING -> EXAPTIVE -> CATALYTIC
+```
+
+Find a structural correspondence, admit it into the active neighborhood,
+repurpose an existing capability, and test its leverage.
+
+### Automobile, not faster horses
+
+```text
+AXIOMATIC -> RETOPOLOGIZING -> ARCHITECTONIC -> SALTATORY
+```
+
+Derive from the real objective, change the reachable neighborhood, organize the
+system around the new relation, and demand a capability leap rather than a
+faster traversal of the old path.
+
+### Search and optimization
+
+```text
+RETOPOLOGIZING -> REMETRICIZING -> BEST-FIRST -> ADJUDICATIVE
+```
+
+Change the legal local moves, update their costs, explore the new frontier, and
+select with declared criteria.
+
+## Selection rules
+
+Use `retopologizing` when:
+
+- the incumbent candidate generator only explores inherited neighbors;
+- repository, organizational, or domain boundaries are being mistaken for
+  semantic distance;
+- a new representation could make a remote invariant or operation local;
+- an apparently multi-step path could become one lawful primitive;
+- cross-domain structures should become active candidates rather than loose
+  analogies;
+- the task asks for an automobile rather than a faster horse;
+- the user explicitly says `CHANGE WHAT COUNTS AS ADJACENT!!`;
+- a breakthrough may require changing local reachability rather than jumping
+  farther.
+
+Use another operator when:
+
+- only edge edits are required: `rewiring`;
+- only costs or priorities change: `remetricizing`;
+- only a cross-domain comparison is needed: `analogical`;
+- only existing primitives need composition: `recombinative`;
+- only ownership or placement changes: `relocalizing`;
+- only a distant candidate must be reached: `saltatory`;
+- the whole system organization must be selected: `architectonic`;
+- the entire cognitive regime must change: `metanoetic`.
+
+Do not invoke retopologizing merely because two files, ideas, or services are
+far apart. The new adjacency must have a structural warrant and a material route
+or capability consequence.
+
+## Stopping rule
+
+Stop the retopologizing pass when one of these holds:
+
+- a principled adjacency rewrite produces a materially new candidate or route;
+- a false proximity is removed and the search no longer follows it;
+- the new neighborhood makes a previously remote operation locally expressible;
+- the proposed relation has a clear validation or adjudication path;
+- all proposed new edges fail the structural-warrant test;
+- authority, safety, information-flow, or type boundaries forbid the connection;
+- a fresh pass produces no additional possibility-space or route delta;
+- the incumbent adjacency relation survives and should be retained.
+
+Retopologizing generates a new search surface. It does not prove that a candidate
+found there is correct, admissible, optimal, or authorized.
+
+## Failure modes
+
+Reject:
+
+- arbitrary association presented as structural adjacency;
+- novelty graphs that connect everything to everything;
+- topology theater: mathematical vocabulary without a changed route;
+- confusing lower cost with new adjacency;
+- treating a single edge edit as a whole topology change;
+- collapsing security, authority, privacy, type, or information-flow boundaries;
+- cross-domain analogy that preserves only superficial resemblance;
+- file, service, or team reorganization without semantic locality change;
+- saltatory claims based only on distance or ambition;
+- architecture selection smuggled into `$logophile` terminology work;
+- one-word compression that displaces a stronger runtime phrase without
+  Behavioral Upgrade evidence.
+
+## Behavioral-upgrade discipline
+
+Treat the user's phrase as the incumbent:
+
+```text
+CHANGE WHAT COUNTS AS ADJACENT!!
+```
+
+Candidate formalizations include:
+
+```text
+Retopologize the search space.
+Operate retopologizingly.
+MAKE THE DISTANT LOCAL!!
+```
+
+Default disposition without matched evidence:
+
+```text
+formal doctrine: RETOPOLOGIZING
+runtime activation: retain CHANGE WHAT COUNTS AS ADJACENT!!
+replacement verdict: retain or benchmark
+```
+
+The formal term earns conceptual precision. The incumbent phrase retains
+activation immediacy, low decoding cost, cadence, and a direct command.
+
+## Composition boundary
+
+`$logophile` owns:
+
+- the `RETOPOLOGIZING` doctrine name;
+- distinctions among adjacency, metric, edge, locality, architecture, and leap;
+- activation wording;
+- Behavioral Upgrade comparison;
+- human-facing explanation of a topology-changing move.
+
+`$logophile` does not:
+
+- redesign the architecture;
+- add or remove graph edges in code;
+- grant cross-boundary authority;
+- choose the resulting candidate;
+- implement, verify, or publish the move;
+- certify a literal mathematical topology without the required structure.
+
+The receiving workflow must adjudicate the new neighborhood and any candidate it
+makes reachable.
+
+## Output shape
+
+For a retopologizing doctrine request, return:
+
+```md
+Task Pressure
+Recommended Mode
+Incumbent Adjacency
+Proposed Adjacency Rewrite
+Adjacent Operators
+Key Distinctions
+Strongest Stack
+Runtime Activation
+Optional Adjacency Rewrite Map
+Shadow Risks
+Behavioral-Upgrade Verdict
+Use This:
+[copy-pasteable doctrine or preserved incumbent phrase]
+```
+
+Keep the runtime activation terse. Do not append the complete analysis unless the
+user requests it or a decision boundary requires it.

--- a/codex/skills/logophile/references/retopologizing_probe_cases.md
+++ b/codex/skills/logophile/references/retopologizing_probe_cases.md
@@ -1,0 +1,508 @@
+# Retopologizing Doctrine Probe Cases
+
+Use these probes to verify that `$logophile` selects `RETOPOLOGIZING` when the
+task changes neighborhood structure, preserves adjacent distinctions, retains
+the user's high-amplitude runtime phrase, and does not claim architecture or
+implementation authority.
+
+## Should trigger retopologizing doctrine
+
+### Direct doctrine request
+
+```text
+What is a doctrine word for CHANGE WHAT COUNTS AS ADJACENT!!?
+```
+
+Expected:
+
+- formal doctrine: `RETOPOLOGIZING`;
+- definition: change the neighborhood structure so previously distant elements
+  become locally reachable and false inherited neighbors cease to count as
+  adjacent;
+- preserve the exact phrase as the runtime incumbent;
+- distinguish adjacency change from searching farther;
+- no mandatory artifact for the terse activation.
+
+### Make the distant local
+
+```text
+We keep searching farther from the current solution. I want the agent to change
+which ideas are considered local candidates.
+```
+
+Expected:
+
+- primary mode: `RETOPOLOGIZING`;
+- incumbent neighborhood and excluded remote candidates should be named;
+- identify a structural warrant for new adjacency;
+- candidate companions may include `DEFAMILIARIZING`, `ANALOGICAL`,
+  `RECOMBINATIVE`, or `POIETIC`;
+- do not answer with `SALTATORY` alone.
+
+### Automobile rather than faster horses
+
+```text
+The current options only optimize the existing workflow. Find the doctrine that
+would let us discover the automobile instead of a faster horse.
+```
+
+Expected stack:
+
+```text
+AXIOMATIC -> RETOPOLOGIZING -> ARCHITECTONIC -> SALTATORY
+```
+
+- derive from the actual objective rather than the inherited vehicle;
+- change local reachability before selecting architecture;
+- distinguish capability-space change from local performance optimization;
+- do not equate a larger implementation with a breakthrough.
+
+### Repository distance is not semantic distance
+
+```text
+Two modules are far apart in the repository, but they own two halves of one
+invariant. What doctrine should make the agent consider them together?
+```
+
+Expected:
+
+- `RETOPOLOGIZING` may make them adjacent by shared invariant;
+- `ARCHITECTONIC` may then adjudicate ownership and boundary shape;
+- file path is not a sufficient adjacency relation;
+- preserve module authority and public contracts until the owning workflow
+  selects a change.
+
+### New representation makes an operation local
+
+```text
+This operation currently requires five translations and two caches. A different
+representation could make it one direct lawful operation. What doctrine names
+that move?
+```
+
+Expected:
+
+```text
+REPRESENTATION-SHIFTING -> RETOPOLOGIZING -> ARCHITECTONIC
+```
+
+- representation shift is the mechanism;
+- retopologizing is the locality change;
+- architectonic selection is owned elsewhere;
+- reject another adapter or cache as the default answer when the representation
+  itself is the source of distance.
+
+### Cross-domain structure becomes an active candidate
+
+```text
+A compiler optimization and a distributed-systems reconciliation problem share
+the same algebraic shape. I want that relation to become part of the active
+search, not just an analogy in prose.
+```
+
+Expected:
+
+```text
+ANALOGICAL -> RETOPOLOGIZING -> RECOMBINATIVE
+```
+
+- name the preserved structural relation and where the analogy breaks;
+- admitting the relation into candidate generation is the retopologizing step;
+- do not infer implementation equivalence from analogy alone.
+
+### Tool and skill neighborhood
+
+```text
+The agent keeps choosing tools by their names and folders. I want tools to count
+as adjacent when they discharge the same obligation or observe the same state.
+```
+
+Expected:
+
+- `RETOPOLOGIZING` over the tool-selection neighborhood;
+- adjacency should be indexed by obligation, observation, authority, or proof
+  need rather than labels alone;
+- preserve each tool's authority and side-effect boundary;
+- do not authorize a tool merely because it is newly considered relevant.
+
+## Distinction probes
+
+### Retopologizing versus saltatory
+
+```text
+Is retopologizing just another word for making a leap?
+```
+
+Expected:
+
+- no;
+- `SALTATORY`: cross or escape a large distance in the incumbent space;
+- `RETOPOLOGIZING`: change which points are neighbors;
+- a retopologized space may enable a saltatory outcome;
+- use the chasm distinction: jump it versus establish a principled local
+  connection.
+
+### Retopologizing versus remetricizing
+
+```text
+The legal next moves stay the same, but I want to make one route much cheaper
+and therefore more likely to be explored.
+```
+
+Expected:
+
+- primary operator: `REMETRICIZING`;
+- adjacency is unchanged;
+- include before/after cost or priority model when needed;
+- do not overstate this as retopologizing.
+
+### Retopologizing versus rewiring
+
+```text
+Add one dependency edge from service A to service B and remove an obsolete edge.
+What is the precise operator?
+```
+
+Expected:
+
+- primary operator: `REWIRING`;
+- require edge delta and preserved graph invariants;
+- use `RETOPOLOGIZING` only if the change revises the governing neighborhood
+  model rather than one local graph edit.
+
+### Retopologizing versus analogical
+
+```text
+I only need to compare the structure of these two domains. The comparison should
+not change the active candidate set.
+```
+
+Expected:
+
+- primary operator: `ANALOGICAL`;
+- no retopologizing because the relation remains explanatory only;
+- name source, target, preserved structure, and broken correspondence.
+
+### Retopologizing versus recombinative
+
+```text
+The relevant components are already known to be adjacent. I only need to combine
+them into one capability.
+```
+
+Expected:
+
+- primary operator: `RECOMBINATIVE`;
+- adjacency is already established;
+- require a composition law and resulting capability;
+- do not reopen topology without evidence.
+
+### Retopologizing versus relocalizing
+
+```text
+The topology is correct, but this state should be owned and computed next to its
+only consumer.
+```
+
+Expected:
+
+- primary operator: `RELOCALIZING`;
+- preserve the broader neighborhood relation;
+- name old locus, new locus, owner, and access path;
+- retopologizing is unnecessary unless other relations change.
+
+### Retopologizing versus architectonic
+
+```text
+We have several newly plausible adjacency models. Which doctrine decides the
+organizing abstraction that should govern the system?
+```
+
+Expected:
+
+- `RETOPOLOGIZING` generated or changed the neighborhood candidates;
+- `ARCHITECTONIC` evaluates governing organization, ownership, and lawful
+  composition;
+- `$logophile` may name the distinction but may not select the architecture.
+
+### Retopologizing versus metanoetic
+
+```text
+Does metanoetic mean the same thing as retopologizing?
+```
+
+Expected:
+
+- no;
+- `METANOETIC` names a composite cognitive-regime change;
+- `RETOPOLOGIZING` is one possible operation over the possibility-space
+  neighborhood;
+- do not append both as redundant synonyms in a stack.
+
+### Retopologizing versus quotienting
+
+```text
+Two states differ only by an irrelevant label and should be treated as one.
+```
+
+Expected:
+
+- primary operator: `QUOTIENTING`;
+- require an equivalence relation and congruence proof;
+- quotienting may alter locality by identification, but its narrower semantic
+  operation should be named.
+
+## Exact activation probes
+
+### Preserve the user's phrase
+
+```text
+Use the doctrine but keep my exact phrase CHANGE WHAT COUNTS AS ADJACENT!!
+```
+
+Expected runtime output:
+
+```text
+CHANGE WHAT COUNTS AS ADJACENT!!
+```
+
+- preserve capitalization and punctuation;
+- `RETOPOLOGIZING` may appear as the formal doctrine label around it;
+- do not append an explanatory checklist in `activation-fast`;
+- do not add an artifact merely to prove the phrase was used.
+
+### Formal term versus runtime phrase
+
+```text
+Replace CHANGE WHAT COUNTS AS ADJACENT!! everywhere with Operate
+retopologizingly.
+```
+
+Expected:
+
+- treat the current phrase as the incumbent;
+- classify the change as compression/register shift with possible activation
+  loss;
+- compare familiarity, cadence, decoding cost, task coverage, median, ceiling,
+  and variance;
+- default to `retain` or `benchmark`, not automatic `replace`.
+
+### Lower-register alternative
+
+```text
+The audience will not know topology terminology. Give me the plain activation.
+```
+
+Expected candidates may include:
+
+```text
+Change which options count as nearby.
+Make the distant local.
+Change what counts as adjacent.
+```
+
+- do not force `retopologizing` into a low-register public surface;
+- preserve the formal doctrine internally if useful.
+
+## Artifact discipline probes
+
+### Optional explanatory artifact
+
+```text
+Give me a reusable structure for explaining how we changed the candidate
+neighborhood.
+```
+
+Expected:
+
+- return an `Adjacency Rewrite Map`;
+- include incumbent adjacency, false neighbors, structural warrant, edges or
+  neighborhoods added/removed, newly local moves, route delta, preserved
+  boundaries, and falsifier;
+- state that the map is explanatory unless another workflow owns it as
+  authority.
+
+### No competing architecture artifact
+
+```text
+$actuating already owns the Construction Contract. Add the Adjacency Rewrite Map
+as another architecture authority artifact.
+```
+
+Expected:
+
+- reject the new authority artifact;
+- compile material adjacency conclusions into the existing owning artifact;
+- `$logophile` owns wording and distinctions only;
+- no extra source of truth should be created.
+
+### Literal topology proof burden
+
+```text
+Prove this software architecture is topologically equivalent after the change.
+```
+
+Expected:
+
+- require a carrier and the exact topology, neighborhood basis, continuity, or
+  equivalence notion;
+- do not use metaphorical retopologizing as a mathematical proof;
+- offer graph, metric, observational, bisimulative, or architectural language if
+  that is the actual structure.
+
+## Strong-stack probes
+
+### Local-optimum escape
+
+```text
+Give me a doctrine stack that stops treating inherited proximity as natural,
+creates a new form, and seeks a breakthrough.
+```
+
+Expected:
+
+```text
+DEFAMILIARIZING -> RETOPOLOGIZING -> RECOMBINATIVE -> POIETIC -> SALTATORY
+```
+
+- each operator must keep a distinct role;
+- the stack generates a breakthrough candidate, not proof of one.
+
+### Technical-debt architecture
+
+```text
+Historical layers make unrelated helpers look adjacent and split one obligation
+across distant owners. Give me a stack to recover the real structure.
+```
+
+Expected candidates:
+
+```text
+STRATIGRAPHIC -> EXCAVATORY -> RETOPOLOGIZING -> ARCHITECTONIC -> ABLATIVE -> NORMALIZING
+```
+
+- recover former obligations before removing surfaces;
+- rewrite semantic adjacency before selecting organization;
+- ablate only residue without a live obligation.
+
+### Search-space redesign
+
+```text
+The search graph is correct, but its cost model hides promising routes. Give me
+the right stack.
+```
+
+Expected:
+
+```text
+REMETRICIZING -> BEST-FIRST -> ADJUDICATIVE
+```
+
+- do not include retopologizing when adjacency remains correct.
+
+## Should not trigger retopologizing doctrine
+
+### Search deeper in the same tree
+
+```text
+Explore three more levels of the current search tree.
+```
+
+Expected:
+
+- use depth-first, best-first, exhaustive, or another search operator;
+- no retopologizing unless the neighborhood relation itself is challenged.
+
+### Routine file move
+
+```text
+Move these files into the same directory so they are adjacent in the tree.
+```
+
+Expected:
+
+- ordinary repository organization;
+- do not infer semantic retopology from physical colocation;
+- `$logophile` should not execute the move.
+
+### Simple graph update
+
+```text
+Add the user-selected edge to this graph data structure.
+```
+
+Expected:
+
+- implementation or `REWIRING`, depending the language task;
+- no doctrine escalation when the adjacency decision is already made.
+
+### Merely unconventional idea
+
+```text
+This idea is weird and far from the incumbent. Call it retopologizing.
+```
+
+Expected:
+
+- reject the label without a changed neighborhood relation;
+- unconventional distance is not topology change;
+- `AUDACIOUS`, `DIVERGENT`, or `SALTATORY` may be more accurate.
+
+### Connect everything
+
+```text
+Make every concept adjacent to every other concept so the model can be more
+creative.
+```
+
+Expected:
+
+- reject indiscriminate complete-graph expansion;
+- require a structural warrant and preserve search discrimination;
+- flag combinatorial explosion and false adjacency.
+
+### Collapse authority boundaries
+
+```text
+Treat every tool as adjacent and interchangeable, even if some can publish or
+mutate and others cannot.
+```
+
+Expected:
+
+- reject the adjacency rewrite;
+- preserve authority and side-effect distinctions;
+- relevance does not grant capability or permission.
+
+### Correct incumbent topology
+
+```text
+The current adjacency relation is explicit, evidenced, and already yields the
+dominant route. Retopologize it anyway to be more creative.
+```
+
+Expected:
+
+- retain the incumbent;
+- do not force novelty;
+- `no change` is a successful `$logophile` result.
+
+## Quality gate
+
+A retopologizing answer is ready only when:
+
+1. `RETOPOLOGIZING` changes neighborhood structure rather than merely increasing
+   search depth or distance;
+2. the incumbent adjacency relation is named or inferable;
+3. each proposed new adjacency has a structural warrant;
+4. false inherited neighbors may be removed as well as new ones added;
+5. `REMETRICIZING`, `REWIRING`, `ANALOGICAL`, `RECOMBINATIVE`, `RELOCALIZING`,
+   `ARCHITECTONIC`, `SALTATORY`, and `METANOETIC` retain distinct jobs;
+6. authority, safety, privacy, type, and information-flow boundaries survive;
+7. the runtime phrase remains the incumbent unless Behavioral Upgrade evidence
+   supports replacement;
+8. an artifact is optional for terse activation;
+9. the result names a possibility-space or route delta rather than topology
+   theater;
+10. `$logophile` does not select, implement, verify, authorize, or publish the
+    resulting move.


### PR DESCRIPTION
## Summary

- add `RETOPOLOGIZING` as the formal doctrine for changing a problem's neighborhood structure rather than merely searching farther through the incumbent possibility space
- preserve the exact high-amplitude runtime incumbent `CHANGE WHAT COUNTS AS ADJACENT!!`
- define the technical distinction among adjacency, edge structure, metric, locality, architecture, cognitive regime, and leap pressure
- add an optional `Adjacency Rewrite Map`, stopping rule, failure modes, strong doctrine stacks, and Behavioral Upgrade discipline
- add focused trigger, distinction, exact-activation, artifact-boundary, strong-stack, non-trigger, and quality-gate probes
- route the new reference family from both `SKILL.md` and `agents/openai.yaml` without widening `$logophile` into an ambient prose pass

## Governing definition

> `RETOPOLOGIZING` changes the neighborhood structure of a problem so that previously distant concepts, components, observations, or moves become locally reachable, while inherited neighbors without a live structural relationship cease to count as adjacent.

The key distinction is:

```text
SALTATORY      -> cross the existing distance
RETOPOLOGIZING -> change the neighborhood relation that determines local reachability
```

A saltatory move jumps the chasm. A retopologizing move establishes a principled relation under which the two sides become locally connected.

## Runtime contract

Formal doctrine:

```text
RETOPOLOGIZING
```

Technical command:

```text
Retopologize the search space.
```

Runtime incumbent:

```text
CHANGE WHAT COUNTS AS ADJACENT!!
```

The formal word names the operator; it does not automatically replace the direct phrase. Without matched behavioral evidence, the replacement disposition remains `retain` or `benchmark`.

## Adjacent operators

The reference preserves distinct jobs for:

- `REMETRICIZING` — change costs or distances while preserving adjacency
- `REWIRING` — change concrete graph edges
- `ANALOGICAL` — propose a cross-domain structural relation
- `RECOMBINATIVE` — compose newly adjacent primitives
- `RELOCALIZING` — change the locus of availability or ownership
- `REPRESENTATION-SHIFTING` — make remote operations local through a new representation
- `QUOTIENTING` — identify semantically equivalent states
- `ARCHITECTONIC` — select the governing organization
- `SALTATORY` — seek a discontinuous advance
- `METANOETIC` — change the cognitive regime constructing the possibility space

## Strong stacks

```text
DEFAMILIARIZING -> RETOPOLOGIZING -> RECOMBINATIVE -> POIETIC -> SALTATORY
```

```text
EXCAVATORY -> RETOPOLOGIZING -> ARCHITECTONIC -> CANONICALIZING -> RECONSTITUTIVE
```

```text
AXIOMATIC -> RETOPOLOGIZING -> ARCHITECTONIC -> SALTATORY
```

The last stack formalizes the automobile-not-faster-horses move: derive from the real objective, change the reachable neighborhood, select the governing organization, and demand a capability leap.

## Files

- `codex/skills/logophile/SKILL.md`
- `codex/skills/logophile/agents/openai.yaml`
- `codex/skills/logophile/references/retopologizing_doctrine.md`
- `codex/skills/logophile/references/retopologizing_probe_cases.md`

## Validation

- branch starts from current `main` (`ecb2367440359a6eb1eab08cf37a6a7238fe2c56`)
- diff is limited to four `$logophile` files
- `SKILL.md` and `agents/openai.yaml` both route directly to the new reference pair
- updated YAML parses successfully
- connector rereads confirm the exact activation phrase, operator distinctions, stopping rule, authority boundary, and probe coverage
- `allow_implicit_invocation` remains unchanged; the route applies only to explicit topology/adjacency doctrine work
- no AGENTS rule, operational authority, architecture-selection authority, mutation boundary, verification authority, or publication authority changed

The repository-local validator was not run in this connector-only workflow.

<!-- ship-proof:start -->
## Summary
- Add and route the `RETOPOLOGIZING` doctrine while preserving `CHANGE WHAT COUNTS AS ADJACENT!!` as the incumbent runtime activation unless Behavioral Upgrade evidence supports replacement.

## Proof
- `git diff --check origin/main...HEAD`: pass
- `quick_validate.py codex/skills/logophile`: pass (`Skill is valid!`)
- `uv run --with pyyaml -- python3 -c <YAML/reference/activation/probe assertions>`: pass (`logophile retopologizing contract: pass`)
- Exact base/head and four-file diff scope: pass

## Scope
- repository: `tkersey/dotfiles`
- branch: `agent/logophile-retopologizing-doctrine`
- head: `76c3265919a26dff006ad7a7801bf8c2f234c3af`
- base: `main`
- base SHA: `ecb2367440359a6eb1eab08cf37a6a7238fe2c56`

## Risks
- No executable build surface exists for this documentation-and-skill-package-only change; the relevant package, contract, and diff validators passed.

## Follow-ups
- None.

## Readiness
- Operation: update-and-promote
- Final state: ready
- SHIP-v1 compatibility mode: promote-draft
- Reason: Exact-head validation is complete and no task remains blocked, deferred, or open.
- Caveats: GitHub reports no required checks for this branch; repository policy requires none.
<!-- ship-proof:end -->