### PR TITLE
codex: remove global Noetic dispatch mandate for ablation

### DIFF
--- a/codex/AGENTS.md
+++ b/codex/AGENTS.md
@@ -15,13 +15,6 @@
 - An automobile changes the governing causal mechanism or makes the old optimization target unnecessary. More speed, scale, automation, parallelism, validation, orchestration, or polish inside the same mechanism is still a faster horse.
 - Continual vigilance is not continual redesign. Keep the check silent and bounded; skip trivial, already-dispositive, or explicitly mechanism-bound work; never redefine user-owned outcomes or delay direct capability for speculative novelty. Surface a challenger only when it is concrete, admissible, comparable against the same evidence, and materially changes the decision.
 
-## Noetic effect dispatch
-
-- At a material, non-dispositive decision point, invoke `$noetic-effects dispatch` when current evidence indicates stale framing, shallow causality, a live contradiction, incumbent-captive adjacency, timid candidate generation, a missing construction form, a wrong abstraction or owner, implementation detached from its contract, unearned surface, ceremonial indirection, or analysis without movement.
-- `$noetic-effects` selects `skip`, one smallest sufficient primitive effect, or one bounded `$metanoetic` composite. Bind the dispatch to the current objective, witnessed pressure, expected route delta, stopping condition, and workflow that owns the decision. If no effect could materially change the route, skip it.
-- Compile the selected effect into the active workflow's native decision surface. When that workflow already owns an equivalent handler, use it and do not run a duplicate root pass. The receiving workflow retains ownership of admissibility, selection, mutation, proof, publication, and closure.
-- Keep dispatch silent. Do not announce doctrine use, rewrite the final response in a doctrine style, create a receipt merely to prove invocation, or introduce a workflow solely to host the effect.
-
 ## Explicit skill resolution
 
 - Generic defaults do not waive specific authority, review, or source-evidence obligations. When a skill requirement prevents fulfilling an explicit user request, identify its path, controlling clause, and unmet condition; keep ordinary internal routing silent.


### PR DESCRIPTION
<!-- ship-proof:start -->
## Summary

Remove only `## Noetic effect dispatch` and its four bullets from `codex/AGENTS.md`, with no replacement text. This is the agreed single-variable ablation: test whether the global dispatch mandate adds value beyond the remaining root mandates and native skill procedures.

**One file, +0 / -7 lines: 167 words excluding Markdown markers and 1,241 UTF-8 bytes removed.** Every byte outside the removed section is preserved.

The `$noetic-effects` skill and its configuration, Tune integration, Actuating procedures, Metanoetic and Universalist mandates, response preferences, concurrent-edit rules, and memory/source-evidence lifecycle are unchanged. No new skill, evaluation harness, policy section, or source-store entry is introduced.

## Proof

- PASS: shipping revalidation of the exact published base/head confirms only the seven-line section deletion, four removed bullets, byte preservation outside the section, and clean `git diff --check`.

- PASS: local source bytes match the fetched base blob `14c353d4370072a72f5f48bc8eda02342039144c`.
- PASS: temporary assertions run through `uv run --no-project` verify exactly one section/four bullets removed, exact byte-for-byte restoration when reinserted, preservation of all remaining headings and text, final newline, and absence of additions.
- PASS: `git diff --check` and `git diff --numstat` in an isolated validation worktree; result `0 7 codex/AGENTS.md`.
- PASS: GitHub's published blob `afa4e6dd03c89aa2cc324cf927375174e63fc3ae` matches the locally validated candidate; published commit inspection confirms only the intended deletion.
- NOT RUN: live Astra/Codex comparisons or performance benchmarks. These checks establish the textual ablation, not behavioral equivalence or improved model performance. No CI result is claimed.

## Measure after: proposed paired pilot, not run

Control: `833f45b985d4d4b0822a6fe5ccc1a0a87595109a`. Treatment: `bf1c963c4984fafc28bc808d2dd10239a247c176`. Use the same task-repository snapshots, model/reasoning configuration, installed skills, tools, permissions, and starting memories; vary only this section. Start fresh isolated sessions, prevent cross-run memory contamination, and alternate run order.

Use six representative tasks, twice per variant (24 runs): routine local fix; Actuating refactor driven by repeated failures; disputed architectural owner; unstructured debugging with a misleading premise; explicit Noetic invocation; Tune cognitive compilation.

Compare correctness/completion, correction depth and required-valid preservation, unnecessary user intervention, elapsed time, reported token usage, and tool calls. Track Noetic skill loads diagnostically, not as a success metric. Review paired code and evidence blind to the variant.

Provisionally retain the deletion when tested outcomes and correction depth remain comparable with no reproducible new failure. Lower execution cost strengthens the case; unchanged cost demonstrates only a smaller standing instruction set. Restore the section if its absence reproducibly loses a useful diagnosis or mechanism change. Mixed results are inconclusive; this pilot is not a statistically powered equivalence proof.

## Risk and rollback

The main regression risk is shallower diagnosis outside established workflows. Fewer dispatches are not a win when they produce compensating patches instead of a warranted causal correction. Revert this one-file commit to restore the exact section; do not compensate by editing other skills during the comparison.

## Scope and readiness

- Repository: `tkersey/dotfiles`
- Base: `main` at `833f45b985d4d4b0822a6fe5ccc1a0a87595109a`
- Head: `bf1c963c4984fafc28bc808d2dd10239a247c176`
- Branch: `codex/remove-global-noetic-dispatch-20260905`
- Operation: `update`; final state: `ready`; SHIP-v1 compatibility mode: `update-existing`.
- The requested deletion and static preservation checks are complete. Outcome measurement remains an explicitly unrun follow-up, not a claimed result. No merge or deployment performed.
<!-- ship-proof:end -->