### PR TITLE
universalist: recognize lawful contextual extension

### DIFF
--- a/codex/skills/universalist/references/effects-and-coalgebras.md
+++ b/codex/skills/universalist/references/effects-and-coalgebras.md
@@ -294,6 +294,89 @@ First seam examples:
 - a schema object plus mappings/constraints/report neighborhood;
 - a component plus provider/dependency/configuration neighborhood.
 
+## Co-Kleisli extension / context-consuming rules
+
+Use when local rules consume structured context and callers repeatedly rebuild
+that context at other positions or between passes. Distinguish consuming context
+`f : W<A> -> B` from assigning a coalgebra structure `h : A -> W<A>`.
+A comonad supplies extension without requiring each value type to have an `h`:
+
+```text
+extract : W<A> -> A
+extend  : (W<A> -> B) x W<A> -> W<B>
+then(f,g)(w) = g(extend(f,w))        f : W<A> -> B; g : W<B> -> C
+```
+
+For pure total rules, require these equations under the declared observations:
+
+```text
+extend(extract,w) = w
+extract(extend(f,w)) = f(w)
+extend(g,extend(f,w)) = extend(v => g(extend(f,v)),w)
+map(k,w) = extend(v => k(extract(v)),w)
+duplicate(w) = extend(v => v,w)
+extend(f,w) = map(f,duplicate(w))
+```
+
+An independently supplied `map` must be a lawful functor and agree with these
+definitions. The first three equations make `extract` the identity and `then`
+associative; they do not assert a universal property. See the standard
+[Comonad interface and laws](https://hackage.haskell.org/package/comonad-5.0.10/docs/Control-Comonad.html).
+Uustalu and Vene's [Comonadic Notions of Computation](https://doi.org/10.1016/j.entcs.2008.05.029)
+develops context-dependent semantics; the following lowering is an engineering example.
+
+### Worked lowering: immutable focused views
+
+Let `View<A>` contain a finite nonempty immutable vector `xs` and a valid focus
+`i`. All elements are already authorized for this view. Empty input and invalid
+indices stay outside this carrier and receive explicit boundary handling; do not
+invent a default element to manufacture total extraction.
+
+```text
+extract({xs,i}) = xs[i]
+refocus({xs,i},j) = {xs,i:j}                           0 <= j < length(xs)
+map(k,{xs,i}) = {xs: [k(x) for x in xs], i}
+extend(f,w) = {xs: [f(refocus(w,j)) for j in indices(w.xs)], i: w.i}
+```
+
+Refocusing shares the same immutable input snapshot. Extension preserves shape
+and focus while replacing every label with its rule result. This derives the
+laws by pointwise equality: extraction selects the original focus, and nested
+extension applies the same rules to the same refocused views.
+
+Suppose normalization doubles the focused number and validation requires every
+number in the view to be even. At focus zero of `[1,3]`:
+
+```text
+normalizeHere(w) = 2 * extract(w)
+validateHere(w) = all(x % 2 == 0 for x in w.xs)
+then(normalizeHere,validateHere)({xs:[1,3],i:0}) = true   derived view [2,6]
+```
+
+Replacing only the center yields `[2,3]` and false: the second rule sees stale
+neighbors. A second negative witness is refocusing by re-fetching a mutable
+source: after it changes to `[2,4]`, `extend(extract,w)` no longer equals the
+original `[1,3]` view. Test both against the stable-snapshot implementation,
+including singleton views, every valid focus, and the boundary rejection cases.
+Bounded examples falsify mistakes; the pointwise argument supplies the general
+law under the stated pure, total, immutable assumptions.
+
+Lower to an existing record/cursor and loop or a staged immutable traversal, not
+a generic comonad runtime. Translate one caller, compare its complete derived
+view with the required semantics, then retire its bespoke reconstruction. Keep
+a simple environment argument when no reconstruction/composition obligation is
+removed: `W<A> = E x A` with `extend(f,(e,a)) = (e,f(e,a))` is already lawful.
+
+Snapshot acquisition, authorization, failure, cancellation, and external writes
+retain their owners. These laws do not permit extra reads, capability widening,
+effect duplication, parallelism, or reassociation of effectful rules. A closure
+capturing mutable data is not a stable snapshot. No performance gain follows:
+nested extension can repeat whole traversals; compare complete staged, memoized,
+or fused workloads before claiming improvement. When inspectable positions or
+composable refocusing witnesses matter, use only the
+[directed-container recipe](mechanics/comonads-as-spaces.md#directed-container-lowering)
+rather than loading density, basis, or sheaf machinery.
+
 ## Density comonads, bases, Day products, and spatial framing
 
 Use density when local patch types generate the situated world:
@@ -324,6 +407,7 @@ The context/halo family must form an honest ordinary, promonoidal, or dependent 
 - Choose **free applicative / Day static descriptions** when the whole operation/dependency shape is known before results and static analysis matters.
 - Choose **Tambara/contextual-morphism structure** when one profunctorial capability must survive several context extensions.
 - Choose **behavioral coalgebra** when the main smell is ongoing behavior with duplicated transition/observation logic.
+- Choose **co-Kleisli extension** when one coherent refocusing/extension operation can replace repeated context reconstruction between local rules; an ordinary view and loop can suffice.
 - Choose **comonadic spatiality** when locality, neighborhoods, restriction, local/global identity, or continuity are semantic.
 - Combine static/applicative descriptions with a Freyd runtime when plans are inspectable but execution order remains effectful.
 - Combine Tambara framing with a Freyd runtime when an effectful capability must retain residual/context semantics but order remains observable.

--- a/codex/skills/universalist/references/latent-structure-recognition.md
+++ b/codex/skills/universalist/references/latent-structure-recognition.md
@@ -270,6 +270,7 @@ The existing comparison universe, dominance relation, current-context contract, 
 | conversions preserve operations across representations | homomorphism / natural transformation | operation then convert equals convert then operation | explicit structure-preserving adapter |
 | many projections define effective equality | observation vocabulary; Yoneda only with its natural correspondence | equivalence is adequate under permitted future operations | observation IR plus one runner |
 | repeated context wrappers around one capability | action / Tambara candidate | real unit, associative framing, and naturality exist | one typed frame operation or reject to ordinary context parameter |
+| local rules repeatedly rebuild views at other positions | comonadic extension / co-Kleisli composition | extraction and nested extension cohere; later rules see derived neighbors, not stale ones | one native refocusing/extension owner; keep an adequate environment parameter |
 | nested decomposition loops combine indexed descriptions | Day or promonoidal composition | all legal decompositions or witnesses must contribute | bounded indexed representation and normalizer |
 | local meanings restrict and must glue across overlaps | presheaf / sheaf candidate | restrictions compose and compatible locals glue uniquely-up-to | usage-site index then exact global model |
 | recursive traversals differ only by result algebra | fold / initial-algebra pattern | constructors determine the traversal homomorphism | one recursion scheme or repository-native fold |
@@ -279,6 +280,13 @@ The existing comparison universe, dominance relation, current-context contract, 
 | runtime processes compose and architecture changes compose separately | double-category candidate | both directions compose; compatibility squares paste; interchange is observable | typed arrows, squares, pasting, and interpreter |
 
 The atlas is abductive guidance, not a replacement registry. If a row's discriminator is absent, leave the candidate unresolved or reject it.
+
+For the contextual-extension row, use the focused-view derivation in
+[`effects-and-coalgebras.md`](effects-and-coalgebras.md#co-kleisli-extension--context-consuming-rules).
+Unlike Tambara framing of both endpoints, this lifts a context-consuming rule
+across coherent alternative views. A fixed environment paired with a value can
+already be a lawful product comonad; reject an unnecessary abstraction for lack
+of dividend, not because that mathematical structure is absent.
 
 ## Worked derivation: compatibility without extra policy
 

--- a/codex/skills/universalist/references/mechanics/comonads-as-spaces.md
+++ b/codex/skills/universalist/references/mechanics/comonads-as-spaces.md
@@ -413,6 +413,71 @@ Halo(point, entries, snapshot)
 
 Use when the relevant neighborhood is finite and snapshot-based.
 
+### Directed-container lowering
+
+Use this recipe only when a context representation needs explicit positions and
+composable changes of viewpoint. It is independent of density/basis claims.
+Ahman and Uustalu's [Directed Containers as Categories, sections 2–3](https://arxiv.org/html/1604.01187)
+identifies directed-container data with small-category data. On `Set`, write:
+
+```text
+W<A> = (s : Shape, labels : Position(s) -> A)
+root(s) : Position(s)
+subshape(s,p) : Shape                               p : Position(s)
+compose_s(p,q) : Position(s)                        q : Position(subshape(s,p))
+```
+
+Positions are arrows out of `s`; `subshape` gives their targets; `root` is the
+identity. Here composition means first `p`, then `q`. Require all five laws,
+with every position well-typed at its source and `t = subshape(s,p)`:
+
+```text
+subshape(s,root(s)) = s
+subshape(s,compose_s(p,q)) = subshape(subshape(s,p),q)
+compose_s(root(s),p) = p
+compose_s(p,root(subshape(s,p))) = p
+compose_s(compose_s(p,q),r) = compose_s(p,compose_t(q,r))
+```
+
+The second equation is target compatibility, not optional bookkeeping. With
+`Shape = Position(s) = {0,1}`, `root(s)=0`, and `subshape(s,p)=s XOR p`, using
+`p OR q` for composition passes identity and associativity but fails target
+compatibility at `p=q=1`. The lawful version uses XOR composition.
+The recipe derives the contextual operations:
+
+```text
+extract(s,labels) = labels(root(s))
+refocus((s,labels),p) = (t, q => labels(compose_s(p,q)))
+duplicate(s,labels) = (s, p => refocus((s,labels),p))
+extend(f,(s,labels)) = (s, p => f(refocus((s,labels),p)))
+```
+
+For the finite focused view, take `s=(n,i)`, `Position(s)=[0,n)`, `root(s)=i`,
+`subshape((n,i),j)=(n,j)`, and `compose_(n,i)(j,k)=k`, with `n>0` and valid
+indices. This is a disjoint family of codiscrete categories, one for each size;
+it lowers to the record and loop in
+[co-Kleisli extension](../effects-and-coalgebras.md#co-kleisli-extension--context-consuming-rules).
+Subtrees or typed paths need their own effective position representation and
+composition laws; they are not justified merely by this example.
+
+A directed graph alone lacks specified identities and composition; its free
+path category is a separate choice and cycles can make positions infinite.
+Keep required parallel witnesses, labels, and provenance even when endpoints
+agree. Prefer a native zipper, index, or path representation only when its
+inspection or composition removes a material obligation. Symbolic or lazy
+positions still need resource bounds; truncation must disclose law/observation
+losses rather than claim the exact comonad automatically.
+
+Do not identify three different categories: the encoded small category has
+shapes and positions; the co-Kleisli category has arrows `W<A> -> B`; the
+Eilenberg–Moore category has lawful structures `A -> W<A>` and their preserving
+maps. Nor does the object-level correspondence identify ordinary functors with
+comonad morphisms. A container map has a forward shape map `t : S -> S'` but
+backward position maps `Position'(t(s)) -> Position(s)`, subject to the directed
+laws; these are opcleavage-like, not arbitrary functors. Specify the actual
+transport and variance before claiming preservation. This complements, rather
+than replaces, the continuous-map distinction above.
+
 ### Bounded approximation
 
 ```text


### PR DESCRIPTION
## Summary

Teach Universalist to derive a useful implementation from comonadic structure, rather than add more general comonad exposition.

- Add a latent-structure recognizer for local rules that repeatedly reconstruct contextual views. Distinguish this from Tambara framing and preserve an adequate ordinary environment parameter.
- Add co-Kleisli extraction, extension, composition, and functor-compatibility laws with an immutable focused-vector lowering. Include concrete stale-neighbor and mixed-snapshot counterexamples.
- Add a directed-container lowering recipe with all five laws, an explicit target-compatibility counterexample, and the correspondence to the native focused view. Keep the encoded small category, co-Kleisli category, and Eilenberg–Moore coalgebra category distinct, including morphism variance.

The engineering examples are identified as applications, with primary mathematical sources linked. Pure/total/stable-snapshot assumptions are explicit; the laws do not grant effect duplication, authority widening, parallelism, or performance claims.

## Scope

Exactly three existing reference files; **157 added lines, no deletions**:

- `codex/skills/universalist/references/latent-structure-recognition.md`
- `codex/skills/universalist/references/effects-and-coalgebras.md`
- `codex/skills/universalist/references/mechanics/comonads-as-spaces.md`

`SKILL.md`, activation, routes, Actuating integration, decision contracts, registry cards, templates, package metadata, and existing doctrine are unchanged. No new files, mandatory passes, runtime code, or shipped tests.

## Validation

Executed a temporary Node.js translation of the documented native operations, outside the repository:

- Exhaustive extension-associativity checks for every Boolean-valued local rule pair and every focused Boolean vector of lengths 1 and 2: **524,320 rule-pair/view combinations**. Also checked extraction identities, duplicate/coassociativity, functor compatibility, and snapshot sharing.
- Directed-container identity, target, and associativity laws for focused shapes of lengths 1–5, plus agreement between the position-based recipe and native extension.
- Three negative controls: center-only normalization leaves stale neighbors; re-fetching a changed source breaks extraction/extension identity; OR composition with XOR targets passes identity/associativity but fails target compatibility.
- Empty-vector/invalid-focus rejection and an ordinary fixed-environment product-comonad control.
- Relative file/heading links, balanced code fences, exact three-file/additions-only scope, and `git diff --check`.
- All original files matched their source Git blob hashes; all uploaded blobs match the validated local files byte-for-byte.

These are finite mathematical/example checks, **not model-efficacy results or a whole-repository test run**. SKDC and Ledger executables were unavailable in this environment; no full routing/artifact-corpus replay, live model comparison, or performance benchmark was run. Direct container cloning was unavailable, so validation used a connector-fetched, blob-verified three-file snapshot of `d24b832`.

The expected efficacy improvement remains a hypothesis: recognize a genuine context-composition boundary while leaving an adequate explicit environment parameter alone.

<!-- ship-proof:start -->
## Summary
Add contextual extension recognition and focused-view/directed-container derivations to three Universalist references.

## Proof
- Current committed diff inspection, three-file scope, balanced code fences, and `git diff --check`: pass.
- Prior finite example validation is documented above; not rerun in this shipping pass.
- Documentation-only change; repository build and full test suite not run. No required CI checks in live branch policy.

## Scope
- repository: tkersey/dotfiles
- branch: codex/universalist-contextual-extension
- head: ed8c3eb1d815d6b75879ca16eaae2dc8fe27ac09
- base: main
- base SHA: d24b83236469b2e80d25703a1050c1e73a63b80a

## Risks
- Model efficacy remains unmeasured, as documented above.

## Follow-ups
- None required for this documentation change.

## Readiness
- Operation: update-and-promote
- Final state: ready
- SHIP-v1 compatibility mode: promote-draft
- Reason: documentation scope is complete; focused checks pass.
- Caveats: no full repository suite or model-efficacy replay.
<!-- ship-proof:end -->