### PR TITLE
Update CAS skill for app-server contract v2

### DIFF
--- a/codex/skills/cas/SKILL.md
+++ b/codex/skills/cas/SKILL.md
@@ -16,14 +16,14 @@ CAS owns route execution and facts it directly observes. It does not decide
 Goal semantics, review credit, finding truth, repairs, mutation, publication,
 closure, what an automation ought to do, or whether its result is correct.
 
-Require installed CAS `0.5.0` or newer. There is no standalone automation
+Require installed CAS `0.6.0` or newer. There is no standalone automation
 product, compatibility skill, or legacy command route.
 
 ## Native surface
 
 ```text
 cas capabilities
-cas app-server <preflight|schema>
+cas app-server <preflight|schema|session|daemon>
 cas account status
 cas automation <doctor|list|show|create|update|enable|disable|run-now|delete|run-due|scheduler>
 cas goal <resolve|get|set|clear|status|wait>
@@ -61,14 +61,20 @@ Use these profiles:
 | release conformance and the complete feature surface | `full` |
 
 Require `status == "compatible"`, the intended resolved Codex path, contract
-ID `codex-app-server-capabilities-v1`, no missing required methods or handlers,
+ID `codex-app-server-capabilities-v2`, no missing required methods or handlers,
 and all required selected-profile probes passed. Codex version and release
 channel are diagnostic only. `degraded` is not compatible proof for a required
 route behavior.
 
+CAS 0.6.0 is qualified against released Codex 0.151.0. That version is an
+evidence baseline, not a runtime pin or upper bound: admit later released
+runtimes when the selected capability profile and probes pass. Do not use an
+unreleased or prerelease build as qualification evidence unless the caller
+explicitly requests prerelease testing.
+
 For review and session inquiry, also require the preflight receipt's
 `transport.selected == "managed-ws"`; a compatible stdio receipt is not
-equivalent proof. CAS 0.5.0 review runs this gate internally before starting
+equivalent proof. CAS 0.6.0 review runs this gate internally before starting
 and reports the realized connection as `selectedTransport == "websocket"`.
 Session inquiry additionally receives `--transport managed-ws` on execution.
 
@@ -86,12 +92,18 @@ See [codex_app_server_contract.md](references/codex_app_server_contract.md) and
 
 Use `cas app-server schema --json` for a non-mutating schema/cache report and
 `cas app-server preflight --json` for the structural and behavioral verdict.
+Use `cas app-server session` for a raw stateful app-server stream and
+`cas app-server daemon` for released daemon lifecycle commands. Both delegate
+to the selected Codex executable, preserve its raw bytes and exit status, and
+accept `--codex-path`; they do not impose a version gate.
 Use `cas smoke_check` for bounded handshake and reachability observations.
 Use `cas instance_runner` for bounded raw requests or fanout. Preserve additive
 response, notification, and item data rather than projecting it away.
 
 Explicit transport or remote Code Mode host selection is fail-closed. The
-outbound Code Mode host is distinct from the inbound app-server endpoint.
+outbound Code Mode host is distinct from the inbound app-server endpoint and
+uses the released HTTP(S) root-endpoint form. Authenticated WebSocket listener
+flags belong to the delegated app-server session surface.
 
 ### Automation
 

--- a/codex/skills/cas/references/codex-app-server-capability-matrix.md
+++ b/codex/skills/cas/references/codex-app-server-capability-matrix.md
@@ -3,10 +3,14 @@
 | Surface | CAS behavior | Required proof |
 |---|---|---|
 | Complete methods | Stable client, server-request, and notification sets are baseline contract data | structural contract |
-| Thread pinning | Preserve `Thread.isPinned`; pin/unpin and list filters | `full` probe |
+| Thread sections | Create/update/delete sections; move, list, and clear thread membership | `full` probe |
+| Thread history | Preserve `historyMode`, turn/item cursors, revert, turns, and items | structural contract and `full` probe |
 | Paginated forks | Exact completed boundary with `lastTurnId`; experimental `beforeTurnId` and `excludeTurns` | `session-inquiry` or `full` probe |
 | Ephemeral forks | `ephemeral == true`, `path == null`, absent from ordinary list | `session-inquiry` or `full` probe |
-| Remote Code Mode host | Exact outbound argument, security policy, redacted identity, no fallback | selected-host probe |
+| Code Mode host | Exact outbound HTTP(S) root endpoint, loopback/TLS policy, identity digest, no fallback | selected-host probe |
+| Raw session | Delegate the stateful app-server byte stream without projecting additive methods or payloads | dispatcher tests and released help surface |
+| Daemon | Delegate daemon bootstrap/start/restart/remote-control/stop/version commands and exit status | dispatcher tests and released help surface |
+| Authenticated listener | Preserve released WebSocket listener authentication flags on delegated sessions | released help surface |
 | Transports | Distinct stdio, WebSocket, and Unix-socket identities | selected transport probe |
 | Initialization | Typed capability profiles plus bounded raw additions for instance runner | core lifecycle probe |
 | Server requests | Named conservative policy for every baseline method; typed auth/attestation provider failures | core coverage probe |

--- a/codex/skills/cas/references/codex_app_server_contract.md
+++ b/codex/skills/cas/references/codex_app_server_contract.md
@@ -1,9 +1,14 @@
 # Codex app-server capability contract
 
-Treat the installed `codex` executable as the runtime schema source. CAS 0.5.0
-compares its compact `codex-app-server-capabilities-v1` contract with both
+Treat the installed `codex` executable as the runtime schema source. CAS 0.6.0
+compares its compact `codex-app-server-capabilities-v2` contract with both
 generated bundles and the selected live behavioral probes. The contract names
 required capabilities, not a Codex release.
+
+Released Codex 0.151.0 is the qualification baseline for this contract, not a
+runtime pin or maximum. Later released runtimes remain admissible when their
+generated schemas and selected live probes pass. Prerelease builds do not
+replace released qualification evidence unless the caller requests that test.
 
 ## Schema and preflight
 
@@ -39,7 +44,7 @@ unsupported-item result.
   bounded overload behavior.
 - `review`: core plus structured review.
 - `session-inquiry`: core plus paginated and ephemeral fork/anchor behavior.
-- `full`: all declared features, including pinning, executor skills and
+- `full`: all declared features, including thread sections, executor skills and
   resources, external import history, review, and inquiry.
 
 An explicit external endpoint must earn its own runtime and behavioral proof;
@@ -59,11 +64,19 @@ Public selection is `auto|stdio|managed-ws|ws|unix`. Explicit selection fails
 instead of changing transports. `auto` alone may use CAS's documented bounded
 preference and fallback order.
 
-`--code-mode-host ws://...|wss://...` is an outbound host passed to the Codex
-app-server process. It is orthogonal to the inbound transport endpoint.
-Loopback may use `ws://`; non-loopback requires `wss://`. CAS redacts userinfo
-and query values, preserves only redacted identity plus a digest when needed,
-and never silently falls back to the in-process host.
+`--code-mode-host http://LOOPBACK/|https://HOST/` is an outbound gRPC host
+passed to the Codex app-server process. It is orthogonal to the inbound
+transport endpoint. Plain HTTP is loopback-only; remote hosts require HTTPS.
+Userinfo, query, fragment, and non-root paths are rejected. CAS preserves only
+the origin plus a digest when needed and never silently falls back to the
+in-process host.
+
+`cas app-server session` delegates the raw stateful app-server surface,
+including stdio, Unix/loopback WebSocket listeners, authenticated non-loopback
+WebSocket listener flags, notifications, and server requests. `cas app-server
+daemon` delegates daemon lifecycle commands. These surfaces preserve the
+selected Codex executable's bytes and exit status so additive released methods
+are not projected away by CAS.
 
 All processes, readiness waits, frames, messages, retry loops, and captured
 output are bounded. App-server overload `-32001` alone uses bounded exponential


### PR DESCRIPTION
<!-- ship-proof:start -->
## Summary
- Update the CAS skill to require CAS 0.6.0 and app-server contract v2.
- Document released Codex 0.151.0 as a qualification baseline rather than a runtime pin.
- Add the raw session, daemon, thread-section, authenticated listener, and HTTP(S) Code Mode guidance.

## Proof
- `uv run --with pyyaml .../quick_validate.py codex/skills/cas`: pass
- `git diff --check`: pass

## Scope
- repository: tkersey/dotfiles
- branch: codex/cas-0.6-skill
- head: c1a7e6889fae4de5590be981b14d561b10200169
- base: main
- base SHA: 7a08b92710f43cbd7cdac46c8b0a946527902e3b
- goal context: sha256:5a18425f2838bbe9ea34efeed22ee3f466762de40ad13e78123475bf6c95b68a
- review contract: sha256:a90e721204f1ee38526c304232ca0d5deb168e8638ed28ea543860c8f4ed60d8

## Risks
- The skill requires the separately released CAS 0.6.0 binary.

## Follow-ups
- None.

## Readiness
- Operation: create
- Final state: ready
- SHIP-v1 compatibility mode: ready
- Reason: the skill contract matches the validated CLI surface and CAS 0.6.0 is publicly released.
- Caveats: none
<!-- ship-proof:end -->
