### PR TITLE
codex: harden Ledger skill bootstrap and result boundaries

### DIFF
--- a/codex/skills/ledger/SKILL.md
+++ b/codex/skills/ledger/SKILL.md
@@ -48,9 +48,10 @@ later workflow action is authorized.
 ## Bootstrap boundary
 
 Before the first native Ledger command in a workflow, load this skill and
-complete `$ledger ensure` once. That readiness applies to every Ledger consumer
-in the workflow; do not bootstrap per skill or per command. `$ledger` is skill
-syntax, not a shell command.
+complete `$ledger ensure` once. Reuse readiness across consumers while the
+resolved executable and execution environment remain unchanged; recheck after
+either changes, not per skill or per command. `$ledger` is skill syntax, not a
+shell command.
 
 Use [scripts/ensure-ledger](scripts/ensure-ledger):
 
@@ -59,8 +60,8 @@ ledger_skill_root="$(realpath "${CODEX_HOME:-$HOME/.codex}/skills/ledger")"
 "$ledger_skill_root/scripts/ensure-ledger"
 ```
 
-After the handler emits `ledger-bootstrap-ready/v1`, invoke the native CLI
-directly:
+After the handler exits successfully and emits `ledger-bootstrap-ready/v1`,
+invoke the native CLI directly:
 
 ```bash
 ledger <native-ledger-arguments...>
@@ -72,16 +73,12 @@ or upgrade the canonical Homebrew formula `tkersey/tap/ledger`. It does not
 proxy native commands. The native CLI owns integrity, stdout, stderr, exit
 status, and failure reporting after readiness.
 
-If `ledger` does not resolve on `PATH`:
-
-1. install only when the current request or standing environment policy
-   authorizes user-level CLI provisioning;
-2. pass `--install` to the bootstrap handler when that authority exists;
-3. otherwise stop with the handler's exact remediation;
-4. never use `curl | sh`, an unpinned download, or an alternate Ledger
-   implementation.
-
-Do not install during an active repository effect.
+If Ledger is missing or incompatible, pass `--install` only when the current
+request or standing environment policy authorizes user-level CLI provisioning;
+otherwise stop with the handler's exact remediation. The formula is fixed, not
+selected through environment overrides. Never use `curl | sh`, an unpinned
+download, or an alternate Ledger implementation. Do not install or upgrade
+during an active repository effect.
 
 ```yaml
 ledger_bootstrap_ready:
@@ -93,9 +90,13 @@ ledger_bootstrap_ready:
   action: none | installed | upgraded
 ```
 
-Bootstrap readiness grants no semantic authority.
+Readiness establishes runtime availability, not compatibility with every
+owner definition. The selected definition's ABI, operators, and storage
+requirements govern compatibility. Use `definition check` when selecting a new
+or changed closure or diagnosing support; do not add a redundant preflight to
+every unchanged operation. Readiness grants no semantic authority.
 
-## Native surface
+## Baseline native surface
 
 ```text
 ledger definition check
@@ -113,7 +114,9 @@ ledger version
 
 Do not invent aliases such as `ledger state`. Load the owning skill for its
 exact definition path, operation names, projection names, parameters, and
-semantic policy.
+semantic policy. Version-dependent maintenance commands are documented in
+[storage-maintenance.md](references/storage-maintenance.md); their availability
+does not authorize their use.
 
 ## Result semantics
 
@@ -136,8 +139,17 @@ semantic policy.
 - `recovery reclaim` performs only an explicitly authorized, transaction-bound
   reclaim after revalidating every required witness.
 
-Preserve the normal result envelope. Use `--payload-only` only for an explicit
-structural pipe whose receiver already owns interpretation.
+Preserve the normal result envelope, including the returned definition-closure
+digest and input, artifact, or store identities applicable to that result.
+A definition ID and ABI alone do not identify the exact law checked. Bind each
+claim to the selected closure and the exact bytes or state actually checked;
+do not apply a prior result to changed inputs, a changed closure, or a later
+store state, or reduce it to an unqualified "valid." Do not invent missing
+identity metadata or add a second receipt format.
+
+Use `--payload-only` only for an explicit structural pipe whose receiver
+already owns interpretation. Do not represent a payload-only projection as
+though it still carried the omitted envelope.
 
 ## Definition ownership
 
@@ -145,50 +157,15 @@ Passive definitions live beside their semantic owners, not in `$ledger`.
 The owner declares the protocol and lists it in that skill's
 `definitions/manifest.json`; Ledger compiles and enforces it generically.
 
-A definition may declare:
-
-- bounded JSON, JSONL, or UTF-8 inputs and codecs;
-- canonicalization and content identity;
-- closed shapes and cross-document laws;
-- pure, addressed-document, or event-log storage;
-- atomic operations, transitions, reducers, replay, and projections;
-- logical slots beneath the selected repository's `.ledger/` control root;
-- explicit output, diagnostic, record, and reducer-state bounds.
-
 Definitions are passive JSON. They must not name hooks, shell commands,
-executables, network calls, or hidden discovery procedures.
+executables, network calls, or hidden discovery procedures. Do not hardcode
+domain artifact families, protocol versions, operations, projections, or closure
+policy in this skill.
 
-### Authoring workflow
-
-1. Establish the semantic owner and the smallest stable artifact or protocol
-   boundary.
-2. Choose pure validation/materialization unless durable identity or history is
-   required; choose addressed storage for replaceable canonical documents and
-   an event log for append-only transitions or auditable replay.
-3. Declare explicit bounded inputs, canonicalization, identity, constraints,
-   storage slots, operations, and projections. Make illegal compositions
-   structurally unrepresentable where the native operator vocabulary permits.
-4. Keep workflow policy outside the definition. Encode only laws that can be
-   decided from admitted inputs and declared storage.
-5. Run `ledger definition check` and `ledger definition describe` before using
-   the definition.
-6. Exercise every operation and projection against representative valid,
-   invalid, boundary, replay, and store-binding cases.
-7. Search all consumers when a definition ID, operation, projection, field, or
-   semantic version changes.
-
-### Extension law
-
-Add or change an owner-local passive definition first. Add a native Ledger
-operator only when the capability is domain-independent, explicitly bounded,
-and either:
-
-- required by at least three unrelated definitions; or
-- necessary to preserve one live behavior without material correctness or
-  performance loss.
-
-Do not turn Ledger into a domain registry or grow native operators merely to
-avoid reconsidering an owner definition.
+Prefer pure validation/materialization unless durable identity or history is
+required. Before authoring, reviewing, debugging, or extending a definition,
+read [definition-authoring.md](references/definition-authoring.md) for the
+bounded vocabulary, counterexample discipline, and native extension law.
 
 ## Storage custody
 
@@ -205,33 +182,25 @@ replaces only binding metadata, and leaves store bytes unchanged. Do not add
 fallback readers, alternate paths, implicit migration, or source dispatch to
 Ledger.
 
-Never open, edit, compact, migrate, or repair a store outside the owning
-definition's operations and exact recovery surface.
+Rebinding establishes custody of a selected replacement, not authority to
+select that history. Do not use it to choose between divergent stores or bless
+an unknown replacement. Establish the authoritative transport first; preserve
+the losing lineage as explicit owner-controlled reconciliation input.
+
+Use the owning definition and selected `ledger transact` operation for normal
+store mutations. Never open, hand-edit, compact, migrate, or repair stores
+outside owner-selected operations and exact authorized maintenance surfaces.
+Fail closed on unknown definition closure, ABI, operator, binding, integrity,
+replay, projection, or recovery state.
 
 ## Recovery boundary
 
-Lease expiry is not authority transfer. Inspect one transaction and require the
-exact resource, lock identity, fencing token, owner, and witnessed lease state
-before reclaiming:
-
-```bash
-ledger recovery inspect \
-  --repo <repo> \
-  --transaction <dtx-id> \
-  --format json
-
-ledger recovery reclaim \
-  --repo <repo> \
-  --transaction <dtx-id> \
-  --resource <path> \
-  --lock-id <dlk-id> \
-  --fencing-token <u64> \
-  --format json
-```
-
-For an original legacy lease only, add `--confirm-no-legacy-writers` with actual
-operator authority and an inspectable basis for that assertion. Do not add it
-for an interrupted current recovery. There is no broad reclaim or repair mode.
+Lease expiry is not authority transfer. Recovery is explicitly authorized and
+bound to one transaction's exact resource, lock identity, fencing token, owner,
+and witnessed lease state; there is no broad reclaim or repair mode. Before
+recovery or version-dependent migration, read
+[storage-maintenance.md](references/storage-maintenance.md). The reference
+preserves the legacy-writer assertion and the native command's witness checks.
 
 ## Trigger cues
 
@@ -251,28 +220,12 @@ protocol.
 
 ## Reporting
 
-Report the operation actually performed, the selected definition ID and ABI,
-the result schema and verdict, whether storage mutated, the exact addressed
-store or transaction when relevant, and any owner action still required.
+Report the operation actually performed, the selected definition ID, closure
+digest and ABI when applicable, the result schema and verdict, whether storage
+mutated, and any owner action still required. Preserve the result identities
+above in the working evidence and surface the exact addressed store or
+transaction when relevant. Missing metadata limits the claim; do not fabricate it.
 
 Do not force unrelated calls into one generic status template. A pure
 validation, durable transaction, store doctor, and recovery inspection have
 different useful outputs.
-
-## Guardrails
-
-- Bootstrap once before the first native command; invoke `ledger` directly
-  afterward.
-- Do not install without current installation authority.
-- Do not install during an active repository effect.
-- Do not hardcode domain artifact families, protocol versions, operations,
-  projections, or closure policy in this skill.
-- Do not add source dispatch, executable hooks, alternate implementations,
-  implicit scanning, fallback paths, or workflow conclusions.
-- Do not treat a valid artifact, healthy store, exact replay, or successful
-  projection as independent semantic authority.
-- Do not mutate a store except through its owning definition and selected
-  `ledger transact` operation.
-- Keep `validate` and `materialize` repository-pure.
-- Fail closed on unknown definition closure, ABI, operator, binding, integrity,
-  replay, projection, or recovery state.

--- a/codex/skills/ledger/references/definition-authoring.md
+++ b/codex/skills/ledger/references/definition-authoring.md
@@ -1,0 +1,56 @@
+# Definition authoring
+
+Read when authoring, reviewing, debugging, or extending a passive definition.
+The owning skill supplies the semantic intent; Ledger checks its encoding.
+
+A definition may declare:
+
+- bounded JSON, JSONL, or UTF-8 inputs and codecs;
+- canonicalization and content identity;
+- closed shapes and cross-document laws;
+- pure, addressed-document, or event-log storage;
+- atomic operations, transitions, reducers, replay, and projections;
+- logical slots beneath the selected repository's `.ledger/` control root;
+- explicit output, diagnostic, record, and reducer-state bounds.
+
+Definitions are passive JSON. They must not name hooks, shell commands,
+executables, network calls, or hidden discovery procedures.
+
+## Authoring workflow
+
+1. Establish the semantic owner and the smallest stable artifact or protocol
+   boundary.
+2. Choose pure validation/materialization unless durable identity or history is
+   required; choose addressed storage for replaceable canonical documents and
+   an event log for append-only transitions or auditable replay.
+3. Declare explicit bounded inputs, canonicalization, identity, constraints,
+   storage slots, operations, and projections. Make illegal compositions
+   structurally unrepresentable where the native operator vocabulary permits.
+4. Keep workflow policy outside the definition. Encode only laws that can be
+   decided from admitted inputs and declared storage.
+5. Run `ledger definition check` and `ledger definition describe` before using
+   the definition.
+6. Exercise every operation and projection against representative valid,
+   invalid, boundary, replay, and store-binding cases. For a changed law, retain
+   its motivating counterexample and a required-valid neighboring case. Derive
+   the expected outcomes from owner intent, not the implementation under test.
+7. Search all consumers when a definition ID, operation, projection, field, or
+   semantic version changes.
+
+A rejected artifact does not by itself establish whether the artifact or the
+law is wrong. Change a definition only when owner intent and evidence justify
+that change; do not weaken it merely to obtain a successful receipt. Recheck
+the same cases and the affected consumers against the changed closure.
+
+## Extension law
+
+Add or change an owner-local passive definition first. Add a native Ledger
+operator only when the capability is domain-independent, explicitly bounded,
+and either:
+
+- required by at least three unrelated definitions; or
+- necessary to preserve one live behavior without material correctness or
+  performance loss.
+
+Do not turn Ledger into a domain registry or grow native operators merely to
+avoid reconsidering an owner definition.

--- a/codex/skills/ledger/references/storage-maintenance.md
+++ b/codex/skills/ledger/references/storage-maintenance.md
@@ -1,0 +1,60 @@
+# Storage maintenance
+
+Read before transaction recovery or a version-dependent storage migration.
+The semantic owner selects the operation; current user or standing authority
+must authorize its effect. Bootstrap readiness alone authorizes neither.
+
+## Exact transaction recovery
+
+Lease expiry is not authority transfer. Inspect one transaction and require the
+exact resource, lock identity, fencing token, owner, and witnessed lease state
+before reclaiming:
+
+```bash
+ledger recovery inspect \
+  --repo <repo> \
+  --transaction <dtx-id> \
+  --format json
+
+ledger recovery reclaim \
+  --repo <repo> \
+  --transaction <dtx-id> \
+  --resource <path> \
+  --lock-id <dlk-id> \
+  --fencing-token <u64> \
+  --format json
+```
+
+For an original legacy lease only, add `--confirm-no-legacy-writers` with actual
+operator authority and an inspectable basis for that assertion. Do not add it
+for an interrupted current recovery. There is no broad reclaim or repair mode.
+
+## Version-dependent segmented migration
+
+Ledger 1.1 documents an explicit `migrate-segmented` maintenance command; it is
+not part of the 1.0.3 baseline. Check the installed native help and capabilities
+and inspect the selected definition with `definition check` and
+`definition describe` before relying on this surface. Missing support blocks that migration,
+not unrelated baseline operations; never emulate the command or silently raise
+the minimum version for every consumer.
+
+Only after the owner selects the applicable migration and its effect is
+explicitly authorized:
+
+```bash
+ledger migrate-segmented \
+  --definition <owner-selected-protocol-definition.json> \
+  --repo <repo> \
+  --format json
+```
+
+A newer installed binary is not a request to migrate. Do not change an owner's
+definition or store format just to enable this command. Preserve the native
+result and verify the resulting store through the selected definition's doctor
+and required projections. Migration does not reconcile divergent histories or
+grant workflow authority. Never repair a failed migration by hand-editing stores
+or metadata; use only the runtime's exact supported maintenance surface.
+
+The [Ledger 1.1.1 runtime documentation](https://github.com/tkersey/skills-zig/blob/ledger-v1.1.1/apps/ledger/README.md)
+describes the command and segmented storage. Use the installed version's
+supported surface rather than assuming every Ledger 1.x binary provides it.

--- a/codex/skills/ledger/scripts/ensure-ledger
+++ b/codex/skills/ledger/scripts/ensure-ledger
@@ -2,9 +2,7 @@
 
 set -euo pipefail
 
-readonly DEFAULT_FORMULA="tkersey/tap/ledger"
-
-formula="${LEDGER_BOOTSTRAP_FORMULA:-$DEFAULT_FORMULA}"
+readonly formula="tkersey/tap/ledger"
 install_allowed=false
 
 usage() {
@@ -52,14 +50,14 @@ inspect_availability() {
 inspect_readiness() {
   local capabilities line minor patch
   local abi_found=false
-  ledger_version="$("$ledger_path" version 2>/dev/null || true)"
+  ledger_version="$("$ledger_path" version 2>/dev/null)" || return 1
   [[ "$ledger_version" =~ ^1\.([0-9]+)\.([0-9]+)$ ]] || return 1
   minor="${BASH_REMATCH[1]}"
   patch="${BASH_REMATCH[2]}"
   if ((10#$minor == 0 && 10#$patch < 3)); then
     return 1
   fi
-  capabilities="$("$ledger_path" capabilities --format text 2>/dev/null || true)"
+  capabilities="$("$ledger_path" capabilities --format text 2>/dev/null)" || return 1
   while IFS= read -r line; do
     if [[ "$line" == "ABI: ledger-artifact-abi/v1" ]]; then
       abi_found=true

--- a/codex/skills/ledger/tests/test_ensure_ledger.py
+++ b/codex/skills/ledger/tests/test_ensure_ledger.py
@@ -1,0 +1,203 @@
+"""Bootstrap regressions; no real Ledger, Homebrew, network, or store access.
+
+Run: uv run codex/skills/ledger/tests/test_ensure_ledger.py
+The isolated PATH contains only Bash, cat, and test doubles. These tests establish
+bootstrap behavior, not native artifact validation or model effectiveness.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import shlex
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+SCRIPT = Path(__file__).resolve().parents[1] / "scripts/ensure-ledger"
+BASH = shutil.which("bash")
+CHMOD = shutil.which("chmod")
+CAT = shutil.which("cat")
+FORMULA = "tkersey/tap/ledger"
+
+
+def ledger_stub(version="1.0.3", abi="ledger-artifact-abi/v1", version_exit=0,
+                capabilities_exit=0):
+    return f"""#!/usr/bin/env bash
+printf '%s\\n' "$*" >> "$MOCK_LEDGER_LOG"
+case "$*" in
+  version)
+    printf '%s\\n' {shlex.quote(version)}
+    exit {version_exit} ;;
+  'capabilities --format text')
+    printf '%s\\n' {shlex.quote('ABI: ' + abi)}
+    exit {capabilities_exit} ;;
+  *) exit 64 ;;
+esac
+"""
+
+
+BREW_STUB = """#!/usr/bin/env bash
+set -eu
+printf '%s\\n' "$*" >> "$MOCK_BREW_LOG"
+case "$1" in
+  list) [[ -f "$MOCK_INSTALLED" ]] ;;
+  install|upgrade)
+    printf '%s\\n' 'mock Homebrew diagnostic' >&2
+    if [[ "${MOCK_BREW_EXIT:-0}" != 0 ]]; then
+      exit "$MOCK_BREW_EXIT"
+    fi
+    printf '%s\\n' "$MOCK_LEDGER_AFTER" > "$MOCK_BIN/ledger"
+    "$MOCK_CHMOD" +x "$MOCK_BIN/ledger"
+    : > "$MOCK_INSTALLED" ;;
+  *) exit 64 ;;
+esac
+"""
+
+
+@unittest.skipUnless(BASH and CHMOD and CAT, "Bash, chmod, and cat are required")
+class BootstrapTests(unittest.TestCase):
+    def setUp(self):
+        directory = tempfile.TemporaryDirectory(prefix="ledger-bootstrap-")
+        self.addCleanup(directory.cleanup)
+        self.root = Path(directory.name)
+        self.bin = self.root / "bin"
+        self.bin.mkdir()
+        (self.bin / "bash").symlink_to(BASH)
+        (self.bin / "cat").symlink_to(CAT)
+        self.brew_log = self.root / "brew.log"
+        self.ledger_log = self.root / "ledger.log"
+        self.installed = self.root / "installed"
+        self.env = {
+            "PATH": str(self.bin), "HOME": str(self.root), "LC_ALL": "C",
+            "TMPDIR": str(self.root), "LEDGER_BOOTSTRAP_OS": "Linux",
+            "MOCK_BIN": str(self.bin), "MOCK_CHMOD": CHMOD,
+            "MOCK_INSTALLED": str(self.installed),
+            "MOCK_BREW_LOG": str(self.brew_log),
+            "MOCK_LEDGER_LOG": str(self.ledger_log),
+            "MOCK_LEDGER_AFTER": ledger_stub(),
+        }
+        self.write_executable("brew", BREW_STUB)
+
+    def write_executable(self, name, content):
+        path = self.bin / name
+        path.write_text(content)
+        path.chmod(0o755)
+
+    def run_bootstrap(self, *args):
+        return subprocess.run([str(SCRIPT), *args], env=self.env, text=True,
+                              capture_output=True, timeout=5, check=False)
+
+    def calls(self, path):
+        return path.read_text().splitlines() if path.exists() else []
+
+    def assert_ready(self, result, action="none", version="1.0.3"):
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(json.loads(result.stdout), {
+            "schema": "ledger-bootstrap-ready/v1", "status": "ready",
+            "path": str(self.bin / "ledger"), "version": version,
+            "abi": "ledger-artifact-abi/v1", "action": action,
+        })
+
+    def assert_blocked(self, result, reason, code=3):
+        self.assertEqual(result.returncode, code, result.stdout + result.stderr)
+        self.assertEqual(result.stdout, "")
+        error = json.loads(result.stderr.splitlines()[-1])
+        self.assertEqual(error["schema"], "ledger-bootstrap-error/v1")
+        self.assertEqual(error["status"], "blocked")
+        self.assertEqual(error["reason"], reason)
+        self.assertTrue(error["remediation"])
+
+    def test_supported_versions_do_not_provision(self):
+        for version in ("1.0.3", "1.0.4", "1.1.1"):
+            with self.subTest(version=version):
+                self.write_executable("ledger", ledger_stub(version=version))
+                self.assert_ready(self.run_bootstrap(), version=version)
+        self.assertEqual(self.calls(self.brew_log), [])
+
+    def test_bad_versions_and_missing_abi_are_blocked(self):
+        for version, abi in (("1.0.2", "ledger-artifact-abi/v1"),
+                             ("0.9.9", "ledger-artifact-abi/v1"),
+                             ("2.0.0", "ledger-artifact-abi/v1"),
+                             ("1.0.3-rc.1", "ledger-artifact-abi/v1"),
+                             ("not-a-version", "ledger-artifact-abi/v1"),
+                             ("1.0.3", "ledger-artifact-abi/v2"),
+                             ("1.0.3", "")):
+            with self.subTest(version=version, abi=abi):
+                self.write_executable("ledger", ledger_stub(version, abi))
+                self.assert_blocked(self.run_bootstrap(), "version-or-abi-mismatch")
+        self.assertEqual(self.calls(self.brew_log), [])
+
+    def test_valid_text_from_failed_probes_is_not_readiness(self):
+        for version_exit, capabilities_exit in ((7, 0), (0, 9), (7, 9)):
+            with self.subTest(version_exit=version_exit,
+                              capabilities_exit=capabilities_exit):
+                self.write_executable("ledger", ledger_stub(
+                    version_exit=version_exit, capabilities_exit=capabilities_exit))
+                self.assert_blocked(self.run_bootstrap(), "version-or-abi-mismatch")
+        self.assertEqual(self.calls(self.brew_log), [])
+
+    def test_missing_binary_does_not_install_without_authority(self):
+        self.assert_blocked(self.run_bootstrap(), "missing")
+        self.assertEqual(self.calls(self.brew_log), [])
+
+    def test_incompatible_binary_does_not_upgrade_without_authority(self):
+        self.write_executable("ledger", ledger_stub(version="1.0.2"))
+        self.installed.touch()
+        self.assert_blocked(self.run_bootstrap(), "version-or-abi-mismatch")
+        self.assertEqual(self.calls(self.brew_log), [])
+
+    def test_install_ignores_formula_override(self):
+        self.env["LEDGER_BOOTSTRAP_FORMULA"] = "other/tap/not-ledger"
+        self.assert_ready(self.run_bootstrap("--install"), action="installed")
+        self.assertEqual(self.calls(self.brew_log),
+                         [f"list --versions {FORMULA}", f"install {FORMULA}"])
+
+    def test_upgrade_ignores_formula_override(self):
+        self.env["LEDGER_BOOTSTRAP_FORMULA"] = "other/tap/not-ledger"
+        self.write_executable("ledger", ledger_stub(version="1.0.2"))
+        self.installed.touch()
+        self.assert_ready(self.run_bootstrap("--install"), action="upgraded")
+        self.assertEqual(self.calls(self.brew_log),
+                         [f"list --versions {FORMULA}", f"upgrade {FORMULA}"])
+
+    def test_failed_probes_after_upgrade_are_not_readiness(self):
+        for version_exit, capabilities_exit in ((7, 0), (0, 9)):
+            with self.subTest(version_exit=version_exit,
+                              capabilities_exit=capabilities_exit):
+                self.write_executable("ledger", ledger_stub(version="1.0.2"))
+                self.installed.touch()
+                self.env["MOCK_LEDGER_AFTER"] = ledger_stub(
+                    version_exit=version_exit, capabilities_exit=capabilities_exit)
+                self.assert_blocked(self.run_bootstrap("--install"),
+                                    "post-upgrade-version-or-abi-mismatch", code=2)
+
+    def test_failed_install_does_not_emit_readiness(self):
+        self.env["MOCK_BREW_EXIT"] = "17"
+        self.assert_blocked(self.run_bootstrap("--install"),
+                            "homebrew-install-failed", code=17)
+
+    def test_failed_upgrade_does_not_emit_readiness(self):
+        self.write_executable("ledger", ledger_stub(version="1.0.2"))
+        self.installed.touch()
+        self.env["MOCK_BREW_EXIT"] = "17"
+        self.assert_blocked(self.run_bootstrap("--install"),
+                            "homebrew-upgrade-failed", code=2)
+
+    def test_nonformula_binary_is_not_upgraded(self):
+        self.write_executable("ledger", ledger_stub(version="1.0.2"))
+        self.assert_blocked(self.run_bootstrap("--install"),
+                            "version-or-abi-mismatch-nonformula", code=2)
+        self.assertEqual(self.calls(self.brew_log), [f"list --versions {FORMULA}"])
+
+    def test_help_and_unknown_arguments_do_not_probe_or_proxy(self):
+        result = self.run_bootstrap("--help")
+        self.assertEqual(result.returncode, 0)
+        self.assertIn("ensure-ledger [--install]", result.stdout)
+        self.assert_blocked(self.run_bootstrap("validate"), "unknown-option", code=2)
+        self.assertEqual(self.calls(self.ledger_log), [])
+        self.assertEqual(self.calls(self.brew_log), [])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

Implement the agreed Ledger skill-package improvements without changing the native CLI.

- Fix `scripts/ensure-ledger` to reject failed version/capability probes even when they emit valid-looking stdout, and remove the environment-based formula override so installation and upgrade always target `tkersey/tap/ledger`.
- Qualify bootstrap readiness by executable/environment stability and selected-definition compatibility. Preserve returned definition-closure and artifact/store identities, distinguish rebinding from authority to select history, and keep validation claims tied to the exact checked bytes/state.
- Move definition-authoring and exact recovery procedures into linked references, retain their substantive safeguards, add counterexample-driven definition-repair guidance, document explicitly authorized version-dependent segmented migration, and remove duplicated closing guardrails.

## Scope

Exactly five files under `codex/skills/ledger`: the skill, bootstrap script, two references, and a focused test file. No changes to the Zig runtime, ABI, result schemas, owner definitions, stores, Homebrew formula, or Ledger 1.0.3 minimum. The bootstrap remains a readiness handler, not a command proxy. No automatic migration or new workflow authority.

## Verification

- `uv run codex/skills/ledger/tests/test_ensure_ledger.py` — all 12 tests pass. The same suite against the unchanged bootstrap produces seven failing assertions covering false readiness (including after upgrade) and noncanonical formula selection.
- Tests use an isolated PATH with Bash, cat, and test doubles; they never invoke real Ledger or Homebrew, access stores, or use the network. Coverage includes supported/unsupported versions, ABI mismatches, failed probes, explicit provisioning authority, canonical install/upgrade, failed provisioning, and non-proxy argument handling.
- `bash -n codex/skills/ledger/scripts/ensure-ledger` passes. Relative Markdown links, code fences, and diff whitespace were checked.
- Published blob hashes match the locally tested/reviewed files; the bootstrap executable bit is preserved.

Verified on Linux with Bash 5.2. Native Ledger integration, real Homebrew provisioning, and macOS/Bash 3.2 were not run. Documentation restructuring is not claimed to improve model effectiveness without measurement.

<!-- ship-proof:start -->
## Summary
Harden Ledger bootstrap probe handling and canonical provisioning; clarify definition and storage boundaries.

## Proof
- `uv run codex/skills/ledger/tests/test_ensure_ledger.py`: pass, 12 tests.
- `bash -n codex/skills/ledger/scripts/ensure-ledger`: pass.
- `git diff --check origin/main...HEAD`: pass.
- Complete five-file diff inspected at the published head.

## Scope
- repository: tkersey/dotfiles
- branch: codex/ledger-skill-hardening-20260906
- head: 232a5f4312caf36975bd9f68eca340df406fd549
- base: main
- base SHA: c04251ef9001543e93b81851e0d7326674220664

## Risks
Native Ledger integration and real Homebrew provisioning were not run; tests use isolated doubles.

## Follow-ups
None required for this scope.

## Readiness
- Operation: update-and-promote
- Final state: ready
- SHIP-v1 compatibility mode: promote-draft
- Reason: focused validation passes and no open work or review concerns remain.
- Caveats: integration limitations above; repository requires no status checks.
<!-- ship-proof:end -->