### PR TITLE
Route accepted memory admissions through memory-source-notes

### DIFF
--- a/codex/AGENTS.md
+++ b/codex/AGENTS.md
@@ -68,7 +68,8 @@
   `ledger transact`; read them only through that definition with
   `ledger project` or `ledger doctor`. Never hand-edit source JSONL.
 - Treat memory-source notes as immutable derived admission snapshots, not canonical stores. Phase 2 owns `memory_summary.md`, `MEMORY.md`, and memory-root `skills/*`; do not edit those outputs directly during ordinary work.
-- Keep `memory-note` as the sole immutable note writer.
+- When `$learnings`, `$negative-ledger`, or `$synesthesia` accepts a memory-source admission, invoke `$memory-source-notes` in the same turn. It owns adapter selection, validation, diagnostics, and delegation to the immutable writer.
+- Keep the `memory-note` CLI as the sole immutable note writer; it is not a skill. Never bypass `$memory-source-notes` when transporting an accepted source admission.
 - Failure to create or update a memory-source admission note must not invalidate or roll back a successful canonical source-store write.
 
 ### Source-evidence retention mandate

--- a/codex/skills/memory-source-notes/SKILL.md
+++ b/codex/skills/memory-source-notes/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: memory-source-notes
-description: "Safely append, inspect, validate, deploy, reconcile, and materialize derived digests for typed source-evidence notes in controlled Codex memory extensions. Use after a handoff from learnings, negative-ledger, or synesthesia; for an explicit custom source capture; or to diagnose canonical-record, immutable-note, digest, and Phase 2 visibility gaps. Never edits compiled memory or decides source eligibility."
+description: "Transport source-approved Learnings, Negative Ledger, and Synesthesia admissions through validated adapters to the `memory-note` CLI; inspect, reconcile, and diagnose immutable-note, digest, and Phase 2 visibility gaps. Never decides source eligibility or edits compiled memory."
 metadata:
-  version: "2.1.0"
+  version: "2.1.1"
 ---
 
 # Memory Source Notes
@@ -41,8 +41,8 @@ source skill or canonical domain store
 - `$learnings` owns the passive Learnings protocol, `.ledger/learnings/events.jsonl`, and learning admission semantics.
 - `$negative-ledger` owns the passive Negative Evidence protocol, `.ledger/negative-ledger/events.jsonl`, and route-state admission semantics.
 - `$synesthesia` owns the passive `synesthesia/protocol` definition, `.ledger/synesthesia/events.jsonl`, sensory mapping semantics, and the admission decision.
-- `memory-note` owns safe immutable transport.
-- this skill owns command syntax, extension-specific adapters, derived digest generation, copy-based instruction deployment, diagnostics, proof-line interpretation, and read-only reconciliation across canonical sources, immutable admissions, and Phase 2 visibility;
+- The `memory-note` CLI owns the final immutable note write.
+- `$memory-source-notes` owns command syntax, extension-specific adapters, derived digest generation, copy-based instruction deployment, diagnostics, proof-line interpretation, and read-only reconciliation across canonical sources, immutable admissions, and Phase 2 visibility.
 - Phase 2 owns promotion, deduplication, supersession, and compiled-memory updates.
 
 Reconciliation diagnoses transport and visibility state. It does not infer source


### PR DESCRIPTION
## Summary

- explicitly invoke `$memory-source-notes` in the same turn after Learnings, Negative Ledger, or Synesthesia accepts a memory-source admission
- distinguish the orchestration skill from the `memory-note` CLI and prohibit bypassing the skill during accepted admission transport
- tighten the skill description and authority model, and bump its patch version to `2.1.1`

## Why

`AGENTS.md` named only the immutable writer executable. That preserved the final write boundary but did not give implicit skill resolution a literal `$memory-source-notes` handoff, allowing accepted admissions to stop before transport.

## Verification

- reviewed the complete two-file diff
- confirmed the branch is based on current `main`
- documentation and routing-policy change only; no executable tests apply

<!-- ship-proof:start -->
## Summary
- Route source-approved Learnings, Negative Ledger, and Synesthesia admissions through `$memory-source-notes` in the accepting turn.
- Preserve `memory-note` as the sole immutable writer CLI while making adapter selection, validation, diagnostics, and transport orchestration skill-owned.
- Clarify the memory-source-notes authority boundary and bump its package version to 2.1.1.

## Proof
- `git diff --check 71ec0478..09253685`: pass
- bundled skill validator for `memory-source-notes`: pass
- SKILL and agent YAML frontmatter/invocation-policy assertions: pass
- manifest and seven referenced Ledger definition JSON documents: pass
- AGENTS routing and immutable-writer authority assertions: pass
- `uv run python3 -m unittest codex/skills/memory-source-notes/tests/test_source_memory_reconcile.py`: pass (8 tests)
- merge-tree simulation against current `main` at `15ea10dc`: pass

## Scope
- repository: tkersey/dotfiles
- branch: fix/memory-source-notes-routing
- head: 09253685bd175c12d8303b54d5797bf7e289bb2f
- base: main
- base SHA: 71ec0478b5fda389a8393c222ee5752e8d23bb8e

## Risks
- The branch merge base predates current main by one commit; current merge-tree simulation is conflict-free and branch freshness is not required by repository policy.

## Follow-ups
- None.

## Readiness
- Operation: update-and-promote
- Final state: ready
- SHIP-v1 compatibility mode: promote-draft
- Reason: exact-head package, routing, unit-test, and current-main compatibility validation passed with no open in-scope work
- Caveats: branch freshness is policy-optional; compatibility with current main was validated by merge-tree simulation
<!-- ship-proof:end -->