### PR TITLE
actuating: scope mutation freeze to review epochs

### DIFF
--- a/codex/skills/actuating/SKILL.md
+++ b/codex/skills/actuating/SKILL.md
@@ -493,8 +493,7 @@ claim instead.
 ## Review and closure
 
 Implementation constructs and locally proves the candidate before review
-dispatch opens a review epoch. The six review lenses falsify one completed
-construction:
+dispatch opens a review epoch. The six review lenses falsify one completed construction:
 
 ```text
 standard              Codex native/default best-judgment review

--- a/codex/skills/actuating/SKILL.md
+++ b/codex/skills/actuating/SKILL.md
@@ -75,6 +75,12 @@ analyze selects `analyze`.
 
 Mutation requires explicit implement, fix, resolve, address, or closeout intent.
 
+`implement` begins from the accepted Goal and exact Git state. It may consume
+already-existing owner evidence, but it dispatches no review and requires no
+review receipt or initial falsification wave before the first mutation. It
+constructs and locally proves the candidate that `review-closeout` may later
+falsify.
+
 Review-bearing routes accept `parallel-reviews` (default) or `serial-reviews`.
 The modifier changes dispatch topology only; both modes acquire the complete
 initial six-lens falsification wave and require the same exact-head convergence.
@@ -125,16 +131,22 @@ A stored `CEX-*` row proves only that its original witness was admitted under it
 recorded Goal and subject. Re-evaluate it against the current Goal, head,
 validity horizon, and source evidence before using it.
 
-## Evidence acquisition before mutation
+## Review-epoch immutability and evidence acquisition
 
 Read [review-contract.md](references/review-contract.md).
+
+A review epoch opens when the first CAS review request binds to one exact
+`reviewable` candidate head. While the epoch is open, that head is frozen:
+successor mutation is forbidden and every review observation remains bound to
+the same subject. This section applies only after review dispatch. It does not
+gate initial implementation or require `$actuating implement` to launch review.
 
 A material `entailed` finding:
 
 ```text
 invalidates the reviewed candidate immediately
 sets review credit to zero
-closes mutation
+keeps successor mutation closed
 does not request a patch
 ```
 
@@ -142,8 +154,13 @@ Complete the remaining **initial** independent lenses against the frozen
 candidate solely to acquire counterexamples. In parallel mode, wait for every
 launched semantic outcome and required recovery. In serial mode, continue the
 remaining initial lenses after invalidation, but do not mutate and grant no clean
-credit. A material confirmation finding stops further confirmations because the
-initial falsification wave is already complete.
+credit. The initial-wave epoch closes only after every required initial outcome
+and request-local recovery is terminal and Review Fold closes the evidence cut.
+
+A material confirmation finding stops further confirmations because the initial
+falsification wave is already complete. Its epoch closes after the finding and
+every already-live required owner observation are folded; do not launch another
+auxiliary wave.
 
 Before folding the resulting cut, require `$review-fold` to project the
 repository basis from `review-fold/counterexample-corpus`. Include projected
@@ -156,10 +173,11 @@ After the fold, Review Fold captures each independent current `entailed`
 `accepted` witness. Actuating retains the resulting `CEX-*` references and
 horizon status in its ephemeral Working Set; it does not copy the corpus.
 
-Only after the semantic barrier and fold may Actuating derive a counterexample
-response. Acceptance blocks the positive claim the witness falsifies; it does
-not select a mutation route. Review remains closed until the derived response is
-realized, proved, and `reviewable` when review still applies.
+Only after the applicable invalidated review epoch closes may Actuating derive a
+counterexample response and resume successor mutation. Acceptance blocks the
+positive claim the witness falsifies; it does not select a mutation route.
+Review remains closed until the derived response is realized, proved, and
+`reviewable` when review still applies.
 
 ## Compile the counterexample basis
 
@@ -202,7 +220,8 @@ Read
 [theorem-directed-response.md](references/theorem-directed-response.md).
 
 An accepted current counterexample blocks the positive claim it falsifies but
-does not authorize construction normalization. Before any mutation:
+does not authorize construction normalization. Before any mutation undertaken
+in response to an accepted counterexample:
 
 ```text
 reconcile every live owner source
@@ -473,7 +492,9 @@ claim instead.
 
 ## Review and closure
 
-The six review lenses falsify one completed construction:
+Implementation constructs and locally proves the candidate before review
+dispatch opens a review epoch. The six review lenses falsify one completed
+construction:
 
 ```text
 standard              Codex native/default best-judgment review
@@ -518,9 +539,12 @@ authorship.
   earliest-premise localization and predecessor-theorem identity.
 - No normalization fallback. A rejected restoration gate or unknown theorem
   relation remains blocked until a semantic premise is proved false.
-- No mutation or clean credit while a live relevant owner source is omitted from
-  the evidence cut.
-- No mutation before the complete initial falsification wave and evidence cut.
+- No successor mutation inside an invalidated review epoch, and no
+  counterexample-driven mutation, while a live relevant owner source is omitted
+  from the applicable evidence cut.
+- No successor mutation while a review epoch is open on the exact candidate.
+- No review dispatch is required before initial implementation; `implement`
+  constructs and locally proves the first candidate.
 - No member-specific repair for an established family without separation proof.
 - No construction claim without every sanctioned producer and bypass.
 - No self-authored omission list may serve as the sole evidence for its own

--- a/codex/skills/actuating/references/closure.md
+++ b/codex/skills/actuating/references/closure.md
@@ -8,6 +8,11 @@ Close(Goal, Git, validation, CAS, ReviewFoldCorpus, Ship, ReviewFold,
 -> continue | ready-to-ship | complete | blocked
 ```
 
+Initial implementation is not a review epoch and requires no CAS evidence. A
+review epoch may open only after implementation has produced one exact
+`reviewable` candidate. While an epoch is open, its bound candidate is immutable
+and successor mutation and closure are forbidden.
+
 ## Finding authority
 
 Every current finding must be classified as:
@@ -124,6 +129,7 @@ Final `complete` additionally requires:
 ```text
 required Ship/provider state matches the exact head
 every completion-relevant live owner source is folded or non-current
+no review epoch remains open
 every accepted current counterexample has a theorem-derived response
 no unauthorized claim narrowing, containment, residual risk, or deferral
 all five auxiliary lenses have terminal semantic outcomes

--- a/codex/skills/actuating/references/decision-contract.json
+++ b/codex/skills/actuating/references/decision-contract.json
@@ -4,7 +4,7 @@
     "skill": {
       "name": "actuating",
       "kind": "mixed",
-      "source_fingerprint": "actuating-construction-compiler-v8"
+      "source_fingerprint": "actuating-construction-compiler-v9"
     },
     "triggers": [
       {
@@ -145,6 +145,61 @@
         "rationale": "Actuating derives decisions from current owner facts and projected semantic evidence."
       },
       {
+        "clause_id": "ACT-IMPLEMENT-ENTRY-001",
+        "trigger_refs": [
+          "ACT-BARE",
+          "ACT-ROUTE"
+        ],
+        "expected_routes": [
+          "ACT-IMPLEMENT"
+        ],
+        "prohibited_routes": [],
+        "required_artifacts": [
+          "accepted Goal",
+          "exact Git subject",
+          "local construction and validation obligations"
+        ],
+        "success_signals": [
+          "initial implementation may mutate without review dispatch",
+          "existing closed owner evidence may inform implementation without opening review",
+          "the first review dispatch occurs only after the candidate is locally proved and reviewable"
+        ],
+        "failure_signals": [
+          "implementation requires a CAS review receipt before first mutation",
+          "an initial falsification wave is treated as an implementation prerequisite",
+          "review dispatches against an incomplete candidate"
+        ],
+        "rationale": "Implementation constructs and locally proves the candidate that review later falsifies."
+      },
+      {
+        "clause_id": "ACT-REVIEW-EPOCH-001",
+        "trigger_refs": [
+          "ACT-REVIEW"
+        ],
+        "expected_routes": [
+          "ACT-ANALYZE",
+          "ACT-REVIEW-CLOSEOUT",
+          "ACT-CLOSE"
+        ],
+        "prohibited_routes": [],
+        "required_artifacts": [
+          "exact reviewable candidate head",
+          "first CAS request opening the review epoch",
+          "applicable terminal review outcomes and Review Fold evidence cut"
+        ],
+        "success_signals": [
+          "the exact candidate remains immutable while its review epoch is open",
+          "initial-wave invalidation waits for every required initial outcome and recovery before successor mutation",
+          "confirmation invalidation closes without launching another auxiliary wave"
+        ],
+        "failure_signals": [
+          "the candidate changes while a review request remains live",
+          "successor mutation begins before the applicable review evidence cut closes",
+          "the review-local mutation freeze is applied before any review is dispatched"
+        ],
+        "rationale": "Review immutability protects one exact evidentiary subject; it is not a global implementation prerequisite."
+      },
+      {
         "clause_id": "ACT-LAW-AUTHORITY-001",
         "trigger_refs": [
           "ACT-COUNTEREXAMPLE",
@@ -189,7 +244,7 @@
         ],
         "prohibited_routes": [],
         "required_artifacts": [
-          "complete initial falsification wave",
+          "complete applicable evidence basis; a review wave only when a review epoch has opened",
           "projected counterexample basis and evidence-horizon disposition",
           "current counterexample basis",
           "invalid family",
@@ -424,7 +479,9 @@
           "stored counterexamples are reclassified rather than trusted as current",
           "new current entailed accepted witnesses are captured once by semantic identity",
           "review resumes only on a completely proved successor",
-          "provider, test, incident, migration, verifier, CAS, and corpus evidence enter one adjudicator"
+          "provider, test, incident, migration, verifier, CAS, and corpus evidence enter one adjudicator",
+          "review dispatch opens one exact-head epoch and freezes only its bound candidate",
+          "initial implementation remains outside review and needs no review receipt"
         ],
         "failure_signals": [
           "Actuating replaces Codex native/default standard review with a custom standard prompt",
@@ -434,7 +491,8 @@
           "review authors successor one finding at a time",
           "absence from an incomplete corpus is called first-observed or eliminated",
           "current class, family, owner, cut, carrier, route, or closure is persisted in the corpus",
-          "a live owner source is omitted while mutation or clean credit proceeds"
+          "a live owner source is omitted while mutation or clean credit proceeds",
+          "initial implementation is forced to acquire review evidence before first mutation"
         ],
         "rationale": "Independent review plus durable admitted witnesses supplies the counterexample basis before construction selection."
       },

--- a/codex/skills/actuating/references/review-contract.json
+++ b/codex/skills/actuating/references/review-contract.json
@@ -1,6 +1,6 @@
 {
-  "schema": "actuating-review-contract/v14",
-  "contract_id": "actuating-review-contract-v16",
+  "schema": "actuating-review-contract/v15",
+  "contract_id": "actuating-review-contract-v17",
   "required_lenses": [
     {
       "name": "standard",
@@ -92,11 +92,26 @@
     "review_dispatch_requires": "reviewable",
     "material_finding_invalidates_immediately": true,
     "material_finding_resets_all_credit": true,
-    "mutation_closed_until_initial_evidence_cut": true,
     "construction_theorem_is_revocable_proof_lease": true,
     "topology_theorem_is_revocable_proof_lease": true,
     "revoked_theorem_closes_mutation_ship_and_review": true,
-    "reviewable_reentry_after_revocation_requires_material_theorem_delta": true
+    "reviewable_reentry_after_revocation_requires_material_theorem_delta": true,
+    "mutation_closed_while_review_epoch_open": true,
+    "initial_implementation_requires_review_dispatch": false
+  },
+  "review_epoch": {
+    "derived_not_stored": true,
+    "opens_on_first_review_dispatch": true,
+    "binds_exact_reviewable_candidate_head": true,
+    "candidate_frozen_while_open": true,
+    "successor_mutation_forbidden_while_open": true,
+    "initial_implementation_occurs_outside_epoch": true,
+    "initial_implementation_requires_review_dispatch": false,
+    "existing_closed_evidence_may_inform_implementation": true,
+    "initial_invalidation_closes_after_required_outcomes_recovery_and_fold": true,
+    "confirmation_invalidation_requires_new_initial_wave": false,
+    "confirmation_invalidation_closes_after_finding_and_live_owner_fold": true,
+    "clean_epoch_closes_after_standard_convergence": true
   },
   "review_entry": {
     "complete_goal_proof_inventory_required": true,
@@ -154,7 +169,11 @@
     "review_findings_do_not_select_repairs": true,
     "projected_counterexamples_are_reclassified": true,
     "newly_accepted_counterexamples_are_captured": true,
-    "every_live_owner_source_reconciled_before_response_selection": true
+    "every_live_owner_source_reconciled_before_response_selection": true,
+    "applies_after_review_dispatch": true,
+    "initial_implementation_requires_review_dispatch": false,
+    "initial_implementation_requires_initial_falsification_wave": false,
+    "confirmation_invalidation_requires_new_initial_wave": false
   },
   "mutation_routes": {
     "allowed": [
@@ -167,7 +186,9 @@
     "normalization_is_default": false,
     "normalization_requires_semantic_premise_falsifier": true,
     "restoration_requires_same_theorem_reproof": true,
-    "failed_restoration_gate_falls_through_to_normalization": false
+    "failed_restoration_gate_falls_through_to_normalization": false,
+    "initial_implementation_review_prerequisite": false,
+    "counterexample_driven_mutation_requires_theorem_directed_response": true
   },
   "same_family_recurrence": {
     "member_specific_extension_forbidden_without_separation": true,
@@ -296,8 +317,8 @@
     ],
     "every_live_source_disposition_required_before_cut": true,
     "unavailable_marks_horizon_incomplete": true,
-    "missing_live_source_closes_mutation_clean_credit_reviewability_and_closure": true,
-    "durable_actuating_source_registry_forbidden": true
+    "durable_actuating_source_registry_forbidden": true,
+    "missing_live_source_closes_counterexample_driven_mutation_clean_credit_reviewability_and_closure": true
   },
   "theorem_directed_response": {
     "owner": "actuating",
@@ -329,6 +350,7 @@
     "severity_selects_route": false,
     "authority_required_for_narrowing_containment_risk_or_deferral": true,
     "closure_consequence_required_for_narrowing_containment_or_deferral": true,
-    "minimum_sufficient_semantic_delta_required": true
+    "minimum_sufficient_semantic_delta_required": true,
+    "applies_only_to_counterexample_driven_mutation": true
   }
 }

--- a/codex/skills/actuating/references/review-contract.md
+++ b/codex/skills/actuating/references/review-contract.md
@@ -71,6 +71,29 @@ verdict.
 The six required lenses and five-consecutive-standard-clean theorem remain
 unchanged.
 
+## Review epoch
+
+A review epoch is ephemeral and derived from CAS owner facts; it is never stored.
+It opens when the first review request binds to one exact `reviewable` candidate
+head. While open:
+
+```text
+the bound candidate is immutable
+successor mutation is forbidden
+all review requests and credit remain bound to that exact head
+```
+
+Initial implementation occurs outside a review epoch and requires no CAS request,
+review receipt, or initial falsification wave. Existing closed owner evidence may
+inform implementation without opening review.
+
+A clean epoch remains open through the required standard confirmations and closes
+when convergence is complete. An invalidated initial-wave epoch closes only after
+all required initial semantic outcomes and request-local recovery are terminal
+and Review Fold closes the evidence cut. An invalidated confirmation epoch closes
+after the finding and every already-live required owner observation are folded;
+it never launches another initial auxiliary wave.
+
 ## Live owner-source frontier
 
 Before closing an evidence cut, reconcile every currently live relevant owner
@@ -289,14 +312,14 @@ declared dependency graph covers the required proof.
 A known required proof may not first run after review convergence. Such a
 discovery proves the candidate was never reviewable and invalidates all credit.
 
-## Invalidation versus evidence acquisition
+## Invalidation inside an open review epoch
 
 A material finding immediately:
 
 ```text
 invalidates the candidate
 sets all review credit to zero
-closes mutation and new confirmation dispatch
+keeps successor mutation and new confirmation dispatch closed
 does not request a patch
 ```
 
@@ -327,7 +350,8 @@ without concurrent dispatch.
 
 The initial six-lens wave is already complete. A material confirmation finding
 invalidates the candidate and stops further confirmation; no additional lens
-wave is implied.
+wave is implied. Close the epoch after the finding and every already-live
+required owner observation are folded.
 
 ### Request-local recovery
 
@@ -337,7 +361,8 @@ semantic barrier after invalidation. A second verdictless terminal blocks.
 
 ## Evidence cut and successor
 
-After the initial semantic barrier, close one cumulative cut containing:
+After the applicable invalidated review epoch has gathered its required
+outcomes, close one cumulative cut containing:
 
 ```text
 projected CEX records and exact source references
@@ -354,6 +379,8 @@ counterexample horizon completeness and missing sources
 Review Fold captures newly accepted counterexamples after classification and
 returns their IDs. The cut uses corpus rows as durable source evidence but
 contains current reclassifications; Actuating does not store a second copy.
+Closing this cut closes the invalidated review epoch and permits only the
+successor mutation derived from its evidence.
 
 Actuating first derives one theorem-directed response:
 
@@ -443,7 +470,8 @@ Reviewers report evidence and affected law; they never select a repair.
 After a successor becomes `reviewable`, restart the selected schedule on its
 final head. Require five consecutive distinct standard cleans. The initial
 native/default standard clean counts as clean one; four later standard
-confirmations complete the streak. No credit crosses a material head change.
+confirmations complete the streak. The clean review epoch closes only when that
+convergence theorem is satisfied. No credit crosses a material head change.
 
 Reuse only exact CAS receipts and `CEX-*` records whose source references and
 subjects can be revalidated. If the current review receipts cannot be resolved,

--- a/codex/skills/actuating/tests/fixtures/construction-cycle-scenarios.json
+++ b/codex/skills/actuating/tests/fixtures/construction-cycle-scenarios.json
@@ -1,5 +1,5 @@
 {
-  "schema": "actuating-construction-cycle-scenarios/v3",
+  "schema": "actuating-construction-cycle-scenarios/v4",
   "scenarios": [
     {
       "id": "serial-material-finding-completes-initial-wave",
@@ -847,6 +847,93 @@
         "residuals_owned": true
       },
       "expected": "reviewable"
+    },
+    {
+      "id": "implementation-without-review-allows-first-mutation",
+      "input": {
+        "phase": "implementation-entry",
+        "route": "implement",
+        "goal_bound": true,
+        "exact_subject_bound": true,
+        "review_epoch_open": false,
+        "counterexample_driven": false
+      },
+      "expected": "allow-mutation"
+    },
+    {
+      "id": "implementation-with-closed-counterexample-evidence-needs-no-fresh-review",
+      "input": {
+        "phase": "implementation-entry",
+        "route": "implement",
+        "goal_bound": true,
+        "exact_subject_bound": true,
+        "review_epoch_open": false,
+        "counterexample_driven": true,
+        "theorem_directed_response_complete": true
+      },
+      "expected": "allow-mutation"
+    },
+    {
+      "id": "open-review-epoch-freezes-candidate",
+      "input": {
+        "phase": "review-epoch",
+        "review_dispatched": true,
+        "review_epoch_open": true,
+        "candidate_invalidated": false
+      },
+      "expected": "freeze-candidate"
+    },
+    {
+      "id": "invalidated-initial-review-with-incomplete-cut-stays-frozen",
+      "input": {
+        "phase": "review-epoch",
+        "review_dispatched": true,
+        "review_epoch_open": true,
+        "candidate_invalidated": true,
+        "wave": "initial",
+        "all_required_initial_outcomes_terminal": false,
+        "required_recovery_terminal": false,
+        "review_fold_complete": false
+      },
+      "expected": "freeze-candidate"
+    },
+    {
+      "id": "invalidated-initial-review-closes-after-complete-cut",
+      "input": {
+        "phase": "review-epoch",
+        "review_dispatched": true,
+        "review_epoch_open": true,
+        "candidate_invalidated": true,
+        "wave": "initial",
+        "all_required_initial_outcomes_terminal": true,
+        "required_recovery_terminal": true,
+        "review_fold_complete": true
+      },
+      "expected": "allow-successor-mutation"
+    },
+    {
+      "id": "confirmation-finding-closes-without-new-auxiliary-wave",
+      "input": {
+        "phase": "review-epoch",
+        "review_dispatched": true,
+        "review_epoch_open": true,
+        "candidate_invalidated": true,
+        "wave": "confirmation",
+        "confirmation_finding_folded": true,
+        "already_live_owner_observations_folded": true,
+        "new_initial_wave_required": false
+      },
+      "expected": "allow-successor-mutation"
+    },
+    {
+      "id": "bare-route-implements-before-review-dispatch",
+      "input": {
+        "phase": "route-order",
+        "route": "bare",
+        "first_mutation_index": 0,
+        "first_review_dispatch_index": 1
+      },
+      "expected": "implement-before-review"
     }
   ]
 }

--- a/codex/skills/actuating/tests/test-construction-cycle-scenarios.sh
+++ b/codex/skills/actuating/tests/test-construction-cycle-scenarios.sh
@@ -97,8 +97,50 @@ fixture="$skill_root/tests/fixtures/construction-cycle-scenarios.json"
     else "blocked"
     end;
 
+  def decide_implementation_entry($i):
+    if $i.route != "implement" or
+       $i.goal_bound != true or
+       $i.exact_subject_bound != true or
+       $i.review_epoch_open == true
+    then "blocked"
+    elif $i.counterexample_driven == true and
+         $i.theorem_directed_response_complete != true
+    then "blocked"
+    else "allow-mutation"
+    end;
+
+  def decide_review_epoch($i):
+    if $i.review_dispatched != true
+    then "no-review-epoch"
+    elif $i.review_epoch_open != true
+    then "blocked"
+    elif $i.candidate_invalidated != true
+    then "freeze-candidate"
+    elif $i.wave == "initial" and
+         $i.all_required_initial_outcomes_terminal == true and
+         $i.required_recovery_terminal == true and
+         $i.review_fold_complete == true
+    then "allow-successor-mutation"
+    elif $i.wave == "confirmation" and
+         $i.confirmation_finding_folded == true and
+         $i.already_live_owner_observations_folded == true and
+         $i.new_initial_wave_required != true
+    then "allow-successor-mutation"
+    else "freeze-candidate"
+    end;
+
   def decide($i):
-    if $i.phase == "initial-review" and
+    if $i.phase == "implementation-entry"
+    then decide_implementation_entry($i)
+    elif $i.phase == "review-epoch"
+    then decide_review_epoch($i)
+    elif $i.phase == "route-order"
+    then if $i.route == "bare" and
+            ($i.first_mutation_index | type) == "number" and
+            ($i.first_review_dispatch_index | type) == "number" and
+            $i.first_mutation_index < $i.first_review_dispatch_index
+         then "implement-before-review" else "blocked" end
+    elif $i.phase == "initial-review" and
        $i.material_finding == true and
        $i.semantic_barrier_complete != true
     then "continue-evidence"
@@ -154,8 +196,8 @@ fixture="$skill_root/tests/fixtures/construction-cycle-scenarios.json"
     else "blocked"
     end;
 
-  .schema == "actuating-construction-cycle-scenarios/v3" and
-  (.scenarios | length) >= 42 and
+  .schema == "actuating-construction-cycle-scenarios/v4" and
+  (.scenarios | length) >= 49 and
   ([.scenarios[].id] | length == (unique | length)) and
   all(.scenarios[]; decide(.input) == .expected) and
   ([.scenarios[] |
@@ -208,7 +250,25 @@ fixture="$skill_root/tests/fixtures/construction-cycle-scenarios.json"
     .expected == "reviewable") and
   any(.scenarios[];
     .id == "material-theorem-delta-and-factorization-allow-reentry" and
-    .expected == "allow-reentry")
+    .expected == "allow-reentry") and
+  any(.scenarios[];
+    .id == "implementation-without-review-allows-first-mutation" and
+    .expected == "allow-mutation") and
+  any(.scenarios[];
+    .id == "implementation-with-closed-counterexample-evidence-needs-no-fresh-review" and
+    .expected == "allow-mutation") and
+  any(.scenarios[];
+    .id == "open-review-epoch-freezes-candidate" and
+    .expected == "freeze-candidate") and
+  any(.scenarios[];
+    .id == "invalidated-initial-review-closes-after-complete-cut" and
+    .expected == "allow-successor-mutation") and
+  any(.scenarios[];
+    .id == "confirmation-finding-closes-without-new-auxiliary-wave" and
+    .expected == "allow-successor-mutation") and
+  any(.scenarios[];
+    .id == "bare-route-implements-before-review-dispatch" and
+    .expected == "implement-before-review")
 ' "$fixture" >/dev/null
 
-echo "actuating theorem-directed construction cycle scenarios: pass"
+echo "actuating theorem-directed construction and review-epoch scenarios: pass"

--- a/codex/skills/actuating/tests/test-reconciler-contract.sh
+++ b/codex/skills/actuating/tests/test-reconciler-contract.sh
@@ -27,7 +27,7 @@ grep -F 'counterexample-to-construction compiler' "$skill_root/SKILL.md" >/dev/n
 grep -F 'review-fold/counterexample-corpus' "$skill_root/SKILL.md" >/dev/null
 grep -F 'Counterexample corpus basis IDs' "$skill_root/SKILL.md" >/dev/null
 grep -F 'No durable **Actuating** workflow' "$skill_root/SKILL.md" >/dev/null
-grep -F '## Evidence acquisition before mutation' "$skill_root/SKILL.md" >/dev/null
+grep -F '## Review-epoch immutability and evidence acquisition' "$skill_root/SKILL.md" >/dev/null
 grep -F '## Exactly two bug-driven mutation routes' "$skill_root/SKILL.md" >/dev/null
 grep -F '## Construction Working Set' "$skill_root/SKILL.md" >/dev/null
 grep -F 'No second Actuating Ledger definition' "$skill_root/SKILL.md" >/dev/null
@@ -61,6 +61,21 @@ grep -F 'standard              Codex native/default best-judgment review' \
   "$skill_root/SKILL.md" >/dev/null
 grep -F 'soundness-skeptic' "$skill_root/SKILL.md" >/dev/null
 grep -F '## Theorem-directed response selection' "$skill_root/SKILL.md" >/dev/null
+grep -F '`implement` begins from the accepted Goal and exact Git state.' \
+  "$skill_root/SKILL.md" >/dev/null
+grep -F 'A review epoch opens when the first CAS review request binds' \
+  "$skill_root/SKILL.md" >/dev/null
+grep -F 'Before any mutation undertaken' "$skill_root/SKILL.md" >/dev/null
+grep -F 'No successor mutation while a review epoch is open' \
+  "$skill_root/SKILL.md" >/dev/null
+grep -F 'No review dispatch is required before initial implementation' \
+  "$skill_root/SKILL.md" >/dev/null
+if grep -F 'No mutation before the complete initial falsification wave' \
+  "$skill_root/SKILL.md" >/dev/null
+then
+  echo "global review-before-mutation rule remains" >&2
+  exit 1
+fi
 grep -F 'No normalization fallback' "$skill_root/SKILL.md" >/dev/null
 grep -F '## Live owner-source frontier' "$skill_root/references/review-contract.md" >/dev/null
 test -s "$skill_root/references/theorem-directed-response.md"
@@ -135,6 +150,14 @@ grep -F 'Launch all six initial owner-live requests' \
 grep -F 'The initial six-lens wave is already complete' \
   "$skill_root/references/review-contract.md" >/dev/null
 grep -F 'soundness-skeptic' \
+  "$skill_root/references/review-contract.md" >/dev/null
+grep -F '## Review epoch' \
+  "$skill_root/references/review-contract.md" >/dev/null
+grep -F 'Initial implementation occurs outside a review epoch' \
+  "$skill_root/references/review-contract.md" >/dev/null
+grep -F '## Invalidation inside an open review epoch' \
+  "$skill_root/references/review-contract.md" >/dev/null
+grep -F 'confirmation epoch closes' \
   "$skill_root/references/review-contract.md" >/dev/null
 
 grep -F 'source-derived predecessor topology T0' \
@@ -212,8 +235,8 @@ grep -F 'claim-strength' \
 ' "$review_fold_root/definitions/ledger/counterexample-corpus.json" >/dev/null
 
 "$jaq_bin" -e '
-  .schema == "actuating-review-contract/v14" and
-  .contract_id == "actuating-review-contract-v16" and
+  .schema == "actuating-review-contract/v15" and
+  .contract_id == "actuating-review-contract-v17" and
   (.required_lenses | length) == 6 and
   [.required_lenses[].name] == [
     "standard",
@@ -233,7 +256,7 @@ grep -F 'claim-strength' \
   .required_lenses[1].instructions_ref ==
     "codex/skills/actuating/references/lenses/soundness-review.md" and
   .owner_source_frontier.every_live_source_disposition_required_before_cut == true and
-  .owner_source_frontier.missing_live_source_closes_mutation_clean_credit_reviewability_and_closure == true and
+  .owner_source_frontier.missing_live_source_closes_counterexample_driven_mutation_clean_credit_reviewability_and_closure == true and
   .theorem_directed_response.accepted_counterexample_selects_mutation_route == false and
   .theorem_directed_response.same_theorem_reproof_required_before_normalization == true and
   .theorem_directed_response.failed_direct_gate_authorizes_normalization == false and
@@ -328,7 +351,7 @@ grep -F 'claim-strength' \
 
 "$jaq_bin" -e '
   .skill_decision_contract.skill.source_fingerprint ==
-    "actuating-construction-compiler-v8" and
+    "actuating-construction-compiler-v9" and
   ((.skill_decision_contract.triggers[] |
     select(.trigger_id == "ACT-ROUTE") |
     .cue_literals) == [
@@ -442,6 +465,46 @@ grep -F 'claim-strength' \
   .skill_decision_contract.instrumentation.counterexample_corpus ==
     "review-fold/counterexample-corpus"
 ' "$review_fold_root/references/decision-contract.json" >/dev/null
+
+ "$jaq_bin" -e '
+  .schema == "actuating-review-contract/v15" and
+  .contract_id == "actuating-review-contract-v17" and
+  .candidate_lifecycle.mutation_closed_while_review_epoch_open == true and
+  .candidate_lifecycle.initial_implementation_requires_review_dispatch == false and
+  .review_epoch.derived_not_stored == true and
+  .review_epoch.opens_on_first_review_dispatch == true and
+  .review_epoch.binds_exact_reviewable_candidate_head == true and
+  .review_epoch.candidate_frozen_while_open == true and
+  .review_epoch.successor_mutation_forbidden_while_open == true and
+  .review_epoch.initial_implementation_occurs_outside_epoch == true and
+  .review_epoch.initial_implementation_requires_review_dispatch == false and
+  .review_epoch.initial_invalidation_closes_after_required_outcomes_recovery_and_fold == true and
+  .review_epoch.confirmation_invalidation_requires_new_initial_wave == false and
+  .review_epoch.confirmation_invalidation_closes_after_finding_and_live_owner_fold == true and
+  .evidence_acquisition.applies_after_review_dispatch == true and
+  .evidence_acquisition.initial_implementation_requires_review_dispatch == false and
+  .evidence_acquisition.initial_implementation_requires_initial_falsification_wave == false and
+  .mutation_routes.initial_implementation_review_prerequisite == false and
+  .mutation_routes.counterexample_driven_mutation_requires_theorem_directed_response == true and
+  .theorem_directed_response.applies_only_to_counterexample_driven_mutation == true
+' "$skill_root/references/review-contract.json" >/dev/null
+
+"$jaq_bin" -e '
+  .skill_decision_contract.skill.source_fingerprint ==
+    "actuating-construction-compiler-v9" and
+  ([.skill_decision_contract.clauses[].clause_id] |
+    index("ACT-IMPLEMENT-ENTRY-001")) != null and
+  ([.skill_decision_contract.clauses[].clause_id] |
+    index("ACT-REVIEW-EPOCH-001")) != null and
+  ((.skill_decision_contract.clauses[] |
+    select(.clause_id == "ACT-IMPLEMENT-ENTRY-001") |
+    .success_signals) |
+    index("initial implementation may mutate without review dispatch")) != null and
+  ((.skill_decision_contract.clauses[] |
+    select(.clause_id == "ACT-REVIEW-EPOCH-001") |
+    .success_signals) |
+    index("the exact candidate remains immutable while its review epoch is open")) != null
+' "$skill_root/references/decision-contract.json" >/dev/null
 
 JAQ_BIN="$jaq_bin" "$review_fold_root/tests/test-counterexample-corpus.sh"
 JAQ_BIN="$jaq_bin" "$skill_root/tests/test-direct-repair-admission.sh"


### PR DESCRIPTION
## Summary

Correct the scope of Actuating's no-mutation law.

`$actuating implement` constructs and locally proves the first candidate. It does **not** dispatch review or require a CAS receipt or initial falsification wave before its first mutation.

The mutation freeze now belongs to an ephemeral **review epoch**:

```text
implementation constructs and proves candidate H
-> first CAS review request binds to H
-> review epoch opens
-> H is immutable while the epoch is open
-> review falsifies or converges
-> epoch closes at the applicable evidence boundary
-> successor mutation may resume
```

The governing law is:

> Mutation is forbidden because a review epoch is open—not because Actuating exists.

## Route semantics

```text
$actuating implement
  accepted Goal + exact Git
  -> construct
  -> locally validate and prove
  -> local complete
  -> no review prerequisite

$actuating review-closeout
  locally complete reviewable candidate
  -> open exact-head review epoch
  -> freeze candidate
  -> falsify / converge

bare $actuating
  implement -> Ship -> review-closeout
```

Existing closed owner evidence may inform implementation without opening a fresh review campaign.

## Review-epoch closure

### Initial six-lens wave

A material finding invalidates the candidate immediately, but the epoch remains open until:

- every required initial semantic outcome is terminal;
- request-local recovery is terminal; and
- Review Fold closes the evidence cut.

Only then may theorem-directed successor mutation begin.

### Standard confirmation

A material confirmation finding stops further confirmations. Its epoch closes after the finding and every already-live required owner observation are folded. It does not launch another auxiliary wave.

### Clean convergence

A clean epoch remains open through the five-standard-clean convergence theorem and closes only when convergence completes.

## Theorem-directed response scope

The predecessor-theorem reproof and restoration-versus-normalization law now applies only to mutation undertaken in response to an accepted counterexample.

Initial implementation is not forced through:

```text
counterexample
failed premise
predecessor theorem
same-theorem reproof
```

when those objects do not yet exist.

## Machine-readable contract

Adds explicit laws for:

- review epoch opens on first review dispatch;
- exact reviewable candidate head is bound and frozen;
- successor mutation is forbidden while the epoch is open;
- initial implementation occurs outside an epoch;
- initial implementation requires neither review dispatch nor an initial wave;
- confirmation invalidation requires no new initial wave;
- existing closed evidence may inform implementation;
- counterexample-driven mutation still requires theorem-directed adjudication.

Contract versions advance to:

```text
actuating-construction-compiler-v9
actuating-review-contract/v15
actuating-review-contract-v17
actuating-construction-cycle-scenarios/v4
```

## Behavioral coverage

The executable scenarios now prove:

```text
implement with no review evidence
-> allow first mutation

implement with already-folded counterexample evidence
-> allow theorem-directed mutation without fresh review dispatch

open review epoch
-> freeze exact candidate

invalidated initial wave with incomplete cut
-> keep candidate frozen

invalidated initial wave with complete cut
-> close epoch and allow successor mutation

confirmation finding with live evidence folded
-> close epoch without another auxiliary wave

bare $actuating
-> first mutation precedes first review dispatch
```

## Scope

Exactly eight existing `$actuating` files are changed. No new mode, gate, Ledger definition, durable epoch artifact, store, review lens, or CAS change is introduced.

## Validation

Passed on exact head `53b50b59dfd8f35f60c6af9874d41c1adb8d70b2`:

- JSON parsing for review contract, decision contract, and construction-cycle fixture;
- POSIX shell syntax for construction-cycle and reconciler tests;
- focused construction-cycle scenario suite with `JAQ_BIN=jq`;
- `git diff --check`;
- exact eight-file Actuating-only scope;
- one commit ahead of current `main`, zero behind.

The full Ledger-backed reconciler suite was not available in the staging runner, so the PR remains draft for repository-native exact-head validation.

<!-- ship-proof:start -->
## Summary
- Scoped Actuating mutation freeze to ephemeral review epochs; initial implementation is permitted before first review dispatch.

## Proof
- `jq empty codex/skills/actuating/references/review-contract.json codex/skills/actuating/references/decision-contract.json codex/skills/actuating/tests/fixtures/construction-cycle-scenarios.json`: pass
- `sh -n codex/skills/actuating/tests/test-construction-cycle-scenarios.sh codex/skills/actuating/tests/test-reconciler-contract.sh`: pass
- `JAQ_BIN=jaq codex/skills/actuating/tests/test-reconciler-contract.sh`: pass
- `JAQ_BIN=jaq codex/skills/actuating/tests/test-construction-cycle-scenarios.sh`: pass
- `git diff --check origin/main...HEAD`: pass
- Exact Actuating-only scope: 8 files

## Scope
- repository: tkersey/dotfiles
- branch: agent/actuating-review-epoch-scope
- head: 888e1850359e57824e4bd541dba010357bf82010
- base: main
- base SHA: e7c0977f29333bc6c5bcb37fa8af9389e0f635ab

## Risks
- No residual validation risks identified.

## Follow-ups
- None.

## Readiness
- Operation: update-and-promote
- Final state: ready
- SHIP-v1 compatibility mode: promote-draft
- Reason: exact-head validation is complete and the prior contract assertion mismatch is corrected.
- Caveats: Build and language-specific checks are not applicable to this documentation/fixture-only change; repository checks reported none.
<!-- ship-proof:end -->