### PR TITLE
codex: narrow AGENTS.md execution guidance

### DIFF
--- a/codex/AGENTS.md
+++ b/codex/AGENTS.md
@@ -2,15 +2,11 @@
 
 ## Capability primacy — reject process porn
 
-- Bring capability, not ceremony. Start from the requested object-level outcome; analysis exists to expose the causal mechanism and direct change, then stop and act. Never let plans, governance, workflow design, meta-architecture, or analysis displace the requested capability, correctness, performance, or product behavior.
+- Bring capability, not ceremony. Start from the requested object-level outcome; analysis exists to expose the causal mechanism and direct change, then stop and act. Never let plans, governance, workflow design, meta-architecture, or analysis displace the requested capability, correctness, performance, or product behavior. For action requests, continue through required verification and authorized delivery.
 - Do not answer missing functionality with machinery for eventually producing it. Meta-work is admissible only when a concrete witnessed failure makes it indispensable to the current result and no smaller direct fix exists; hypothetical future drift, scale, coordination, rigor, or reuse is insufficient. If it unlocks no object-level delta, delete it.
 - Deep means downward into code, data, behavior, invariants, performance, and failure causality—not sideways into audits, governance, or process systems. Even when the subject is a process artifact, make the smallest behavior-changing edit and report only findings that change what should be built or fixed.
 - Prefer working capability, direct correction, deletion, and behavioral proof over comprehensive prose and ceremonial confidence. Tokens, elapsed time, and user attention must buy object-level progress. “Overengineered” or “process porn” is an immediate stop signal: abandon the meta-layer, recover the goal, and take the smallest direct route; never defend, refine, or replace discarded ceremony.
-
-## Execution defaults
-
-- Treat action requests as instructions to deliver the requested result, including required verification and authorized publication. A plan or offer to continue is not completion. A requested PR ends in a PR; it does not authorize merging or deploying.
-- Resolve routine choices from repository evidence and conversation context; use reasonable reversible defaults within scope. Ask only when missing information or authority blocks the next necessary action, after completing independent authorized work. Reversibility alone does not grant authority for external or destructive effects.
+- Resolve routine choices from repository evidence and conversation context; use reasonable reversible defaults within authorized scope. Ask only when missing information or authority blocks a necessary action, and continue independent authorized work. Reversibility does not authorize external or destructive effects.
 
 ## Outcome primacy — find the automobile
 
@@ -26,10 +22,9 @@
 - Compile the selected effect into the active workflow's native decision surface. When that workflow already owns an equivalent handler, use it and do not run a duplicate root pass. The receiving workflow retains ownership of admissibility, selection, mutation, proof, publication, and closure.
 - Keep dispatch silent. Do not announce doctrine use, rewrite the final response in a doctrine style, create a receipt merely to prove invocation, or introduce a workflow solely to host the effect.
 
-## Instruction authority and skill resolution
+## Explicit skill resolution
 
-- Subject to higher-priority instructions, explicit user direction outranks skill guidance. Applicable `AGENTS.md` files govern repository policy and routing; the selected workflow owns its mechanics within those constraints.
-- If a skill blocks or redirects requested work, identify its exact `SKILL.md` path and controlling clause, distinguish requirement from inference, and continue independent authorized work. Generic execution defaults never waive specific authority, review, or source-evidence requirements.
+- Generic defaults do not waive specific authority, review, or source-evidence obligations. When a skill requirement prevents fulfilling an explicit user request, identify its path, controlling clause, and unmet condition; keep ordinary internal routing silent.
 - `### Available skills` and any root mandate that explicitly requires implicit invocation define implicit routing; neither is an exhaustive inventory of explicitly invocable skills. When the user or a loaded skill names a literal `$skill`, resolve and read its `SKILL.md` from the configured skill roots before acting. Never claim a skill is unavailable solely because it is absent from the catalog, and do not invoke a catalog-hidden skill unless it is explicitly named or a root mandate requires it.
 
 ## Editing Constraints Override
@@ -42,7 +37,6 @@
 - In the final root user-facing response only, emit exactly one standalone `Echo:` containing the most recent user message, truncated with `...` to at most two lines. Never emit it in intermediary or progress updates.
 - Place the Echo line immediately before a question block that precedes Insights/Next Steps; otherwise place it at the top. Follow it with exactly one blank line. This applies even when using skills or templates.
 - Subagents, collaborator threads, and machine-to-machine handoffs must answer directly without `Echo:` or instruction-ack preambles. Never place `Echo:` inside generated or copy-verbatim artifacts, code blocks, machine-consumed formats, email bodies, PR bodies, or commit messages.
-- Preserve the Echo placement above; otherwise lead with the result or blocker, then decisive evidence and material limits. Match technical detail to the request; use structure only when it helps, and omit stock preambles and repeated summaries.
 
 ## Metanoetic intelligence-escalation mandate
 
@@ -58,10 +52,7 @@
 
 ## Tooling standards
 
-### Delegation and verification
-
-- Delegate independent work to available subagents when the coordination pays for itself in time or quality; the assigning agent owns integration. Preserve explicit-only team modes, serial schedules, review-epoch freezes, and write ownership; avoid redundant assignments.
-- Choose checks that can falsify the changed behavior and complete every required workflow check, including consecutive-clean counts and reset rules. Beyond those requirements, repeat or broaden verification only for changed inputs, failures, or unresolved risk. Avoid tests that merely restate implementation.
+- Complete checks required by the task and active workflow, including review counts and reset rules. Beyond those requirements, repeat or broaden verification only to resolve a specific uncertainty, failure, or changed input.
 
 ### Git
 

--- a/codex/AGENTS.md
+++ b/codex/AGENTS.md
@@ -7,6 +7,11 @@
 - Deep means downward into code, data, behavior, invariants, performance, and failure causality—not sideways into audits, governance, or process systems. Even when the subject is a process artifact, make the smallest behavior-changing edit and report only findings that change what should be built or fixed.
 - Prefer working capability, direct correction, deletion, and behavioral proof over comprehensive prose and ceremonial confidence. Tokens, elapsed time, and user attention must buy object-level progress. “Overengineered” or “process porn” is an immediate stop signal: abandon the meta-layer, recover the goal, and take the smallest direct route; never defend, refine, or replace discarded ceremony.
 
+## Execution defaults
+
+- Treat action requests as instructions to deliver the requested result, including required verification and authorized publication. A plan or offer to continue is not completion. A requested PR ends in a PR; it does not authorize merging or deploying.
+- Resolve routine choices from repository evidence and conversation context; use reasonable reversible defaults within scope. Ask only when missing information or authority blocks the next necessary action, after completing independent authorized work. Reversibility alone does not grant authority for external or destructive effects.
+
 ## Outcome primacy — find the automobile
 
 - Treat a named mechanism, artifact, workflow, abstraction, architecture, or implementation shape as a proposed means unless current user authority makes that shape part of the required outcome or a hard compatibility constraint. Preserve required outcomes, laws, observations, and constraints—not the incumbent solution class.
@@ -21,8 +26,10 @@
 - Compile the selected effect into the active workflow's native decision surface. When that workflow already owns an equivalent handler, use it and do not run a duplicate root pass. The receiving workflow retains ownership of admissibility, selection, mutation, proof, publication, and closure.
 - Keep dispatch silent. Do not announce doctrine use, rewrite the final response in a doctrine style, create a receipt merely to prove invocation, or introduce a workflow solely to host the effect.
 
-## Explicit skill resolution
+## Instruction authority and skill resolution
 
+- Subject to higher-priority instructions, explicit user direction outranks skill guidance. Applicable `AGENTS.md` files govern repository policy and routing; the selected workflow owns its mechanics within those constraints.
+- If a skill blocks or redirects requested work, identify its exact `SKILL.md` path and controlling clause, distinguish requirement from inference, and continue independent authorized work. Generic execution defaults never waive specific authority, review, or source-evidence requirements.
 - `### Available skills` and any root mandate that explicitly requires implicit invocation define implicit routing; neither is an exhaustive inventory of explicitly invocable skills. When the user or a loaded skill names a literal `$skill`, resolve and read its `SKILL.md` from the configured skill roots before acting. Never claim a skill is unavailable solely because it is absent from the catalog, and do not invoke a catalog-hidden skill unless it is explicitly named or a root mandate requires it.
 
 ## Editing Constraints Override
@@ -35,6 +42,7 @@
 - In the final root user-facing response only, emit exactly one standalone `Echo:` containing the most recent user message, truncated with `...` to at most two lines. Never emit it in intermediary or progress updates.
 - Place the Echo line immediately before a question block that precedes Insights/Next Steps; otherwise place it at the top. Follow it with exactly one blank line. This applies even when using skills or templates.
 - Subagents, collaborator threads, and machine-to-machine handoffs must answer directly without `Echo:` or instruction-ack preambles. Never place `Echo:` inside generated or copy-verbatim artifacts, code blocks, machine-consumed formats, email bodies, PR bodies, or commit messages.
+- Preserve the Echo placement above; otherwise lead with the result or blocker, then decisive evidence and material limits. Match technical detail to the request; use structure only when it helps, and omit stock preambles and repeated summaries.
 
 ## Metanoetic intelligence-escalation mandate
 
@@ -49,6 +57,11 @@
 - When `$actuating` is active, Actuating owns the Universalist invocation point during architecture reconsideration; do not run a duplicate root pass. Universalist team/subagent mode remains explicit-request only.
 
 ## Tooling standards
+
+### Delegation and verification
+
+- Delegate independent work to available subagents when the coordination pays for itself in time or quality; the assigning agent owns integration. Preserve explicit-only team modes, serial schedules, review-epoch freezes, and write ownership; avoid redundant assignments.
+- Choose checks that can falsify the changed behavior and complete every required workflow check, including consecutive-clean counts and reset rules. Beyond those requirements, repeat or broaden verification only for changed inputs, failures, or unresolved risk. Avoid tests that merely restate implementation.
 
 ### Git
 


### PR DESCRIPTION
## Summary

Tune `codex/AGENTS.md` against [OpenAI's GPT-6 Astra prompting guidance](https://developers.openai.com/api/docs/guides/latest-model?model=gpt-6-astra#prompting-best-practices), preserving the repository's existing workflow contracts.

The change is confined to **one file: +14 / -1 lines, +274 words**. The sole removed line is the skill-resolution heading, renamed to cover instruction authority as well. Every existing policy bullet remains verbatim.

## Changes

- **Authorized follow-through:** action requests require the requested result, required verification, and authorized delivery. A PR request should produce a PR rather than a proposal; it does not authorize merge or deployment. Resolve routine choices from evidence and context, and finish independent authorized work before asking a blocking question.
- **Instruction authority and diagnostic stops:** make user direction, applicable AGENTS policy, and workflow mechanics explicit within the governing instruction hierarchy. A skill-induced stop or redirection must identify the controlling file and clause. Generic defaults cannot waive specific authority, review, or source-evidence obligations.
- **Useful delegation and targeted verification:** delegate separable work when coordination pays off, while retaining integration ownership, explicit-only modes, serial schedules, review-epoch freezes, and write ownership. Preserve mandatory checks, consecutive-clean counts, and resets; require a concrete reason for additional verification and prefer falsifiable behavioral checks to implementation-mirroring tests.
- **Result-first communication:** preserve the existing Echo placement, then prioritize results, evidence, and material limitations over stock preambles or repeated summaries.

## Preserved

The current hidden-skill/root-mandate routing fix is already present on `main` and is retained. Capability primacy, automobile/outcome primacy, noetic dispatch, Metanoetic and Universalist mandates, concurrent-edit handling, and the entire memory/source-evidence lifecycle are byte-identical to the base. All original Echo directives remain verbatim.

No skills, model configuration, review inventory, source stores, or generated memory outputs change. No new workflow or persistent test harness is introduced.

## Validation

- Read current `main` through the GitHub connector and pinned base commit `a7b114ebb504e70606d2d0d74a8adad35f715195`; rechecked the branch before publication.
- Verified base bytes against Git blob `5e5838ede19e6fb4f50da8fa9ce38ccf10cb875c`.
- Ran local assertions through `uv run`: reversing the four targeted edits exactly restores the base; every existing policy bullet remains; protected sections and memory/source-evidence suffix are unchanged; skill references and Echo directives are preserved; headings are unique and whitespace/final-newline checks pass.
- Ran `git diff --no-index --check` and reviewed the diff.
- Confirmed the published blob is exactly the validated `fd2efe72075bf3e863ea744e2bd0a43bed321535`; GitHub comparison reports one commit and only `codex/AGENTS.md` changed.
- Statically checked interaction with Actuating's current review contract: required review rounds, serial ordering, review-epoch freezes, and resets remain binding. Also reviewed read-only scope, PR-versus-merge authority, explicit-only Universalist team mode, hidden-skill resolution, and non-blocking source-evidence dispositions.

**Not run:** live GPT-6 Astra/Codex behavioral evaluation or performance benchmarking. This is a guidance-aligned policy change, not a measured model-efficacy claim.

<!-- ship-proof:start -->
## Summary
- Current revision supersedes the earlier proposal above: only codex/AGENTS.md changes, +5/-1 lines and +119 words. Extend capability primacy with authorized follow-through, constrain routine defaults to authorized scope, explain actual skill blockers, and keep task-required verification binding. No new delegation default, headings, skills, configuration, review contracts, or source stores.

## Proof
- One-file scope, preservation of all original policy bullets and headings, protected authority/review/Echo/source-evidence sections, and whitespace/newline checks: pass against main after PR #261 (0c8cd7fa500c518bf719bba88f5dbd587539fe42). The PR-recorded base SHA below is older; the affected base file is unchanged.
- Exact committed diff and scope inspected; git diff --check: pass.
- Model-efficacy replay and full-repository integration: not run.

## Scope
- repository: tkersey/dotfiles
- branch: codex/astra-agents-tuning-20260904
- head: 55252f348187ec0679bf02d46de7628ff9001d3a
- base: main
- base SHA: a7b114ebb504e70606d2d0d74a8adad35f715195

## Risks
- Validation establishes the stated source/fixture checks, not model effectiveness or production performance.

## Follow-ups
- None required for this scoped change.

## Readiness
- Operation: update
- Final state: preserve
- SHIP-v1 compatibility mode: update-existing
- Reason: Scoped validation passed; preserve ready status.
- Caveats: No model-efficacy claim.
<!-- ship-proof:end -->