### PR TITLE
actuating: collapse read-only routes into analyze

### DIFF
--- a/codex/skills/actuating/SKILL.md
+++ b/codex/skills/actuating/SKILL.md
@@ -65,11 +65,14 @@ Working Sets, review summaries, gate packets, and prior threads are hypotheses.
 |---|---|---:|---|
 | Bare `$actuating` or `/goal $actuating` | implement -> Ship -> review-closeout | Explicitly authorized | `complete` |
 | `$actuating implement` | compile and realize locally | Explicitly authorized | local `complete` |
-| `$actuating triage` | acquire and classify evidence | Forbidden | evidence and construction pressure |
-| `$actuating remediation-plan` | compile a non-executable construction | Forbidden | plan |
+| `$actuating analyze` | compile the deepest honest read-only construction judgment | Forbidden | construction, incomparability, containment, or obstruction |
 | `$actuating review-closeout` | falsify, compile successor, realize, Ship, converge | Explicitly authorized | `complete` |
 
-An unqualified request to review, inspect, audit, or classify selects `triage`.
+`analyze` runs the complete counterexample-to-construction compiler as far as
+current evidence permits, but it may not mutate, publish, grant review credit, or
+claim closure. An unqualified request to review, inspect, audit, classify, or
+analyze selects `analyze`.
+
 Mutation requires explicit implement, fix, resolve, address, or closeout intent.
 
 Review-bearing routes accept `parallel-reviews` (default) or `serial-reviews`.

--- a/codex/skills/actuating/references/decision-contract.json
+++ b/codex/skills/actuating/references/decision-contract.json
@@ -4,7 +4,7 @@
     "skill": {
       "name": "actuating",
       "kind": "mixed",
-      "source_fingerprint": "actuating-construction-compiler-v5"
+      "source_fingerprint": "actuating-construction-compiler-v6"
     },
     "triggers": [
       {
@@ -19,11 +19,10 @@
       },
       {
         "trigger_id": "ACT-ROUTE",
-        "description": "Explicit routes select implement, triage, remediation-plan, or review-closeout.",
+        "description": "Explicit routes select implement, analyze, or review-closeout.",
         "cue_literals": [
           "$actuating implement",
-          "$actuating triage",
-          "$actuating remediation-plan",
+          "$actuating analyze",
           "$actuating review-closeout"
         ],
         "cue_regexes": [],
@@ -85,18 +84,10 @@
         "terminal": false
       },
       {
-        "route_id": "ACT-TRIAGE",
-        "description": "Acquire and classify evidence without mutation.",
+        "route_id": "ACT-ANALYZE",
+        "description": "Compile the deepest honest read-only construction judgment from current evidence.",
         "aliases": [
-          "triage"
-        ],
-        "terminal": true
-      },
-      {
-        "route_id": "ACT-REMEDIATION",
-        "description": "Compile a non-executable construction.",
-        "aliases": [
-          "remediation-plan"
+          "analyze"
         ],
         "terminal": true
       },
@@ -129,8 +120,7 @@
         ],
         "expected_routes": [
           "ACT-IMPLEMENT",
-          "ACT-TRIAGE",
-          "ACT-REMEDIATION",
+          "ACT-ANALYZE",
           "ACT-REVIEW-CLOSEOUT",
           "ACT-CLOSE"
         ],
@@ -162,8 +152,7 @@
         ],
         "expected_routes": [
           "ACT-IMPLEMENT",
-          "ACT-TRIAGE",
-          "ACT-REMEDIATION",
+          "ACT-ANALYZE",
           "ACT-REVIEW-CLOSEOUT",
           "ACT-CLOSE"
         ],
@@ -194,7 +183,7 @@
         ],
         "expected_routes": [
           "ACT-IMPLEMENT",
-          "ACT-REMEDIATION",
+          "ACT-ANALYZE",
           "ACT-REVIEW-CLOSEOUT",
           "ACT-CLOSE"
         ],
@@ -256,7 +245,7 @@
         ],
         "expected_routes": [
           "ACT-IMPLEMENT",
-          "ACT-REMEDIATION",
+          "ACT-ANALYZE",
           "ACT-REVIEW-CLOSEOUT",
           "ACT-CLOSE"
         ],
@@ -295,7 +284,7 @@
         ],
         "expected_routes": [
           "ACT-IMPLEMENT",
-          "ACT-REMEDIATION",
+          "ACT-ANALYZE",
           "ACT-REVIEW-CLOSEOUT",
           "ACT-CLOSE"
         ],
@@ -369,7 +358,7 @@
           "ACT-COUNTEREXAMPLE"
         ],
         "expected_routes": [
-          "ACT-TRIAGE",
+          "ACT-ANALYZE",
           "ACT-REVIEW-CLOSEOUT",
           "ACT-CLOSE"
         ],

--- a/codex/skills/actuating/tests/test-reconciler-contract.sh
+++ b/codex/skills/actuating/tests/test-reconciler-contract.sh
@@ -50,6 +50,16 @@ grep -F 'No self-authored omission list may serve as the sole evidence' \
   "$skill_root/SKILL.md" >/dev/null
 grep -F 'A sanctioned path absent from the topology basis revokes' \
   "$skill_root/SKILL.md" >/dev/null
+grep -F '| `$actuating analyze` |' "$skill_root/SKILL.md" >/dev/null
+grep -F '`analyze` runs the complete counterexample-to-construction compiler' \
+  "$skill_root/SKILL.md" >/dev/null
+
+if grep -F '$actuating triage' "$skill_root/SKILL.md" >/dev/null ||
+   grep -F '$actuating remediation-plan' "$skill_root/SKILL.md" >/dev/null
+then
+  echo "retired Actuating public route remains in SKILL.md" >&2
+  exit 1
+fi
 
 grep -F '# Counterexample-to-Construction Compilation' \
   "$skill_root/references/counterexample-guided-normalization.md" >/dev/null
@@ -222,9 +232,32 @@ done
 
 "$jaq_bin" -e '
   .skill_decision_contract.skill.source_fingerprint ==
-    "actuating-construction-compiler-v5" and
+    "actuating-construction-compiler-v6" and
+  ((.skill_decision_contract.triggers[] |
+    select(.trigger_id == "ACT-ROUTE") |
+    .cue_literals) == [
+      "$actuating implement",
+      "$actuating analyze",
+      "$actuating review-closeout"
+    ]) and
+  ([.skill_decision_contract.routes[].route_id] | sort) ==
+    (["ACT-IMPLEMENT", "ACT-ANALYZE", "ACT-REVIEW-CLOSEOUT", "ACT-CLOSE"] | sort) and
+  ((.skill_decision_contract.routes[] |
+    select(.route_id == "ACT-ANALYZE") |
+    .aliases) == ["analyze"]) and
+  ((.skill_decision_contract.routes[] |
+    select(.route_id == "ACT-ANALYZE") |
+    .terminal) == true) and
+  ([.skill_decision_contract.routes[].route_id] | index("ACT-TRIAGE")) == null and
+  ([.skill_decision_contract.routes[].route_id] | index("ACT-REMEDIATION")) == null and
+  all(.skill_decision_contract.clauses[];
+    (.expected_routes | index("ACT-TRIAGE")) == null and
+    (.expected_routes | index("ACT-REMEDIATION")) == null) and
   ([.skill_decision_contract.clauses[].clause_id] |
     index("ACT-CONSTRUCTION-COMPILER-001")) != null and
+  ((.skill_decision_contract.clauses[] |
+    select(.clause_id == "ACT-CONSTRUCTION-COMPILER-001") |
+    .expected_routes) | index("ACT-ANALYZE")) != null and
   ((.skill_decision_contract.clauses[] |
     select(.clause_id == "ACT-CONSTRUCTION-COMPILER-001") |
     .required_artifacts) |


### PR DESCRIPTION
## Summary

Simplify `$actuating` around user intent rather than exposing two internal stopping points in the same read-only compiler.

This is a hard cut:

```text
remove: $actuating triage
remove: $actuating remediation-plan
add:    $actuating analyze
```

No compatibility aliases are retained.

## Analyze route

`$actuating analyze` runs the complete counterexample-to-construction compiler as far as current evidence honestly permits:

```text
Goal + exact subject + current/historical counterexamples
-> evidence adjudication
-> invalid family
-> source-derived topology
-> Metanoetic challenge when activated
-> Universalist total boundary transformation
-> constructional comparison
-> selected construction, incomparability, containment, or obstruction
```

The route is strictly read-only. It may not mutate, publish, grant review credit, or claim closure.

An unqualified request to review, inspect, audit, classify, or analyze now selects `analyze`.

## Public surface after this change

```text
$actuating
$actuating implement
$actuating analyze
$actuating review-closeout
```

The two review scheduling modes remain unchanged:

```text
parallel-reviews
serial-reviews
```

The two bug-driven mutation routes also remain unchanged:

```text
construction-normalization
isolated-restoration
```

## Why

`triage` and `remediation-plan` represented different stop points inside one read-only semantic operation:

```text
triage
  evidence -> classification -> stop

remediation-plan
  evidence -> classification -> construction -> stop
```

That distinction forced the caller to choose how far Actuating should run through its own compiler. `analyze` now returns the deepest honest non-mutating judgment instead.

## Process boundary

This removes a public route and an internal route ID. It adds no:

- mode;
- gate;
- skill;
- store;
- artifact;
- review lens;
- compatibility layer.

## Changed surface

Three existing `$actuating` files:

- `codex/skills/actuating/SKILL.md`
- `codex/skills/actuating/references/decision-contract.json`
- `codex/skills/actuating/tests/test-reconciler-contract.sh`

The decision-contract fingerprint advances to:

```text
actuating-construction-compiler-v6
```

The reconciler contract now proves the exact four-route surface, the `ACT-ANALYZE` alias, and the absence of `ACT-TRIAGE`, `ACT-REMEDIATION`, and both retired invocation literals.

## Validation

Verified through GitHub on the exact branch head:

- one commit, zero commits behind current `main`;
- exactly three `$actuating` files changed;
- public route table contains `analyze` and neither retired route;
- machine-readable route and expected-route surfaces use `ACT-ANALYZE` consistently;
- diff contains no compatibility alias or unrelated change.

The full repository reconciler and transitive package suites were not executed in this connector environment. The PR remains draft pending repository-native exact-head validation.

<!-- ship-proof:start -->
## Summary
- Collapse the two read-only Actuating stopping points into one complete `$actuating analyze` route while retaining the existing implementation and review-closeout routes.

## Proof
- `codex/skills/actuating/tests/test-reconciler-contract.sh`: pass
- `sh -n codex/skills/actuating/tests/test-reconciler-contract.sh`: pass
- `jaq -e . codex/skills/actuating/references/decision-contract.json`: pass
- `git diff --check eac1038738713c58432e17c9781977c1d05dda01...248003d80d24551dc80f5ee9d17c9ebefdbd3061`: pass

## Scope
- repository: `tkersey/dotfiles`
- branch: `agent/actuating-analyze-route`
- head: `248003d80d24551dc80f5ee9d17c9ebefdbd3061`
- base: `main`
- base SHA: `eac1038738713c58432e17c9781977c1d05dda01`

## Risks
- This is an intentional hard cut: the retired `$actuating triage` and `$actuating remediation-plan` literals have no compatibility aliases.

## Follow-ups
- None.

## Readiness
- Operation: update-and-promote
- Final state: ready
- SHIP-v1 compatibility mode: promote-draft
- Reason: the exact live head passed the repository-native contract and syntax checks.
- Caveats: no generic build target applies to this three-file skill-contract change; GitHub reports no status checks on the head.
<!-- ship-proof:end -->