### PR TITLE
actuating: revoke repeatedly falsified construction theorems

### DIFF
--- a/codex/skills/actuating/SKILL.md
+++ b/codex/skills/actuating/SKILL.md
@@ -321,6 +321,21 @@ A same-family successor finding means the family, carrier, cut, factorization,
 bypass closure, realization, or proof was incomplete. Reopen the construction
 decision; never append another named-member guard under the same claim.
 
+Construction completeness is a revocable proof lease. A direct falsifier of the
+declared family, carrier, cut, producer factorization, or bypass theorem revokes
+that theorem immediately. Otherwise, the first exact `same-claim` successor
+invalidation may retain the theorem only with exact evidence that the failed
+premise is confined to realization or proof. A second exact `same-claim`
+successor invalidation under a materially unchanged theorem revokes the theorem
+and its `reviewable` claim.
+
+After revocation, mutation, Ship, and review remain closed. Re-entry requires a
+source-derived admission topology, a material theorem delta, and an executable or
+exhaustive factorization witness capable of failing when a sanctioned producer or
+bypass is omitted. Same law or owner alone is insufficient; Review Fold must
+establish the exact same claim. No third reviewable candidate may be issued under
+a materially unchanged construction theorem.
+
 Read [closure.md](references/closure.md). Final completion still requires exact
 Git, validation, Ship/provider, CAS, and five-consecutive-standard-clean
 evidence. Review is adversarial falsification, not incremental architecture
@@ -332,6 +347,8 @@ authorship.
 - No mutation before the complete initial falsification wave and evidence cut.
 - No member-specific repair for an established family without separation proof.
 - No construction claim without every sanctioned producer and bypass.
+- No third reviewable candidate under a materially unchanged theorem after two
+  exact same-claim successor invalidations.
 - No closure from repaired examples alone.
 - No durable **Actuating** workflow, corpus, carrier, factor, gate, or closure
   store. Use the Review Fold corpus only as owner-issued counterexample evidence.
@@ -342,5 +359,7 @@ authorship.
 - No factor-first or line-count-first architecture selection.
 - No review dispatch on an incomplete construction or proof inventory.
 - No silent Goal expansion.
-- Keep `$metanoetic` before `$universalist`; do not add a second pass.
+- Keep `$metanoetic` before `$universalist`; do not add a second pass on an
+  unchanged decision surface. A revoked theorem is material new evidence and a
+  changed decision surface.
 - Complete object-level work before optional learnings or memory capture.

--- a/codex/skills/actuating/references/review-contract.json
+++ b/codex/skills/actuating/references/review-contract.json
@@ -1,6 +1,6 @@
 {
-  "schema": "actuating-review-contract/v9",
-  "contract_id": "actuating-review-contract-v11",
+  "schema": "actuating-review-contract/v10",
+  "contract_id": "actuating-review-contract-v12",
   "required_lenses": [
     {
       "name": "standard",
@@ -78,7 +78,10 @@
     "review_dispatch_requires": "reviewable",
     "material_finding_invalidates_immediately": true,
     "material_finding_resets_all_credit": true,
-    "mutation_closed_until_initial_evidence_cut": true
+    "mutation_closed_until_initial_evidence_cut": true,
+    "construction_theorem_is_revocable_proof_lease": true,
+    "revoked_theorem_closes_mutation_ship_and_review": true,
+    "reviewable_reentry_after_revocation_requires_material_theorem_delta": true
   },
   "review_entry": {
     "complete_goal_proof_inventory_required": true,
@@ -124,7 +127,18 @@
   "same_family_recurrence": {
     "member_specific_extension_forbidden_without_separation": true,
     "reopens_construction_theorem": true,
-    "historical_absence_requires_complete_corpus_horizon": true
+    "historical_absence_requires_complete_corpus_horizon": true,
+    "same_claim_evidence_required": true,
+    "same_law_or_owner_alone_insufficient": true,
+    "direct_theorem_premise_falsifier_revokes_immediately": true,
+    "first_same_claim_successor_invalidation_may_retain_only_if_realization_or_proof_local": true,
+    "second_same_claim_successor_invalidation_under_unchanged_theorem_revokes_theorem": true,
+    "third_reviewable_candidate_under_unchanged_theorem_forbidden": true,
+    "material_theorem_delta_required_for_reentry": true,
+    "source_anchored_admission_topology_required_for_reentry": true,
+    "executable_or_exhaustive_factorization_witness_required_for_reentry": true,
+    "same_law_different_family_does_not_increment": true,
+    "repeated_recurrence_changes_decision_surface": true
   },
   "standard_convergence": {
     "required_consecutive_clean_attempts": 5,

--- a/codex/skills/actuating/references/review-contract.md
+++ b/codex/skills/actuating/references/review-contract.md
@@ -104,6 +104,60 @@ invalidated
 
 Only `reviewable` may dispatch closure review.
 
+### Construction-theorem proof lease
+
+A construction theorem is the current conjunction of:
+
+```text
+accepted Goal and law
+invalid-family predicate and comparison domain
+canonical owner and earliest enforceable cut
+admitted carrier and semantic identity
+sanctioned producer and trusted-consumer topology
+producer factorization and bypass dispositions
+required-valid interpretation
+proof universe, falsifier, validity horizon, and claim strength
+```
+
+Its completeness claim is a revocable proof lease, not a reusable assertion.
+A direct falsifier of any declared theorem premise revokes the theorem
+immediately.
+
+Otherwise, recurrence is adjudicated only from exact Review Fold evidence:
+
+```text
+first exact same-claim successor invalidation
+  -> invalidate the candidate
+  -> localize the earliest failed premise
+  -> retain the theorem only when exact evidence confines the defect
+     to realization or proof
+
+second exact same-claim successor invalidation under a materially unchanged theorem
+  -> revoke the theorem and its reviewable claim
+  -> close mutation, Ship, and review
+  -> prohibit a third reviewable candidate under that theorem
+```
+
+`same-law-different-family`, `outside-horizon`, `different-law`, and `unknown`
+do not increment this recurrence. Same owner or broad law alone is insufficient.
+
+A theorem is materially changed only when the successor revises at least one
+falsified semantic premise or its proof universe—not merely code, prose, tests,
+or the reviewed head. Re-entry after revocation requires:
+
+```text
+source-derived disposition for every producer, parser, serializer, adapter,
+  compatibility path, recovery path, trusted consumer, and bypass
+material theorem delta tied to the failed premise
+executable or exhaustive factorization witness capable of failing when one
+  sanctioned producer or bypass is omitted
+fresh exact-head construction proof
+```
+
+Repeated recurrence is material new evidence. It may re-open Metanoetic and
+Universalist reclassification on the changed decision surface; it does not add a
+second pass on an unchanged surface.
+
 ## Review entry
 
 Require on the exact head:
@@ -259,5 +313,7 @@ restart from the initial standard. If historical counterexample evidence cannot
 be resolved, mark the horizon incomplete; never reconstruct it from prose or
 memory.
 
-A same-family finding reopens the construction theorem, not a member-specific
-patch.
+A first exact same-claim successor finding reopens and localizes the construction
+theorem. A second under a materially unchanged theorem revokes it. No third
+reviewable candidate may issue until the theorem materially changes and its
+source topology and factorization are proved.

--- a/codex/skills/actuating/tests/fixtures/construction-cycle-scenarios.json
+++ b/codex/skills/actuating/tests/fixtures/construction-cycle-scenarios.json
@@ -98,6 +98,90 @@
       "expected": "construction-normalization"
     },
     {
+      "id": "first-same-claim-successor-reopens-construction",
+      "input": {
+        "phase": "post-review",
+        "same_claim_finding": true,
+        "prior_same_claim_successor_invalidations": 0,
+        "theorem_materially_changed": false
+      },
+      "expected": "construction-normalization"
+    },
+    {
+      "id": "second-same-claim-successor-revokes-unchanged-theorem",
+      "input": {
+        "phase": "post-review",
+        "same_claim_finding": true,
+        "prior_same_claim_successor_invalidations": 1,
+        "theorem_materially_changed": false
+      },
+      "expected": "theorem-rederive-required"
+    },
+    {
+      "id": "direct-theorem-falsifier-revokes-immediately",
+      "input": {
+        "phase": "post-review",
+        "same_claim_finding": true,
+        "prior_same_claim_successor_invalidations": 0,
+        "direct_theorem_falsifier": true
+      },
+      "expected": "theorem-rederive-required"
+    },
+    {
+      "id": "same-law-different-family-does-not-increment-recurrence",
+      "input": {
+        "phase": "post-review",
+        "same_claim_finding": false,
+        "same_law_finding": true,
+        "prior_same_claim_successor_invalidations": 1,
+        "theorem_materially_changed": false
+      },
+      "expected": "construction-normalization"
+    },
+    {
+      "id": "revoked-theorem-blocks-third-candidate",
+      "input": {
+        "phase": "review-entry",
+        "theorem_revoked": true,
+        "construction_complete": true,
+        "proof_inventory_current": true
+      },
+      "expected": "blocked"
+    },
+    {
+      "id": "material-theorem-delta-and-factorization-allow-reentry",
+      "input": {
+        "phase": "theorem-reentry",
+        "theorem_revoked": true,
+        "theorem_materially_changed": true,
+        "source_topology_complete": true,
+        "factorization_witness_current": true
+      },
+      "expected": "allow-reentry"
+    },
+    {
+      "id": "theorem-delta-without-source-topology-blocks-reentry",
+      "input": {
+        "phase": "theorem-reentry",
+        "theorem_revoked": true,
+        "theorem_materially_changed": true,
+        "source_topology_complete": false,
+        "factorization_witness_current": true
+      },
+      "expected": "blocked"
+    },
+    {
+      "id": "theorem-delta-without-factorization-witness-blocks-reentry",
+      "input": {
+        "phase": "theorem-reentry",
+        "theorem_revoked": true,
+        "theorem_materially_changed": true,
+        "source_topology_complete": true,
+        "factorization_witness_current": false
+      },
+      "expected": "blocked"
+    },
+    {
       "id": "incomplete-proof-is-not-reviewable",
       "input": {
         "phase": "review-entry",

--- a/codex/skills/actuating/tests/test-construction-cycle-scenarios.sh
+++ b/codex/skills/actuating/tests/test-construction-cycle-scenarios.sh
@@ -6,6 +6,9 @@ jaq_bin=${JAQ_BIN:-jaq}
 fixture="$skill_root/tests/fixtures/construction-cycle-scenarios.json"
 
 "$jaq_bin" -e '
+  def same_claim($i):
+    ($i.same_claim_finding // $i.same_family_finding // false);
+
   def decide($i):
     if $i.phase == "initial-review" and
        $i.material_finding == true and
@@ -14,9 +17,25 @@ fixture="$skill_root/tests/fixtures/construction-cycle-scenarios.json"
     elif $i.phase == "confirmation" and $i.material_finding == true
     then "close-cut"
     elif $i.phase == "post-review" and
-         $i.same_family_finding == true and
-         $i.separation_proof != true
+         $i.direct_theorem_falsifier == true
+    then "theorem-rederive-required"
+    elif $i.phase == "post-review" and
+         same_claim($i) == true and
+         $i.theorem_materially_changed != true and
+         (($i.prior_same_claim_successor_invalidations // 0) >= 1)
+    then "theorem-rederive-required"
+    elif $i.phase == "post-review" and same_claim($i) == true
     then "construction-normalization"
+    elif $i.phase == "post-review" and $i.same_law_finding == true
+    then "construction-normalization"
+    elif $i.phase == "theorem-reentry"
+    then if $i.theorem_revoked == true and
+            $i.theorem_materially_changed == true and
+            $i.source_topology_complete == true and
+            $i.factorization_witness_current == true
+         then "allow-reentry" else "blocked" end
+    elif $i.phase == "review-entry" and $i.theorem_revoked == true
+    then "blocked"
     elif $i.phase == "review-entry"
     then if $i.construction_complete == true and
             $i.proof_inventory_current == true
@@ -55,7 +74,7 @@ fixture="$skill_root/tests/fixtures/construction-cycle-scenarios.json"
     end;
 
   .schema == "actuating-construction-cycle-scenarios/v1" and
-  (.scenarios | length) >= 18 and
+  (.scenarios | length) >= 24 and
   ([.scenarios[].id] | length == (unique | length)) and
   all(.scenarios[]; decide(.input) == .expected) and
   ([.scenarios[] |
@@ -77,8 +96,23 @@ fixture="$skill_root/tests/fixtures/construction-cycle-scenarios.json"
     .id == "mixed-successor-routes-are-representable" and
     .expected == "mixed-successor") and
   any(.scenarios[];
-    .id == "same-family-successor-reopens-construction" and
-    .expected == "construction-normalization")
+    .id == "first-same-claim-successor-reopens-construction" and
+    .expected == "construction-normalization") and
+  any(.scenarios[];
+    .id == "second-same-claim-successor-revokes-unchanged-theorem" and
+    .expected == "theorem-rederive-required") and
+  any(.scenarios[];
+    .id == "direct-theorem-falsifier-revokes-immediately" and
+    .expected == "theorem-rederive-required") and
+  any(.scenarios[];
+    .id == "same-law-different-family-does-not-increment-recurrence" and
+    .expected == "construction-normalization") and
+  any(.scenarios[];
+    .id == "revoked-theorem-blocks-third-candidate" and
+    .expected == "blocked") and
+  any(.scenarios[];
+    .id == "material-theorem-delta-and-factorization-allow-reentry" and
+    .expected == "allow-reentry")
 ' "$fixture" >/dev/null
 
 echo "actuating construction cycle scenarios: pass"

--- a/codex/skills/actuating/tests/test-reconciler-contract.sh
+++ b/codex/skills/actuating/tests/test-reconciler-contract.sh
@@ -30,6 +30,10 @@ grep -F '## Evidence acquisition before mutation' "$skill_root/SKILL.md" >/dev/n
 grep -F '## Exactly two bug-driven mutation routes' "$skill_root/SKILL.md" >/dev/null
 grep -F '## Construction Working Set' "$skill_root/SKILL.md" >/dev/null
 grep -F 'No second Actuating Ledger definition' "$skill_root/SKILL.md" >/dev/null
+grep -F 'Construction completeness is a revocable proof lease' \
+  "$skill_root/SKILL.md" >/dev/null
+grep -F 'No third reviewable candidate under a materially unchanged theorem' \
+  "$skill_root/SKILL.md" >/dev/null
 
 grep -F '# Counterexample-to-Construction Compilation' \
   "$skill_root/references/counterexample-guided-normalization.md" >/dev/null
@@ -66,6 +70,12 @@ grep -F 'for evidence only' \
 grep -F 'A material confirmation finding' \
   "$skill_root/references/review-contract.md" >/dev/null
 grep -F '## Counterexample history projection' \
+  "$skill_root/references/review-contract.md" >/dev/null
+grep -F '### Construction-theorem proof lease' \
+  "$skill_root/references/review-contract.md" >/dev/null
+grep -F 'second exact same-claim successor invalidation' \
+  "$skill_root/references/review-contract.md" >/dev/null
+grep -F 'executable or exhaustive factorization witness' \
   "$skill_root/references/review-contract.md" >/dev/null
 
 for lens in \
@@ -115,8 +125,8 @@ done
 ' "$review_fold_root/definitions/ledger/counterexample-corpus.json" >/dev/null
 
 "$jaq_bin" -e '
-  .schema == "actuating-review-contract/v9" and
-  .contract_id == "actuating-review-contract-v11" and
+  .schema == "actuating-review-contract/v10" and
+  .contract_id == "actuating-review-contract-v12" and
   (.required_lenses | length) == 5 and
   .review_scheduling.default_mode == "parallel-reviews" and
   .review_scheduling.modes["parallel-reviews"].non_cancelling == true and
@@ -128,6 +138,9 @@ done
   .counterexample_corpus.capture_after_current_fold == true and
   .counterexample_corpus.current_applicability_recomputed == true and
   .counterexample_corpus.actuating_copy_or_store_forbidden == true and
+  .candidate_lifecycle.construction_theorem_is_revocable_proof_lease == true and
+  .candidate_lifecycle.revoked_theorem_closes_mutation_ship_and_review == true and
+  .candidate_lifecycle.reviewable_reentry_after_revocation_requires_material_theorem_delta == true and
   .evidence_acquisition.initial_falsification_wave_complete_before_successor_selection == true and
   .evidence_acquisition.projected_counterexamples_are_reclassified == true and
   .review_entry.admitted_carrier_required == true and
@@ -135,6 +148,15 @@ done
   .review_entry.complete_bypass_disposition_required == true and
   .mutation_routes.allowed ==
     ["construction-normalization", "isolated-restoration"] and
+  .same_family_recurrence.same_claim_evidence_required == true and
+  .same_family_recurrence.same_law_or_owner_alone_insufficient == true and
+  .same_family_recurrence.direct_theorem_premise_falsifier_revokes_immediately == true and
+  .same_family_recurrence.second_same_claim_successor_invalidation_under_unchanged_theorem_revokes_theorem == true and
+  .same_family_recurrence.third_reviewable_candidate_under_unchanged_theorem_forbidden == true and
+  .same_family_recurrence.material_theorem_delta_required_for_reentry == true and
+  .same_family_recurrence.source_anchored_admission_topology_required_for_reentry == true and
+  .same_family_recurrence.executable_or_exhaustive_factorization_witness_required_for_reentry == true and
+  .same_family_recurrence.same_law_different_family_does_not_increment == true and
   .standard_convergence.required_consecutive_clean_attempts == 5
 ' "$skill_root/references/review-contract.json" >/dev/null
 


### PR DESCRIPTION
## Summary

Stop `$actuating` from repeatedly publishing and reviewing successors under a construction theorem that review has already falsified twice.

The current contract correctly reopens construction on a same-family finding, but it does not revoke the completeness claim. That permits:

```text
falsified theorem
-> local refinement
-> reviewable successor
-> same-claim finding
-> repeat
```

This change makes construction completeness a revocable proof lease.

## Recurrence law

```text
direct theorem-premise falsifier
  -> revoke immediately

first exact same-claim successor invalidation
  -> localize the failed premise
  -> retain only with exact realization/proof-local evidence

second exact same-claim successor invalidation under an unchanged theorem
  -> revoke theorem and reviewable claim
  -> close mutation, Ship, and review
  -> prohibit a third candidate under that theorem
```

Same law or owner alone is insufficient. `same-law-different-family`, `outside-horizon`, `different-law`, and `unknown` evidence do not increment the breaker.

## Re-entry

After revocation, another candidate may become reviewable only after:

- source-derived dispositions for every producer, parser, serializer, adapter, compatibility/recovery path, trusted consumer, and bypass;
- a material theorem delta tied to the failed premise;
- an executable or exhaustive factorization witness that fails when a sanctioned producer or bypass is omitted;
- fresh exact-head construction proof.

Repeated recurrence is material new evidence, so Metanoetic and Universalist may reclassify the changed decision surface. This does not introduce a second pass on an unchanged surface.

## Process boundary

No new:

- gate;
- Ledger definition;
- store;
- mode;
- lens;
- workflow artifact;
- durable Actuating state.

The Review Fold corpus supplies exact historical witnesses. Git and CAS continue to own heads and review attempts. Actuating derives the live recurrence judgment in its ephemeral Working Set.

## Changed surface

Six existing `$actuating` files:

- root skill;
- Markdown and JSON review contracts;
- construction-cycle fixture and executable test;
- existing reconciler assertions.

## Validation

Passed:

- changed JSON parsing;
- changed shell syntax;
- focused construction-cycle scenario suite with `jq`;
- exact remote comparison: one commit and six Actuating-only files.

Not run in this connector environment:

- full repository reconciler, Ledger, and package suites.

The PR remains draft pending repository-native exact-head validation.

<!-- ship-proof:start -->
## Summary
- Make Actuating revoke a repeatedly falsified construction theorem, block a third unchanged-theorem candidate, and require source topology plus a material theorem delta and factorization witness for re-entry.

## Proof
- `jaq empty codex/skills/actuating/references/review-contract.json codex/skills/actuating/tests/fixtures/construction-cycle-scenarios.json`: pass
- `sh -n codex/skills/actuating/tests/test-construction-cycle-scenarios.sh codex/skills/actuating/tests/test-reconciler-contract.sh`: pass
- `JAQ_BIN=jaq codex/skills/actuating/tests/test-reconciler-contract.sh`: pass; includes the Review Fold corpus, direct-repair admission, semantic-hotspot, post-elimination, construction-cycle, and reconciler contract checks
- `git diff --check origin/main...ec4dd5622da04341eb01d3b7c54e063396af17f4`: pass

## Scope
- repository: `tkersey/dotfiles`
- branch: `agent/actuating-construction-theorem-recurrence`
- head: `ec4dd5622da04341eb01d3b7c54e063396af17f4`
- base: `main`
- base SHA: `b70a035d02409c69597c74168a806ba6899d6921`

## Risks
- No residual merge-blocking risk identified; the change is confined to six Actuating contract, fixture, and test files.

## Follow-ups
- None.

## Readiness
- Operation: update-and-promote
- Final state: ready
- SHIP-v1 compatibility mode: promote-draft
- Reason: repository-native validation passes on the exact remote head and no in-scope work remains open.
- Caveats: no build target applies to this Markdown, JSON, fixture, and POSIX-shell-only change.
<!-- ship-proof:end -->