### PR TITLE
elenctic: require blockers to survive falsification

### DIFF
--- a/codex/skills/elenctic/SKILL.md
+++ b/codex/skills/elenctic/SKILL.md
@@ -175,6 +175,59 @@ merge obligation where the governing contract permits it; never invent a
 waiver. State the minimum clarification, validation, or obligation needed,
 without choosing a repair, invoking another reviewer, or opening a new workflow.
 
+## Falsify provisional blockers
+
+Before reporting findings, drafting inline comments, or selecting the final
+verdict, treat every provisional merge blocker as a claim to falsify. Reread the
+exact base and candidate evidence, affected paths, governing authority, and
+verification results without relying on the narrative that produced the
+finding. Use a fresh-eyes stance over the blocker claim inside this investigation;
+do not invoke `$fresh-eyes`, spawn another reviewer, or reopen a whole-target
+review. This is a mandatory adjudication cut, not another review lane.
+
+For each provisional blocker, construct the strongest evidence-backed case that
+it should not block merge. Determine whether:
+
+- the selected change actually introduces, newly exposes, or materially worsens
+  the violation; for a verification blocker, the requirement applies to this
+  change and remains unsatisfied;
+- the cited requirement, invariant, compatibility obligation, or merge
+  condition is accepted, applicable, and mandatory before merge;
+- the triggering path is supported and reachable, or the exact mandatory
+  evidence is identified and genuinely absent;
+- caller obligations, existing defenses, companion changes, mitigations, base
+  behavior, or an applicable authorized exception defeat or narrow the claim;
+- the required outcome is truly a merge prerequisite rather than an optional
+  strengthening, preference, legitimate follow-up, or speculative redesign.
+
+Inspect readily available evidence that could exonerate or narrow the finding.
+Do not retain a blocker merely because it is severe, plausible, confidently
+worded, or expensive to dismiss. Do not demand impossible universal proof; test
+the blocker against the strongest concrete counter-case supported by the bound
+candidate and accepted authority.
+
+Assign each provisional blocker exactly one result:
+
+- **Retained merge blocker:** delta causality, mandatory authority, concrete
+  basis, and merge necessity survive the strongest counter-case.
+- **Reclassified risk:** a credible conditional mechanism remains, but an
+  unresolved premise prevents establishing a material mandatory violation.
+- **Reclassified concern:** a grounded nonblocking observation remains without
+  an established material failure path or unmet merge condition.
+- **Rejected:** the claim is false, refuted, unrelated, preference-only, already
+  satisfied, or pre-existing without a new exposure, material worsening, or
+  contract violation caused by this delta.
+- **Incomplete:** evidence needed to decide the blocker claim is missing or
+  stale; name the gap instead of preserving or inventing a blocker.
+
+Run this cut once per provisional blocker. Do not recursively reconsider an
+unchanged result. A newly discovered issue must pass the ordinary investigation,
+adjudication, and this cut if provisionally blocking; do not generate a
+replacement finding merely because another blocker was rejected. Move
+reclassified findings to their resulting report group, omit rejected claims,
+and carry decision-limiting gaps into coverage. After this cut, only retained
+merge blockers are real blockers.
+
 ## Return one report
 
 Group findings as **Merge blockers**, **Risks**, then **Concerns**, ordered by
@@ -213,26 +266,34 @@ Boil the adjudicated report down to a concise final decision at the very end:
 what actually must be satisfied before this change should merge? This is
 synthesis of the same evidence, not another review, a fourth finding category,
 or permission to discard inconvenient blockers. Keep the findings and verdict
-consistent; resolve or reclassify a blocker only with evidence or an applicable
-authorized exception.
+consistent; resolve or reclassify a blocker only through the falsification cut,
+new evidence, or an applicable authorized exception.
 
 | Verdict | Decision rule |
 |---|---|
-| **BLOCKED — Real blockers:** | At least one supported merge blocker remains, even if other paths are incomplete. List every distinct unsatisfied merge obligation using the numbered format below, with why it blocks and the minimum evidence or outcome needed to clear it; refer to findings instead of restating the report. |
+| **BLOCKED — Real blockers:** | At least one retained merge blocker remains after falsification, even if other paths are incomplete. List every distinct unsatisfied merge obligation using the numbered format below, with why it survived the strongest counter-case and the minimum evidence or outcome needed to clear it; refer to findings instead of restating the report. |
 | **APPROVE — No real blockers in the reviewed scope.** | The selected review is complete, no supported merge blocker remains, and no material evidence gap prevents the decision. Approval may coexist with nonblocking risks or concerns; briefly say why they do not block. Do not demand optional improvements or invent risk-acceptance gates. |
 | **INCOMPLETE — Approval withheld.** | No supported blocker is established, but missing/stale evidence, required lens coverage, relevant integration coverage, or an unreviewed/no-delta target prevents a decision. Name the specific missing evidence; do not invent a defect. |
 
 For **BLOCKED**, give a numbered list with one entry per distinct real merge
 blocker, ordered by severity. Each entry names the blocker, references its
-finding, and contains the proposed inline review comment separately from its
-location metadata:
+finding, states why it survived falsification, and contains the proposed inline
+review comment separately from its location metadata:
 
 ```markdown
 1. **<Blocker title>** — `<path>:<line or range>` (<diff side/view>; <finding>)
 
+   **Why this is a real blocker:** <How this delta introduces, newly exposes, or
+   materially worsens the violation; the mandatory authority; and why the
+   strongest relevant counter-case or defense does not defeat it.>
+
    **Proposed inline review comment:**
    > <Subject> should <minimum required outcome>, because <failure or unmet obligation and its impact>.
 ```
+
+The survival explanation must identify evidence, not merely restate confidence
+or severity. Draft the inline comment only after the blocker survives
+falsification.
 
 Write each comment to this instruction: **"Be succinct, suggestive, provide the
 why and use should not could."** Prefer one or two sentences. Direct the

--- a/codex/skills/elenctic/agents/openai.yaml
+++ b/codex/skills/elenctic/agents/openai.yaml
@@ -3,4 +3,4 @@ policy:
 interface:
   display_name: "elenctic"
   short_description: "Review one file's impact; give blockers or approval"
-  default_prompt: "Use $elenctic to review the selected file's changes and their consequences throughout the codebase in one read-only investigation. Adjudicate merge blockers, risks, and concerns, then end with the real blockers or an explicit scoped approval; withhold approval when material evidence is incomplete."
+  default_prompt: "Use $elenctic to review the selected file's changes and their consequences throughout the codebase in one read-only investigation. Adjudicate merge blockers, risks, and concerns, then falsify every provisional blocker against the exact change, governing authority, counterevidence, and existing defenses before ending with retained real blockers or an explicit scoped approval; withhold approval when material evidence is incomplete."


### PR DESCRIPTION
## Summary

Add a mandatory **blocker falsification cut** to `$elenctic` so a plausible finding does not reach the user as a real merge blocker merely because the first investigation framed it that way.

After provisional adjudication—and before findings are reported, inline comments are drafted, or the final verdict is selected—the agent must reread the underlying base/candidate evidence and make the strongest evidence-backed case that each provisional blocker **should not** block merge.

A real blocker is now the residue left after that explicit attempt to refute it.

## Blocker falsification cut

For every provisional merge blocker, Elenctic rechecks:

- **Delta attachment:** the selected change introduces, newly exposes, or materially worsens the violation; verification requirements must apply to this exact change and remain unsatisfied.
- **Merge authority:** the cited requirement, invariant, compatibility obligation, or merge condition is accepted, applicable, and mandatory before merge.
- **Concrete basis:** the triggering path is supported and reachable, or the exact mandatory evidence is identified and genuinely absent.
- **Defense survival:** caller obligations, existing defenses, companion changes, mitigations, base behavior, and applicable authorized exceptions do not defeat or narrow the claim.
- **Merge necessity:** the required outcome is genuinely a prerequisite rather than an optional strengthening, preference, legitimate follow-up, or speculative redesign.

The agent must inspect readily available exculpatory evidence and may not preserve a blocker merely because it is severe, plausible, confidently worded, or expensive to dismiss.

## Exact outcomes

Each provisional blocker receives exactly one result:

1. **Retained merge blocker** — delta causality, mandatory authority, concrete basis, and merge necessity survive the strongest counter-case.
2. **Reclassified risk** — a credible conditional mechanism remains, but an unresolved premise prevents establishing a material mandatory violation.
3. **Reclassified concern** — a grounded nonblocking observation remains.
4. **Rejected** — false, refuted, unrelated, already satisfied, preference-only, or pre-existing without a new exposure, worsening, or contract violation caused by this delta.
5. **Incomplete** — evidence needed to decide is missing or stale; the gap is reported instead of preserving or inventing a blocker.

The cut runs once per provisional blocker. It does not recursively reconsider unchanged results, launch a new whole-target review, or manufacture replacement findings when a blocker is rejected.

## Fresh-eyes stance, not another review lane

This intentionally does **not** invoke the standalone `$fresh-eyes` skill. Elenctic uses a fresh-eyes stance over the blocker claim inside the same investigation, preserving its existing one-agent, one-investigation architecture and avoiding a duplicate whole-target review.

## Real-blocker output

Only blockers retained by the falsification cut may appear under **BLOCKED — Real blockers**. Every listed blocker now includes:

```markdown
**Why this is a real blocker:** <How this delta introduces, newly exposes, or
materially worsens the violation; the mandatory authority; and why the
strongest relevant counter-case or defense does not defeat it.>
```

The explanation must identify evidence rather than restating confidence or severity. The proposed inline review comment is drafted only after the blocker survives falsification and retains the existing instruction:

> Be succinct, suggestive, provide the why and use should not could.

## Scope

Changed only:

```text
codex/skills/elenctic/SKILL.md
codex/skills/elenctic/agents/openai.yaml
```

The default prompt now explicitly primes blocker falsification. Explicit-only invocation, read-only behavior, auxiliary-lens fusion, scoped approval, incomplete verdicts, and draft-only inline comments remain unchanged.

## Validation

- Rechecked `main` at `2cb6744a41cf485af6b22f61773fcb387d310a82` immediately before opening the PR.
- GitHub comparison reports the branch is exactly two commits ahead and changes only the two Elenctic files: `SKILL.md` (+66/-5) and `agents/openai.yaml` (+1/-1).
- Inspected the published branch content to confirm the cut occurs after provisional adjudication and before reporting, comments, and verdict selection.
- Confirmed reclassified findings move to their resulting groups, rejected claims are omitted, incomplete evidence enters coverage, and only retained blockers feed the final blocker list.
- Confirmed the standalone `$fresh-eyes` skill is not invoked and the existing no-auxiliary/no-extra-review boundary remains intact.

These are instruction and repository-structure checks. A live Codex invocation/model-efficacy evaluation was **not run**.

<!-- ship-proof:start -->
## Summary
- Require every provisional Elenctic merge blocker to survive an explicit evidence-backed falsification cut before reporting.

## Proof
- Published branch/file-scope comparison: pass
- Instruction ordering and outcome routing inspection: pass
- Live Codex invocation/model-efficacy evaluation: not-run
- GitHub required checks: pass (repository policy reports none)

## Scope
- repository: tkersey/dotfiles
- branch: codex/elenctic-blocker-falsification-cut
- head: 2469cd3e5526266b64f1aab667893ca93871fea3
- base: main
- base SHA: 2cb6744a41cf485af6b22f61773fcb387d310a82

## Risks
- Model-efficacy behavior was not evaluated through a live Codex invocation.

## Follow-ups
- None required for this instruction-only change.

## Readiness
- Operation: update-and-promote
- Final state: ready
- SHIP-v1 compatibility mode: promote-draft
- Reason: The exact published head and scope are validated; the documented model-efficacy limitation is non-blocking.
- Caveats: Live model-efficacy evaluation was not run.
<!-- ship-proof:end -->