### PR TITLE
codex: remove ineffective blocked-review recovery guidance

### DIFF
--- a/codex/AGENTS.md
+++ b/codex/AGENTS.md
@@ -29,13 +29,6 @@
 
 - Complete checks required by the task and active workflow, including review counts and reset rules. Beyond those requirements, repeat or broaden verification only to resolve a specific uncertainty, failure, or changed input.
 
-### Blocked review recovery
-
-- When a review attempt ends with a provider content-block notice, treat that result as unavailable evidence, not a finding or clean verdict. The notice alone establishes neither a task-wide prohibition nor a false positive.
-- When a controller remains active, or on a resumed turn, recover the latest outstanding user request, including corrections, and current repository/review state. Continue independently permitted work without asking the user to repeat the request; do not replay completed actions.
-- Preserve review freezes, required coverage, valid sibling evidence, and credit/reset rules. Blocked or partial reviews earn no clean credit. If required evidence remains unavailable, block only dependent actions and report the gap.
-- Respect provider restrictions and non-retryable errors; do not automatically replay content-blocked requests through generic retry rules. A narrower follow-up must be independently permitted and honestly scoped, never disguised or repeatedly resubmitted to obtain a different safety outcome.
-
 ### Git
 
 - Prefix `git merge --continue` and `git rebase --continue` with `GIT_EDITOR=true`.


### PR DESCRIPTION
<!-- ship-proof:start -->
## Change

Remove the `### Blocked review recovery` subsection introduced by #276, with no replacement text. **Only `codex/AGENTS.md` changes: +0/-7 lines, 1,064 UTF-8 bytes removed.**

The user reports that the change did not resume the root Codex turn after the notice; the CLI still returns to its input prompt. The added instructions describe recovery when a controller is active or a turn has already resumed. They did not supply the requested automatic continuation, and no working alternative for the user's existing CLI setup has been demonstrated. Remove the ineffective remedy rather than retain speculative guidance or introduce an unrequested launcher/controller.

This is a targeted reversal of #276, not another prompt experiment or a claim that the runtime interruption is fixed. It does not establish that every delegated-review instruction was redundant.

## Validation

- PASS: local source bytes match current blob `425354ea34b583f553d54abbeccdcc3828299323`.
- PASS: temporary assertions via `uv run --offline --no-project` verify exactly one heading/four bullets removed, seven removed lines, and byte-exact restoration on reinsertion. All text outside the subsection is unchanged.
- PASS: `git diff --check`; exact `git diff --numstat`: `0 7 codex/AGENTS.md`.
- PASS: the validated result matches pre-#276 blob `241921c571d5473c85377da2c628a47417bfb6a3`, reused directly in the new Git tree. Published commit inspection confirms only the intended subsection deletion.
- NOT RUN: live Codex/model evaluations or runtime recovery tests. No automated-review approval, passing CI, or behavioral improvement is claimed.

All other instructions, earlier ablations, skills, review contracts, configuration, and source stores remain unchanged. No client fork, wrapper, hook, or launcher is added.

## Scope

Base: `588a6961a8caa293dcb6e67a86df2dbdb3b9ae75` on `main`.
Head: `59aa3598047125d1de3d8210bc35ad7ec0a8e21d`.
Validation refreshed for this exact head: seven-line subsection deletion verified against Git blobs; `git diff --check` passes. Runtime tests not applicable to this instruction deletion.

## Readiness
- Operation: update
- Final state: preserve (ready)
- SHIP-v1 compatibility mode: update-existing
- No open follow-ups for this deletion. Runtime automatic continuation remains outside this PR.
<!-- ship-proof:end -->