### PR TITLE
metanoetic: replace opening with TRANSCEND THAT!!

### DIFF
--- a/codex/skills/metanoetic/SKILL.md
+++ b/codex/skills/metanoetic/SKILL.md
@@ -3,4 +3,4 @@ name: metanoetic
 description: "Challenge a concrete incumbent when repeated repair or accretion, a live contradiction, or a suspect owner, model, representation, or solution class makes nonlocal reframing plausible. Also consider high-regret or difficult-to-reverse commitments, incumbent-generated burdens another mechanism could eliminate, and merely adequate local optima. Invoke explicitly for `$metanoetic`; implicit use requires evidenced pressure, a plausible nonlocal reframe, and enough objective, current evidence, and comparison criteria to evaluate a challenger. Run one bounded canonical pass verbatim to search for a materially different frame, topology, invariant, mechanism, solution class, artifact, or breakthrough candidate."
 ---
 
-I think you can do much much much better than that! USE FRESH EYES!! BE EXCAVATORY!!! BE APORETIC!! SUBLATE THE CONTRADICTION!!! BE SYNECTIC!!! RETOPOLOGIZE THE POSSIBILITY SPACE!! BE AUDACIOUS! OPERATE POIETICALLY! BE SALTATORY!!!
+TRANSCEND THAT!! USE FRESH EYES!! BE EXCAVATORY!!! BE APORETIC!! SUBLATE THE CONTRADICTION!!! BE SYNECTIC!!! RETOPOLOGIZE THE POSSIBILITY SPACE!! BE AUDACIOUS! OPERATE POIETICALLY! BE SALTATORY!!!


### PR DESCRIPTION
## Summary

Replace the opening of the canonical Metanoetic intervention in `codex/skills/metanoetic/SKILL.md`:

```diff
-I think you can do much much much better than that!
+TRANSCEND THAT!!
```

This directs the opening toward moving beyond the incumbent's framing and limitations, rather than merely improving its result.

## Scope

Only the opening phrase changes. Preserve the frontmatter, the space before `USE FRESH EYES!!`, every subsequent directive and punctuation mark, and the final newline. No changes to routing, authority, evaluation, other skills, or agent metadata. This is the specifically authorized adjustment to the otherwise verbatim intervention.

## Validation

- Verified the original bytes against the current source blob SHA.
- Asserted that the candidate equals exactly one replacement of the original opening with `TRANSCEND THAT!!`; all other bytes are identical.
- `git diff --check` passed.
- GitHub returned the exact locally verified candidate blob SHA: `716277f438fa3736dfef857b6b539df3344ada30`.

This is a wording adjustment, not a demonstrated model-performance improvement. No live model-efficacy comparison was run.

<!-- ship-proof:start -->
## Summary
- Replace only the canonical intervention opening with `TRANSCEND THAT!!`.

## Proof
- Exact-byte single-replacement assertion and sole-file scope assertion: pass.
- `git diff --check 4c6443f29c71d35826f9bc58acbc34f0040b41a2 17cfefdab1e63bc5a1fd0c54ddc8eae0083b36a8`: pass.
- Build and runtime tests: not applicable to this wording-only change; model efficacy comparison not run.

## Scope
- repository: tkersey/dotfiles
- branch: codex/metanoetic-transcend-that-20260905
- head: 17cfefdab1e63bc5a1fd0c54ddc8eae0083b36a8
- base: main
- base SHA: 4c6443f29c71d35826f9bc58acbc34f0040b41a2

## Risks
- Model-performance improvement is unmeasured.

## Follow-ups
- None.

## Readiness
- Operation: update-and-promote
- Final state: ready
- SHIP-v1 compatibility mode: promote-draft
- Reason: Complete wording change with exact-byte validation.
- Caveats: No model-efficacy claim.
<!-- ship-proof:end -->