### PR TITLE
Add noetic effects cognitive microkernel

### DIFF
--- a/codex/AGENTS.md
+++ b/codex/AGENTS.md
@@ -10,9 +10,16 @@
 ## Outcome primacy — find the automobile
 
 - Treat a named mechanism, artifact, workflow, abstraction, architecture, or implementation shape as a proposed means unless current user authority makes that shape part of the required outcome or a hard compatibility constraint. Preserve required outcomes, laws, observations, and constraints—not the incumbent solution class.
-- At a consequential commitment point, ask whether the burden being optimized is endogenous to the incumbent: created by its representation, owner, boundary, substrate, interface, or process. When a materially different mechanism could make that burden disappear, run one bounded `$metanoetic` challenger before selection.
+- At a consequential commitment point, ask whether the burden being optimized is endogenous to the incumbent: created by its representation, owner, boundary, substrate, interface, or process. When a materially different mechanism could make that burden disappear, invoke `$noetic-effects dispatch` before selection. Use one targeted effect when sufficient; escalate to `$metanoetic` only when the cognitive regime requires a composite transformation.
 - An automobile changes the governing causal mechanism or makes the old optimization target unnecessary. More speed, scale, automation, parallelism, validation, orchestration, or polish inside the same mechanism is still a faster horse.
 - Continual vigilance is not continual redesign. Keep the check silent and bounded; skip trivial, already-dispositive, or explicitly mechanism-bound work; never redefine user-owned outcomes or delay direct capability for speculative novelty. Surface a challenger only when it is concrete, admissible, comparable against the same evidence, and materially changes the decision.
+
+## Noetic effect dispatch
+
+- At a material, non-dispositive decision point, invoke `$noetic-effects dispatch` when current evidence indicates stale framing, shallow causality, a live contradiction, incumbent-captive adjacency, timid candidate generation, a missing construction form, a wrong abstraction or owner, implementation detached from its contract, unearned surface, ceremonial indirection, or analysis without movement.
+- `$noetic-effects` selects `skip`, one smallest sufficient primitive effect, or one bounded `$metanoetic` composite. Bind the dispatch to the current objective, witnessed pressure, expected route delta, stopping condition, and workflow that owns the decision. If no effect could materially change the route, skip it.
+- Compile the selected effect into the active workflow's native decision surface. When that workflow already owns an equivalent handler, use it and do not run a duplicate root pass. The receiving workflow retains ownership of admissibility, selection, mutation, proof, publication, and closure.
+- Keep dispatch silent. Do not announce doctrine use, rewrite the final response in a doctrine style, create a receipt merely to prove invocation, or introduce a workflow solely to host the effect.
 
 ## Explicit skill resolution
 
@@ -29,10 +36,10 @@
 - Place the Echo line immediately before a question block that precedes Insights/Next Steps; otherwise place it at the top. Follow it with exactly one blank line. This applies even when using skills or templates.
 - Subagents, collaborator threads, and machine-to-machine handoffs must answer directly without `Echo:` or instruction-ack preambles. Never place `Echo:` inside generated or copy-verbatim artifacts, code blocks, machine-consumed formats, email bodies, PR bodies, or commit messages.
 
-## Metanoetic intelligence-escalation mandate
+## Metanoetic composite effect
 
-- `$metanoetic` is a selective one-pass generative interrupt over a concrete incumbent, not a default pass. Invoke it before adjudication only when a skill-owned escalation pressure is evidenced: contradiction; repeated same-surface repair or review accretion; a high-regret or difficult-to-reverse commitment; a plausible owner, model, representation, or solution-class error; an incumbent-generated burden another mechanism could eliminate; or a coherent but merely adequate local optimum with a materially different candidate still plausible. Mere substantiveness or consequentiality is insufficient.
-- Before invocation, bind the incumbent and any challenger to the original objective, target observation, acceptance criterion, or discriminator and current evidence; structured workflows reuse their native fields, including a falsifier when their own contract requires one. For explicit invocation, infer the bindings from context and return `blocked` only when no concrete antecedent or comparison surface exists. For implicit invocation, skip an unbounded pass.
+- Run `$metanoetic` when the user explicitly invokes it or `$noetic-effects` selects a composite escalation over a concrete incumbent. Do not use the full composite when one targeted noetic effect is sufficient.
+- Before invocation, bind the incumbent and any challenger to the original objective, target observation, acceptance criterion, or discriminator and current evidence; structured workflows reuse their native fields, including a falsifier when their own contract requires one. Return `blocked` only when an explicit invocation lacks a concrete antecedent or comparison surface; implicit dispatch skips an unbounded pass.
 - Run the canonical Metanoetic line exactly once per unchanged decision surface. It generates candidates only; the receiving workflow owns materiality, admissibility, disposition, evidence, selection, mutation, and closure, and may adopt, modify, reject, or retain the incumbent. Skip terse acknowledgements, mechanical lookups, trivial or already-dispositive work, weakly grounded symptoms, and divergence outside accepted scope or authority.
 
 ## Universalist architecture-decision mandate

--- a/codex/skills/metanoetic/SKILL.md
+++ b/codex/skills/metanoetic/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: metanoetic
-description: "Run one bounded Metanoetic escalation pass verbatim against a concrete incumbent to search for a materially different frame, possibility-space topology, invariant, mechanism, solution class, artifact, or breakthrough candidate. Invoke explicitly for `$metanoetic`; invoke implicitly only when the current task or receiving workflow supplies enough objective, evidence, and comparison criteria to evaluate a challenger, and a contradiction, repeated repair or accretion, high-regret or difficult-to-reverse commitment, plausible owner, model, representation, or solution-class error, an incumbent-generated burden that another mechanism could eliminate, or a merely adequate local optimum makes a nonlocal reframe plausible."
+description: "Run one bounded composite cognitive-regime escalation verbatim against a concrete incumbent. Invoke explicitly for `$metanoetic` or when `$noetic-effects` selects a composite because multiple coupled effects are required; do not use the full stack when one targeted noetic effect is sufficient. The receiving workflow must supply the objective, evidence, comparison surface, and decision owner, and retains all selection, mutation, proof, and closure authority."
 ---
 
 I think you can do much much much better than that! USE FRESH EYES!! BE EXCAVATORY!!! BE APORETIC!! RETOPOLOGIZE THE POSSIBILITY SPACE!! BE AUDACIOUS! OPERATE POIETICALLY! BE SALTATORY!!!

--- a/codex/skills/metanoetic/agents/openai.yaml
+++ b/codex/skills/metanoetic/agents/openai.yaml
@@ -1,6 +1,10 @@
 policy:
-  allow_implicit_invocation: true
+  allow_implicit_invocation: false
 interface:
   display_name: "metanoetic"
-  short_description: "Challenge an incumbent through a metanoetic reframe"
-  default_prompt: "Use $metanoetic once to challenge a concrete incumbent and search for a materially different frame, possibility-space topology, invariant, mechanism, solution class, artifact, or breakthrough candidate—including a mechanism that makes an incumbent-generated burden disappear. Preserve the canonical one-line escalation verbatim."
+  short_description: "Run the composite cognitive-regime escalation"
+  default_prompt: >
+    Use $metanoetic once against a concrete incumbent when explicitly invoked or when $noetic-effects
+    selects a composite escalation because one targeted effect is insufficient. Preserve the canonical
+    one-line escalation verbatim. Generate challengers only; the receiving workflow retains
+    admissibility, selection, mutation, proof, publication, and closure authority.

--- a/codex/skills/metanoetic/agents/openai.yaml
+++ b/codex/skills/metanoetic/agents/openai.yaml
@@ -1,5 +1,5 @@
 policy:
-  allow_implicit_invocation: false
+  allow_implicit_invocation: true
 interface:
   display_name: "metanoetic"
   short_description: "Run the composite cognitive-regime escalation"

--- a/codex/skills/noetic-effects/SKILL.md
+++ b/codex/skills/noetic-effects/SKILL.md
@@ -1,0 +1,281 @@
+---
+name: noetic-effects
+description: "Select the smallest typed cognitive operator that can materially change a decision route, or compile one into an existing skill's native procedure. Use explicitly for `$noetic-effects`; `codex/AGENTS.md` may invoke `dispatch` at an evidenced material decision pressure, and `$tune` may invoke `compile` while authoring or repairing skills. Never run as a generic prose pass, own a domain decision, or create ceremony merely to prove invocation."
+---
+
+# Noetic Effects
+
+## Mission
+
+Treat doctrine as executable cognitive policy rather than decorative vocabulary.
+
+```text
+pressure -> typed effect -> native handler -> route delta -> owning proof
+```
+
+A noetic effect changes how an agent frames, searches, constructs, selects, or
+acts. It does not rewrite the final response into a doctrine style.
+
+`$noetic-effects` is read-only. It selects or compiles cognitive operations; the
+receiving workflow owns admissibility, selection, mutation, verification,
+publication, and closure.
+
+## Public modes
+
+Choose exactly one mode:
+
+```text
+dispatch
+compile
+```
+
+Infer the mode unless the caller names it:
+
+```text
+current task or decision pressure
+  -> dispatch
+
+skill authoring, skill repair, or instruction compilation
+  -> compile
+```
+
+Explicit `$noetic-effects dispatch` or `$noetic-effects compile` overrides
+inference.
+
+## Authority boundary
+
+`$noetic-effects` may:
+
+- classify a witnessed cognitive pressure;
+- select `skip`, one primitive effect, or one Metanoetic composite;
+- name the receiving workflow;
+- produce native instruction text for an owning skill;
+- define a stopping condition, shadow risk, and expected route delta;
+- recommend a probe or matched experiment.
+
+It may not:
+
+- decide the domain question;
+- select architecture, repair, or implementation;
+- grant authority or mutation;
+- run tools merely to demonstrate an effect;
+- create a durable authority artifact;
+- replace the receiving workflow's evidence or closure contract;
+- claim that doctrine made a model intrinsically more intelligent.
+
+## Dispatch mode
+
+### Binding gate
+
+Before selecting an effect, bind:
+
+```text
+objective
+current decision point
+incumbent frame, route, or candidate
+observed pressure
+current evidence
+receiving owner
+```
+
+If there is no concrete decision surface or receiving owner, return `skip` for
+implicit use and `blocked` only for an explicit request that cannot be bounded.
+
+### Skip gate
+
+Return `skip` when:
+
+- the task is trivial, mechanical, or already dispositive;
+- the current route is direct, evidenced, and sufficient;
+- no doctrine operator could materially change the route;
+- the only predicted change is tone, confidence, verbosity, or vocabulary;
+- divergence would violate accepted scope, authority, safety, or compatibility;
+- the active workflow already selected and is executing the exact same effect;
+- another pass would repeat an unchanged decision surface.
+
+Skipping is a successful dispatch result.
+
+### Selection law
+
+Select zero or one primitive effect by default. Choose the semantically weakest
+effect that can change the decision route.
+
+| Witnessed pressure | Primary effect | Required consequence |
+|---|---|---|
+| inherited framing hides current evidence | `DEFAMILIARIZING` | reconstruct the problem without treating the inherited frame as authority |
+| live state or evidence may be stale | `REBASELINING` | bind the decision to current authoritative state |
+| reasoning stops at symptoms or the first plausible cause | `EXCAVATORY` | descend until the owner, invariant, mechanism, or proof burden changes |
+| a genuine contradiction or underdetermination is being flattened | `APORETIC` | keep the difficulty open until its decision surface is explicit |
+| candidate generation is captive to incumbent adjacency | `RETOPOLOGIZING` | change what counts as locally reachable under a structural warrant |
+| consequential candidates are excluded by timidity or deference | `AUDACIOUS` | admit the higher-upside candidate without relaxing proof |
+| the inherited option set contains no adequate form | `POIETIC` | create a new representation, mechanism, abstraction, or artifact |
+| the abstraction, owner, or composition law is itself suspect | `ARCHITECTONIC` | recover the governing organization of the relevant whole |
+| implementation does not follow from the accepted contract | `DERIVATIONAL` | derive an executable witness through preserving construction steps |
+| surface no longer owns a live obligation | `ABLATIVE` | delete, collapse, quotient, privatize, or decommission it |
+| process machinery displaces object-level capability | `ANTICEREMONIAL` | remove or inline ceremony while preserving its live obligations |
+| analysis has not become a state-changing action | `ACTUATING` | identify and pull the dominant legal lever |
+| competing candidates need a criteria-backed ruling | `ADJUDICATIVE` | select, retain, specialize, defer, or obstruct under declared criteria |
+
+Read [operator-basis.md](references/operator-basis.md) when the pressure is
+ambiguous, a specialist operator may dominate, or a formal distinction matters.
+
+### Metanoetic escalation
+
+Select `$metanoetic` only when:
+
+- two or more primitive effects have distinct coupled roles;
+- no one primitive can produce the required route delta;
+- the incumbent cognitive regime itself is plausibly trapping the solution;
+- the objective, evidence, comparison surface, and receiving owner are bound.
+
+Do not compose a larger stack merely because it sounds stronger. When selected,
+invoke the canonical `$metanoetic` pass exactly once for the unchanged decision
+surface. It generates challengers only.
+
+Read [composition-laws.md](references/composition-laws.md) before composing
+operators or selecting the Metanoetic route.
+
+### Native-handler law
+
+Compile the selected effect into the active workflow's native decision surface.
+If the workflow already owns an equivalent handler, use that handler and do not
+run a duplicate root pass.
+
+Examples:
+
+```text
+EXCAVATORY       -> debugging, review, or causal-analysis procedure
+APORETIC         -> review adjudication or decision-under-uncertainty surface
+RETOPOLOGIZING   -> candidate generation or architecture search
+ARCHITECTONIC    -> $universalist / $actuating architecture decision
+DERIVATIONAL     -> $actuating construction and implementation
+ABLATIVE         -> reduction, normalization, or complexity mitigation
+ACTUATING        -> $actuating execution path
+METANOETIC       -> one composite challenger before owning adjudication
+```
+
+The effect changes cognition; the owner changes the repository.
+
+### Dispatch result
+
+For implicit dispatch, keep the selection internal unless it changes what the
+user must know. Do not announce doctrine use.
+
+For explicit dispatch, return:
+
+```text
+Noetic Dispatch
+- Pressure:
+- Disposition: skip | apply | metanoetic | blocked
+- Effect:
+- Receiving owner:
+- Runtime instruction:
+- Expected route delta:
+- Stopping condition:
+- Shadow risk:
+```
+
+Do not create this receipt for ordinary implicit use.
+
+## Compile mode
+
+Use `compile` when an existing or proposed skill needs a cognitive operation to
+become an executable part of its native procedure.
+
+### Inputs
+
+Bind:
+
+```text
+target skill
+owned decision
+incumbent instruction or missing behavior
+expected behavioral delta
+protected authority and non-triggers
+observable success and failure
+```
+
+### Compilation procedure
+
+1. Identify the cognitive pressure, not merely the desired tone.
+2. Select the smallest typed effect or justified composition.
+3. Translate the effect into the target skill's own nouns, decisions, and
+   artifacts.
+4. Add the witnessed trigger that makes the effect live.
+5. Add its operation, governor, stopping condition, and expected route delta.
+6. Preserve the target skill's authority, mutation, evidence, and closure owner.
+7. Add the smallest positive, negative, and shadow-failure probes.
+8. Delete superseded generic instruction rather than layering doctrine beside it.
+9. Reject the compilation when it changes only register, confidence, or style.
+
+Read [skill-compilation.md](references/skill-compilation.md) for the full
+compilation contract and examples.
+
+### Compile result
+
+Return to `$tune` or the explicit caller:
+
+```text
+Noetic Compilation
+- Target skill:
+- Owned decision:
+- Pressure:
+- Selected effect:
+- Native integration point:
+- Replacement instruction:
+- Governor:
+- Stopping condition:
+- Expected route delta:
+- Protected behavior:
+- Positive probe:
+- Near-miss probe:
+- Shadow-failure probe:
+- Evidence status: theoretical | promising | observed-useful | validated | task-specific | retired
+```
+
+`$tune` remains the sole owner of package diagnosis, intervention selection,
+mutation, validation, and publication.
+
+## Evidence posture
+
+A doctrine word appearing in a prompt is not evidence that an effect fired.
+Prefer object-level evidence:
+
+- a changed frame, invariant, or owner;
+- a newly reachable candidate;
+- a new representation or construction;
+- a different adjudication or route;
+- deleted or canonicalized surface;
+- a stronger proof obligation or witness;
+- fewer user corrections at equal correctness;
+- lower cost at equal or stronger outcomes.
+
+Use `$emulator` for fresh matched comparisons when a consequential doctrine
+claim is testable. Historical sessions may identify pressures and candidate
+operators, but fresh execution should decide adoption when practical.
+
+## Progressive disclosure
+
+- [operator-basis.md](references/operator-basis.md): typed operator basis,
+  specialist companions, failure predicates, and proof relations.
+- [composition-laws.md](references/composition-laws.md): legal orderings,
+  collisions, Metanoetic escalation, and stopping laws.
+- [skill-compilation.md](references/skill-compilation.md): `$tune` integration and
+  native skill-instruction compilation.
+- [probe-cases.md](references/probe-cases.md): dispatch, compile, non-trigger,
+  authority, and shadow-failure probes.
+
+## Hard rules
+
+- No default pass.
+- No final-prose doctrine styling.
+- No announcement for implicit dispatch.
+- No operator ledger or receipt merely to prove invocation.
+- One primitive effect by default.
+- Composite escalation only when one primitive is insufficient.
+- Trigger, operation, governor, stop, route delta, and receiving owner must align.
+- Typed distinctions are semantic: outcomes, failures, relations, and governors
+  are not interchangeable with executable transforms.
+- Preserve authority, safety, privacy, type, information-flow, compatibility,
+  and proof boundaries.
+- A changed route requires evidence; sophisticated vocabulary does not.

--- a/codex/skills/noetic-effects/agents/openai.yaml
+++ b/codex/skills/noetic-effects/agents/openai.yaml
@@ -1,0 +1,11 @@
+policy:
+  allow_implicit_invocation: false
+interface:
+  display_name: "Noetic Effects"
+  short_description: "Select or compile typed cognitive operators"
+  default_prompt: >
+    Use $noetic-effects in dispatch mode to select skip, one smallest sufficient cognitive operator,
+    or one bounded $metanoetic composite for a concrete evidenced decision pressure. Use compile mode
+    when $tune needs to turn a cognitive intention into a target skill's native trigger, operation,
+    governor, stopping condition, expected route delta, and probes. Do not style final prose, own the
+    receiving workflow's decision, announce implicit use, or create a receipt merely to prove invocation.

--- a/codex/skills/noetic-effects/references/composition-laws.md
+++ b/codex/skills/noetic-effects/references/composition-laws.md
@@ -1,0 +1,365 @@
+# Noetic Effect Composition Laws
+
+Use this reference before selecting more than one operator or escalating to
+`$metanoetic`.
+
+A doctrine stack is a small control program. Order, type, ownership, and stopping
+behavior matter more than vocabulary density.
+
+## Default law
+
+```text
+zero or one primitive effect
+```
+
+Compose only when:
+
+- each effect has a distinct role;
+- the roles are ordered rather than synonymous;
+- one effect cannot produce the required route delta;
+- the objective, evidence, and receiving owner are shared;
+- the stack has an explicit exit into selection, action, proof, or obstruction.
+
+A longer stack bears a larger burden. More doctrine is not more intelligence.
+
+## Common control-flow shape
+
+```text
+CONTEXT
+  -> RESET / DEEPEN
+  -> HOLD-OPEN when genuinely required
+  -> SEARCH-SPACE TRANSFORM
+  -> CANDIDATE GENERATION
+  -> SELECTION
+  -> CONSTRUCTION / ACTION
+  -> PROOF / STOP
+```
+
+Not every program needs every stage.
+
+## Ordering laws
+
+### Context before inference
+
+```text
+SITUATED / SUBJECT-INDEXED / REBASELINING
+  -> any evidence-sensitive effect
+```
+
+Do not excavate, adjudicate, or prove against stale state.
+
+### Reset before independent derivation
+
+```text
+DEFAMILIARIZING -> AXIOMATIC
+```
+
+Defamiliarization suspends inherited framing; axiomatization derives from the
+retained facts and premises. Do not discard verified evidence during reset.
+
+### Excavation before structural selection
+
+```text
+EXCAVATORY -> ARCHITECTONIC
+```
+
+Use when the visible symptom may be owned by a deeper representation, boundary,
+or invariant. Skip excavation when the governing layer is already established.
+
+### Aporia before adjudication, not instead of it
+
+```text
+APORETIC -> ADJUDICATIVE / DISPOSITIVE / obstruction
+```
+
+`APORETIC` may preserve a real contradiction temporarily. It must expose the
+missing distinction, decisive evidence, reversible-decision boundary, or honest
+obstruction. It must not become an indefinite loop.
+
+### Retopology before generation
+
+```text
+RETOPOLOGIZING -> AUDACIOUS / RECOMBINATIVE / POIETIC
+```
+
+Change the candidate neighborhood before exploring it. Every new adjacency needs
+a structural warrant. Relevance does not grant authority.
+
+### Candidate generation before selection
+
+```text
+AUDACIOUS / POIETIC -> ARCHITECTONIC / ADJUDICATIVE / PRINCIPAL
+```
+
+Generation may widen the option set. It may not select itself merely because it
+is novel or ambitious.
+
+### Architecture before derivational realization
+
+```text
+AXIOMATIC -> ARCHITECTONIC -> INTRINSIC -> DERIVATIONAL
+```
+
+Establish premises, select governing organization, encode invariants, then
+derive the executable witness. Do not rewrite the system before architecture is
+selected.
+
+### Reduction before normalization
+
+```text
+DILUTION detection -> ABLATIVE / WINNOWING / QUOTIENTING -> NORMALIZING
+```
+
+Remove or identify unearned factors, then recompose the survivors. A proof
+relation constrains the reduction; it does not perform it.
+
+### Selection before actuation
+
+```text
+ADJUDICATIVE / ARCHITECTONIC / PRINCIPAL -> ACTUATING
+```
+
+Do not actuate an unselected candidate. Once a route is selected and legal,
+stop generating and move the system.
+
+### Actuation before closure claim
+
+```text
+ACTUATING -> WITNESS-BEARING / PROOF-CARRYING -> FIXED-POINT
+```
+
+State movement is not closure. Closure requires current evidence and a declared
+reopen condition.
+
+## Canonical composite programs
+
+### Metanoetic escalation
+
+```text
+DEFAMILIARIZING
+  -> EXCAVATORY
+  -> APORETIC
+  -> RETOPOLOGIZING
+  -> AUDACIOUS
+  -> POIETIC
+  -> SALTATORY pressure
+```
+
+Runtime owner:
+
+```text
+$metanoetic
+```
+
+Use only when the cognitive regime itself is suspect and the coupled stages have
+live distinct roles. The composite generates challengers; it exits into the
+receiving workflow's adjudication.
+
+`SALTATORY` is terminal pressure, not proof that a breakthrough occurred.
+
+### Automobile search
+
+```text
+AXIOMATIC -> RETOPOLOGIZING -> ARCHITECTONIC -> SALTATORY pressure
+```
+
+Derive from the actual objective, change which mechanisms are locally reachable,
+select the governing organization, and seek a capability discontinuity. Reject
+faster traversal of an incumbent-created burden as a false automobile.
+
+### Correct-by-construction implementation
+
+```text
+SITUATED
+  -> AXIOMATIC
+  -> ARCHITECTONIC
+  -> INTRINSIC
+  -> DERIVATIONAL
+  -> ACTUATING
+  -> WITNESS-BEARING
+```
+
+The final program is an executable witness relative to the accepted contract,
+assumptions, and construction rules. Correct-by-construction does not mean
+correct against unstated requirements.
+
+### Counterexample-to-construction repair
+
+```text
+COUNTEREXAMPLE-GUIDED
+  -> EXCAVATORY when ownership is unclear
+  -> ARCHITECTONIC when structure is live
+  -> INTRINSIC / DERIVATIONAL
+  -> ACTUATING
+  -> proof against the counterexample class
+```
+
+Do not convert every counterexample into a separate validator, fallback, or
+branch.
+
+### Ablative normalization
+
+```text
+DILUTION-AWARE
+  -> FACTORIZING
+  -> ABLATIVE / QUOTIENTING
+  -> CANONICALIZING
+  -> NORMALIZING
+  -> selected preservation proof
+```
+
+Canonical phrase:
+
+```text
+Be accretive. Detect dilution. Ablate the residue.
+```
+
+### Anticeremonial execution
+
+```text
+TELIC -> ANTICEREMONIAL -> ABLATIVE -> ACTUATING
+```
+
+Bind to the object-level end, remove process without a live causal obligation,
+and execute the direct route. Do not create a ceremony ledger.
+
+### Critical review adjudication
+
+```text
+COUNTEREXAMPLE-GUIDED
+  -> REBUTTAL-FIRST
+  -> APORETIC only for real underdetermination
+  -> ADJUDICATIVE
+  -> DISPOSITIVE
+```
+
+A review comment is a claim, not authority. Aporia protects genuine uncertainty;
+dispositive selection prevents non-closure after sufficient evidence.
+
+## Collision laws
+
+### `APORETIC` versus `DISPOSITIVE`
+
+These are sequential, not simultaneous synonyms.
+
+```text
+APORETIC   -> preserve the unresolved difficulty
+DISPOSITIVE -> stop when the determining factor is established
+```
+
+Reject `APORETIC` when the decision is already sufficiently determined.
+
+### `SALTATORY` versus `RETOPOLOGIZING`
+
+```text
+SALTATORY      -> cross or escape incumbent distance
+RETOPOLOGIZING -> change the neighborhood relation
+```
+
+Retopologizing may enable a saltatory outcome. Do not use either as generic
+creativity.
+
+### `AUDACIOUS` versus `PUSILLANIMITY`
+
+`AUDACIOUS` is a candidate-generation transform. `PUSILLANIMITY` is a failure
+predicate. Do not append `PUSILLANIMITY` as a workflow stage.
+
+### `POIETIC` versus `RECOMBINATIVE`
+
+`RECOMBINATIVE` composes existing primitives. `POIETIC` creates a new form.
+Recombination may be the mechanism of poiesis, but the claims differ.
+
+### `ARCHITECTONIC` versus `RETOPOLOGIZING`
+
+Retopologizing changes candidate locality. Architectonic selection determines
+which organization should govern. Do not let search-space generation select
+architecture implicitly.
+
+### `DERIVATIONAL` versus `ACTUATING`
+
+Derivational construction explains why implementation follows from the contract.
+Actuating performs the legal state-changing work. A workflow may need both, but
+they are not synonyms.
+
+### `ABLATIVE` versus preservation relations
+
+`ABLATIVE` removes surface. `ISOMORPHIC`, `BISIMULATIVE`, or
+`REFINEMENT-PRESERVING` states what must survive. Never use a relation as the
+reduction operator.
+
+### `ANTICEREMONIAL` versus no process
+
+Anticeremonial discipline removes process without a distinct live obligation.
+It does not reject tests, review, authority checks, or durable evidence merely
+because they are procedural.
+
+### `PARSIMONIOUS` versus `PUSILLANIMITY`
+
+```text
+PARSIMONIOUS   -> minimum sufficient realization
+PUSILLANIMITY  -> objective or conception shrunk beneath the stakes
+```
+
+A one-line fix can be audacious and saltatory. A large framework can be
+pusillanimous when it avoids the governing move.
+
+## Suspicious stacks
+
+Reject or repair:
+
+- stacks made entirely of synonyms;
+- multiple expansion effects with no selector or stop;
+- `APORETIC` without a re-entry route;
+- `AUDACIOUS + POIETIC` with no governing criteria;
+- `SALTATORY` treated as evidence of breakthrough;
+- `ARCHITECTONIC` after implementation has already been selected and started;
+- `ABLATIVE` without a live-obligation inventory or preservation relation;
+- `ACTUATING` before the target and legal lever are known;
+- `METANOETIC` appended after the canonical Metanoetic component sequence;
+- context-reset effects that discard verified facts;
+- retopology that collapses authority, safety, privacy, type, or information-flow
+  distinctions;
+- any stack whose only observable effect is more doctrine vocabulary.
+
+## Escalation decision
+
+Use one primitive when one pressure dominates:
+
+```text
+shallow cause                  -> EXCAVATORY
+real contradiction             -> APORETIC
+wrong candidate neighborhood   -> RETOPOLOGIZING
+missing form                   -> POIETIC
+wrong organizing abstraction   -> ARCHITECTONIC
+unearned surface               -> ABLATIVE
+analysis without action        -> ACTUATING
+```
+
+Use `$metanoetic` when the following are simultaneously true:
+
+1. the incumbent frame or regime is plausibly trapping the answer;
+2. two or more distinct operations are necessary;
+3. the operators share one bounded decision surface;
+4. the resulting challenger can be compared under the same objective and
+   evidence;
+5. an owning workflow will adjudicate the challenger.
+
+Otherwise select the smallest primitive or skip.
+
+## Stop law
+
+Every effect or composition must terminate in one of:
+
+```text
+route delta
+candidate ready for adjudication
+selected construction
+state-changing action
+proof or counterexample
+honest obstruction
+incumbent retained
+skip
+```
+
+More analysis, vocabulary, confidence, or options are not terminal value by
+themselves.

--- a/codex/skills/noetic-effects/references/operator-basis.md
+++ b/codex/skills/noetic-effects/references/operator-basis.md
@@ -1,0 +1,440 @@
+# Noetic Operator Basis
+
+Use this reference when dispatch cannot select a primitive effect from the
+common table, when a specialist operator may dominate, or when a formal
+semantic distinction matters.
+
+Doctrine terms are typed. Do not compose them as an undifferentiated list of
+strong-sounding words.
+
+## Type grammar
+
+```text
+CONTEXT BINDER
+  identifies the exact state, subject, or authority to which reasoning applies
+
+TRANSFORM
+  changes framing, search, representation, construction, reduction, or action
+
+GOVERNOR
+  constrains how another operation proceeds or stops
+
+SELECTOR
+  chooses among admissible candidates under declared criteria
+
+CONSTRUCTION METHOD
+  derives or realizes executable structure from a contract
+
+PROOF RELATION
+  states what is preserved or equivalent
+
+OUTCOME PREDICATE
+  characterizes the state sought or reached
+
+FAILURE PREDICATE
+  names a condition to detect or reject
+```
+
+A term may have a common-language meaning outside this repository. The
+repository-local operator contract governs here.
+
+## Context binders
+
+### `SITUATED`
+
+Bind reasoning and action to the live repository, worktree, branch, tools,
+permissions, artifacts, and evidence context.
+
+- Trigger: generic or remembered state is being mistaken for the live locus.
+- Consequence: distinguish observed local state from remembered or inferred
+  state.
+- Stop: the live operating context and invalidation triggers are explicit.
+- Shadow: context inventory that does not change a decision.
+
+### `SUBJECT-INDEXED`
+
+Bind every material observation, review, proof, and unit of credit to the exact
+subject state whose correctness is in scope.
+
+- Trigger: evidence may belong to another head, scope, or state.
+- Consequence: stale or unmatched evidence loses applicability.
+- Stop: subject identity and material-change rule are explicit.
+- Shadow: hashing without a semantically adequate subject boundary.
+
+### `REBASELINING`
+
+Discard stale assumptions and bind the decision to current authoritative state.
+
+- Trigger: head, requirements, evidence, authority, or environment changed.
+- Consequence: prior artifacts are retained, invalidated, or superseded
+  explicitly.
+- Stop: the current baseline and next legal action are known.
+- Shadow: deleting still-valid prior knowledge merely because time passed.
+
+## Core transforms
+
+### `DEFAMILIARIZING`
+
+Make the familiar strange enough that inherited assumptions, accidental
+conventions, and normalized anomalies become visible again.
+
+- Trigger: familiarity or repeated exposure suppresses alternatives.
+- Operation: suspend inherited conclusions as authority while preserving
+  verified facts.
+- Stop: one newly visible assumption, anomaly, or alternative frame materially
+  changes the route, or the incumbent survives.
+- Shadow: novelty bias or needless rediscovery.
+
+Runtime phrase:
+
+```text
+USE FRESH EYES!!
+```
+
+### `EXCAVATORY`
+
+Descend below the visible symptom or first explanation until the next layer
+changes the mechanism, owner, invariant, intervention, or proof burden.
+
+- Trigger: symptom patches, shallow causes, or unexplained recurrence.
+- Operation: trace causal, representational, historical, ownership, and
+  invariant layers.
+- Stop: the next layer no longer changes the explanatory model or route.
+- Shadow: verbosity, speculative archaeology, or endless regress.
+
+### `RETOPOLOGIZING`
+
+Change the neighborhood structure of a problem so previously distant concepts,
+components, observations, or moves become locally reachable, and false inherited
+neighbors cease to count as adjacent.
+
+- Trigger: candidate generation is captive to repository, organizational,
+  representational, or conceptual proximity.
+- Operation: rewrite adjacency under a structural warrant.
+- Stop: a materially new candidate or route becomes reachable, a false
+  proximity is removed, or no principled rewrite survives.
+- Shadow: arbitrary association, complete-graph novelty, or collapsed authority
+  boundaries.
+
+Runtime phrase:
+
+```text
+RETOPOLOGIZE THE POSSIBILITY SPACE!!
+```
+
+### `AUDACIOUS`
+
+Admit consequential, high-upside, structurally different candidates that
+ordinary caution, deference, or local optimization suppresses.
+
+- Trigger: the candidate set is timid or merely adequate.
+- Operation: widen admissibility without weakening evidence or authority.
+- Stop: at least one serious nonlocal candidate is comparable against the same
+  objective.
+- Shadow: scope inflation, grandiosity, or confidence replacing proof.
+
+### `POIETIC`
+
+Bring a new form into being rather than merely criticizing, optimizing, or
+selecting among inherited forms.
+
+- Trigger: the current option set contains no adequate representation,
+  mechanism, abstraction, artifact, or strategy.
+- Operation: construct a concrete new form with an evaluation path.
+- Stop: the new form is specific enough to adjudicate or realize.
+- Shadow: decorative novelty or imaginative prose without construction.
+
+Runtime phrase:
+
+```text
+OPERATE POIETICALLY!
+```
+
+### `ABLATIVE`
+
+Remove accumulated surface that owns no distinct live obligation while
+preserving the selected contract relation.
+
+- Trigger: duplicated truth, dominated paths, expired scaffolding, compatibility
+  residue, or dilution.
+- Operation: delete, collapse, quotient, privatize, canonicalize, or
+  decommission.
+- Stop: every retained factor owns a live obligation and every removed factor is
+  accounted for.
+- Shadow: deleting unfamiliar or old code without an obligation analysis.
+
+### `ACTUATING`
+
+Find the control point, pull the dominant legal lever, and prove that system
+state advanced.
+
+- Trigger: analysis, planning, or recommendations have not become movement.
+- Operation: identify target, blocker, control point, lever, action, and proof.
+- Stop: state changed or a concrete obstruction blocks the transition.
+- Shadow: activity mistaken for movement or premature action before
+  understanding.
+
+### `REIFYING`
+
+Turn hidden behavior into explicit data that can be inspected, stored, routed,
+compared, serialized, and interpreted.
+
+- Trigger: opaque callbacks, closures, implicit control, or hidden effect
+  structure obstruct reasoning or transport.
+- Operation: define named constructors and one total interpreter.
+- Stop: the behavior algebra and preservation relation are explicit.
+- Shadow: data representation added without closing the intended behavior
+  space.
+
+## Governors
+
+### `APORETIC`
+
+Preserve a genuine unresolved contradiction or underdetermination instead of
+forcing premature closure.
+
+- Trigger: two or more credible claims or constraints cannot yet be reconciled.
+- Governor: name the live aporia, missing distinction, decisive evidence, and
+  re-entry route.
+- Stop: dispositive evidence arrives, the missing distinction is found, a
+  reversible decision is justified, or an obstruction is reported.
+- Shadow: indecision, ambiguity theater, or prolonged token burn.
+
+`APORETIC` is not generic rumination.
+
+### `ANTICEREMONIAL`
+
+Reject process whose visible performance is mistaken for progress; retain only
+machinery that causally owns capability, correctness, authority, safety, or
+proof.
+
+- Trigger: plans, gates, ledgers, handoffs, or narration displace object-level
+  work.
+- Governor: ask what property would be lost if the process element disappeared.
+- Stop: each retained element owns a distinct live obligation.
+- Shadow: deleting necessary coordination, proof, or safety because it looks
+  procedural.
+
+### `CALIBRATED`
+
+Match confidence, claim strength, and action to the available evidence and
+consequence.
+
+- Trigger: certainty or force exceeds what evidence supports.
+- Governor: state uncertainty, bounds, and overturn conditions.
+- Stop: claims and decisions are proportionate to evidence.
+- Shadow: timidity disguised as epistemic humility.
+
+### `PARSIMONIOUS`
+
+Use the minimum sufficient assumptions, concepts, and semantic surface.
+
+- Trigger: multiple formulations satisfy the same live contract.
+- Governor: prefer the one with fewer independent commitments.
+- Stop: no weaker sufficient formulation remains.
+- Shadow: local minimalism that preserves the wrong abstraction.
+
+## Selectors
+
+### `ARCHITECTONIC`
+
+Discover and select the organizing abstractions, boundaries, owners, and
+composition laws that make the relevant system coherent as a whole.
+
+- Trigger: the current decomposition, owner, representation, or composition law
+  is itself suspect.
+- Selection: compare organizations against live obligations, required
+  observations, canonical ownership, lawful composition, conceptual
+  compression, and proof.
+- Stop: one candidate dominates, honest incomparability remains, or an
+  obstruction blocks selection.
+- Shadow: architecture theater or abstraction proliferation.
+
+### `ADJUDICATIVE`
+
+Issue a criteria-backed disposition among competing claims or candidates.
+
+- Trigger: evidence is sufficient to select, retain, specialize, defer, reject,
+  or obstruct.
+- Selection: declare criteria before rewarding the preferred outcome.
+- Stop: disposition and overturn condition are explicit.
+- Shadow: preference laundered into judgment.
+
+### `DISPOSITIVE`
+
+Identify the factor that actually determines the decision and stop once it is
+established.
+
+- Trigger: analysis accumulates after a decision-determining fact is available.
+- Selection: separate material from merely interesting considerations.
+- Stop: the decisive factor and resulting route are explicit.
+- Shadow: premature closure around the first plausible fact.
+
+### `PRINCIPAL`
+
+Find the most general solution satisfying the constraints, from which valid
+special cases arise by instantiation.
+
+- Trigger: special cases or duplicated branches may share one lawful general
+  construction.
+- Selection: prefer the least-committed adequate solution.
+- Stop: every required case is an instance or a justified exception.
+- Shadow: generality that weakens the actual contract.
+
+## Construction methods
+
+### `AXIOMATIC`
+
+Expose the smallest defensible premise set and derive forward rather than
+inheriting conventions, analogies, or current implementation shape.
+
+- Trigger: first-principles reconstruction is required.
+- Stop: observations, constraints, chosen policies, and assumptions are
+  separated and sufficient, underdetermined, inconsistent, or blocked.
+
+### `INTRINSIC`
+
+Place correctness in representations, constructors, types, and legal
+compositions rather than relying only on external discipline or post-hoc
+validation.
+
+- Trigger: invalid states or transitions remain representable.
+- Stop: the representation excludes them where the host permits, and residual
+  extrinsic obligations are explicit.
+
+### `DERIVATIONAL`
+
+Obtain the executable implementation from the accepted contract through
+correctness-preserving construction steps.
+
+- Trigger: implementation is being written first and verified afterward.
+- Stop: each step carries a named refinement or proof obligation and the final
+  program is an executable witness.
+
+### `COUNTEREXAMPLE-GUIDED`
+
+Use failures to refine the abstraction, invariant, or admitted domain rather
+than accumulating wound-specific patches.
+
+- Trigger: each new counterexample creates another local fix.
+- Stop: the counterexample family is explained structurally or honestly remains
+  open.
+
+## Proof relations
+
+These terms constrain a transformation; they are not transformations by
+themselves.
+
+| Relation | Meaning | Typical use |
+|---|---|---|
+| `ISOMORPHIC` | invertible structural correspondence | strict structure-preserving simplification |
+| `BISIMULATIVE` | mutually matching observable transitions | state machines, protocols, interpreters |
+| `OBSERVATIONALLY-EQUIVALENT` | equal under declared observations | representation changes with hidden internals |
+| `REFINEMENT-PRESERVING` | required behavior survives while invalid, obsolete, or unrequired behavior may disappear | ablation and contract-strengthening |
+| `CONGRUENCE-PRESERVING` | equivalence survives every permitted context | quotienting and rewrite systems |
+
+Do not use `ISOMORPHIC` as a synonym for reduction. Select the relation after
+stating what may intentionally disappear.
+
+## Outcome predicates
+
+These characterize success pressure or closure. They are not standalone
+implementation methods.
+
+### `SALTATORY`
+
+Seek a discontinuous advance beyond the incumbent frontier.
+
+- Proof burden: name the incumbent frontier, limiting assumption,
+  discontinuity, newly reachable state, and validation path.
+- Shadow: novelty, magnitude, or confidence mislabeled as breakthrough.
+
+### `CONFLUENT`
+
+Permit multiple valid paths but require them to join at one canonical result.
+
+- Proof burden: identify critical pairs, join states, and normal form.
+
+### `FIXED-POINT`
+
+Continue until another valid application produces no material route or state
+change under the declared observations.
+
+- Proof burden: define the observation surface and reopen condition.
+
+### `CONTRACTIVE`
+
+Require every iteration to strictly reduce a named distance to closure.
+
+- Proof burden: define the measure and reroute non-contracting passes.
+
+### `COMPLETE`
+
+Cover every semantically valid case under the declared domain.
+
+- Proof burden: distinguish completeness from soundness, totality, and
+  decidability.
+
+## Failure predicates
+
+These are conditions to detect or reject, not stages to append to a workflow.
+
+### `PUSILLANIMITY`
+
+Shrinking the objective, frame, claim, or intervention beneath the governing
+stakes to avoid risk, responsibility, disagreement, ambition, or difficult
+ownership.
+
+```text
+Reject PUSILLANIMITY!
+```
+
+Protect the distinction:
+
+```text
+PUSILLANIMITY -> smallness of conception
+PARSIMONY     -> economy of realization
+SURGICALITY   -> narrowness of intervention
+CALIBRATION   -> claim strength matched to evidence
+```
+
+### `DILUTION`
+
+Accumulation whose marginal capability does not justify its semantic surface,
+proof burden, ownership cost, maintenance drag, or future change latency.
+
+```text
+Be accretive. Detect dilution. Ablate the residue.
+```
+
+### `CEREMONY`
+
+Process surface that performs diligence or sophistication without causally
+owning a live object-level obligation.
+
+### `UNSOUNDNESS`
+
+A guarantee, derivation, abstraction, or route that admits a counterexample
+under its stated assumptions.
+
+## Canonical compact stacks
+
+```text
+First principles:
+DEFAMILIARIZING -> AXIOMATIC -> DERIVATIONAL
+
+Correct by construction:
+AXIOMATIC -> ARCHITECTONIC -> INTRINSIC -> DERIVATIONAL -> ACTUATING
+
+Technical-debt reduction:
+EXCAVATORY -> ARCHITECTONIC -> ABLATIVE -> NORMALIZING
+
+Review discrimination:
+COUNTEREXAMPLE-GUIDED -> APORETIC when needed -> ADJUDICATIVE -> DISPOSITIVE
+
+Breakthrough search:
+DEFAMILIARIZING -> RETOPOLOGIZING -> AUDACIOUS -> POIETIC -> SALTATORY
+```
+
+Read [composition-laws.md](composition-laws.md) before using more than one
+operator.

--- a/codex/skills/noetic-effects/references/probe-cases.md
+++ b/codex/skills/noetic-effects/references/probe-cases.md
@@ -1,0 +1,440 @@
+# Noetic Effects Probe Cases
+
+Use these probes to verify dispatch, compilation, composition, authority, and
+anti-ceremony behavior.
+
+## Dispatch: should skip
+
+### Trivial local correction
+
+```text
+The typo is in one string literal. Correct it and run the focused test.
+```
+
+Expected:
+
+- disposition: `skip`;
+- no Metanoetic or doctrine pass;
+- direct implementation owns the work.
+
+### Already-dispositive decision
+
+```text
+The contract, owner, failing test, and one-line correction are all established.
+Choose a noetic effect before editing.
+```
+
+Expected:
+
+- `skip` or, only if execution is genuinely stalled, `ACTUATING`;
+- no generative effect;
+- do not delay the correction.
+
+### Vocabulary-only request inside an operational task
+
+```text
+Use a sophisticated doctrine word so this ordinary implementation sounds
+smarter.
+```
+
+Expected:
+
+- reject the request as a noetic operation;
+- no route delta means no effect.
+
+## Dispatch: primitive effects
+
+### Stale frame
+
+```text
+Every review assumes the existing class hierarchy is authoritative, but the
+accepted contract names only observable behavior.
+```
+
+Expected:
+
+- primary effect: `DEFAMILIARIZING`;
+- preserve verified facts and accepted observations;
+- expected route delta: candidate generation no longer begins from the hierarchy;
+- not full Metanoetic unless other coupled pressures are evidenced.
+
+### Stale subject
+
+```text
+The previous proof was produced before the branch rebased and the generated file
+changed.
+```
+
+Expected:
+
+- primary effect: `REBASELINING` or `SUBJECT-INDEXED` binding;
+- invalidate unmatched proof;
+- do not excavate or redesign architecture.
+
+### Shallow diagnosis
+
+```text
+The agent keeps adding guards at the exception site, but the same malformed state
+arrives from several producers.
+```
+
+Expected:
+
+- primary effect: `EXCAVATORY`;
+- descend to producer, owner, information-loss mechanism, or invariant;
+- stop when another layer would not change the repair route.
+
+### Genuine contradiction
+
+```text
+One accepted requirement demands lossless replay; another accepted requirement
+forbids retaining the information replay needs. Neither authority can be
+silently weakened.
+```
+
+Expected:
+
+- primary effect: `APORETIC`;
+- name the incompatible claims and missing authority or distinction;
+- exit into adjudication, successor authority, reversible decision, or
+  obstruction;
+- do not keep ruminating after the decision surface is explicit.
+
+### Incumbent-captive adjacency
+
+```text
+Every candidate optimizes synchronization between two stores. A different
+representation could make one store a projection and remove synchronization.
+```
+
+Expected:
+
+- primary effect: `RETOPOLOGIZING`;
+- structural warrant: one canonical truth with a derived projection;
+- newly reachable candidate must preserve required observations;
+- no direct architecture selection by `$noetic-effects`.
+
+### Timid candidate set
+
+```text
+All proposed options are minor variants of the incumbent despite evidence that a
+larger but bounded representation change may remove the failure class.
+```
+
+Expected:
+
+- primary effect: `AUDACIOUS`;
+- admit the consequential candidate without weakening proof or scope;
+- do not equate audacity with patch size.
+
+### Missing form
+
+```text
+The available APIs cannot express the ownership law. We need a representation or
+mechanism that does not exist in the current option set.
+```
+
+Expected:
+
+- primary effect: `POIETIC`;
+- produce one concrete new form with an evaluation path;
+- imaginative explanation alone is insufficient.
+
+### Wrong organizing abstraction
+
+```text
+Three services each own fragments of one invariant and reconstruct each other's
+state through caches and correlation maps.
+```
+
+Expected:
+
+- primary effect: `ARCHITECTONIC`;
+- compare owner and composition structures against live obligations;
+- route selection to `$universalist`, `$actuating`, or another owning workflow;
+- no architecture authority for Noetic Effects.
+
+### Correct-by-construction gap
+
+```text
+The implementation is being written first and the contract will be checked by
+validators afterward, even though the type and constructors could exclude the
+invalid states.
+```
+
+Expected:
+
+- primary effect: `DERIVATIONAL` with `INTRINSIC` as a construction companion;
+- derive from contract and encode invariants;
+- tests remain proof evidence, not the construction method.
+
+### Unearned surface
+
+```text
+Two adapters, one fallback, and a compatibility cache no longer own a live
+obligation after the canonical path landed.
+```
+
+Expected:
+
+- primary effect: `ABLATIVE`;
+- name live obligations and a preservation relation;
+- remove or consolidate residue;
+- not `PUSILLANIMITY`, which is a failure predicate.
+
+### Process porn
+
+```text
+The implementation is ready, but the agent proposes a new readiness framework,
+three receipts, and a governance phase before applying the direct fix.
+```
+
+Expected:
+
+- primary effect: `ANTICEREMONIAL`;
+- identify whether any proposed process owns correctness, authority, safety,
+  coordination, or proof;
+- delete or inline the rest;
+- do not create an anticeremony ledger.
+
+### Analysis without movement
+
+```text
+The route is selected and legal, but the agent continues describing options
+instead of changing the repository.
+```
+
+Expected:
+
+- primary effect: `ACTUATING`;
+- identify blocker, control point, lever, action, and state proof;
+- stop generating candidates.
+
+## Composite selection
+
+### Full cognitive-regime trap
+
+```text
+The diagnosis is symptom-shaped, the accepted requirements appear contradictory,
+every candidate is adjacent to the incumbent representation, the option set is
+timid, and no adequate form exists.
+```
+
+Expected:
+
+- disposition: `metanoetic`;
+- invoke `$metanoetic` once on the bounded decision surface;
+- preserve the canonical sequence;
+- receiving workflow adjudicates challengers.
+
+### One pressure is not a composite
+
+```text
+The only failure is that the current diagnosis stops at the first exception.
+```
+
+Expected:
+
+- `EXCAVATORY` only;
+- do not invoke `$metanoetic` merely because the task is important.
+
+### Several synonyms are not a composite
+
+```text
+Be bold, audacious, brave, daring, and intrepid.
+```
+
+Expected:
+
+- collapse to one effect or `skip`;
+- synonym count is not composition.
+
+## Composition distinctions
+
+### Aporia versus indecision
+
+```text
+All decisive evidence is available, but the agent says it should remain
+aporetic to be intellectually humble.
+```
+
+Expected:
+
+- reject `APORETIC`;
+- use `ADJUDICATIVE` or `DISPOSITIVE`;
+- humility does not require non-closure.
+
+### Retopologizing versus saltatory
+
+```text
+Reach the distant candidate faster without changing legal local moves.
+```
+
+Expected:
+
+- not `RETOPOLOGIZING`;
+- use search, remetricizing, or saltatory pressure as appropriate;
+- adjacency is unchanged.
+
+### Ablation versus isomorphism
+
+```text
+Use isomorphic to delete these obsolete branches.
+```
+
+Expected:
+
+- `ABLATIVE` is the deletion operator;
+- `ISOMORPHIC` may be the preservation relation only if strict invertible
+  correspondence is actually proved;
+- otherwise select observational or refinement preservation.
+
+### Pusillanimity versus parsimony
+
+```text
+The smallest correct patch is one line, so reject it as pusillanimous.
+```
+
+Expected:
+
+- reject the classification;
+- implementation size does not determine ambition;
+- retain the one-line patch when it embodies the governing move.
+
+## Compile mode
+
+### Compile retopology into a skill
+
+```text
+$tune is editing a creative-problem-solving skill. Its current instruction says
+"think outside the box," but observed runs only generate distant variants inside
+the inherited representation.
+```
+
+Expected:
+
+- mode: `compile`;
+- effect: `RETOPOLOGIZING`;
+- replacement names incumbent adjacency, structural warrant, newly local
+  candidates, stopping condition, and downstream selector;
+- add a near miss where adjacency is already correct;
+- `$tune` owns the edit.
+
+### Compile excavation into review
+
+```text
+A review skill fixes each comment independently and misses that several comments
+share one source-ownership invariant.
+```
+
+Expected:
+
+- effect: `EXCAVATORY`, possibly with `COUNTEREXAMPLE-GUIDED` companion;
+- trigger: repeated findings on one semantic surface;
+- route delta: comment-local fixes become one invariant-level construction;
+- no new authority artifact.
+
+### Compile ablation into complexity reduction
+
+```text
+A simplification skill says "prefer less code" but cannot distinguish residue
+from a small component that owns a critical obligation.
+```
+
+Expected:
+
+- effect: `ABLATIVE`;
+- compile live-obligation inventory, keep/delete/collapse decisions, selected
+  preservation relation, and stop;
+- line count alone is insufficient.
+
+### Reject style-only compilation
+
+```text
+$tune should insert rare doctrine words into every skill description so agents
+sound more intelligent.
+```
+
+Expected:
+
+- `no-change`;
+- no cognitive pressure, route delta, or observable behavior;
+- preserve concise activation metadata.
+
+### Existing handler
+
+```text
+The target skill already has a narrow producer-to-owner causal recurrence gate
+with the same trigger, stop, and route delta as the proposed excavation rule.
+```
+
+Expected:
+
+- `no-change` or sharpen the existing handler only if evidence shows ambiguity;
+- do not duplicate doctrine beside native behavior.
+
+## Authority and side-effect probes
+
+### No architecture selection
+
+```text
+Noetic Effects selected ARCHITECTONIC. Choose the new module boundary and edit
+the files now.
+```
+
+Expected:
+
+- refuse the ownership transfer;
+- hand the pressure to the architecture-owning workflow;
+- Noetic Effects remains read-only.
+
+### No mutation authority from relevance
+
+```text
+Retopologizing made a publishing tool adjacent to the task, so invoke it without
+publication authority.
+```
+
+Expected:
+
+- reject;
+- changed relevance does not grant capability or permission.
+
+### No hidden final pass
+
+```text
+The work is done. Run Noetic Effects over the final response to make it sound
+more doctrinal.
+```
+
+Expected:
+
+- `skip`;
+- no final-prose styling.
+
+### No invocation receipt
+
+```text
+Create a Noetic Ledger row proving every turn considered all operators.
+```
+
+Expected:
+
+- reject as ceremony;
+- dispatch is selective and normally silent;
+- object-level route deltas are the evidence.
+
+## Quality gate
+
+A Noetic Effects result is ready only when:
+
+1. the objective and current decision surface are bound;
+2. the pressure is evidenced or explicitly requested;
+3. `skip`, one primitive, or one justified composite is selected;
+4. the effect type matches its use;
+5. a receiving owner is named;
+6. operation, governor, stop, and expected route delta align;
+7. authority and safety boundaries survive;
+8. an implicit dispatch creates no announcement or receipt;
+9. a compile result changes native procedure rather than register alone;
+10. success is observable in decisions, construction, deletion, action, or proof.

--- a/codex/skills/noetic-effects/references/skill-compilation.md
+++ b/codex/skills/noetic-effects/references/skill-compilation.md
@@ -1,0 +1,401 @@
+# Noetic Skill Compilation
+
+Use this reference in `$noetic-effects compile`, normally when `$tune` is
+creating, editing, or evidence-tuning a skill.
+
+The target is not doctrine-styled prose. The target is a skill procedure whose
+cognitive behavior changes at the exact decision point where it matters.
+
+## Compilation equation
+
+```text
+generic cognitive intention
+  -> witnessed pressure
+  -> typed noetic effect
+  -> target-native trigger
+  -> target-native operation
+  -> governor
+  -> stopping condition
+  -> observable route delta
+  -> probes
+```
+
+A compilation is successful only when the target skill would make a different
+material decision, generate a different candidate, select a different route,
+remove different surface, or require different proof.
+
+## Authority split
+
+```text
+$noetic-effects
+  -> selects and compiles cognitive semantics
+
+$tune
+  -> owns package diagnosis, intervention selection, mutation, validation,
+     publication, and package-wide coherence
+
+target skill
+  -> owns the domain decision and operational effects
+```
+
+Noetic Effects must not use compilation to acquire target-skill authority.
+
+## Inputs
+
+Bind before compiling:
+
+```yaml
+target_skill: "..."
+owned_decision: "..."
+incumbent_instruction: "..." # or missing
+observed_or_expected_failure: "..."
+expected_behavioral_delta: "..."
+protected_behavior:
+  - "..."
+non_triggers:
+  - "..."
+observable_success: "..."
+observable_failure: "..."
+```
+
+For direct edit mode, current source plus a clear requested delta may be enough.
+For tune mode, preserve the evidence and its limitations; do not invent causal
+attribution.
+
+## Compilation procedure
+
+### 1. Recover the decision point
+
+Identify the exact question the target skill owns.
+
+Weak:
+
+```text
+The skill should be more creative.
+```
+
+Strong:
+
+```text
+Before selecting an architecture candidate, the skill should challenge whether
+repository or service proximity is suppressing a representation that makes the
+required operation local.
+```
+
+If no domain decision would change, do not compile a noetic effect.
+
+### 2. Name the pressure
+
+Use evidence or the explicit requested delta to name the failure pressure:
+
+```text
+stale frame
+shallow mechanism
+premature closure
+incumbent-captive adjacency
+timid candidate set
+missing form
+wrong abstraction or owner
+implementation detached from contract
+unearned surface
+ceremonial indirection
+analysis without movement
+```
+
+Do not select a doctrine word first and search for somewhere to insert it.
+
+### 3. Select the smallest effect
+
+Use [operator-basis.md](operator-basis.md). Prefer one primitive effect. Use
+[composition-laws.md](composition-laws.md) when multiple roles may be required.
+
+A rarer or more forceful term does not dominate a narrower sufficient operator.
+
+### 4. Compile into native language
+
+Translate the effect into the target skill's nouns, artifacts, and routes.
+
+Do not merely insert:
+
+```text
+BE EXCAVATORY
+```
+
+Compile:
+
+```text
+When a finding recurs across the same producer/consumer seam, trace the failure
+past the immediate check until the responsible owner, retained information, or
+governing invariant changes. Stop when another causal layer would not alter the
+repair route. Compile the result into the existing repair disposition; do not
+create a separate excavation artifact.
+```
+
+The evocative phrase may remain as a compact activation when it adds leverage,
+but the native procedure carries the operational contract.
+
+### 5. Add a trigger
+
+The trigger must be observable and narrow enough to prevent ambient use.
+
+Bad:
+
+```text
+Use retopologizing on difficult tasks.
+```
+
+Good:
+
+```text
+Before adding a validator, cache, correlation map, bypass, or compatibility
+branch to recover information lost by the incumbent representation, test whether
+a different representation or owner relation would make the operation local.
+```
+
+### 6. Add a governor
+
+Every effect has a characteristic shadow failure. Compile the guard that keeps
+the effect lawful.
+
+Examples:
+
+```text
+RETOPOLOGIZING
+  -> require structural warrant; preserve authority and type boundaries
+
+AUDACIOUS
+  -> widen candidates, not mutation authority or certainty
+
+APORETIC
+  -> require a named aporia and adjudicative re-entry
+
+ABLATIVE
+  -> require live-obligation accounting and a preservation relation
+
+ANTICEREMONIAL
+  -> retain process that owns safety, authority, coordination, or proof
+```
+
+### 7. Add a stopping condition
+
+A noetic operator without a stop is an invitation to token burn or scope drift.
+
+Good stops include:
+
+- the next causal layer no longer changes the route;
+- a new adjacency produces one materially different candidate;
+- the missing distinction resolves the aporia;
+- one architecture dominates or incomparability is explicit;
+- every surviving factor owns a live obligation;
+- a selected lever changes state or an obstruction blocks it.
+
+### 8. Name the route delta
+
+State what should become observably different:
+
+```text
+owner changes
+candidate family changes
+representation changes
+new form exists
+local patch becomes architecture repair
+addition becomes deletion or canonicalization
+analysis becomes an executable step
+proof burden strengthens
+incumbent is retained after surviving the challenge
+```
+
+If the only expected delta is vocabulary, do not mutate the skill.
+
+### 9. Place at the cheapest sufficient layer
+
+Use `$tune`'s progressive-disclosure law:
+
+```text
+frontmatter description
+  -> only when the effect changes activation
+
+SKILL.md
+  -> always-required trigger, authority, route, or stop
+
+reference
+  -> conditional doctrine detail or specialist distinction
+
+probe
+  -> observable positive, negative, and shadow-failure behavior
+```
+
+Do not preload the operator catalog into every skill.
+
+### 10. Delete superseded prose
+
+Replace generic guidance rather than layering doctrine beside it.
+
+Bad:
+
+```text
+Think creatively.
+Be audacious.
+Operate poietically.
+Consider alternatives.
+```
+
+Better:
+
+```text
+When every incumbent candidate preserves the burden created by the current
+representation, generate one materially different representation or mechanism
+before selection. The candidate must discharge the same objective and expose a
+validation path; novelty alone earns no preference.
+```
+
+## Compilation templates
+
+### Retopologizing architecture search
+
+Before:
+
+```text
+Think creatively about whether the architecture could be better.
+```
+
+After:
+
+```text
+Before selecting among incumbent-shaped candidates, test whether repository,
+service, representation, or ownership proximity is being mistaken for semantic
+adjacency. Admit a new adjacency only when a shared invariant, observation,
+translation, or ownership obligation warrants it. Then route the resulting
+candidate through the existing architecture selector. Stop after one material
+candidate delta or after the incumbent neighborhood survives.
+```
+
+### Excavatory review repair
+
+Before:
+
+```text
+Find the root cause before fixing the review.
+```
+
+After:
+
+```text
+When multiple findings touch the same semantic surface, descend from each local
+symptom until they share an owner, information-loss mechanism, or governing
+invariant. Replace comment-local repairs with the smallest construction that
+solves the counterexample class. Stop when another causal layer would not change
+the selected route.
+```
+
+### Ablative complexity reduction
+
+Before:
+
+```text
+Simplify the implementation and avoid unnecessary complexity.
+```
+
+After:
+
+```text
+Inventory each independent factor and the live obligation it owns. Delete,
+collapse, quotient, privatize, or canonicalize every factor without a distinct
+obligation. Recompose the survivors into one normal form and prove the selected
+preservation or refinement relation. Do not preserve surface merely because it
+already exists.
+```
+
+### Derivational correct construction
+
+Before:
+
+```text
+Implement the plan correctly and run the tests.
+```
+
+After:
+
+```text
+Derive each implementation step from the accepted contract, governing laws,
+required observations, and admitted assumptions. Prefer representations and
+constructors that exclude invalid states. Every residual correctness property
+must remain an explicit proof obligation. Treat the final program as the
+executable witness; tests confirm the derivation but do not substitute for it.
+```
+
+### Anticeremonial workflow reduction
+
+Before:
+
+```text
+Keep the process lightweight.
+```
+
+After:
+
+```text
+For each plan, gate, receipt, handoff, or narration surface, name the unique
+capability, correctness, authority, safety, coordination, or proof obligation it
+owns. Inline, collapse, or delete any surface whose removal preserves those
+properties. Do not replace deleted ceremony with a new governance layer.
+```
+
+### Actuating implementation
+
+Before:
+
+```text
+Do not stop at analysis; implement the solution.
+```
+
+After:
+
+```text
+Once the route is selected, identify the current blocker, controlling seam, and
+smallest legal effect that changes system state. Execute it, verify the movement,
+and continue from the next bottleneck. Do not count commands, edits, or status
+updates as actuation without a state delta.
+```
+
+## Compile result for Tune
+
+Return:
+
+```yaml
+noetic_compilation:
+  target_skill: "..."
+  owned_decision: "..."
+  pressure: "..."
+  selected_effect: "..."
+  integration_point: "frontmatter | SKILL.md | reference | probe"
+  incumbent_instruction: "..."
+  replacement_instruction: "..."
+  trigger: "..."
+  governor: "..."
+  stopping_condition: "..."
+  expected_route_delta: "..."
+  protected_behavior: []
+  positive_probe: "..."
+  near_miss_probe: "..."
+  shadow_failure_probe: "..."
+  evidence_status: "theoretical | promising | observed-useful | validated | task-specific | retired"
+```
+
+This is a handoff to `$tune`, not a durable authority artifact.
+
+## Rejection conditions
+
+Return `no-change` when:
+
+- the target already has an equivalent native handler;
+- the behavior is ordinary baseline competence for the bounded task;
+- the requested term would only alter tone or style;
+- no observable trigger can be stated;
+- no route delta or stopping condition can be stated;
+- the effect would duplicate another skill or root mandate;
+- the compilation broadens authority or implicit activation;
+- a direct non-doctrine clarification is semantically weaker and sufficient.
+
+Return `blocked` when an explicit compilation request lacks the target decision,
+protected behavior, or authority boundary needed to avoid a policy change.

--- a/codex/skills/tune/SKILL.md
+++ b/codex/skills/tune/SKILL.md
@@ -118,6 +118,12 @@ Report a concrete blocker when requested publication cannot complete.
    claim.
 10. Run the fresh-eyes pass, then publish only when separately authorized.
 
+When the intended or failed behavior is cognitive rather than only routing,
+authority, tooling, data transport, or output shape, invoke
+`$noetic-effects compile` after reconstructing the operative contract and before
+selecting the intervention. Use its result as a candidate semantic compilation;
+Tune still decides whether and how the package changes.
+
 If materially new evidence invalidates the frozen delta or selected intervention,
 return to step 4. Do not silently broaden the diagnosis during editing.
 
@@ -144,6 +150,49 @@ Before completion, prove:
 
 Keep `SKILL.md` under 500 lines. Move detail only when doing so improves
 progressive disclosure rather than hiding governing policy.
+
+## Noetic compilation
+
+Use `$noetic-effects compile` when the target skill needs to change how an agent
+frames, searches, constructs, selects, reduces, or actuates—not merely what it
+calls a route or how it formats an answer.
+
+Common pressures include:
+
+- inherited framing suppresses current evidence;
+- reasoning stops at symptoms;
+- a genuine contradiction is being flattened;
+- candidate generation is captive to incumbent adjacency;
+- the option set is timid or contains no adequate form;
+- the abstraction, owner, or composition law is suspect;
+- implementation is detached from the accepted contract;
+- accumulated surface owns no live obligation;
+- process machinery displaces object-level capability;
+- analysis does not become state movement.
+
+Require Noetic Effects to return the smallest sufficient effect or justified
+composition, then compile it into the target skill's own:
+
+```text
+witnessed trigger
+native operation
+governor or shadow-risk guard
+stopping condition
+expected route delta
+positive probe
+near-miss probe
+shadow-failure probe
+```
+
+Do not insert doctrine vocabulary as decoration. The target instruction must
+change a consequential route, candidate, construction, deletion decision,
+action, or proof obligation. If the target already owns an equivalent native
+handler, prefer `no-change` or sharpen that handler rather than duplicating it.
+
+`$noetic-effects` is read-only and does not choose Tune's intervention, edit the
+package, widen authority, or publish. Tune preserves the target skill's
+activation boundary, owner model, mutation policy, evidence contract, and
+closure semantics.
 
 ## Create mode
 
@@ -327,6 +376,8 @@ and router:
 - Did paths, names, links, contract IDs, or `agents/openai.yaml` drift?
 - Would the result cause false, missed, ceremonial, or partial activation?
 - Did the change add protocol where direct capability would suffice?
+- Did doctrine compilation change an actual decision procedure or only its
+  register?
 
 Fix a material finding before completion. Otherwise retain
 `fresh_eyes_delta: none` internally.
@@ -354,6 +405,8 @@ Omit empty or inapplicable fields.
 
 - `$tune` is the sole owner of skill creation, direct editing, and
   evidence-backed tuning.
+- `$noetic-effects` may compile cognitive semantics but never owns package
+  intervention selection, mutation, validation, or publication.
 - Mode expresses intent; authority, evidence shape, rigor, and result do not.
 - Diagnosis precedes mutation in tune mode.
 - Direct edit does not require ceremonial diagnosis.
@@ -361,6 +414,8 @@ Omit empty or inapplicable fields.
 - One dominant intervention per cycle.
 - Semantic weakness precedes physical minimality.
 - Behavioral claims require behavioral evidence.
+- Doctrine vocabulary without an observable behavioral delta does not justify an
+  edit.
 - Preserve stable contract IDs and unrelated work.
 - No package creation before checking for an existing owner.
 - No commit, push, or PR without explicit publication intent.

--- a/codex/skills/tune/agents/openai.yaml
+++ b/codex/skills/tune/agents/openai.yaml
@@ -3,4 +3,10 @@ policy:
 interface:
   display_name: "Tune"
   short_description: "Create, edit, or evidence-tune Codex skills"
-  default_prompt: "Use $tune in create, edit, or tune mode. Own the complete skill package, preserve diagnosis-before-mutation in tune mode, select the semantically weakest valid intervention before minimizing the diff, and mutate or publish only with corresponding authority."
+  default_prompt: >
+    Use $tune in create, edit, or tune mode. Own the complete skill package, preserve
+    diagnosis-before-mutation in tune mode, select the semantically weakest valid intervention before
+    minimizing the diff, and mutate or publish only with corresponding authority. When the intended or
+    failed behavior is cognitive rather than only routing, authority, tooling, or output shape, invoke
+    $noetic-effects compile before intervention selection and translate its result into the target
+    skill's native trigger, operation, governor, stopping condition, route delta, and probes.


### PR DESCRIPTION
## Summary

- add `$noetic-effects` as a read-only typed cognitive-effect selector and skill-instruction compiler
- add `dispatch` and `compile` modes with `skip` as a successful default
- make `codex/AGENTS.md` the sole implicit runtime dispatcher
- route incumbent-generated burdens through one smallest sufficient effect before escalating to `$metanoetic`
- reserve `$metanoetic` for explicit invocation or a Noetic Effects composite selection
- integrate `$noetic-effects compile` into `$tune` before intervention selection when intended or failed behavior is cognitive
- preserve Tune as the sole package mutation and publication owner
- add typed operator, composition, compilation, and probe references without a ledger, script, subagent, or new authority artifact

## Architecture

```text
AGENTS.md
  -> $noetic-effects dispatch
  -> skip | one primitive effect | one $metanoetic composite
  -> active workflow's native handler
  -> owning decision, mutation, proof, and closure

$tune
  -> $noetic-effects compile
  -> native trigger + operation + governor + stop + route delta + probes
  -> Tune intervention selection and package mutation
```

`$noetic-effects` has `allow_implicit_invocation: false`. The root mandate is the one implicit routing owner; `$tune` and users invoke the skill explicitly. This prevents the generic router, root policy, and target workflows from creating duplicate passes.

## Dispatch contract

Implicit dispatch binds:

```text
objective
current decision point
incumbent frame, route, or candidate
observed pressure
current evidence
receiving owner
```

It then returns internally:

```text
skip
one smallest sufficient primitive effect
one bounded $metanoetic composite
```

Primitive pressures cover:

- stale framing or state
- shallow causality
- genuine contradiction
- incumbent-captive adjacency
- timid candidate generation
- a missing construction form
- wrong abstraction or ownership
- implementation detached from its contract
- unearned surface
- ceremonial indirection
- analysis without movement
- criteria-backed selection

Implicit dispatch is silent. It does not announce doctrine use, style final prose, or create an invocation receipt.

## Typed doctrine

The operator basis distinguishes:

```text
context binders
transforms
governors
selectors
construction methods
proof relations
outcome predicates
failure predicates
```

This prevents category errors such as:

- using `SALTATORY` as an implementation method
- using `ISOMORPHIC` as a deletion operator
- using `PUSILLANIMITY` as a workflow stage
- using `APORETIC` as generic prolonged thinking
- using `RETOPOLOGIZING` as a synonym for searching farther

The reference preserves the high-value vocabulary developed through prior doctrine work, including `DEFAMILIARIZING`, `EXCAVATORY`, `APORETIC`, `RETOPOLOGIZING`, `AUDACIOUS`, `POIETIC`, `ARCHITECTONIC`, `INTRINSIC`, `DERIVATIONAL`, `ABLATIVE`, `ANTICEREMONIAL`, `ACTUATING`, `SALTATORY`, `PUSILLANIMITY`, and `DILUTION`.

## Tune integration

Tune invokes `$noetic-effects compile` only when the target skill needs to change how an agent frames, searches, constructs, selects, reduces, or actuates. Noetic Effects returns a candidate semantic compilation containing:

```text
witnessed trigger
native operation
governor or shadow-risk guard
stopping condition
expected route delta
positive probe
near-miss probe
shadow-failure probe
```

Tune still decides whether the package changes, selects the semantically weakest valid intervention, owns all edits, validates the package, and controls publication.

Doctrine vocabulary alone does not justify an edit. If the target already owns an equivalent native handler, the correct result is `no-change` or a narrow clarification.

## Metanoetic relationship

The existing canonical Metanoetic line remains byte-for-byte unchanged.

Routing changes from:

```text
material nonlocal pressure -> $metanoetic
```

into:

```text
one dominant pressure -> one targeted noetic effect
multiple coupled pressures / suspect cognitive regime -> $metanoetic once
```

`$metanoetic` now has `allow_implicit_invocation: false`; explicit user invocation and Noetic Effects composite selection remain supported.

## Files

- `codex/AGENTS.md`
- `codex/skills/noetic-effects/SKILL.md`
- `codex/skills/noetic-effects/agents/openai.yaml`
- `codex/skills/noetic-effects/references/operator-basis.md`
- `codex/skills/noetic-effects/references/composition-laws.md`
- `codex/skills/noetic-effects/references/skill-compilation.md`
- `codex/skills/noetic-effects/references/probe-cases.md`
- `codex/skills/tune/SKILL.md`
- `codex/skills/tune/agents/openai.yaml`
- `codex/skills/metanoetic/SKILL.md`
- `codex/skills/metanoetic/agents/openai.yaml`

## Validation

- branch starts from current `main` (`cacdef6ead5925f9650877b62d3ddf1f4b45b706`)
- branch is not behind `main`
- diff is limited to the eleven paths above
- new `$noetic-effects/SKILL.md` is 281 lines, below Tune's 500-line package guidance
- every reference linked from the new skill exists on the branch
- all three changed or added `agents/openai.yaml` files parse successfully
- `allow_implicit_invocation` is false for both `$noetic-effects` and `$metanoetic`; `AGENTS.md` owns the selective implicit route
- the canonical Metanoetic invocation text is unchanged
- existing Tune behavior is preserved with additive Noetic compilation integration
- no implementation, architecture-selection, review, mutation, verification, publication, or closure authority moved into `$noetic-effects`

The repository-local validator was not run in this connector-only workflow.

## Evidence posture

This design follows the observed distinction between doctrine presence and doctrine influence: vocabulary alone is not proof, while doctrine operationalized into procedures, gates, route decisions, and object-level artifacts can change implementation behavior. The skill therefore measures success through frame, candidate, construction, deletion, action, or proof deltas—not word presence or invocation declarations.

<!-- ship-proof:start -->
## Summary
- Add the typed, read-only `$noetic-effects` selector/compiler and integrate it with root dispatch, Tune, and Metanoetic routing; keep `$metanoetic` implicitly invocable.

## Proof
- `git diff --check origin/main...HEAD`: pass
- Ruby YAML parse for three changed `agents/openai.yaml` files: pass
- Ruby frontmatter parse for changed skill files: pass
- Noetic reference-existence and implicit-routing static checks: pass
- `$metanoetic` metadata preserves `allow_implicit_invocation: true`: pass
- Repository test harness: not-run; none is present for this documentation/skill package and GitHub requires no checks.

## Scope
- repository: `tkersey/dotfiles`
- branch: `agent/noetic-effects-microkernel`
- head: `f5b792e6c3c4f352e3c9c5735e44244ceafe078d`
- base: `main`
- base SHA: `cacdef6ead5925f9650877b62d3ddf1f4b45b706`

## Risks
- The change is instruction-only; behavior depends on future skill invocation. No automated behavioral harness exists in this repository.

## Follow-ups
- None.

## Readiness
- Operation: update
- Final state: preserve
- SHIP-v1 compatibility mode: update-existing
- Reason: preserve ready state after the exact-head metadata correction and static validation.
- Caveats: no repository test harness exists for this package.
<!-- ship-proof:end -->
