### PR TITLE
elenctic: draft inline review comments for every real blocker

### DIFF
--- a/codex/skills/elenctic/SKILL.md
+++ b/codex/skills/elenctic/SKILL.md
@@ -209,7 +209,7 @@ complete; never present missing lens instructions or stale evidence as clean.
 
 ## End with the decision
 
-Boil the adjudicated report down to one short bottom line at the very end:
+Boil the adjudicated report down to a concise final decision at the very end:
 what actually must be satisfied before this change should merge? This is
 synthesis of the same evidence, not another review, a fourth finding category,
 or permission to discard inconvenient blockers. Keep the findings and verdict
@@ -218,9 +218,37 @@ authorized exception.
 
 | Verdict | Decision rule |
 |---|---|
-| **BLOCKED — Real blockers:** | At least one supported merge blocker remains, even if other paths are incomplete. Summarize every distinct unsatisfied merge obligation, why it blocks, and the minimum evidence or outcome needed to clear it; refer to findings instead of restating the report. |
+| **BLOCKED — Real blockers:** | At least one supported merge blocker remains, even if other paths are incomplete. List every distinct unsatisfied merge obligation using the numbered format below, with why it blocks and the minimum evidence or outcome needed to clear it; refer to findings instead of restating the report. |
 | **APPROVE — No real blockers in the reviewed scope.** | The selected review is complete, no supported merge blocker remains, and no material evidence gap prevents the decision. Approval may coexist with nonblocking risks or concerns; briefly say why they do not block. Do not demand optional improvements or invent risk-acceptance gates. |
 | **INCOMPLETE — Approval withheld.** | No supported blocker is established, but missing/stale evidence, required lens coverage, relevant integration coverage, or an unreviewed/no-delta target prevents a decision. Name the specific missing evidence; do not invent a defect. |
+
+For **BLOCKED**, give a numbered list with one entry per distinct real merge
+blocker, ordered by severity. Each entry names the blocker, references its
+finding, and contains the proposed inline review comment separately from its
+location metadata:
+
+```markdown
+1. **<Blocker title>** — `<path>:<line or range>` (<diff side/view>; <finding>)
+
+   **Proposed inline review comment:**
+   > <Subject> should <minimum required outcome>, because <failure or unmet obligation and its impact>.
+```
+
+Write each comment to this instruction: **"Be succinct, suggestive, provide the
+why and use should not could."** Prefer one or two sentences. Direct the
+suggestion at the code or required verification, use "should" rather than
+"could", and explain the evidence-backed mechanism or unmet obligation and why
+it matters. Recommend the required outcome, not a speculative patch or
+successor architecture; do not overstate evidence to make the comment firmer.
+
+Verify proposed locations against the reviewed diff, including the base side
+for deletions. For a propagated blocker, use a relevant causal anchor and name
+the affected dependent in the comment. If no valid inline location is available,
+retain the blocker and draft text, mark **inline location unavailable**, and
+cite the actual evidence location rather than inventing an anchor. Drafts are
+for human approval only; do not post comments or submit a review. Include every
+real blocker once; do not promote risks, concerns, or evidence gaps to fill the
+list. For APPROVE or INCOMPLETE, omit the blocker list and proposed comments.
 
 Approval covers only the selected change and traced consequences in the
 identified candidate view, not the whole PR or unverified merge integration.


### PR DESCRIPTION
## Summary

Follow up on merged #245: make Elenctic's final **BLOCKED — Real blockers** decision a numbered list with one entry per distinct real merge blocker, ordered by severity. Each entry identifies the blocker, its supporting finding, the proposed inline location, and a separately quoted, copy-ready review comment.

Comments follow the requested instruction:

> Be succinct, suggestive, provide the why and use should not could.

Prefer one or two sentences. Recommend the minimum required outcome or verification using **should**, explain the evidence-backed failure or unmet obligation and its consequence, and avoid speculative patches or successor architectures.

## Output shape

```markdown
BLOCKED — Real blockers:

1. **<Blocker title>** — `<path>:<line or range>` (<diff side/view>; <finding>)

   **Proposed inline review comment:**
   > <Subject> should <minimum required outcome>, because <failure or unmet obligation and its impact>.
```

## Boundaries

- Every real blocker appears once. Nonblocking risks, concerns, and decision-limiting evidence gaps are not promoted just to populate the list.
- Verify locations against the reviewed diff, including the base side for deletions. Propagated blockers retain a relevant causal anchor and name the affected dependent in the comment.
- When no valid inline location is available, retain the blocker and draft text, explicitly mark **inline location unavailable**, and cite the actual evidence rather than invent an anchor.
- Comments remain proposals for human approval. Elenctic does not post comments or submit a GitHub review.
- APPROVE and INCOMPLETE retain their existing decision rules and do not generate a blocker list or proposed blocker comments.

## Scope

Only `codex/skills/elenctic/SKILL.md` changes: **30 additions, 2 deletions**, all within **End with the decision**. All preceding instructions, frontmatter, `agents/openai.yaml`, auxiliary lenses, Actuating, and `AGENTS.md` remain unchanged. No new runtime, workflow, or test framework is introduced.

## Validation

- Reconstructed local source bytes were checked against the GitHub blob identities before editing.
- **16 executed static checks passed**, covering YAML frontmatter, unchanged explicit-only invocation metadata, preservation of the earlier instructions and APPROVE/INCOMPLETE rules, numbered output structure, the exact requested style instruction, draft-only behavior, missing-anchor handling, Markdown fences, UTF-8, and final newlines/whitespace.
- `git diff --check` passed in an isolated local Git fixture with the fetched source blobs as its baseline.
- Inspected the local and GitHub-generated diffs; only the intended file and final-decision section changed.
- The published content blob `789cbce3253fb7ba6612d5f3f8b178e824794f65` exactly matches the locally validated candidate.
- Rechecked `main` at `bc8ff674e2aee515b1b597c66b8b9b788b799758` before opening this PR.

These checks validate the instruction edit and its packaging; a live Codex review/model-efficacy evaluation was **not run**.

<!-- ship-proof:start -->
## Summary
- Require Elenctic BLOCKED decisions to enumerate every distinct real blocker and provide a separately quoted, location-checked inline review-comment draft.

## Proof
- `git diff --check bc8ff674e2aee515b1b597c66b8b9b788b799758..f9a8216de95b7f981b44d5994bbb2232ab992438`: pass
- Scope and content inspection of `codex/skills/elenctic/SKILL.md`: pass
- Remote head/ref and published blob identity readback: pass
- Live model-efficacy evaluation: not-run

## Scope
- repository: tkersey/dotfiles
- branch: codex/elenctic-inline-blocker-comments
- head: f9a8216de95b7f981b44d5994bbb2232ab992438
- base: main
- base SHA: bc8ff674e2aee515b1b597c66b8b9b788b799758

## Risks
- The instruction shape is statically verified; live model-efficacy was not evaluated.

## Follow-ups
- None.

## Readiness
- Operation: update-and-promote
- Final state: ready
- SHIP-v1 compatibility mode: promote-draft
- Reason: The exact published head is complete and its relevant static validation passes.
- Caveats: Live model-efficacy evaluation was not run.
<!-- ship-proof:end -->