### PR TITLE
codex: symlink split configs through existing installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ config file or old symlink, choose `o` at that destination's overwrite prompt
 to replace it with the new link. Overwrite removes the old file or link; keep
 any needed contents before selecting it. Choose `s` to preserve an existing
 file instead. The separate config-copying operation is removed.
+The installer sets the home config's repository target to mode `0600` before
+linking it, keeping personal settings private.
 
 Reopen Codex after installation. Shared defaults live in
 `etc/codex/config.toml`; personal settings and the Developer Docs MCP server

--- a/README.md
+++ b/README.md
@@ -5,44 +5,35 @@ git clone https://github.com/tkersey/dotfiles.git ~/.dotfiles && cd ~/.dotfiles 
 
 ### Codex configuration
 
-The installer copies the two repository configs into regular files:
+The two repository configs are installed as symlinks:
 
-| Repository file | Installed file |
+| Repository file | Symlink |
 | --- | --- |
 | `etc/codex/config.toml` | `/etc/codex/config.toml` |
 | `home/.codex/config.toml` | `~/.codex/config.toml` |
 
-To migrate, quit Codex/ChatGPT and running Codex CLI sessions, preserve any
-uncommitted config changes, and check out the revision containing the split.
-Then run the repository installer as your normal user:
+Quit Codex/ChatGPT and running Codex CLI sessions, preserve any config edits
+that should be kept, and update your checkout. Then run the existing installer
+as your normal user:
 
 ```sh
 cd ~/.dotfiles
-./install --codex-config
+./install --symlink
 ```
 
-The installer requests `sudo` only for the system file. It replaces existing
-config symlinks with regular files without changing their targets, and saves
-readable previous contents beside each destination as `config.toml.backup.*`.
-An old link whose target was removed by checkout is replaced directly.
-Identical regular file contents are left alone, and permissions are corrected
-on every run. The system file is installed with mode
-644 and the user file with mode 600. The default `./install` also includes this
-step; `--symlink` handles the remaining links only.
+The default `./install` includes the same symlink step. The installer requests
+`sudo` only when creating or replacing `/etc/codex/config.toml`. For an existing
+config file or old symlink, choose `o` at that destination's overwrite prompt
+to replace it with the new link. Overwrite removes the old file or link; keep
+any needed contents before selecting it. Choose `s` to preserve an existing
+file instead. The separate config-copying operation is removed.
 
-Reopen Codex and check that your model, plugins, and MCP tools load. User config
-values override system defaults. Installed files are independent of the
-checkout: pulling repository changes does not update them. Run
-`./install --codex-config` again to apply the repository versions; differing
-live settings are backed up before replacement.
-
-For an isolated installation check, the following prefixes both destinations
-with the staging path and does not use `sudo`. `DESTDIR` is supported only for
-this operation.
-
-```sh
-DESTDIR=/absolute/staging/path ./install --codex-config
-```
+Reopen Codex after installation. Shared defaults live in
+`etc/codex/config.toml`; personal settings and the Developer Docs MCP server
+live in `home/.codex/config.toml`. User values override system defaults.
+Because the live files link into this checkout, edits and repository updates
+are reflected through those links. Keep the checkout at a revision containing
+both files.
 
 ### iCloud directory backups
 

--- a/fish/completions/install.fish
+++ b/fish/completions/install.fish
@@ -7,7 +7,6 @@ complete -c install -f
 complete -c install -l dotfiles -d 'Process .symlink files'
 complete -c install -l symlink-files -d 'Process custom symlinks from links.conf'
 complete -c install -l homebrew -d 'Run homebrew installation/update'
-complete -c install -l codex-config -d 'Install regular system and user Codex config files'
 complete -c install -l help -d 'Show help message'
 
 # If the install script is not in the PATH, you may need to add completions for the full path
@@ -15,5 +14,4 @@ complete -c ./install -f
 complete -c ./install -l dotfiles -d 'Process .symlink files'
 complete -c ./install -l symlink-files -d 'Process custom symlinks from links.conf'
 complete -c ./install -l homebrew -d 'Run homebrew installation/update'
-complete -c ./install -l codex-config -d 'Install regular system and user Codex config files'
 complete -c ./install -l help -d 'Show help message'

--- a/install
+++ b/install
@@ -88,6 +88,9 @@ run_for_destination() {
 }
 
 setup_files () {
+  if [ "$2" = "$HOME/.codex/config.toml" ]; then
+    chmod 600 "$1"
+  fi
   run_for_destination "$2" mkdir -p "$(dirname "$2")"
   run_for_destination "$2" ln -s "$1" "$2"
   success "linked $1 to $2"

--- a/install
+++ b/install
@@ -8,7 +8,6 @@ BACKUP_SCRIPT="$DOTFILES_ROOT/backups/backup"
 
 # Default flags
 DO_SYMLINK=false
-DO_CODEX_CONFIG=false
 DO_HOMEBREW=false
 DO_ICLOUD_BACKUP=false
 DO_ALL=true
@@ -24,10 +23,6 @@ while [ $# -gt 0 ]; do
       DO_HOMEBREW=true
       DO_ALL=false
       ;;
-    --codex-config)
-      DO_CODEX_CONFIG=true
-      DO_ALL=false
-      ;;
     --icloud-backup)
       DO_ICLOUD_BACKUP=true
       DO_ALL=false
@@ -36,7 +31,6 @@ while [ $# -gt 0 ]; do
       echo "Usage: $0 [options]"
       echo "Options:"
       echo "  --symlink        Create symlinks from links.conf"
-      echo "  --codex-config   Install regular system and user Codex config files"
       echo "  --homebrew       Run homebrew installation/update"
       echo "  --icloud-backup  Install the rclone iCloud backup LaunchAgent"
       echo "  --help           Show this help message"
@@ -57,7 +51,6 @@ done
 # If no specific flags were set, do everything
 if [ "$DO_ALL" = true ]; then
   DO_SYMLINK=true
-  DO_CODEX_CONFIG=true
   DO_HOMEBREW=true
   DO_ICLOUD_BACKUP=true
 fi
@@ -84,60 +77,20 @@ fail () {
   exit 1
 }
 
-setup_files () {
-  mkdir -p $(dirname "$2")
-  ln -s "$1" "$2"
-  success "linked $1 to $2"
-}
-
-install_config_file() {
-  local source_file="$1" destination="$2" mode="$3" backup temporary
-  shift 3
-
-  if [ -f "$destination" ] && [ ! -L "$destination" ] && cmp -s "$source_file" "$destination"; then
-    "$@" chmod "$mode" "$destination"
-    success "verified $destination"
-    return
-  fi
-
-  "$@" mkdir -p "$(dirname "$destination")"
-  if [ -f "$destination" ]; then
-    backup=$("$@" mktemp "$destination.backup.XXXXXX")
-    "$@" cp "$destination" "$backup"
-    success "backed up $destination to $backup"
-  fi
-
-  # Rename a prepared regular file over the destination, never write through a symlink.
-  temporary=$("$@" mktemp "$destination.install.XXXXXX")
-  if "$@" install -m "$mode" "$source_file" "$temporary" &&
-     "$@" mv -f "$temporary" "$destination"; then
-    success "installed $destination"
+run_for_destination() {
+  local destination="$1"
+  shift
+  if [ "$destination" = "/etc/codex/config.toml" ] && [ "$EUID" -ne 0 ]; then
+    sudo "$@"
   else
-    "$@" rm -f "$temporary"
-    fail "could not install $destination"
+    "$@"
   fi
 }
 
-install_codex_config() {
-  local system_config="${DESTDIR:-}/etc/codex/config.toml"
-  local user_config="${DESTDIR:-}$HOME/.codex/config.toml"
-  local config
-  local privilege=()
-
-  for config in "$DOTFILES_ROOT/etc/codex/config.toml" "$DOTFILES_ROOT/home/.codex/config.toml"; do
-    [ -f "$config" ] || fail "Source not found: $config"
-  done
-  for config in "$system_config" "$user_config"; do
-    if [ -e "$config" ] && [ ! -f "$config" ]; then
-      fail "Expected a file at $config"
-    fi
-  done
-  if [ -z "${DESTDIR:-}" ] && [ "$EUID" -ne 0 ]; then
-    privilege=(sudo)
-  fi
-
-  install_config_file "$DOTFILES_ROOT/etc/codex/config.toml" "$system_config" 644 "${privilege[@]}"
-  install_config_file "$DOTFILES_ROOT/home/.codex/config.toml" "$user_config" 600
+setup_files () {
+  run_for_destination "$2" mkdir -p "$(dirname "$2")"
+  run_for_destination "$2" ln -s "$1" "$2"
+  success "linked $1 to $2"
 }
 
 install_homebrew() {
@@ -225,7 +178,7 @@ symlink_files() {
       fi
 
       if [ "$overwrite" = "true" ] || [ "$overwrite_all" = "true" ]; then
-        rm -rf "$dest_path"
+        run_for_destination "$dest_path" rm -rf "$dest_path"
         success "removed $dest_path"
         if [ "$overwrite_all" = "false" ]; then
           echo ''
@@ -249,20 +202,6 @@ symlink_files() {
 }
 
 # Run installations based on flags
-if [ -n "${DESTDIR:-}" ]; then
-  case "$DESTDIR" in
-    /*) ;;
-    *) fail "DESTDIR must be an absolute path" ;;
-  esac
-  if [ "$DO_SYMLINK" = true ] || [ "$DO_HOMEBREW" = true ] || [ "$DO_ICLOUD_BACKUP" = true ]; then
-    fail "DESTDIR is supported only with --codex-config"
-  fi
-fi
-
-if [ "$DO_CODEX_CONFIG" = true ]; then
-  install_codex_config
-fi
-
 if [ "$DO_HOMEBREW" = true ]; then
   install_homebrew
   brew bundle

--- a/links.conf
+++ b/links.conf
@@ -14,6 +14,8 @@ codex/AGENTS.md:$HOME/.claude/CLAUDE.md
 # Codex configuration
 $HOME/Library/Mobile Documents/com~apple~CloudDocs/ai/codex/sessions:$HOME/.codex/sessions
 codex/AGENTS.md:$HOME/.codex/AGENTS.md
+etc/codex/config.toml:/etc/codex/config.toml
+home/.codex/config.toml:$HOME/.codex/config.toml
 codex/agents:$HOME/.codex/agents
 codex/skills:$HOME/.agents/skills
 


### PR DESCRIPTION
<!-- ship-proof:start -->
## Changes

Install the split Codex configs as symlinks through the existing `links.conf` workflow:

- `etc/codex/config.toml` → `/etc/codex/config.toml`
- `home/.codex/config.toml` → `~/.codex/config.toml`

`./install` and `./install --symlink` both install these links. The installer uses sudo for system-config link creation/replacement and retains the existing overwrite/skip prompts. Remove the config-copying code, `--codex-config`, and its completion. Update the migration instructions.

Config contents are unchanged: Developer Docs MCP remains in the home config, and both memory model overrides remain removed. No test files added.

## Verification

- `bash -n install`, `fish -n fish/completions/install.fish`, `git diff --check`: pass.
- One-off isolated installer execution: both symlinks created and an existing regular config replaced through the overwrite prompt. Destinations were redirected into a temporary fixture; no live installation performed.
- Current-head isolated installer check: a 0644 home-config target becomes 0600 before symlink installation; live filesystem operations redirected into a fixture. No test files added.
- TOML assertions and Git comparison: config placement and contents preserved.

## Scope and readiness

- Repository: `tkersey/dotfiles`
- Branch: `codex/restore-config-symlinks`
- Head: `4d3cc7ec64aecf1901db7d4bae576dc6900e270f`
- Base: `main` at `69b49e1e627f7cad58e674d87a7652c4ee41cb5d`
- Operation: update; final state: ready; SHIP-v1 mode: update-existing.
- Caveat: live privileged installation not performed. Preserve needed live config contents before selecting overwrite.
- Follow-up: merge and run the repository installer.
<!-- ship-proof:end -->
