### PR TITLE
codex: harden Actuating composition without changing review policy

### DIFF
--- a/codex/skills/actuating/SKILL.md
+++ b/codex/skills/actuating/SKILL.md
@@ -101,8 +101,13 @@ underdetermined   seek authority; no correctness mutation from the claim
 Only current accepted witnesses authorize counterexample response. Duplicate
 observations add provenance, not independent failures. Historical absence cannot
 prove first occurrence, disjointness, or elimination under an incomplete horizon.
-Review Fold captures newly accepted independent witnesses; Actuating neither
-copies the corpus nor persists its current interpretation.
+Review Fold captures newly accepted independent witnesses only with enclosing
+corpus-write authority. Pass `corpus_write_authorized` on every handoff: true when
+that effect is authorized; `corpus_write_authorized: false` for `analyze` or absent
+authority. Read-only analysis may project and adjudicate available evidence but
+never writes repository/source-memory stores or provisions tools for capture.
+Other routes inherit their actual effect scope; supporting skills cannot expand it.
+Actuating neither copies the corpus nor persists its current interpretation.
 
 A rejected strengthening must not enter code to placate a reviewer or protect a
 clean streak. Reopen authority or remove it. Correcting an unsupported public
@@ -162,7 +167,9 @@ when the Goal or evidence makes a boundary a live semantic decision. Do not wait
 for a pre-mutation theorem-identity certificate to reconsider the mechanism.
 
 1. Bind the incumbent-independent premise basis with `$first-principles` and
-   the cumulative Review Fold. Preserve source-fixed boundaries.
+   the cumulative Review Fold. Reuse adequate derivations and re-examine only
+   premises material to this decision. Source-fixed outcomes remain chosen
+   objectives even when not derivable from technical premises. Preserve them.
 2. When the existing Metanoetic trigger fires, read both skills and apply `$glaze`
    then `$metanoetic` verbatim in the same bounded challenger pass, before
    `$universalist`. Run once per unchanged decision surface; reuse an already
@@ -179,9 +186,11 @@ for a pre-mutation theorem-identity certificate to reconsider the mechanism.
    remains legitimate. Add no separate Glaze report or adjudication stage.
 3. Give `$universalist` one independently governed axis, one typed hole, and
    the strongest source-derived domain evidence for the seam. Require `candidate`,
-   `preserve-incumbent`, or `obstructed` with a code-bound construction argument,
+   `preserve-incumbent`, `unresolved`, or `obstructed` with a code-bound argument,
    not a second description of the Working Set. Split independent seams and prove
-   their composition. Universalist nominates; Actuating selects and proves.
+   their composition. `unresolved` preserves missing evidence or incomparability;
+   it is not a new mode, obstruction proof, or permission to pick arbitrarily.
+   Universalist nominates; Actuating selects and proves.
 4. Choose the exact-head verifier before implementation. Compile the nomination's
    actual admission, transition, coverage, preservation, migration, and residual
    obligations into the existing work. Native evidence may discharge them directly;

--- a/codex/skills/actuating/references/architecture-reconciliation.md
+++ b/codex/skills/actuating/references/architecture-reconciliation.md
@@ -48,7 +48,7 @@ of a previously proposed restoration label.
 
 Give Universalist one live independently governed axis, one typed hole, the
 Goal's construction obligation or source-supported loss of guarantee, required
-observations, and available source-domain evidence. Require `candidate`, `preserve-incumbent`, or `obstructed`
+observations, and available source-domain evidence. Require `candidate`, `preserve-incumbent`, `unresolved`, or `obstructed`
 with the proposed construction or reason to preserve the owner, its discriminator,
 preservation obligations, and material migration or residual consequences. This replaces a duplicate
 Working Set projection, not its semantic obligations. Split independent seams
@@ -82,8 +82,10 @@ changed boundary.
 
 A sanctioned path omitted from either coverage basis revokes that claim
 immediately. An exact same-claim successor finding reopens the causal explanation; do not append named-member
-guards or reset recurrence through a new label. Preserve material incomparability
-and return a bounded obstruction when evidence cannot choose an adequate candidate.
+guards or reset recurrence through a new label. Missing evidence or incomparable
+adequate candidates return `unresolved`, not an invented winner or obstruction.
+Actuating decides the smallest authorized discriminator and blocks only dependent
+work. Reserve `obstructed` for an evidenced obstruction.
 
 Git and executed verifiers own the result. Actuating retains only the current
 Working Set: Goal/head, causal basis/discriminator, selected mechanism, source-domain

--- a/codex/skills/actuating/references/closure.md
+++ b/codex/skills/actuating/references/closure.md
@@ -34,37 +34,18 @@ Correcting unsupported prose does not waive a required behavior.
 
 ## Construction adequacy
 
-Use the same proof obligations for local corrections and redesigned constructions:
+Apply the [common proof obligations](../SKILL.md#realization-and-common-proof-obligations)
+and their [construction argument](counterexample-guided-normalization.md) to the
+actual exact head. Those obligations govern local corrections and redesigned
+constructions alike; closure consumes their evidence rather than restating or
+weakening them. In particular, coverage is not transition preservation, sampled
+success is not universal proof, and an independent oracle is not redundant merely
+because it checks the producer's law.
 
-```text
-applicable current and retained witnesses addressed
-source-supported causal explanation and declared invalid-family domain
-required-valid behavior, observations, progress, and compatibility preserved
-preselected sibling/domain discriminator executed with its real evidence strength
-actual admission, permitted-transition preservation, and closure of sanctioned escapes
-all relevant sanctioned paths and bypasses accounted for
-proof authority and public claims bound to exact inputs and execution
-redundant primary compensation retired or justified by distinct obligations
-complete Goal-required proof inventory on the exact candidate
-```
-
-A restoration label, theorem digest, plan, green sample, or review streak cannot
-substitute for those observations. Do not classify several independent obligations
-as local merely because they share a commit or a broad causal theme.
-
-For a changed boundary, verify every applicable construction obligation using
-[counterexample-guided-normalization.md](counterexample-guided-normalization.md).
-Adequate native admission/operation evidence needs no duplicate topology report;
-explicit topology remains necessary where route or migration coverage needs it.
-Cut coverage does not establish preservation after admission. The source domain
-must not come solely from the candidate's asserted list, and a residual admitting
-the family precludes complete elimination under either proof representation.
-
-A complete domain requires an adequate construction/preservation proof or finite
-exhaustion. Generated samples and sibling probes alone remain bounded evidence.
-If proof is weaker, state the scope and residuals honestly; do not silently narrow
-accepted requirements. No independent oracle may be deleted merely for checking
-the same law as a constructor.
+Reuse current verifier evidence; an invalidated subject, assumption, domain, or
+claim requires the affected proof again. No route label, review streak, nomination,
+or digest substitutes for that evidence. Independent obligations retain their
+own authority even when one successor realizes them.
 
 ## Reviewability and completion
 

--- a/codex/skills/actuating/references/review-contract.json
+++ b/codex/skills/actuating/references/review-contract.json
@@ -243,6 +243,7 @@
     "allowed_nomination_results": [
       "candidate",
       "preserve-incumbent",
+      "unresolved",
       "obstructed"
     ],
     "independently_governed_axes_require_split": true,

--- a/codex/skills/actuating/tests/test-composition-contract.sh
+++ b/codex/skills/actuating/tests/test-composition-contract.sh
@@ -1,0 +1,86 @@
+#!/bin/sh
+set -eu
+skill_root=$(CDPATH='' cd -- "$(dirname -- "$0")/.." && pwd)
+node --input-type=module - "$skill_root" <<'JS'
+import assert from 'node:assert/strict';
+import {createHash} from 'node:crypto';
+import {readFileSync} from 'node:fs';
+import {resolve} from 'node:path';
+const root = process.argv[2];
+const text = path => readFileSync(resolve(root,path),'utf8');
+const section = (s, heading) => {
+  assert(s.includes(`## ${heading}\n`), `missing section: ${heading}`);
+  return s.split(`## ${heading}\n`)[1].split('\n## ')[0];
+};
+const sha256 = s => createHash('sha256').update(s).digest('hex');
+const canonical = v => Array.isArray(v) ? v.map(canonical) : v && typeof v === 'object'
+  ? Object.fromEntries(Object.keys(v).sort().map(k => [k,canonical(v[k])])) : v;
+const policy = JSON.parse(text('references/review-contract.json'));
+// Protect the accepted review process, not just one count or flag. These
+// identities are pinned to the audited policy at a6499e818910; intentional
+// policy changes must explicitly update these regression expectations.
+const reviewKeys = ["required_lenses", "review_scheduling", "candidate_lifecycle", "review_epoch", "review_entry", "evidence_acquisition", "standard_convergence", "material_change", "transport_recovery", "attempt_quality"];
+assert.equal(sha256(JSON.stringify(canonical(Object.fromEntries(reviewKeys.map(k => [k,policy[k]]))))),
+  '7a45af557a2c21095e49146d8458990fa3b0ecc87c59f11f2b65a653a2104545', 'review process changed');
+const skill = text('SKILL.md');
+const protectedSections = {
+  "Public routes": "8e2aec586fe33dfc69d573c15a9fdc425547bf8bdf8c4952e5f0fbdd8fb6c222",
+  "Review-epoch immutability and evidence acquisition": "1db48d44444f7f346820393de4305a42da9da7e3f4a2ea1acce4563a3867aed4",
+  "Review and closure": "9e9bf083b07812cb0cb2675d223bc94554fb51cfeecc1f1b7b3ff9edd0752225",
+  "Realization and common proof obligations": "df2f70beac4ca71c55ca4e4bc8c6f63c23453aafe8ef7406102832f658055ad8"
+};
+for (const [name, digest] of Object.entries(protectedSections))
+  assert.equal(sha256(section(skill,name)),digest,`protected Actuating section: ${name}`);
+const lensBlobs = {
+  'soundness-review.md':'58949402e604ee35a2454e64e98532a82825cde4',
+  'footgun-review.md':'00d80db3e5f94cc5365594c059c65ec27b737db4',
+  'invariant-review.md':'275cc488e082c493463c846ed47ec211ea3565d9',
+  'complexity-review.md':'d92f5244415343c9b6bb27c10f09cf991f74bf69',
+  'fresh-eyes-review.md':'e927acc958eae56c5ef5f7a0e42697162a114e71'
+};
+for (const [name, digest] of Object.entries(lensBlobs)) {
+  const bytes = Buffer.from(text(`references/lenses/${name}`));
+  assert.equal(createHash('sha1').update(`blob ${bytes.length}\0`).update(bytes).digest('hex'),
+    digest,`review instruction bytes changed: ${name}`);
+}
+// Source-contract checks below validate the declared handoffs. They do not
+// simulate an agent, execute Ledger/CAS, or prove model effectiveness.
+const nominationResults = ['candidate','preserve-incumbent','unresolved','obstructed'];
+assert.deepEqual(policy.universalist_compilation.allowed_nomination_results,nominationResults);
+for (const path of ['SKILL.md','references/architecture-reconciliation.md',
+  '../universalist/SKILL.md','../universalist/README.md']) {
+  const source = text(path);
+  for (const result of nominationResults) assert(source.includes(result),`${path}: missing ${result}`);
+}
+const universalist = section(text('../universalist/SKILL.md'),'Actuating composition');
+assert.match(universalist,/Return `unresolved` when evidence is missing or adequate candidates remain\s+incomparable/);
+assert.match(universalist,/not a new route or mode/);
+const fold = text('../review-fold/SKILL.md');
+const corpus = text('../review-fold/references/counterexample-corpus.md');
+assert.match(fold,/corpus_write_authorized: true \| false # enclosing task; omitted means false/);
+assert.match(section(fold,'Effect authority'),/always false in\s+Actuating `analyze`/);
+assert.match(section(fold,'Procedure'),/When `corpus_write_authorized` is true, capture/);
+assert.match(section(corpus,'Capture after folding'),/corpus_write_authorized = true/);
+assert.match(section(corpus,'Effect authority'),/not `ledger transact`/);
+assert.match(skill,/corpus_write_authorized: false/);
+for (const name of ['challenged_judgment','earliest_failed_premise','claim_strength_consequence'])
+  assert(fold.includes(name),`lost judgment-challenge field: ${name}`);
+assert.match(fold,/Missing proof alone is not evidence that the behavior is false/);
+assert.match(fold,/never rewrites\s+an owner-issued `findings` verdict into `clean`/);
+const visibility = text('../cas/references/review-proof-boundary.md');
+assert.match(visibility,/does not deliver the hashed context or prove that a reviewer saw it/);
+assert.match(visibility,/parent-only conversation premises are not implicitly inherited/);
+assert.match(visibility,/adds no context packet, prompt argument, review gate, attempt/);
+for (const [name,lens] of Object.entries({
+  'invariant-ace':'invariant','footgun-finder':'footgun','complexity-mitigator':'complexity'
+})) {
+  const composition = section(text(`../${name}/SKILL.md`),'Actuating composition');
+  assert(composition.includes(`../actuating/references/lenses/${lens}-review.md`),name);
+  assert.match(composition,/takes precedence over/,name);
+  assert.match(composition,/unchanged/,name);
+}
+assert.match(section(text('../invariant-ace/SKILL.md'),'Actuating composition'),/Do not launch authority fanout/);
+assert(!text('../complexity-mitigator/SKILL.md').includes('complexity_evidence:'), 'duplicate composition table');
+assert.match(text('references/closure.md'),/\.\.\/SKILL\.md#realization-and-common-proof-obligations/);
+console.log('actuating: composition source contracts, unchanged modes, review policy, proof bar, and exact lens bytes passed');
+JS

--- a/codex/skills/actuating/tests/test-construction-cycle-scenarios.sh
+++ b/codex/skills/actuating/tests/test-construction-cycle-scenarios.sh
@@ -48,7 +48,13 @@ function observe(i) {
   const folded = last.every(r => i.folded.includes(r.id));
   const sourcesFolded = i.sources.every(s => s.status !== 'unfolded');
   const completionSources = i.sources.every(s => !s.required || ['folded', 'non-current'].includes(s.status));
-  const cleanStandards = invalidated ? 0 : last.filter(r => r.lens === 'standard' && r.verdict === 'clean').length;
+  // Adjudication cannot turn a non-clean owner verdict into clean credit.
+  // Verdictless transport attempts are not semantic outcomes; recovery stays
+  // in the existing barrier. Count the ordered semantic suffix, not totals.
+  let cleanStandards = 0;
+  for (const r of i.receipts) if (r.lens === 'standard' && semantic(r))
+    cleanStandards = r.verdict === 'clean' ? cleanStandards + 1 : 0;
+  if (invalidated) cleanStandards = 0;
   const converged = barrier && !invalidated && folded && sourcesFolded &&
     cleanStandards >= policy.standard_convergence.required_consecutive_clean_attempts;
   const cutClosed = invalidated && barrier && folded && sourcesFolded;
@@ -87,6 +93,38 @@ const recovered = {...cleanInput, receipts:cleanInput.receipts.flatMap(r =>
   r.lens === 'fresh-eyes' ? [fixture.receipt_catalog.r13, fixture.receipt_catalog.r14] : [r])};
 assert.deepEqual(observe(recovered), {mutable:false, epoch_open:true, complete:false, may_dispatch:false});
 assert.equal(observe({...recovered, folded:[...recovered.folded, fixture.receipt_catalog.r14.id]}).complete, true);
+
+// A rejected strengthening breaks the native clean suffix without becoming
+// mutation authority. These traces previously completed on five TOTAL cleans.
+const initial = cleanInput.receipts.filter(r => r.phase === 'initial');
+const confirmation = (n, verdict = 'clean', authority = 'strengthening') => ({
+  id:`suffix-${n}`, slot:`suffix-${n}`, phase:'confirmation', lens:'standard',
+  head:cleanInput.head, verdict,
+  ...(verdict === 'findings' ? {findings:[{authority, applicability:'current'}]} : {})
+});
+const evaluate = receipts => observe({...cleanInput, receipts, folded:receipts.map(r => r.id)});
+for (const authority of ['strengthening','preference']) {
+  const prefix = [...initial, confirmation(1), confirmation(2,'findings',authority)];
+  for (let count = 0; count <= 5; count++) {
+    const receipts = [...prefix, ...Array.from({length:count}, (_,n) => confirmation(n+3))];
+    assert.deepEqual(evaluate(receipts),
+      {mutable:count === 5, epoch_open:count !== 5, complete:count === 5, may_dispatch:false},
+      `${authority}: suffix ${count}, not cumulative clean count`);
+  }
+}
+// An auxiliary non-liability does not interrupt the standard-only suffix.
+const auxiliaryFinding = cleanInput.receipts.map(r => r.lens === 'footgun-finder'
+  ? {...r, verdict:'findings', findings:[{authority:'preference', applicability:'current'}]} : r);
+assert.equal(evaluate(auxiliaryFinding).complete, true);
+// A verdictless final confirmation remains pending, then its one fresh semantic
+// recovery can complete the existing suffix; it supplies no extra clean itself.
+const pending = [...initial, ...[1,2,3].map(n => confirmation(n)), confirmation(4,'verdictless')];
+assert.equal(evaluate(pending).complete, false);
+assert.equal(evaluate([...pending, {...confirmation(4), id:'suffix-4-recovery'}]).complete, true);
+// A material finding invalidates all credit and forbids more confirmations.
+const materialCut = [...initial, confirmation(1,'findings','entailed')];
+assert.deepEqual(evaluate(materialCut), {mutable:true, epoch_open:false, complete:false, may_dispatch:false});
+assert.throws(() => evaluate([...materialCut, confirmation(2)]), /confirmation after material finding/);
 
 // Executable finite discriminator: a guard for the observed enum case misses
 // a sum/product sibling. An independent inhabitant enumerator also prevents the
@@ -204,3 +242,4 @@ assert.throws(() => verifyDelta(before, {...correction, streaming:'new-requireme
 verifyDelta(before, {...correction, streaming:'new-requirement'}, new Set(['evidenceSource','streaming']));
 console.log(`actuating: ${fixture.scenarios.length} receipt scenarios and finite family/path/preservation/authority discriminators passed`);
 JS
+sh "$skill_root/tests/test-composition-contract.sh"

--- a/codex/skills/cas/references/review-proof-boundary.md
+++ b/codex/skills/cas/references/review-proof-boundary.md
@@ -70,7 +70,18 @@ The workflow binding remains opaque:
 }
 ```
 
-CAS echoes it and does not infer Actuating policy.
+CAS echoes it and does not infer Actuating policy. The echo binds identity;
+it does not deliver the hashed context or prove that a reviewer saw it.
+
+Repository sources and references accessible through the existing review backend
+are evidence; parent-only conversation premises are not implicitly inherited.
+For a premise-dependent judgment, distinguish an accessible accepted source from
+an opaque digest or an unresolved reference. The same diff under different
+compatibility contracts cannot be distinguished by digest alone. Preserve any
+material access limitation in the caller's existing evidence horizon, without
+rewriting the owner verdict or asserting review of an undisclosed premise.
+This clarification adds no context packet, prompt argument, review gate, attempt,
+or retry. Native standard and exact auxiliary instruction bytes remain unchanged.
 
 ## Receipt interpretation
 

--- a/codex/skills/complexity-mitigator/SKILL.md
+++ b/codex/skills/complexity-mitigator/SKILL.md
@@ -52,38 +52,17 @@ Handoff instead:
 7. State the recomposition rule and smallest proof signal.
 8. Return a handoff; do not implement.
 
-## Review handoff
+## Actuating composition
 
-When selected as an Actuating review lens, return only current-head evidence:
-
-```yaml
-complexity_evidence:
-  bound_head:
-  owner_boundary:
-  governing_law:
-  participating_abstractions:
-    - abstraction:
-      live_obligation:
-      status: retain | retire | collapse | delegate | replace | validate-first
-  dominated_factors: []
-  smallest_local_repair:
-  local_repair_adds_semantic_machinery: true | false
-  structural_pressure: []
-  proof_surface_before: []
-  proof_surface_after: []
-  falsifier:
-  evidence_refs: []
-```
-
-`$review-fold` may use this evidence while classifying the current review
-horizon. `$actuating` evaluates the fold against the incumbent architecture and
-its ephemeral Architecture Working Set. This lens never selects a repair,
-reopens architecture, grants mutation, or persists workflow state.
-
-If a local repair introduces a protocol, state, helper abstraction, repeated
-branch family, compatibility route, or wound-specific proof family, mark it as
-semantic growth. Actuating decides whether the incumbent remains closed under
-the obligation or architecture selection must reopen.
+Within Actuating, the checked-in [complexity review lens](../actuating/references/lenses/complexity-review.md)
+owns the lane's scope and return shape. Its focus is unnecessary correctness
+machinery and duplicate semantic ownership, not the full standalone comprehension
+preflight. Return the duplicated obligation, evidence, and implicated owner defect;
+distinguish legitimate derived guards. Do not select a repair, launch companion
+reviews, or emit a second preflight, evidence table, or proposed-repair agenda.
+Review Fold adjudicates and Actuating owns the construction decision. This section
+takes precedence over standalone workflow, routing, and output only within
+Actuating. Standalone behavior is unchanged.
 
 ## Output
 

--- a/codex/skills/footgun-finder/SKILL.md
+++ b/codex/skills/footgun-finder/SKILL.md
@@ -31,6 +31,16 @@ copy/paste or default use preserves the trap
 
 If no plausible actor and action exist, classify the candidate as `not_a_footgun` even if the code looks odd.
 
+## Actuating composition
+
+Within Actuating, the checked-in [footgun review lens](../actuating/references/lenses/footgun-review.md)
+owns the lane's scope and return shape: plausible misuse that bypasses the admitted
+construction, not the full standalone affordance audit. Preserve its actor, easy
+path, reasonable belief, hidden bypass, consequence, and affected law. Return
+only that evidence; do not launch companion reviews, select mitigations, or emit
+a standalone ledger or agenda. This section takes precedence over standalone
+routing and output below only within Actuating; standalone modes are unchanged.
+
 ## Boundary with companion skills
 
 Use this skill with, but do not replace:

--- a/codex/skills/invariant-ace/SKILL.md
+++ b/codex/skills/invariant-ace/SKILL.md
@@ -11,6 +11,17 @@ Turn "should never happen" into "cannot happen" with minimal, high-leverage chan
 
 This skill is **discriminative**, not decorative. An invariant proposal is a claim to adjudicate, not a mandate to add checks. A property may be true, useful, or reviewer-sounding and still be the wrong invariant, wrong owner, wrong scope, wrong phase, wrong witness, or wrong boundary.
 
+## Actuating composition
+
+Within Actuating, the checked-in [invariant review lens](../actuating/references/lenses/invariant-review.md)
+owns the lane's scope and return shape. Use that evidence-only contract, not a
+second authority workflow. Return concrete invariant/transition witnesses to
+Review Fold; Actuating retains selection, implementation, proof, and closure.
+Do not launch authority fanout, emit clearance packets, or require the standalone
+Invariant Gate. This section takes precedence over the standalone modes, gates,
+output templates, and companion routing below only within Actuating. Standalone
+invocation is unchanged; no review lane or proof obligation is added or removed.
+
 ## Default mode
 
 Use **Authority-Gated v1** when invariant analysis can affect implementation, review adjudication, proof closure, validation, or downstream handoff.

--- a/codex/skills/review-fold/SKILL.md
+++ b/codex/skills/review-fold/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: review-fold
-description: "Classify and quotient current review findings, tests, incidents, and other witnessed falsifiers while preserving original provenance. Decide current applicability and whether each proposed law is entailed by the accepted Goal, a strengthening, preference, new requirement, or underdetermined. Persist only accepted entailed witnesses in the Review Fold counterexample corpus; recompute classes, families, recurrence, architecture, and closure from current evidence."
+description: "Classify and quotient current review findings, tests, incidents, and other witnessed falsifiers while preserving original provenance. Decide current applicability and whether each proposed law is entailed by the accepted Goal, a strengthening, preference, new requirement, or underdetermined. With enclosing write authority, persist only accepted entailed witnesses in the Review Fold counterexample corpus; recompute classes, families, recurrence, architecture, and closure from current evidence."
 ---
 
 # Review Fold
@@ -17,8 +17,8 @@ current owner evidence
 + projected counterexample corpus
 + optional current elimination-claim excerpt
 -> facts, law authority, applicability, observational classes, blockers
--> accepted counterexample capture
--> no mutation or architecture authority
+-> accepted counterexample capture when authorized
+-> no implementation mutation or architecture authority
 ```
 
 `$review-fold` owns evidence classification, Goal-law relation, observational
@@ -39,6 +39,7 @@ review_fold_input:
   repository:
   base:
   current_head:
+  corpus_write_authorized: true | false # enclosing task; omitted means false
   current_elimination_claim: null | {
     law:
     family:
@@ -67,6 +68,16 @@ rows as currently applicable without re-evaluation.
 
 Read [counterexample-corpus.md](references/counterexample-corpus.md) before the
 first corpus projection or capture in a workflow.
+
+## Effect authority
+
+`corpus_write_authorized` must follow the enclosing task's actual effect scope;
+review pressure and corpus ownership cannot grant it. It is always false in
+Actuating `analyze`. Adjudication and available read-only projection remain
+permitted without capture. Do not repair bindings, provision a tool, or write a
+source-memory note to evade that boundary. Return accepted in-context evidence
+and empty `captured_ids` when writing is unauthorized; do not claim persistence
+or block unrelated analysis solely because capture was intentionally skipped.
 
 ## Minimal law
 
@@ -123,7 +134,18 @@ underdetermined
   -> blocked with authority_action: seek-authority
 ```
 
-Reviewer consensus does not manufacture entailment.
+Reviewer consensus does not manufacture entailment. Adjudication never rewrites
+an owner-issued `findings` verdict into `clean`.
+
+Preserve a judgment challenge's positive claim, earliest failed premise, and
+claim-strength consequence in the existing witness handoff. Distinguish an
+observed behavior violation from an omitted coverage path or an unsupported
+proof claim. Missing proof alone is not evidence that the behavior is false;
+it may falsify an accepted evidence or truthfulness obligation. Apply the same
+law-authority test before admission and let Actuating decide the response.
+A workflow fingerprint binds identity, not reviewer access to parent-only
+premises; preserve material evidence-access limitations in the existing horizon.
+Do not infer a new correctness liability from an unavailable premise.
 
 ## Output
 
@@ -158,6 +180,10 @@ review_fold:
       post_elimination_basis:
       witnesses:
         - observed_fact:
+          # Optional, only when the source challenges a positive judgment:
+          challenged_judgment:
+          earliest_failed_premise:
+          claim_strength_consequence:
           witness_subject:
             repository:
             git_head_or_build:
@@ -214,9 +240,10 @@ witness subject, and observed fact.
 12. If an eliminated claim is supplied, classify exact relation to its law,
     family, validity horizon, and reconsideration falsifier. Do not revoke or
     preserve the claim; Actuating owns that effect.
-13. Capture each independent witness whose current applicability is
-    `still-present` or `transformed-applicable`, law authority is `entailed`, and
-    disposition is `accepted`.
+13. When `corpus_write_authorized` is true, capture each independent witness
+    whose current applicability is `still-present` or `transformed-applicable`,
+    law authority is `entailed`, and disposition is `accepted`. Otherwise retain
+    that accepted evidence only in the current fold.
 14. Return the fold and corpus IDs directly.
 
 A clean source may return an empty `classes` list and performs no capture.

--- a/codex/skills/review-fold/references/counterexample-corpus.md
+++ b/codex/skills/review-fold/references/counterexample-corpus.md
@@ -38,6 +38,19 @@ Actuating
 A stored row never proves that the witness remains applicable or belongs to the
 current family. Persist counterexamples; recompile their meaning.
 
+## Effect authority
+
+Capture additionally requires `corpus_write_authorized: true` from the enclosing
+task. Omitted or false authority permits available read-only projection and
+adjudication, not `ledger transact`, binding repair, provisioning, or source-memory
+writes. Actuating `analyze` always supplies false. Corpus ownership cannot grant
+these effects. A doctor-prescribed repair still needs the enclosing authority.
+
+With no write authority, retain accepted witnesses in context and return empty
+`captured_ids`; report non-persistence only when material to the handoff. This is
+not a failed adjudication or a new workflow mode. Current claims use the available
+source evidence; historical absence still needs a complete relevant horizon.
+
 ## Store and definition
 
 ```text
@@ -84,9 +97,10 @@ Use `law-history` for a focused exact-law projection and `record` for one known
 
 ## Capture after folding
 
-Capture one record for each independent witness satisfying all of:
+With enclosing write authority, capture one record for each independent witness satisfying all of:
 
 ```text
+corpus_write_authorized = true
 current applicability = still-present | transformed-applicable
 law authority = entailed
 disposition = accepted

--- a/codex/skills/universalist/README.md
+++ b/codex/skills/universalist/README.md
@@ -89,8 +89,13 @@ it only when architecture reconsideration is live. Universalist nominates only:
 ```text
 candidate
 preserve-incumbent
+unresolved
 obstructed
 ```
+
+`unresolved` reports missing evidence or incomparable adequate candidates. It is
+a nomination result, not a new mode or evidence of obstruction. Actuating owns
+any further authorized discrimination.
 
 Do not run a duplicate root or worker pass merely because realization crosses an
 already accepted boundary. Actuating reconstructs the incumbent from the

--- a/codex/skills/universalist/SKILL.md
+++ b/codex/skills/universalist/SKILL.md
@@ -254,12 +254,19 @@ invocation point and calls Universalist only after architecture reconsideration
 is live. Do not run a duplicate root or worker pass merely because Actuating
 will cross a boundary while realizing an already selected architecture.
 
-Return `candidate`, `preserve-incumbent`, or `obstructed` with the smallest
+Return `candidate`, `preserve-incumbent`, `unresolved`, or `obstructed` with the smallest
 code-bound argument that changes Actuating's decision: trigger evidence, owner
 and operation, required law/observations, discriminator, and material migration,
 residual, or invalidation consequences. For counterexample-driven work, identify
 the enabling freedom removed or lawfully controlled. Reuse supplied facts and proof references. No fixed field projection
 or second Working Set report is required.
+
+Return `unresolved` when evidence is missing or adequate candidates remain
+incomparable; name that reason and the smallest available discriminator. This
+is a supporting result, not a new route or mode. Do not convert uncertainty into
+`obstructed`, preserve an unjustified incumbent, or invent a winner. Actuating
+owns any authorized experiment outside an open review epoch and blocks only the
+affected decision. Obstruction still requires the evidence specified below.
 
 An ordinary nomination can be direct: derive the receipt subject from the
 execution-owned evidence instead of accepting both independently; retire the


### PR DESCRIPTION
## Summary

Implement the cross-skill improvements from the Actuating audit in one PR, under the explicit constraint that the existing modes and review process remain unchanged.

- **Honor read-only authority through Review Fold.** Carry `corpus_write_authorized` from the enclosing task; `analyze` and omitted authority do not permit corpus capture, binding repair, provisioning, or source-memory writes. Available projection and adjudication still return useful accepted evidence without claiming persistence.
- **Represent unresolved nominations honestly.** Add `unresolved` to the existing Universalist-to-Actuating result vocabulary for missing evidence or incomparable adequate candidates. This is not a new mode or route, and uncertainty cannot be mislabeled as obstruction or arbitrary selection.
- **Preserve evidence meaning.** Retain a soundness challenge's positive judgment, earliest failed premise, and claim-strength consequence. Distinguish a behavior violation from missing proof. An adjudicated finding never rewrites the owner-issued verdict to `clean`.
- **Clarify reviewer evidence access without changing dispatch.** A CAS workflow fingerprint binds identity; it does not deliver parent-only context. Reuse evidence accessible through the existing backend and preserve material limitations in the existing evidence horizon. No new context transport, prompt argument, review gate, request, retry, or durable packet is introduced.
- **Make named skill composition unambiguous.** Invariant Ace, Footgun Finder, and Complexity Mitigator explicitly defer to the existing Actuating-owned evidence-only lens files. Standalone fanout, gates, companion reviews, tables, and repair agendas do not silently become additional Actuating requirements. Standalone modes remain unchanged.
- **Reduce duplicated obligations.** Closure consumes the existing common construction-proof contract instead of maintaining another full checklist. First-principles work reuses adequate derivations and remains bounded to material premises while preserving user-fixed outcomes.

## Review process preserved

The PR leaves the public routes, their effects, both scheduling modes, default parallel scheduling, six-lens initial order, non-cancelling siblings, frozen review epochs, recovery allowance, native/default standard review, five-consecutive-standard-clean requirement, and material-finding/head-change resets unchanged.

All five auxiliary instruction files are byte-for-byte unchanged. The common proof-obligation section is also byte-for-byte unchanged. Neither `$metanoetic` nor `$glaze` is modified. No review lane, mode, production gate, workflow store, or runtime score is added.

The only change in `review-contract.json` is the supporting nomination result `unresolved`; scheduling and review-policy fields do not change.

## Receipt-model correction

The previous **test-only reference model** counted total clean standards instead of the ordered clean suffix. It could accept `clean, clean, findings(strengthening), clean, clean, clean` despite having only three consecutive cleans.

The model now follows the already-declared policy. Regressions cover zero through five clean confirmations following a non-liability finding, auxiliary non-liabilities, verdictless confirmation recovery, and material invalidation. This repairs test semantics; it does not change live review policy.

The new composition test is included by the existing construction-cycle test. It protects the audited review configuration, route/epoch/closure/common-proof sections, and exact auxiliary instruction identities, and checks cross-file handoff consistency. These checks are source-contract tests, not evidence of model efficacy.

<!-- ship-proof:start -->
## Summary
- Clarify cross-skill authority and evidence handoffs while preserving review modes and process; correct the test model's consecutive-clean count.

## Proof
- Exact-head construction-cycle suite: pass (27 scenarios plus composition contracts).
- Shell syntax checks for both changed test scripts: pass.
- git diff --check: pass.
- Full repository and integration suites and live model campaigns: not run.
- Automated GitHub review unavailable due to reviewer usage limits; no review result claimed.

## Scope
- repository: tkersey/dotfiles
- branch: codex/actuating-composition-preserve-review
- head: 6c2b16987d3f58e2bf7a987685afb43566b3a065
- base: main
- base SHA: e5d524bf2ab31c2d5de35993393142db3ff19544

## Risks
- Source-contract tests do not establish model efficacy or runtime enforcement.

## Follow-ups
- None required for this publication.

## Readiness
- Operation: update
- Final state: preserve (ready)
- SHIP-v1 compatibility mode: update-existing
- Reason: focused validation passes; existing ready PR.
- Caveats: broader and live-model validation not run, as above.
<!-- ship-proof:end -->