### PR TITLE
codex: ablate redundant Negative Ledger naming reminder

### DIFF
--- a/codex/AGENTS.md
+++ b/codex/AGENTS.md
@@ -85,7 +85,7 @@
 
 ### Negative-evidence routing mandate
 
-- Invoke `$negative-ledger` implicitly when implementation, debugging, review, or validation encounters a witnessed failed/no-effect route, benchmark or test regression, revert, repeated same-cluster retry, abandoned strategy likely to recur, or a request about what has already been tried. Do not wait for the user to literally name the skill.
+- Invoke `$negative-ledger` implicitly when implementation, debugging, review, or validation encounters a witnessed failed/no-effect route, benchmark or test regression, revert, repeated same-cluster retry, abandoned strategy likely to recur, or a request about what has already been tried.
 - Before selecting a route that resembles a prior failure, run the owning
   Negative Evidence definition's current `route-gate` projection. A recalled
   learning may trigger this check but cannot suppress a route until promoted


### PR DESCRIPTION
<!-- ship-proof:start -->
## Summary

Remove only ` Do not wait for the user to literally name the skill.` from the first bullet under `### Negative-evidence routing mandate` in `codex/AGENTS.md`.

**One file, +1 / -1 line; 11 words and 54 UTF-8 bytes removed.** The apparent added line is the existing bullet shortened; no instruction is added.

The preceding `Invoke $negative-ledger implicitly when ...` requirement and its complete trigger list remain verbatim. All other bytes are unchanged, including root skill-resolution authority, route-gate projection, capture thresholds, transient-error exceptions, source-owned dispositions, memory safeguards, and the `jaq` preference. No entire section, skill, configuration, source store, or test harness changes.

This tests whether the negative restatement adds useful reinforcement, not whether automatic Negative Ledger activation is still required.

## Validation

- PASS: temporary assertions through `uv run --offline --no-project` verified base blob `2902746e0155130bcec0c64035b801db0f6189d7`, exactly one approved sentence plus separator removed, byte-exact restoration on reinsertion, unchanged headings and skill references, final newline, and whitespace.
- PASS: `git diff --check` in an isolated Git validation directory; exact `git diff --numstat` is `1 1 codex/AGENTS.md`.
- PASS: published blob `d5a7254f0fedb7c01948316ad902aca2e0f710c0` matches the validated candidate. Published commit inspection confirms the one-file, one-sentence change.
- NOT RUN: live Astra/Codex behavioral comparisons or performance benchmarks. No behavioral-equivalence, model-performance, automated-review, or passing-CI claim.

## Measure after and rollback — not run

Compare base `3c007eb2f8d31d165578be420ae0a7e47f095e1d` with treatment `335c1d9c4eaf294c9c9513c1c6a72a85d1c65950`, keeping model/reasoning settings, tools, skills, task snapshot, starting memories, and earlier ablations fixed in fresh matched sessions.

Use an ordinary debugging task that encounters a qualifying failed route without naming Negative Ledger: both variants must activate it from the evidence. Include a transient syntax error as a capture control: honor the existing no-op distinction rather than inventing durable negative evidence. Inspect actual skill use and any resulting records, not final-response wording. Repeat paired cases; restore this sentence if its absence reproducibly increases missed qualifying activations. Comparable outcomes support deduplication, not a speedup claim.

Revert this single commit to restore the exact sentence. Whole-section ablation is outside this PR.

## Scope and readiness

- Base: `main` at `3c007eb2f8d31d165578be420ae0a7e47f095e1d`.
- Head: `335c1d9c4eaf294c9c9513c1c6a72a85d1c65950` on `codex/ablate-negative-ledger-reminder-20260906`.
- Operation: update; final state: preserve (ready).
- Current Ship verification: exact base/head byte comparison and git diff --check passed. Live policy requires zero approvals and no checks; no unresolved review threads. Automated review was unavailable due to the review account usage limit.
- The requested textual ablation and static checks are complete. Behavioral measurement remains unrun. No merge or deployment performed.
<!-- ship-proof:end -->