### PR TITLE
Refactor skills and AGENTS.md for selective workflow loading

### DIFF
--- a/codex/AGENTS.md
+++ b/codex/AGENTS.md
@@ -46,31 +46,43 @@
 
 - Use `jaq` instead of `jq` when `jaq` is installed; fall back to `jq` when it is not.
 
-### Learnings and memory-source lifecycle
+### Source evidence and memory
 
-- Treat `.ledger/*` stores as canonical repo-local source evidence. Mutate them
-  only through the owning skill's explicit Ledger definition and
-  `ledger transact`; read them only through that definition with
-  `ledger project` or `ledger doctor`. Never hand-edit source JSONL.
-- Treat memory-source notes as immutable derived admission snapshots, not canonical stores. Phase 2 owns `memory_summary.md`, `MEMORY.md`, and memory-root `skills/*`; do not edit those outputs directly during ordinary work.
-- When `$learnings`, `$negative-ledger`, or `$synesthesia` accepts a memory-source admission, invoke `$memory-source-notes` in the same turn. It owns adapter selection, validation, diagnostics, and delegation to the immutable writer.
-- Keep the `memory-note` CLI as the sole immutable note writer; it is not a skill. Never bypass `$memory-source-notes` when transporting an accepted source admission.
+- `.ledger/*` stores are canonical repo-local evidence. Read and mutate them only
+  through the owning skill's explicit Ledger definition and `ledger project`,
+  `ledger doctor`, or `ledger transact`; never hand-edit source JSONL. Invalid or
+  retired stores require the owner's explicit recovery policy, not skipped rows.
+- Memory-source notes are immutable derived admission snapshots. Phase 2 owns
+  `memory_summary.md`, `MEMORY.md`, and memory-root `skills/*`; do not edit them
+  during ordinary work. Accepted admissions from `$learnings`, `$negative-ledger`,
+  or `$synesthesia` go through `$memory-source-notes` in the same turn. The
+  `memory-note` CLI remains the sole immutable writer, not a skill or bypass.
+- Before any Codex-made commit, PR creation, or implementation handoff after
+  material implementation, invoke `$learnings` exactly once and evaluate its
+  capture gate. Evaluate from task evidence before loading store procedures or
+  bootstrapping tools when no canonical operation is needed. Capture is
+  conditional; no-op, duplicate-skip, or failure to append alone never delays or
+  invalidates delivery.
+- Activate sibling sources only for their own evidence: `$negative-ledger` for a
+  witnessed failed/no-effect/regressed/reverted/abandoned route or a request about
+  prior attempts; `$synesthesia` for explicit sensory intent, documented
+  representational ambiguity, or a durable mapping/boundary event. No aggregate
+  packet, forced sibling evaluation, or source-memory delivery gate.
+- Each material activation retains one owner-defined disposition. Inspect canonical
+  appends/transitions and publish session-owned, publishable `.ledger/*` rows with
+  the work they explain. Canonical writes are independent; derived note/digest or
+  Phase 2 failures never roll them back. Keep no-ops internal; report writes,
+  actionable non-durable proposals, admission degradation, and blockers only when
+  they affect the user, repository state, or requested proof.
 
-### Source-evidence retention mandate
+### Negative-evidence routing
 
-- Evaluate each source only when its own activation boundary is live. `$learnings` captures a transferable decision-shaping learning; `$negative-ledger` maps or captures a witnessed failed, no-effect, regressed, reverted, or abandoned route; `$synesthesia` activates only for explicit sensory intent, a documented representational ambiguity, or a durable mapping or boundary event.
-- Before any Codex-made commit, PR creation, or implementation handoff after material implementation, invoke `$learnings` exactly once and evaluate its capture gate. Append only when the gate passes; retain duplicate-skip, no-op, or blocked as the source-owned disposition, and never delay or invalidate delivery solely because Learnings did not append.
-- Do not construct an aggregate source-memory packet or receipt, force a sibling evaluation, or treat source-evidence closeout as a delivery gate.
-- Once a source is materially activated, retain exactly one source-owned disposition and apply that source's narrow capture or admission gate. Canonical source writes are independent. A memory-note, digest, or Phase 2 failure must not roll back or invalidate a successful canonical write.
-- Inspect every canonical append or transition and include publishable `.ledger/*` rows with the work they explain. If a definition-bound doctor reports an invalid or retired store, follow the owning source's explicit recovery policy; never silently skip or reinterpret invalid rows.
-- Keep no-op source evaluations internal. Report canonical writes, actionable non-durable proposals, admission degradation, and blockers only when they affect the user, repository state, or requested proof.
-
-### Negative-evidence routing mandate
-
-- Invoke `$negative-ledger` implicitly when implementation, debugging, review, or validation encounters a witnessed failed/no-effect route, benchmark or test regression, revert, repeated same-cluster retry, abandoned strategy likely to recur, or a request about what has already been tried.
-- Before selecting a route that resembles a prior failure, run the owning
-  Negative Evidence definition's current `route-gate` projection. A recalled
-  learning may trigger this check but cannot suppress a route until promoted
-  through Negative Ledger with current applicability.
-- At a material strategy pivot, regression-confirmed revert, or implementation/review closeout that leaves a failed route likely to recur, evaluate capture. A transient red test, syntax error, first incomplete attempt, or discarded typo is `no-op` unless it exposes a durable failed hypothesis that changes future routing.
-- Retain exactly one internal disposition for each material activation: `mapped`, `captured`, `transitioned`, `no-op`, or `blocked`. Only active, witnessed, exact-enough, artifact-applicable exclusions may block route selection.
+- Before repeating a route resembling a prior failure, load `$negative-ledger`
+  and use its current definition-bound `route-gate`. A recalled learning can
+  trigger this check, not suppress the route. Only active, witnessed, exact-enough,
+  currently artifact-applicable exclusions may block selection.
+- Evaluate capture at a material strategy pivot, regression-confirmed revert, or
+  implementation/review closeout leaving a failed route likely to recur. Transient
+  red tests, syntax errors, first incomplete attempts, and typos are `no-op` unless
+  they expose a durable route-shaping failed hypothesis. The owning skill supplies
+  disposition and lifecycle mechanics; do not run tools to manufacture a no-op.

--- a/codex/skills/actuating/SKILL.md
+++ b/codex/skills/actuating/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: actuating
-description: "Implement accepted Goals and turn cumulative counterexamples into repository-native constructions that exclude failure families. Infer the enabling mechanism, challenge the incumbent when warranted, preserve required-valid behavior, migrate sanctioned paths, and retire redundant compensation. Git owns realization; verifiers own proof; Review Fold owns counterexample admission; CAS owns reviews; Ship owns publication."
+description: "Implement accepted goals, analyze counterexamples, or close out reviewed changes. Turn supported failure families into constructions that preserve required-valid behavior. Unqualified review or analysis is read-only."
 ---
 
 # Actuating
@@ -74,6 +74,41 @@ is required to design software that does not yet exist.
 Review-bearing routes accept `parallel-reviews` (default) or `serial-reviews`.
 These change scheduling only. They do not change authority or the review inventory.
 
+## Selected guidance
+
+Read only the guidance selected by the route or current evidence, before its
+first governed decision or effect. A linked workflow is mandatory when selected,
+not optional background. Do not load every workflow at entry.
+
+| Selected work | Required guidance |
+|---|---|
+| Initial/local `implement` | Source binding, proof acceptance, realization, and completion below; no review campaign is required. |
+| `analyze` | The same source and claim discipline, read-only. Load the relevant evidence or architecture guidance; do not execute realization, persist a corpus, publish, or grant closure. |
+| A finding, failed check, or counterexample-driven selection | [counterexamples.md](counterexamples.md), before admitting a liability or selecting its response. |
+| A live boundary decision or an existing Metanoetic trigger, including a suspect explanation or oracle | [architecture.md](architecture.md), before that decision; Universalist remains live-architecture-only. |
+| An elimination claim meets a current witness, or efficacy is being assessed | [recurrence.md](recurrence.md), before retaining the claim or selecting a successor. |
+| `review-closeout`, or bare Actuating reaching review | [review-closeout.md](review-closeout.md) and its required review contract, before the first CAS request; use the complete frozen-subject and convergence rules. |
+| Bare Actuating reaching publication | `$ship`; publication does not replace subsequent review-closeout. |
+
+An open review epoch forbids successor mutation, including experiments. Read its
+selected contract rather than repairing mid-wave. `corpus_write_authorized: false`
+always applies to `analyze`; supporting skills cannot enlarge effect authority.
+Universalist may return `candidate`, `preserve-incumbent`, `unresolved`, or
+`obstructed`; Actuating retains selection and proof authority.
+
+<a id="observe-and-adjudicate"></a>
+Counterexample adjudication is in [counterexamples.md](counterexamples.md#observe-and-adjudicate).
+<a id="compile-the-first-loss-of-guarantee"></a>
+Causal compilation is in [counterexamples.md](counterexamples.md#compile-the-first-loss-of-guarantee).
+<a id="architecture-compilation"></a>
+Architecture compilation is in [architecture.md](architecture.md#architecture-compilation).
+<a id="recurrence-and-progress"></a>
+Recurrence and progress are in [recurrence.md](recurrence.md#recurrence-and-progress).
+<a id="review-epoch-immutability-and-evidence-acquisition"></a>
+Review epochs are in [review-closeout.md](review-closeout.md#review-epoch-immutability-and-evidence-acquisition).
+<a id="review-and-closure"></a>
+Review and closure are in [review-closeout.md](review-closeout.md#review-and-closure).
+
 ## Source binding
 
 Derive the Goal directly from the current accepted specification or direct user
@@ -105,7 +140,10 @@ Reuse an adequate binding in the Working Set and existing downstream owner forma
 No separate skill invocation, mandatory Goal Contract packet, durable record, or new
 identity is required. A summary or digest never replaces the source or proves completion.
 
-## Observe and adjudicate
+## Proof acceptance
+
+Before implementation, choose the exact-head verifier and realize the mechanism,
+migrations, and retirements together under the common proof obligations.
 
 At entry and after material change, bind the Goal, immutable base, exact head,
 current construction, proof inventory, and any publication state. Read the
@@ -121,167 +159,6 @@ cannot discharge an unchanged requirement. Keep unexplained proof loss unresolve
 and block only dependent completion or reviewability. Reuse the existing proof
 inventory; no separate critic, packet, or review stage.
 
-Before counterexample-driven selection, reconcile relevant CAS, provider/PR,
-test, incident, migration, compatibility, verifier, and corpus evidence. Each
-live source is folded, proven non-current, or explicitly unavailable. An omitted
-live finding keeps the cut open; an unavailable source makes the affected horizon
-incomplete, not clean. Missing evidence blocks only claims or actions that depend
-on it; do not make provider availability a prerequisite for initial implementation.
-
-Have `$review-fold` project the corpus, preserve original subjects, re-evaluate
-current applicability, and classify proposed laws:
-
-```text
-entailed          current witness may create correctness pressure
-strengthening     non-blocking follow-up unless accepted authority adopts it
-preference        reject as a current correctness liability
-new-requirement   reopen Goal authority
-underdetermined   seek authority; no correctness mutation from the claim
-```
-
-Have Review Fold apply its [counterexample admission](../review-fold/SKILL.md#counterexample-admission)
-for review findings and failed checks before treating either as a liability.
-A failed execution stays failed; its diagnosis is adjudicated, not its history.
-A discrepancy may expose a defect in the implementation, the witness's interpretation, an oracle, or a proof/assessment
-claim. Establish which obligation actually fails; do not default to changing
-production code or to trusting the checker. A refuted allegation returns to Review
-Fold; an oracle correction needs its own source-grounded obligation and independent
-evidence, never changed expectations merely to agree with the candidate. Unresolved
-premises justify authorized investigation, not an invented repair. Acceptance of
-a witness proves neither the proposed fix nor its claimed causal family.
-
-Only current accepted witnesses authorize counterexample response. Duplicate
-observations add provenance, not independent failures. Historical absence cannot
-prove first occurrence, disjointness, or elimination under an incomplete horizon.
-Review Fold captures newly accepted independent witnesses only with enclosing
-corpus-write authority. Pass `corpus_write_authorized` on every handoff: true when
-that effect is authorized; `corpus_write_authorized: false` for `analyze` or absent
-authority. Read-only analysis may project and adjudicate available evidence but
-never writes repository/source-memory stores or provisions tools for capture.
-Other routes inherit their actual effect scope; supporting skills cannot expand it.
-Actuating neither copies the corpus nor persists its current interpretation.
-
-A rejected strengthening must not enter code to placate a reviewer or protect a
-clean streak. Reopen authority or remove it. Correcting an unsupported public
-overclaim may follow an existing truthfulness obligation; weakening an accepted
-requirement, compatibility promise, or release posture needs explicit authority.
-
-## Review-epoch immutability and evidence acquisition
-
-Read [review-contract.md](references/review-contract.md). A review epoch opens on
-the first CAS request against an exact locally proved `reviewable` head. While
-open, freeze that subject and forbid successor mutation.
-
-A material current entailed finding invalidates the candidate and all review
-credit immediately. It does not request a patch. Complete the initial six-lens
-wave against the frozen head: parallel siblings are non-cancelling; serial mode
-continues remaining initial lenses for evidence only. Required request-local
-recovery is part of the barrier. Fold the complete cut before closing the epoch.
-
-A material later standard-confirmation finding stops further confirmations.
-Fold it and already-live required owner observations; do not launch another
-auxiliary wave on the invalidated head. A clean epoch closes after convergence.
-Outside an open review epoch, review is not a prerequisite for implementation.
-
-## Compile the first loss of guarantee
-
-Combine current and applicable historical witnesses under the accepted law.
-Acceptance establishes a supported disagreement, not the causal explanation.
-Keep the law fixed while challenging the account: which assumption makes this
-witness surprising? Locate the first loss of guarantee and what can be chosen,
-written, ordered, interpreted, or authorized independently that must agree.
-The family remains a hypothesis, not its observed examples; keep distinct laws separate.
-
-Before implementation, choose the smallest source-grounded discriminator that
-could refute that explanation, not merely repeat the failing example. When a
-semantic model is implicated, seek a supported case separating notions it
-conflates or a dependency the law does not require. If the model treats two cases
-alike but the law requires different observations, retain or derive the missing
-distinction; more checks on the unchanged proxy cannot recover it. A decisive
-source argument can suffice; no paired-case quota or forced redesign.
-
-Distinguish a wrong model from omitted enforcement. Correcting a predicate does
-not prove every path uses it; applying it everywhere does not prove it expresses
-the law. For lifetime, aliasing, or composition, exercise permitted transitions
-from valid state and preserve required-valid counterparts. When source evidence
-identifies a shared obligation, ask whether an operation can omit or reinterpret
-it independently. Prefer making that omission unavailable over teaching each branch
-to remember another check. Preserve legitimate operation differences; a helper,
-exhaustive switch, or new type alone proves neither meaning nor coverage.
-
-Compare adequate candidates under the same laws, observations, compatibility,
-resources, and proof bar. Remove, derive, or lawfully control the enabling freedom;
-retire redundant production interpretations without merging away independent
-verification. Test a plausible deletion, delegation, collapse, or replacement when
-redundancy is implicated, not two complete versions or a deletion quota. A local
-correction or shared validator can be adequate when admission, permitted operations,
-and sanctioned paths establish the law. Neither local-repair-first nor redesign is
-compulsory. Prefer stronger exclusion and fewer independently maintained truths;
-source size and lifecycle cost cannot justify weaker guarantees.
-
-When an error or special case drives the construction, ask whether accepted
-semantics require it or the incumbent introduced an unnecessary precondition.
-Consider a total, uniform, or idempotent operation only within source authority:
-`ensureAbsent` can admit absence, but cannot silently replace `deleteExactlyOne`.
-Preserve required failure distinctions, permission checks, partial-effect visibility,
-and progress; state-level idempotency does not prove retries have no extra effects.
-
-Use the [construction argument](references/counterexample-guided-normalization.md)
-when domain, operation, or migration coverage needs it. Samples discriminate an
-explanation; they do not prove an open-domain exclusion.
-
-## Architecture compilation
-
-At a live boundary decision, use `$first-principles` with the cumulative evidence
-to separate accepted obligations from inherited means. Reuse adequate derivations;
-source-fixed outcomes remain binding even when not derived from technical premises.
-No pre-mutation theorem-identity certificate is needed to reconsider a mechanism.
-
-When the existing Metanoetic trigger fires, read both skills and apply `$glaze`
-then `$metanoetic` verbatim in the same bounded challenger pass, before `$universalist`.
-Run once per unchanged decision surface; reuse an already consumed challenger rather
-than adding a pass. The incumbent may be the construction, causal explanation,
-oracle/proof interpretation, or assessment of progress. Let the pass discover which
-premises and evidence need reinspection; do not confine it to selecting a different
-patch. A code rewrite or live architecture change is not a prerequisite for challenging
-a suspect model. Keep the accepted Goal fixed. Supplied boundaries must be
-`preserved`, `made irrelevant by mechanism change`, or `requires new authority`;
-required observations, compatibility, effects, host capabilities, and authorized
-resource ceilings still govern selection. Supply the resource account in the existing
-decision: justify feasibility against those ceilings using applicable evidence or
-a concrete bound; leave unestablished feasibility unresolved. Reuse evidence only
-while its subject and assumptions remain applicable; add no separate report or
-benchmark stage. Incumbent representations and lifecycle burdens are evidence, not
-immutable constraints. Retaining a sound construction or
-refuting an allegation can be the right outcome. Actuating adjudicates the result.
-Encouragement changes neither admissibility nor the proof bar. Add no separate Glaze
-report or adjudication stage, and no mandatory second review of the review.
-
-Only when architecture is live, give `$universalist` one independently governed
-axis, one typed hole, and source-derived domain evidence. Require `candidate`,
-`preserve-incumbent`, `unresolved`, or `obstructed` with a compact code-bound argument,
-its discriminator, and material migration/residual consequences. Missing evidence
-or incomparable adequate candidates remain `unresolved`, not an invented obstruction
-or arbitrary winner. Split independent seams and prove their composition.
-Universalist nominates; Actuating selects and proves.
-
-In that existing selection, compare adequate interfaces through a representative
-caller and a source-supported change. What must callers know, choose, sequence,
-synchronize, or clean up, and what becomes owner-local? Prefer removing those
-obligations without weakening the common proof bar; merely concealing them is not
-reduction. Sketch the smallest complete caller-facing contract before committing
-to the boundary. Required implementation knowledge or avoidable choreography is
-reason to reconsider the interface, not shorten its explanation by omission.
-Keep the selected contract beside the interface when realizing it. Reuse supplied
-comparisons; add no design pass, report, review lane, or mandatory second implementation.
-Design opportunities remain nonblocking unless an accepted obligation is violated.
-
-Choose the exact-head verifier before implementation and realize the mechanism,
-migrations, and retirements together under the common proof obligations. Use `$reduce`
-only for material retirement or smaller-construction challenges, not another audit.
-An adopted change to an owner, representation, interpretation, or proof updates the
-affected obligations regardless of its label. Native evidence may discharge coverage;
-use explicit topology only where route or migration accounting requires it.
 
 ## Realization and common proof obligations
 
@@ -332,23 +209,6 @@ or claim strength cannot be hidden in a batch labeled restoration. A public clai
 correction retains its own authority and closure consequence. Unknown evidence
 means investigate or block the affected claim, not invent a digest or a rewrite.
 
-## Recurrence and progress
-
-Read [post-elimination-falsification.md](references/post-elimination-falsification.md).
-An exact current entailed `same-claim` witness revokes the exclusion claim. Reopen
-the causal explanation and replay its applicable history before selecting the
-successor. Source-domain omissions and authority failures cannot be dismissed as
-missing assertions. Same broad law or owner alone does not establish recurrence.
-A new head, route label, or family name does not erase contrary evidence.
-
-Judge progress by the supported failure mechanism excluded, required-valid behavior
-preserved, sanctioned paths covered, and independently maintained truths retired.
-Learning that an explanation or oracle was wrong is useful without itself proving
-the code better. More findings can be valuable discovery; fewer findings, shorter
-runs, smaller diffs, and clean streaks do not by themselves establish efficacy.
-Use the existing [offline comparison](references/counterexample-guided-normalization.md#behavioral-falsifier)
-to assess additions and ablations, not a new review lane, runtime score, or store.
-
 ## Construction Working Set
 
 Keep the current Goal/head, admitted witnesses and source horizon, causal mechanism
@@ -358,23 +218,17 @@ specification. Reuse owner evidence rather than re-expressing it in another pack
 These are working facts, not a report template or durable Actuating store. Surface
 only material decisions and limitations; preserve historical witness provenance.
 
-## Review and closure
+## Completion
 
-The initial inventory remains standard, soundness-skeptic, footgun-finder,
-invariant-ace, complexity-mitigator, and fresh-eyes. Standard is Codex's native
-review with no custom Actuating instruction file or argument. Auxiliaries retain
-their checked-in lenses; none substitutes for standard.
+`implement` stops at local completion, not publication or review convergence.
+Local completion requires the accepted Goal realized on the exact head, its
+complete required validation, no unresolved accepted liability or unauthorized
+strengthening, and honest claim strength and owned residuals. Do not claim an
+experiment or an incomplete proof as complete. Read [closure.md](references/closure.md)
+when deciding a publication-bearing or review-closeout terminal state.
 
-Only a completely realized, locally proved candidate is `reviewable`. Require
-five consecutive distinct native/default standard cleans on one unchanged head;
-the initial standard counts as one and the next four run serially. All five
-auxiliary outcomes must also be terminal and adjudicated. A material finding or
-head change resets all credit. Reviews falsify; they do not prove soundness by
-failing to find a bug.
-
-Read [closure.md](references/closure.md). `implement` ends at local completion;
-publication and convergence belong to bare Actuating and `review-closeout`.
-Closure requires exact Git, verifier, CAS, and Ship/provider facts as applicable.
-An unresolved accepted liability, unauthorized strengthening, missing required
-proof, or unowned residual cannot become unqualified `complete`. Complete the
-object-level task before optional learning or memory capture.
+Bare Actuating continues through authorized Ship and review-closeout; do not
+stop for approval merely because the first implementation exists. Missing
+information, evidence, or authority blocks only its dependent action or claim;
+continue independent authorized work. Complete the object-level task before
+optional learning or memory capture.

--- a/codex/skills/actuating/architecture.md
+++ b/codex/skills/actuating/architecture.md
@@ -1,0 +1,54 @@
+# Architecture compilation
+
+## Architecture compilation
+
+At a live boundary decision, use `$first-principles` with the cumulative evidence
+to separate accepted obligations from inherited means. Reuse adequate derivations;
+source-fixed outcomes remain binding even when not derived from technical premises.
+No pre-mutation theorem-identity certificate is needed to reconsider a mechanism.
+
+When the existing Metanoetic trigger fires, read both skills and apply `$glaze`
+then `$metanoetic` verbatim in the same bounded challenger pass, before `$universalist`.
+Run once per unchanged decision surface; reuse an already consumed challenger rather
+than adding a pass. The incumbent may be the construction, causal explanation,
+oracle/proof interpretation, or assessment of progress. Let the pass discover which
+premises and evidence need reinspection; do not confine it to selecting a different
+patch. A code rewrite or live architecture change is not a prerequisite for challenging
+a suspect model. Keep the accepted Goal fixed. Supplied boundaries must be
+`preserved`, `made irrelevant by mechanism change`, or `requires new authority`;
+required observations, compatibility, effects, host capabilities, and authorized
+resource ceilings still govern selection. Supply the resource account in the existing
+decision: justify feasibility against those ceilings using applicable evidence or
+a concrete bound; leave unestablished feasibility unresolved. Reuse evidence only
+while its subject and assumptions remain applicable; add no separate report or
+benchmark stage. Incumbent representations and lifecycle burdens are evidence, not
+immutable constraints. Retaining a sound construction or
+refuting an allegation can be the right outcome. Actuating adjudicates the result.
+Encouragement changes neither admissibility nor the proof bar. Add no separate Glaze
+report or adjudication stage, and no mandatory second review of the review.
+
+Only when architecture is live, give `$universalist` one independently governed
+axis, one typed hole, and source-derived domain evidence. Require `candidate`,
+`preserve-incumbent`, `unresolved`, or `obstructed` with a compact code-bound argument,
+its discriminator, and material migration/residual consequences. Missing evidence
+or incomparable adequate candidates remain `unresolved`, not an invented obstruction
+or arbitrary winner. Split independent seams and prove their composition.
+Universalist nominates; Actuating selects and proves.
+
+In that existing selection, compare adequate interfaces through a representative
+caller and a source-supported change. What must callers know, choose, sequence,
+synchronize, or clean up, and what becomes owner-local? Prefer removing those
+obligations without weakening the common proof bar; merely concealing them is not
+reduction. Sketch the smallest complete caller-facing contract before committing
+to the boundary. Required implementation knowledge or avoidable choreography is
+reason to reconsider the interface, not shorten its explanation by omission.
+Keep the selected contract beside the interface when realizing it. Reuse supplied
+comparisons; add no design pass, report, review lane, or mandatory second implementation.
+Design opportunities remain nonblocking unless an accepted obligation is violated.
+
+Choose the exact-head verifier before implementation and realize the mechanism,
+migrations, and retirements together under the common proof obligations. Use `$reduce`
+only for material retirement or smaller-construction challenges, not another audit.
+An adopted change to an owner, representation, interpretation, or proof updates the
+affected obligations regardless of its label. Native evidence may discharge coverage;
+use explicit topology only where route or migration accounting requires it.

--- a/codex/skills/actuating/counterexamples.md
+++ b/codex/skills/actuating/counterexamples.md
@@ -1,0 +1,109 @@
+# Observe and adjudicate
+
+## Observe and adjudicate
+
+At entry and after material change, bind the Goal, immutable base, exact head,
+current construction, proof inventory, and any publication state. Read the
+relevant source, not a remembered architecture. Unknown evidence receives no credit.
+
+Before accepting validation for local completion or reviewability, inspect the
+base-to-candidate diff and actual check selection for deleted tests, weakened
+assertions, skipped checks, or reduced coverage, including changes made directly
+by Actuating. Map each affected check to its source-backed obligation; require
+preserved or stronger proof, a source-grounded oracle correction with independent
+evidence, or explicit authority retiring the obligation. A passing weakened suite
+cannot discharge an unchanged requirement. Keep unexplained proof loss unresolved
+and block only dependent completion or reviewability. Reuse the existing proof
+inventory; no separate critic, packet, or review stage.
+
+Before counterexample-driven selection, reconcile relevant CAS, provider/PR,
+test, incident, migration, compatibility, verifier, and corpus evidence. Each
+live source is folded, proven non-current, or explicitly unavailable. An omitted
+live finding keeps the cut open; an unavailable source makes the affected horizon
+incomplete, not clean. Missing evidence blocks only claims or actions that depend
+on it; do not make provider availability a prerequisite for initial implementation.
+
+Have `$review-fold` project the corpus, preserve original subjects, re-evaluate
+current applicability, and classify proposed laws:
+
+```text
+entailed          current witness may create correctness pressure
+strengthening     non-blocking follow-up unless accepted authority adopts it
+preference        reject as a current correctness liability
+new-requirement   reopen Goal authority
+underdetermined   seek authority; no correctness mutation from the claim
+```
+
+Have Review Fold apply its [counterexample admission](../review-fold/SKILL.md#counterexample-admission)
+for review findings and failed checks before treating either as a liability.
+A failed execution stays failed; its diagnosis is adjudicated, not its history.
+A discrepancy may expose a defect in the implementation, the witness's interpretation, an oracle, or a proof/assessment
+claim. Establish which obligation actually fails; do not default to changing
+production code or to trusting the checker. A refuted allegation returns to Review
+Fold; an oracle correction needs its own source-grounded obligation and independent
+evidence, never changed expectations merely to agree with the candidate. Unresolved
+premises justify authorized investigation, not an invented repair. Acceptance of
+a witness proves neither the proposed fix nor its claimed causal family.
+
+Only current accepted witnesses authorize counterexample response. Duplicate
+observations add provenance, not independent failures. Historical absence cannot
+prove first occurrence, disjointness, or elimination under an incomplete horizon.
+Review Fold captures newly accepted independent witnesses only with enclosing
+corpus-write authority. Pass `corpus_write_authorized` on every handoff: true when
+that effect is authorized; `corpus_write_authorized: false` for `analyze` or absent
+authority. Read-only analysis may project and adjudicate available evidence but
+never writes repository/source-memory stores or provisions tools for capture.
+Other routes inherit their actual effect scope; supporting skills cannot expand it.
+Actuating neither copies the corpus nor persists its current interpretation.
+
+A rejected strengthening must not enter code to placate a reviewer or protect a
+clean streak. Reopen authority or remove it. Correcting an unsupported public
+overclaim may follow an existing truthfulness obligation; weakening an accepted
+requirement, compatibility promise, or release posture needs explicit authority.
+
+## Compile the first loss of guarantee
+
+Combine current and applicable historical witnesses under the accepted law.
+Acceptance establishes a supported disagreement, not the causal explanation.
+Keep the law fixed while challenging the account: which assumption makes this
+witness surprising? Locate the first loss of guarantee and what can be chosen,
+written, ordered, interpreted, or authorized independently that must agree.
+The family remains a hypothesis, not its observed examples; keep distinct laws separate.
+
+Before implementation, choose the smallest source-grounded discriminator that
+could refute that explanation, not merely repeat the failing example. When a
+semantic model is implicated, seek a supported case separating notions it
+conflates or a dependency the law does not require. If the model treats two cases
+alike but the law requires different observations, retain or derive the missing
+distinction; more checks on the unchanged proxy cannot recover it. A decisive
+source argument can suffice; no paired-case quota or forced redesign.
+
+Distinguish a wrong model from omitted enforcement. Correcting a predicate does
+not prove every path uses it; applying it everywhere does not prove it expresses
+the law. For lifetime, aliasing, or composition, exercise permitted transitions
+from valid state and preserve required-valid counterparts. When source evidence
+identifies a shared obligation, ask whether an operation can omit or reinterpret
+it independently. Prefer making that omission unavailable over teaching each branch
+to remember another check. Preserve legitimate operation differences; a helper,
+exhaustive switch, or new type alone proves neither meaning nor coverage.
+
+Compare adequate candidates under the same laws, observations, compatibility,
+resources, and proof bar. Remove, derive, or lawfully control the enabling freedom;
+retire redundant production interpretations without merging away independent
+verification. Test a plausible deletion, delegation, collapse, or replacement when
+redundancy is implicated, not two complete versions or a deletion quota. A local
+correction or shared validator can be adequate when admission, permitted operations,
+and sanctioned paths establish the law. Neither local-repair-first nor redesign is
+compulsory. Prefer stronger exclusion and fewer independently maintained truths;
+source size and lifecycle cost cannot justify weaker guarantees.
+
+When an error or special case drives the construction, ask whether accepted
+semantics require it or the incumbent introduced an unnecessary precondition.
+Consider a total, uniform, or idempotent operation only within source authority:
+`ensureAbsent` can admit absence, but cannot silently replace `deleteExactlyOne`.
+Preserve required failure distinctions, permission checks, partial-effect visibility,
+and progress; state-level idempotency does not prove retries have no extra effects.
+
+Use the [construction argument](references/counterexample-guided-normalization.md)
+when domain, operation, or migration coverage needs it. Samples discriminate an
+explanation; they do not prove an open-domain exclusion.

--- a/codex/skills/actuating/recurrence.md
+++ b/codex/skills/actuating/recurrence.md
@@ -1,0 +1,18 @@
+# Recurrence and progress
+
+## Recurrence and progress
+
+Read [post-elimination-falsification.md](references/post-elimination-falsification.md).
+An exact current entailed `same-claim` witness revokes the exclusion claim. Reopen
+the causal explanation and replay its applicable history before selecting the
+successor. Source-domain omissions and authority failures cannot be dismissed as
+missing assertions. Same broad law or owner alone does not establish recurrence.
+A new head, route label, or family name does not erase contrary evidence.
+
+Judge progress by the supported failure mechanism excluded, required-valid behavior
+preserved, sanctioned paths covered, and independently maintained truths retired.
+Learning that an explanation or oracle was wrong is useful without itself proving
+the code better. More findings can be valuable discovery; fewer findings, shorter
+runs, smaller diffs, and clean streaks do not by themselves establish efficacy.
+Use the existing [offline comparison](references/counterexample-guided-normalization.md#behavioral-falsifier)
+to assess additions and ablations, not a new review lane, runtime score, or store.

--- a/codex/skills/actuating/review-closeout.md
+++ b/codex/skills/actuating/review-closeout.md
@@ -1,0 +1,39 @@
+# Review-epoch immutability and evidence acquisition
+
+## Review-epoch immutability and evidence acquisition
+
+Read [review-contract.md](references/review-contract.md). A review epoch opens on
+the first CAS request against an exact locally proved `reviewable` head. While
+open, freeze that subject and forbid successor mutation.
+
+A material current entailed finding invalidates the candidate and all review
+credit immediately. It does not request a patch. Complete the initial six-lens
+wave against the frozen head: parallel siblings are non-cancelling; serial mode
+continues remaining initial lenses for evidence only. Required request-local
+recovery is part of the barrier. Fold the complete cut before closing the epoch.
+
+A material later standard-confirmation finding stops further confirmations.
+Fold it and already-live required owner observations; do not launch another
+auxiliary wave on the invalidated head. A clean epoch closes after convergence.
+Outside an open review epoch, review is not a prerequisite for implementation.
+
+## Review and closure
+
+The initial inventory remains standard, soundness-skeptic, footgun-finder,
+invariant-ace, complexity-mitigator, and fresh-eyes. Standard is Codex's native
+review with no custom Actuating instruction file or argument. Auxiliaries retain
+their checked-in lenses; none substitutes for standard.
+
+Only a completely realized, locally proved candidate is `reviewable`. Require
+five consecutive distinct native/default standard cleans on one unchanged head;
+the initial standard counts as one and the next four run serially. All five
+auxiliary outcomes must also be terminal and adjudicated. A material finding or
+head change resets all credit. Reviews falsify; they do not prove soundness by
+failing to find a bug.
+
+Read [closure.md](references/closure.md). `implement` ends at local completion;
+publication and convergence belong to bare Actuating and `review-closeout`.
+Closure requires exact Git, verifier, CAS, and Ship/provider facts as applicable.
+An unresolved accepted liability, unauthorized strengthening, missing required
+proof, or unowned residual cannot become unqualified `complete`. Complete the
+object-level task before optional learning or memory capture.

--- a/codex/skills/actuating/tests/test-composition-contract.sh
+++ b/codex/skills/actuating/tests/test-composition-contract.sh
@@ -29,13 +29,20 @@ const protectedSections = {
   "Review and closure": "9e9bf083b07812cb0cb2675d223bc94554fb51cfeecc1f1b7b3ff9edd0752225",
   "Realization and common proof obligations": "df2f70beac4ca71c55ca4e4bc8c6f63c23453aafe8ef7406102832f658055ad8"
 };
+// Relocation changes where the section is read, not its accepted bytes.
+const protectedSources = {
+  "Review-epoch immutability and evidence acquisition": text('review-closeout.md'),
+  "Review and closure": text('review-closeout.md')
+};
+assert(skill.includes('[review-closeout.md](review-closeout.md)'), 'review guide not routed');
 for (const [name, digest] of Object.entries(protectedSections))
-  assert.equal(sha256(section(skill,name)),digest,`protected Actuating section: ${name}`);
+  assert.equal(sha256(section(protectedSources[name] ?? skill,name)),digest,`protected Actuating section: ${name}`);
 // Four auxiliary lenses now return the native structured review object.
 // These pins preserve the reviewed output correction and all search instructions.
 const lensBlobs = {
   'soundness-review.md':'0969ec78b6f03d73ab0bdeae1f5a987c8e8d477f',
-  'footgun-review.md':'13307f0864172c1972584372ca406b0b1dbfdccd',
+  // #285 changed the caller-expectation inquiry; pin the already-merged bytes.
+  'footgun-review.md':'68a0b86f1e902817320c3f817c0490c3e384bcbc',
   'invariant-review.md':'0c945b75733ef5dc80d51033217d729dc9529f6e',
   'complexity-review.md':'70e1fbab51f246b4f8aacb8fcc7f649339381a2e',
   'fresh-eyes-review.md':'392289a1e913435e5ad9abf2721b24ad0119682f'
@@ -54,7 +61,8 @@ for (const path of ['SKILL.md',
   const source = text(path);
   for (const result of nominationResults) assert(source.includes(result),`${path}: missing ${result}`);
 }
-const universalist = section(text('../universalist/SKILL.md'),'Actuating composition');
+assert(text('../universalist/SKILL.md').includes('[actuating-composition.md](actuating-composition.md)'), 'composition guide not routed');
+const universalist = section(text('../universalist/actuating-composition.md'),'Actuating composition');
 assert.match(universalist,/Return `unresolved` when evidence is missing or adequate candidates remain\s+incomparable/);
 assert.match(universalist,/not a new route or mode/);
 const fold = text('../review-fold/SKILL.md');

--- a/codex/skills/actuating/tests/test-reconciler-contract.sh
+++ b/codex/skills/actuating/tests/test-reconciler-contract.sh
@@ -83,7 +83,7 @@ for (const obligation of ['admission and transition preservation','source-derive
   'migration and retirement','residual obligations']) assert(compilation.required_obligation_classes.includes(obligation));
 assert.match(c.construction_selection.causal_target, /construction or transition/);
 assert.match(c.construction_selection.discriminator_target, /valid-state transition/);
-const universalist = text('../universalist/SKILL.md');
+const universalist = [text('../universalist/SKILL.md'), text('../universalist/actuating-composition.md')].join('\n');
 const reduction = text('../reduce/SKILL.md').split('## Actuating composition')[1].split('## Implementation mode')[0];
 assert(!universalist.includes('Selected counterexample theory:'));
 assert(!universalist.includes('single bounded co-refinement'));
@@ -158,7 +158,7 @@ assert(ownerFacts.required_artifacts.includes('accepted Goal bound directly to c
 assert(ownerFacts.success_signals.includes('source revisions reclassify applicable evidence without erasing unresolved provenance'));
 // End source-binding regressions.
 // Verifier-integrity regressions; source consistency is not model-efficacy evidence.
-const proofAcceptance = text('SKILL.md').split('## Observe and adjudicate\n')[1]?.split('\n## ')[0].replace(/\s+/g, ' ');
+const proofAcceptance = text('SKILL.md').split('## Proof acceptance\n')[1]?.split('\n## ')[0].replace(/\s+/g, ' ');
 assert(proofAcceptance, 'missing root proof acceptance');
 for (const rule of [
   'Before accepting validation for local completion or reviewability',
@@ -176,8 +176,9 @@ assert(closureProof.success_signals.includes('test retirement preserves proof or
 assert(closureProof.failure_signals.includes('passing a weakened suite discharges an unchanged requirement'));
 // End verifier-integrity regressions.
 // Admission/model-refinement source contracts; not a model-efficacy result.
-assert(proofAcceptance.includes('for review findings and failed checks before treating either as a liability'));
-const causal = text('SKILL.md').split('## Compile the first loss of guarantee\n')[1].split('\n## ')[0].replace(/\s+/g, ' ');
+assert(text('counterexamples.md').includes('for review findings and failed checks before treating either as a liability'));
+assert(text('SKILL.md').includes('[counterexamples.md](counterexamples.md)'), 'counterexample guide not routed');
+const causal = text('counterexamples.md').split('## Compile the first loss of guarantee\n')[1].split('\n## ')[0].replace(/\s+/g, ' ');
 for (const rule of [
   'Acceptance establishes a supported disagreement, not the causal explanation',
   'source-grounded discriminator that could refute that explanation',
@@ -193,7 +194,8 @@ assert(construction.success_signals.includes('model adequacy, permitted-operatio
 assert(construction.failure_signals.includes('a shared predicate, exhaustive switch, or new type is treated as proof of meaning or coverage'));
 // End admission/model-refinement source contracts.
 // Pairing source-contract regressions; these do not measure model efficacy.
-const rootStep = text('SKILL.md').split('## Architecture compilation')[1].split('\n## ')[0].replace(/\s+/g, ' ');
+assert(text('SKILL.md').includes('[architecture.md](architecture.md)'), 'architecture guide not routed');
+const rootStep = text('architecture.md').split('## Architecture compilation')[1].split('\n## ')[0].replace(/\s+/g, ' ');
 assert(rootStep.includes('When the existing Metanoetic trigger fires'));
 assert(rootStep.includes('apply `$glaze` then `$metanoetic` verbatim in the same bounded challenger pass, before `$universalist`'));
 assert(rootStep.includes('once per unchanged decision surface'));
@@ -203,8 +205,8 @@ assert(rootStep.includes('Add no separate Glaze report or adjudication stage'));
 assert(rootStep.includes('Let the pass discover which premises and evidence need reinspection'));
 assert(rootStep.includes('Keep the accepted Goal fixed'));
 assert(rootStep.includes('Only when architecture is live'));
-assert(text('SKILL.md').includes('never changed expectations merely to agree with the candidate'));
-assert(text('SKILL.md').includes('Prefer making that omission unavailable'));
+assert(text('counterexamples.md').includes('never changed expectations merely to agree with the candidate'));
+assert(text('counterexamples.md').includes('Prefer making that omission unavailable'));
 assert(text('references/counterexample-guided-normalization.md').includes('required-valid observation preservation'));
 assert(text('agents/openai.yaml').includes('Glaze then Metanoetic verbatim in the same bounded challenger pass'));
 const challenger = d.clauses.find(cl => cl.clause_id === 'ACT-METANOETIC-ADMISSIBILITY-001');

--- a/codex/skills/cas/SKILL.md
+++ b/codex/skills/cas/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cas
-description: "Use the native CAS Codex control-plane CLI for app-server inspection and transport, account and goal facts, automations, smoke and conformance checks, instance fanout, tuple-bound reviews, and session inquiry. CAS owns execution and directly observed facts; callers retain semantic authority."
+description: "Operate the CAS Codex control-plane CLI: app-server, automations, account/goal facts, reviews, session inquiry, smoke/conformance checks, and instance fanout. Callers retain semantic authority."
 ---
 
 # CAS
@@ -37,75 +37,36 @@ cas conformance
 Underscore/hyphen spelling conveniences already shown by `cas --help` may be
 used. They do not create another product identity.
 
-## Runtime compatibility gate
+## Selected guidance
 
-Before an app-server-backed route whose compatibility has not already been
-established for the exact resolved Codex executable and current schema cache,
-run:
+Load the selected route before issuing its commands. Before an app-server-backed
+route, read [runtime-compatibility.md](runtime-compatibility.md) and establish its
+required profile for the exact executable/schema cache, or reuse an unchanged
+compatible result. Version strings alone are not compatibility proof.
 
-```bash
-cas app-server preflight \
-  --cwd <repo> \
-  --profile <core|review|session-inquiry|full> \
-  --app-server-transport <selected-transport> \
-  --json
-```
-
-Use these profiles:
-
-| Route | Profile |
+| Route | Selected guidance |
 |---|---|
-| schema inspection, smoke check, generic instance execution | `core` |
-| `cas review run|start` | `review` with `managed-ws` preflight |
-| `cas session_inquiry preflight|run|start` | `session-inquiry` with `managed-ws` preflight and execution |
-| release conformance and the complete feature surface | `full` |
+| App-server, smoke, instance fanout, conformance | [app-server.md](app-server.md) plus the applicable compatibility profile |
+| Tuple-bound review | [reviews.md](reviews.md) plus `review`/`managed-ws` compatibility |
+| Session inquiry | [session-inquiry.md](session-inquiry.md) plus `session-inquiry`/`managed-ws` compatibility |
+| Automation | Automation below; use its store/scheduler doctor, not an unrelated app-server preflight. |
+| Account and native goals | Account and goals below |
 
-Require `status == "compatible"`, the intended resolved Codex path, contract
-ID `codex-app-server-capabilities-v2`, no missing required methods or handlers,
-and all required selected-profile probes passed. Codex version and release
-channel are diagnostic only. `degraded` is not compatible proof for a required
-route behavior.
+Read a deeper reference only where the selected route requires it. Do not preload
+review, inquiry, and automation manuals together.
 
-CAS 0.6.0 is qualified against released Codex 0.151.0. That version is an
-evidence baseline, not a runtime pin or upper bound: admit later released
-runtimes when the selected capability profile and probes pass. Do not use an
-unreleased or prerelease build as qualification evidence unless the caller
-explicitly requests prerelease testing.
+<a id="runtime-compatibility-gate"></a>
+Runtime compatibility: [runtime-compatibility.md](runtime-compatibility.md).
+<a id="route-guidance"></a>
+The selected-route table above replaces the combined route manual.
+<a id="app-server-smoke-and-instances"></a>
+App-server, smoke, and instances: [app-server.md](app-server.md).
+<a id="review"></a>
+Review: [reviews.md](reviews.md).
+<a id="session-inquiry"></a>
+Session inquiry: [session-inquiry.md](session-inquiry.md).
 
-For review and session inquiry, also require the preflight receipt's
-`transport.selected == "managed-ws"`; a compatible stdio receipt is not
-equivalent proof. CAS 0.6.0 review runs this gate internally before starting
-and reports the realized connection as `selectedTransport == "websocket"`.
-Session inquiry additionally receives `--transport managed-ws` on execution.
-
-Compile-time capabilities report what CAS implements. They do not prove that
-the resolved runtime implements it. For review, require both the compatible
-`review` preflight and
-`cas_capabilities.features.cas_structured_review_v1 == true`.
-
-See [codex_app_server_contract.md](references/codex_app_server_contract.md) and
-[codex-app-server-capability-matrix.md](references/codex-app-server-capability-matrix.md).
-
-## Route guidance
-
-### App-server, smoke, and instances
-
-Use `cas app-server schema --json` for a non-mutating schema/cache report and
-`cas app-server preflight --json` for the structural and behavioral verdict.
-Use `cas app-server session` for a raw stateful app-server stream and
-`cas app-server daemon` for released daemon lifecycle commands. Both delegate
-to the selected Codex executable, preserve its raw bytes and exit status, and
-accept `--codex-path`; they do not impose a version gate.
-Use `cas smoke_check` for bounded handshake and reachability observations.
-Use `cas instance_runner` for bounded raw requests or fanout. Preserve additive
-response, notification, and item data rather than projecting it away.
-
-Explicit transport or remote Code Mode host selection is fail-closed. The
-outbound Code Mode host is distinct from the inbound app-server endpoint and
-uses the released HTTP(S) root-endpoint form. Authenticated WebSocket listener
-flags belong to the delegated app-server session surface.
-
-### Automation
+## Automation
 
 Use `cas automation` for every automation operation. When store or scheduler
 compatibility is uncertain, and before troubleshooting or mutation that relies
@@ -122,50 +83,7 @@ non-default database; automation files still belong to the existing Codex
 automation root. See [automation.md](references/automation.md) and
 [automation-db.md](references/automation-db.md).
 
-### Review
-
-Use `run` for a standalone one-off review. Use one owner-lived
-`start --wait` process for workflow-bound or Actuating review. Use `wait` only
-to recover or inspect an already-started admissible attempt.
-
-```bash
-cas app-server preflight --cwd <repo> --profile review \
-  --app-server-transport managed-ws --json
-
-cas review run --cwd <repo> --base <base> \
-  --custom-instructions @<instructions> \
-  --timeout-ms 2700000 --json
-
-cas review start --wait --cwd <repo> --base <base> \
-  --custom-instructions @<instructions> \
-  --workflow-binding-json @<binding.json> \
-  --timeout-ms 2700000 --json
-```
-
-A process is not a review. An attempt exists only after `reviewThreadId`; a
-semantic verdict exists only when the structured verdict binds the exact
-target tuple. CAS reports the backend. The caller decides credit and finding
-disposition. See [review-proof-boundary.md](references/review-proof-boundary.md).
-
-When the caller admits a new same-target attempt after terminal evidence, pass
-`--fresh-attempt <source-bound-reason>`. CAS records the reason; it does not
-decide whether the new attempt is permitted.
-
-### Session inquiry
-
-Use the `session-inquiry` preflight profile before execution. A paginated source
-is admissible when the exact runtime probe passes. Fork boundary and anchor
-digest verification remain mandatory. A successful paginated fork is not proof
-of historical workspace reconstruction.
-
-Pass `--transport managed-ws` to `session_inquiry run|start`; do not let the
-execution fall back to its `auto` default after proving a selected transport.
-
-Validate Retrace inputs with their owner definitions and validate the returned
-FIR with CAS's passive definition before interpreting it. See
-[retrace-session-inquiry.md](references/retrace-session-inquiry.md).
-
-### Account and goals
+## Account and goals
 
 `cas account status` reports account facts and preserves plan values as data.
 `cas goal` resolves, observes, mutates, or waits for native CAS goal state only

--- a/codex/skills/cas/app-server.md
+++ b/codex/skills/cas/app-server.md
@@ -1,0 +1,18 @@
+# App-server, smoke, and instances
+
+## App-server, smoke, and instances
+
+Use `cas app-server schema --json` for a non-mutating schema/cache report and
+`cas app-server preflight --json` for the structural and behavioral verdict.
+Use `cas app-server session` for a raw stateful app-server stream and
+`cas app-server daemon` for released daemon lifecycle commands. Both delegate
+to the selected Codex executable, preserve its raw bytes and exit status, and
+accept `--codex-path`; they do not impose a version gate.
+Use `cas smoke_check` for bounded handshake and reachability observations.
+Use `cas instance_runner` for bounded raw requests or fanout. Preserve additive
+response, notification, and item data rather than projecting it away.
+
+Explicit transport or remote Code Mode host selection is fail-closed. The
+outbound Code Mode host is distinct from the inbound app-server endpoint and
+uses the released HTTP(S) root-endpoint form. Authenticated WebSocket listener
+flags belong to the delegated app-server session surface.

--- a/codex/skills/cas/reviews.md
+++ b/codex/skills/cas/reviews.md
@@ -1,0 +1,30 @@
+# Review
+
+## Review
+
+Use `run` for a standalone one-off review. Use one owner-lived
+`start --wait` process for workflow-bound or Actuating review. Use `wait` only
+to recover or inspect an already-started admissible attempt.
+
+```bash
+cas app-server preflight --cwd <repo> --profile review \
+  --app-server-transport managed-ws --json
+
+cas review run --cwd <repo> --base <base> \
+  --custom-instructions @<instructions> \
+  --timeout-ms 2700000 --json
+
+cas review start --wait --cwd <repo> --base <base> \
+  --custom-instructions @<instructions> \
+  --workflow-binding-json @<binding.json> \
+  --timeout-ms 2700000 --json
+```
+
+A process is not a review. An attempt exists only after `reviewThreadId`; a
+semantic verdict exists only when the structured verdict binds the exact
+target tuple. CAS reports the backend. The caller decides credit and finding
+disposition. See [review-proof-boundary.md](references/review-proof-boundary.md).
+
+When the caller admits a new same-target attempt after terminal evidence, pass
+`--fresh-attempt <source-bound-reason>`. CAS records the reason; it does not
+decide whether the new attempt is permitted.

--- a/codex/skills/cas/runtime-compatibility.md
+++ b/codex/skills/cas/runtime-compatibility.md
@@ -1,0 +1,50 @@
+# Runtime compatibility gate
+
+## Runtime compatibility gate
+
+Before an app-server-backed route whose compatibility has not already been
+established for the exact resolved Codex executable and current schema cache,
+run:
+
+```bash
+cas app-server preflight \
+  --cwd <repo> \
+  --profile <core|review|session-inquiry|full> \
+  --app-server-transport <selected-transport> \
+  --json
+```
+
+Use these profiles:
+
+| Route | Profile |
+|---|---|
+| schema inspection, smoke check, generic instance execution | `core` |
+| `cas review run|start` | `review` with `managed-ws` preflight |
+| `cas session_inquiry preflight|run|start` | `session-inquiry` with `managed-ws` preflight and execution |
+| release conformance and the complete feature surface | `full` |
+
+Require `status == "compatible"`, the intended resolved Codex path, contract
+ID `codex-app-server-capabilities-v2`, no missing required methods or handlers,
+and all required selected-profile probes passed. Codex version and release
+channel are diagnostic only. `degraded` is not compatible proof for a required
+route behavior.
+
+CAS 0.6.0 is qualified against released Codex 0.151.0. That version is an
+evidence baseline, not a runtime pin or upper bound: admit later released
+runtimes when the selected capability profile and probes pass. Do not use an
+unreleased or prerelease build as qualification evidence unless the caller
+explicitly requests prerelease testing.
+
+For review and session inquiry, also require the preflight receipt's
+`transport.selected == "managed-ws"`; a compatible stdio receipt is not
+equivalent proof. CAS 0.6.0 review runs this gate internally before starting
+and reports the realized connection as `selectedTransport == "websocket"`.
+Session inquiry additionally receives `--transport managed-ws` on execution.
+
+Compile-time capabilities report what CAS implements. They do not prove that
+the resolved runtime implements it. For review, require both the compatible
+`review` preflight and
+`cas_capabilities.features.cas_structured_review_v1 == true`.
+
+See [codex_app_server_contract.md](references/codex_app_server_contract.md) and
+[codex-app-server-capability-matrix.md](references/codex-app-server-capability-matrix.md).

--- a/codex/skills/cas/session-inquiry.md
+++ b/codex/skills/cas/session-inquiry.md
@@ -1,0 +1,15 @@
+# Session inquiry
+
+## Session inquiry
+
+Use the `session-inquiry` preflight profile before execution. A paginated source
+is admissible when the exact runtime probe passes. Fork boundary and anchor
+digest verification remain mandatory. A successful paginated fork is not proof
+of historical workspace reconstruction.
+
+Pass `--transport managed-ws` to `session_inquiry run|start`; do not let the
+execution fall back to its `auto` default after proving a selected transport.
+
+Validate Retrace inputs with their owner definitions and validate the returned
+FIR with CAS's passive definition before interpreting it. See
+[retrace-session-inquiry.md](references/retrace-session-inquiry.md).

--- a/codex/skills/codebase-doctrine/SKILL.md
+++ b/codex/skills/codebase-doctrine/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: codebase-doctrine
-description: "Recover a repository's latent constitution: the scoped authorities, governing laws, permitted variations, historical wounds, proof obligations, and governed aporia that explain how it remains correct and how future agents should act. Use for deep codebase learning plus durable doctrine, correctness atlases, authority/law/failure/proof analysis, doctrine refresh, audit, task-context projection, or evidence-based repository-skill candidacy. Research before asserting and preserve rival models until evidence discriminates them. Not for quick onboarding, one isolated invariant, implementation, generic review, or direct skill creation."
+description: "Derive or refresh durable, evidence-backed repository doctrine, including correctness atlases, doctrine audits, task-context projections, and repository-skill recommendations. Not quick onboarding, ordinary implementation, or generic review."
 metadata:
   version: "3.0.0"
   activation_cost: high
@@ -100,118 +100,24 @@ synthetic IDs, bidirectional graph bookkeeping, schemas, validators, compilers,
 or validation receipts merely to perform the inquiry. Never use `validated` as a
 generic synonym for convincing.
 
-See [doctrine-induction.md](references/doctrine-induction.md).
+Read [doctrine-induction.md](references/doctrine-induction.md) when inducing or
+reconstructing doctrine; projection alone does not require a new induction.
 
-## Workflow
+## Selected inquiry
 
-### 1. Frame the decision horizon
+Select from the existing inquiry dimensions, not a new mode enum:
 
-Name:
+| Current need | Read before proceeding |
+|---|---|
+| Discover doctrine, or reconstruct an unsupported part | [discovery.md](discovery.md); it retains the complete induction and adequacy workflow. |
+| Refresh existing doctrine | Refresh below; reopen changed/invalidated seams, using discovery only where the prior basis must be reconstructed. |
+| Project doctrine for a named task | Task-context projection below and [context-rendering.md](references/context-rendering.md); verify relevant current evidence rather than rerunning whole-repository discovery. |
+| Deep search or an unresolved high-impact question needs specialists | [specialists.md](specialists.md); all specialist authority remains read-only. |
+| Portfolio or skill recommendations | Induce the relevant doctrine first, then [skill-candidacy.md](references/skill-candidacy.md); an explicit portfolio request is required. |
 
-- the intended consumer;
-- the repository scope;
-- the likely classes of future change;
-- the consequences the doctrine must protect;
-- whether the requested posture is descriptive, prescriptive, comparative, or
-  intentionally undecided.
-
-Do not ask the user for repository facts that can be discovered. Ask only for
-material user-owned judgments that cannot be inferred or safely branched.
-
-### 2. Trace change-bearing seams
-
-Do not tour directories. Follow places where correctness can change:
-
-```text
-creation
-mutation
-validation
-certification
-publication
-irreversible effect
-authority transfer
-compatibility conversion
-migration
-rollback
-retirement or invalidation
-```
-
-At each seam ask:
-
-```text
-Who may act?
-What state or evidence crosses?
-What becomes observable?
-What plausible bypass exists?
-What can fail?
-Who may reverse or retire it?
-What proof makes the transition credible?
-What design decision should callers not need to know?
-Who still knows it, and which local change forces coordinated edits?
-```
-
-Writes and transitions outrank readers and names when identifying authority.
-Architecture is a hypothesis supported by responsibilities, dependency direction,
-and preserved observations, not folder names. Trace shared design knowledge, not
-just execution phases; keep independent verification and authority boundaries.
-
-### 3. Form rival explanations
-
-Before accepting an architectural or doctrinal explanation, construct at least
-one credible rival when the evidence permits.
-
-For each rival record privately:
-
-```text
-what it explains
-what it fails to explain
-which evidence strengthens it
-which evidence weakens it
-what exact search would discriminate it
-```
-
-Do not let the first coherent narrative become doctrine.
-
-### 4. Recover selection pressures
-
-For every apparent law, awkward abstraction, duplicated check, fallback, or
-boundary ask:
-
-```text
-Why did this survive?
-What recurring failure or requirement selected it?
-What cleaner-looking alternative would lose a required observation?
-Which earlier route was rejected?
-Is this design principled structure, temporary migration, defensive duplication,
-or scar tissue?
-```
-
-History is useful when it explains current structure. Current code and current
-proof outrank stale historical rationale.
-
-### 5. Derive jurisdictions and authorities
-
-For important state, evidence, and effects determine who may create, mutate,
-validate, certify, publish, transfer, consume, roll back, retire, or invalidate
-them.
-
-Name:
-
-- the jurisdiction in which the authority applies;
-- the canonical transition paths;
-- shadow owners and bypasses;
-- late validation;
-- ambiguous or conditional authority transfer;
-- exceptions and their owners.
-
-A validator or reader is not an owner merely because it observes the state.
-
-### 6. Derive laws and freedoms together
-
-A governing law is not a field-complete sentence. It is a scoped constraint that
-explains observations and changes future decisions.
-
-For each consequential law state:
+Do not treat an old doctrine or a summary as current authority. Missing evidence
+reopens only the affected claim and its dependencies, not an automatic repo tour.
+The complete law form remains required for consequential laws in every rendering:
 
 ```text
 Law                  what must remain true
@@ -225,200 +131,25 @@ Proof burden          what must establish preservation or refinement
 Invalidators          what would make the law obsolete, local, or contested
 ```
 
-Record freedoms and deliberate non-laws prominently. Doctrine must prevent cargo
-cult preservation by distinguishing required observations from replaceable
-representations, algorithms, layouts, and control flow.
+<a id="workflow"></a>
+The discovery workflow is in [discovery.md](discovery.md#workflow).
+<a id="read-only-specialists"></a>
+Specialist rules are in [specialists.md](specialists.md#read-only-specialists).
 
-Begin invariant work with a bad trace:
+## Task-context projection
 
-```text
-valid state -> transition -> invalid observable state
-```
+Bind the named consumer, task, and change horizon. Recover the exact existing
+doctrine and inspect current evidence for its relevant jurisdictions, freedoms,
+proof obligations, and invalidators. Project only what could change this task's
+decisions; preserve governing contradictions and evidence limits rather than
+turning a descriptive observation into a requirement.
 
-Downgrade an invariant that lacks an owner, initialization, preserving
-transitions, a violating counterexample, enforcement boundary, exception owner,
-and proof posture.
-
-### 7. Perform failure archaeology
-
-Normalize local wounds:
-
-```text
-local failure
--> recurring family
--> violated law or authority
--> incorrect representation, boundary, transition, or proof shape
--> selection pressure on the surviving design
-```
-
-Distinguish:
-
-- one failed attempt from a recurring route failure;
-- historical rationale from current doctrine;
-- scar tissue from a still-live constraint;
-- witnessed negative evidence from fuzzy similarity.
-
-Only a current canonical negative-ledger projection may forbid a route. Other
-failure evidence may warn, prioritize inquiry, or suggest a falsifier, but may
-not silently prohibit action.
-
-### 8. Map proof as claim coverage
-
-For each law or invariant identify how the repository currently establishes it:
-
-```text
-representation or type
-opaque constructor
-canonical transition
-static analysis
-test or property
-state-machine/model proof
-integration proof
-runtime witness
-manual or reviewer judgment
-CI or release gate
-```
-
-Distinguish proof design, current execution, historical execution, and manual
-judgment. A test path is not evidence that the test currently passes, and a
-passing suite is not evidence that it covers the claimed law.
-
-Ask whether the proof:
-
-- targets the law or only one historical example;
-- covers transitions, failure, rollback, and exceptions;
-- can pass a bad implementation;
-- transfers to a novel case;
-- has an invalidation trigger.
-
-### 9. Preserve governed aporia
-
-Do not average incompatible claims. A material contradiction may remain when it
-is real.
-
-A governed aporia names:
-
-```text
-the incompatible claims
-where each is authoritative
-the evidence for each
-which operations are unsafe or conditional because of the tension
-what evidence or owner decision could resolve it
-how future changes must behave while it remains unresolved
-```
-
-The inquiry may stop with unresolved material tension when the tension is
-represented and behaviorally bounded. The stopping condition is not "no
-contradiction"; it is "no material contradiction remains hidden or operationally
-unbounded."
-
-### 10. Compress to the doctrine basis
-
-Admit a finding to durable doctrine only when forgetting it could produce a
-plausible wrong decision.
-
-Use this admission test:
-
-1. Is it nonlocal or easy to misinfer from local code?
-2. Would forgetting it materially change implementation, review, migration, or
-   proof?
-3. Does it apply beyond one isolated incident?
-4. Is it stable enough to survive several future changes?
-5. Can evidence and a meaningful counterexample be named?
-6. Can its jurisdiction, freedoms, and invalidators be stated?
-7. Does it change what a future agent inspects, preserves, rejects, changes, or
-   proves?
-
-If not, retain necessary local API knowledge for interface-contract routing;
-keep other material as evidence, local implementation detail, or noise.
-
-### 11. Route durable knowledge
-
-Route knowledge only after doctrine induction. Prefer the strongest owner:
-
-```text
-representation or code
-test, property, model, or static tooling
-CI or release gate
-local interface contract
-concise repository guidance
-ADR or reference
-canonical negative ledger
-repository-specific skill for recurring judgment
-retain in doctrine
-reject
-```
-
-Important does not imply skill-worthy. Zero repository-specific skills is a
-valid result.
-
-See [knowledge-routing.md](references/knowledge-routing.md) and
-[skill-candidacy.md](references/skill-candidacy.md).
-
-### 12. Render exact context
-
-Separate:
-
-```text
-research record      material used to reason honestly
-doctrine             compressed latent constitution
-consumer context     the doctrine projection needed for one decision horizon
-evidence appendix    support for consequential claims
-```
-
-Default to readable Markdown. Do not emit YAML merely because indentation looks
-formal. Use a machine format only when a real downstream consumer requires one
-and its contract is supplied by that owner.
-
-See [context-rendering.md](references/context-rendering.md).
-
-### 13. Test behavioral adequacy
-
-Before finalizing, rehearse the context against future decisions:
-
-- simulate an extension, a migration, and removal of an apparent workaround;
-- test whether it defeats the repository's most tempting wrong mental model;
-- apply its laws to a novel case;
-- ablate each doctrine item and remove those whose absence changes no plausible
-  decision;
-- name the drift that would invalidate each consequential law.
-
-If the context fails, perform the smallest targeted inquiry that could repair the
-failure. Do not respond by adding ceremonial fields.
-
-See [behavioral-adequacy.md](references/behavioral-adequacy.md).
-
-## Read-only specialists
-
-Use specialists in deep search or for unresolved high-impact questions. Launch
-only workers whose answer could change the doctrine or rendering.
-
-Recommended sequence:
-
-```text
-1. codebase_cartographer + authority_state_mapper
-2. behavioral_law_miner / failure_forensics_analyst /
-   codebase_doctrine_proof_mapper for identified seams
-3. doctrine_portfolio_skeptic only when a portfolio is requested
-4. doctrine_adequacy_auditor after a complete draft
-```
-
-Assignments must be discriminating questions or bounded seam excavations, not
-requests to fill a doctrine section.
-
-Every specialist is read-only, does not spawn children, and returns:
-
-```text
-scope inspected
-observations with concrete evidence
-rival models supported or weakened
-selection pressures or counterexamples found
-unresolved questions
-why the result changes or fails to change the doctrine
-```
-
-Specialists do not author the final doctrine, propose pseudo-patches, or return
-schema-shaped packets. The root rechecks high-impact claims and owns synthesis.
+Refresh invalidated claims using Refresh below. Use the relevant parts of
+[discovery.md](discovery.md) when the evidence basis is missing; a projection is
+not permission to invent doctrine. Apply the existing
+[behavioral adequacy](references/behavioral-adequacy.md) to the projected context
+and the task's plausible changes. No implementation, persistence, or skill creation
+is authorized by this rendering.
 
 ## Evidence providers
 
@@ -433,7 +164,7 @@ See [evidence-provider-handoffs.md](references/evidence-provider-handoffs.md).
 
 Read [context-rendering.md](references/context-rendering.md) for the requested
 repository doctrine, task-context, audit, or portfolio view. Use the complete law
-form above; render only decision-relevant evidence and do not dump raw search notes.
+form in Selected inquiry; render only decision-relevant evidence and do not dump raw search notes.
 Portfolio analysis requires already-induced doctrine and an explicit request.
 
 ## Refresh

--- a/codex/skills/codebase-doctrine/discovery.md
+++ b/codex/skills/codebase-doctrine/discovery.md
@@ -1,0 +1,287 @@
+# Doctrine discovery
+
+## Workflow
+
+### 1. Frame the decision horizon
+
+Name:
+
+- the intended consumer;
+- the repository scope;
+- the likely classes of future change;
+- the consequences the doctrine must protect;
+- whether the requested posture is descriptive, prescriptive, comparative, or
+  intentionally undecided.
+
+Do not ask the user for repository facts that can be discovered. Ask only for
+material user-owned judgments that cannot be inferred or safely branched.
+
+### 2. Trace change-bearing seams
+
+Do not tour directories. Follow places where correctness can change:
+
+```text
+creation
+mutation
+validation
+certification
+publication
+irreversible effect
+authority transfer
+compatibility conversion
+migration
+rollback
+retirement or invalidation
+```
+
+At each seam ask:
+
+```text
+Who may act?
+What state or evidence crosses?
+What becomes observable?
+What plausible bypass exists?
+What can fail?
+Who may reverse or retire it?
+What proof makes the transition credible?
+What design decision should callers not need to know?
+Who still knows it, and which local change forces coordinated edits?
+```
+
+Writes and transitions outrank readers and names when identifying authority.
+Architecture is a hypothesis supported by responsibilities, dependency direction,
+and preserved observations, not folder names. Trace shared design knowledge, not
+just execution phases; keep independent verification and authority boundaries.
+
+### 3. Form rival explanations
+
+Before accepting an architectural or doctrinal explanation, construct at least
+one credible rival when the evidence permits.
+
+For each rival record privately:
+
+```text
+what it explains
+what it fails to explain
+which evidence strengthens it
+which evidence weakens it
+what exact search would discriminate it
+```
+
+Do not let the first coherent narrative become doctrine.
+
+### 4. Recover selection pressures
+
+For every apparent law, awkward abstraction, duplicated check, fallback, or
+boundary ask:
+
+```text
+Why did this survive?
+What recurring failure or requirement selected it?
+What cleaner-looking alternative would lose a required observation?
+Which earlier route was rejected?
+Is this design principled structure, temporary migration, defensive duplication,
+or scar tissue?
+```
+
+History is useful when it explains current structure. Current code and current
+proof outrank stale historical rationale.
+
+### 5. Derive jurisdictions and authorities
+
+For important state, evidence, and effects determine who may create, mutate,
+validate, certify, publish, transfer, consume, roll back, retire, or invalidate
+them.
+
+Name:
+
+- the jurisdiction in which the authority applies;
+- the canonical transition paths;
+- shadow owners and bypasses;
+- late validation;
+- ambiguous or conditional authority transfer;
+- exceptions and their owners.
+
+A validator or reader is not an owner merely because it observes the state.
+
+### 6. Derive laws and freedoms together
+
+A governing law is not a field-complete sentence. It is a scoped constraint that
+explains observations and changes future decisions.
+
+For each consequential law state:
+
+```text
+Law                  what must remain true
+Jurisdiction         where and when it applies
+Selection pressure   why the repository needs it
+Evidence              current observations supporting it
+Counterexample        a trace that would violate it
+Permitted variation  what may change without violating it
+Operational effect   how future work should change because of it
+Proof burden          what must establish preservation or refinement
+Invalidators          what would make the law obsolete, local, or contested
+```
+
+Record freedoms and deliberate non-laws prominently. Doctrine must prevent cargo
+cult preservation by distinguishing required observations from replaceable
+representations, algorithms, layouts, and control flow.
+
+Begin invariant work with a bad trace:
+
+```text
+valid state -> transition -> invalid observable state
+```
+
+Downgrade an invariant that lacks an owner, initialization, preserving
+transitions, a violating counterexample, enforcement boundary, exception owner,
+and proof posture.
+
+### 7. Perform failure archaeology
+
+Normalize local wounds:
+
+```text
+local failure
+-> recurring family
+-> violated law or authority
+-> incorrect representation, boundary, transition, or proof shape
+-> selection pressure on the surviving design
+```
+
+Distinguish:
+
+- one failed attempt from a recurring route failure;
+- historical rationale from current doctrine;
+- scar tissue from a still-live constraint;
+- witnessed negative evidence from fuzzy similarity.
+
+Only a current canonical negative-ledger projection may forbid a route. Other
+failure evidence may warn, prioritize inquiry, or suggest a falsifier, but may
+not silently prohibit action.
+
+### 8. Map proof as claim coverage
+
+For each law or invariant identify how the repository currently establishes it:
+
+```text
+representation or type
+opaque constructor
+canonical transition
+static analysis
+test or property
+state-machine/model proof
+integration proof
+runtime witness
+manual or reviewer judgment
+CI or release gate
+```
+
+Distinguish proof design, current execution, historical execution, and manual
+judgment. A test path is not evidence that the test currently passes, and a
+passing suite is not evidence that it covers the claimed law.
+
+Ask whether the proof:
+
+- targets the law or only one historical example;
+- covers transitions, failure, rollback, and exceptions;
+- can pass a bad implementation;
+- transfers to a novel case;
+- has an invalidation trigger.
+
+### 9. Preserve governed aporia
+
+Do not average incompatible claims. A material contradiction may remain when it
+is real.
+
+A governed aporia names:
+
+```text
+the incompatible claims
+where each is authoritative
+the evidence for each
+which operations are unsafe or conditional because of the tension
+what evidence or owner decision could resolve it
+how future changes must behave while it remains unresolved
+```
+
+The inquiry may stop with unresolved material tension when the tension is
+represented and behaviorally bounded. The stopping condition is not "no
+contradiction"; it is "no material contradiction remains hidden or operationally
+unbounded."
+
+### 10. Compress to the doctrine basis
+
+Admit a finding to durable doctrine only when forgetting it could produce a
+plausible wrong decision.
+
+Use this admission test:
+
+1. Is it nonlocal or easy to misinfer from local code?
+2. Would forgetting it materially change implementation, review, migration, or
+   proof?
+3. Does it apply beyond one isolated incident?
+4. Is it stable enough to survive several future changes?
+5. Can evidence and a meaningful counterexample be named?
+6. Can its jurisdiction, freedoms, and invalidators be stated?
+7. Does it change what a future agent inspects, preserves, rejects, changes, or
+   proves?
+
+If not, retain necessary local API knowledge for interface-contract routing;
+keep other material as evidence, local implementation detail, or noise.
+
+### 11. Route durable knowledge
+
+Route knowledge only after doctrine induction. Prefer the strongest owner:
+
+```text
+representation or code
+test, property, model, or static tooling
+CI or release gate
+local interface contract
+concise repository guidance
+ADR or reference
+canonical negative ledger
+repository-specific skill for recurring judgment
+retain in doctrine
+reject
+```
+
+Important does not imply skill-worthy. Zero repository-specific skills is a
+valid result.
+
+See [knowledge-routing.md](references/knowledge-routing.md) and
+[skill-candidacy.md](references/skill-candidacy.md).
+
+### 12. Render exact context
+
+Separate:
+
+```text
+research record      material used to reason honestly
+doctrine             compressed latent constitution
+consumer context     the doctrine projection needed for one decision horizon
+evidence appendix    support for consequential claims
+```
+
+Default to readable Markdown. Do not emit YAML merely because indentation looks
+formal. Use a machine format only when a real downstream consumer requires one
+and its contract is supplied by that owner.
+
+See [context-rendering.md](references/context-rendering.md).
+
+### 13. Test behavioral adequacy
+
+Before finalizing, rehearse the context against future decisions:
+
+- simulate an extension, a migration, and removal of an apparent workaround;
+- test whether it defeats the repository's most tempting wrong mental model;
+- apply its laws to a novel case;
+- ablate each doctrine item and remove those whose absence changes no plausible
+  decision;
+- name the drift that would invalidate each consequential law.
+
+If the context fails, perform the smallest targeted inquiry that could repair the
+failure. Do not respond by adding ceremonial fields.
+
+See [behavioral-adequacy.md](references/behavioral-adequacy.md).

--- a/codex/skills/codebase-doctrine/specialists.md
+++ b/codex/skills/codebase-doctrine/specialists.md
@@ -1,0 +1,33 @@
+# Read-only specialists
+
+## Read-only specialists
+
+Use specialists in deep search or for unresolved high-impact questions. Launch
+only workers whose answer could change the doctrine or rendering.
+
+Recommended sequence:
+
+```text
+1. codebase_cartographer + authority_state_mapper
+2. behavioral_law_miner / failure_forensics_analyst /
+   codebase_doctrine_proof_mapper for identified seams
+3. doctrine_portfolio_skeptic only when a portfolio is requested
+4. doctrine_adequacy_auditor after a complete draft
+```
+
+Assignments must be discriminating questions or bounded seam excavations, not
+requests to fill a doctrine section.
+
+Every specialist is read-only, does not spawn children, and returns:
+
+```text
+scope inspected
+observations with concrete evidence
+rival models supported or weakened
+selection pressures or counterexamples found
+unresolved questions
+why the result changes or fails to change the doctrine
+```
+
+Specialists do not author the final doctrine, propose pseudo-patches, or return
+schema-shaped packets. The root rechecks high-impact claims and owns synthesis.

--- a/codex/skills/learnings/SKILL.md
+++ b/codex/skills/learnings/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: learnings
-description: "Capture, browse, query, supersede, and selectively admit evidence-backed execution learnings through the passive Learnings protocol definition. Trigger for `$learnings`, browse/recent/search learnings, lessons learned, takeaways, wrap up, handoff, validation transitions, strategy pivots, footguns, retry loops, or memory admission of a durable learning."
+description: "Capture or recall evidence-backed execution learnings; evaluate capture at validation transitions, strategy pivots, footguns, retry loops, and material delivery or handoff. Also handle explicit learning-memory admission and supersession."
 metadata:
   version: "8.1.0"
 ---
@@ -40,33 +40,39 @@ Do not duplicate every learning into memory notes. For an accepted admission, lo
 - before a Codex-made commit/PR/handoff after material implementation;
 - explicit request to promote/admit a learning to memory.
 
-## Canonical Store
+## Selected guidance
 
-Before the first native Ledger command in this workflow, load `$ledger` and
-complete `$ledger ensure`. Require Ledger 1.0.3 or newer within major version 1
-and `ledger-artifact-abi/v1`.
-Set:
+At a delivery/capture trigger, evaluate Capture Gate below from task evidence
+first. If it fails and no recall or canonical operation was requested, retain
+`no-op` and return without loading store/admission manuals or bootstrapping Ledger.
+The delivery-time evaluation remains mandatory; an append remains conditional.
 
-```bash
-learnings_definition="$(realpath "${CODEX_HOME:-$HOME/.codex}/skills/learnings/definitions/ledger/learnings-protocol.json")"
-```
+| Selected operation | Read before the operation |
+|---|---|
+| Canonical browse, query, or recall | [store.md](store.md) and [recall.md](recall.md) |
+| Accepted capture or canonical supersession | [store.md](store.md) and [capture.md](capture.md) |
+| Evaluate or perform memory admission, supersession, or withdrawal | [memory-admission.md](memory-admission.md); canonical operations also require the store/capture guidance as applicable. |
+| Generated digest | `$memory-source-notes`; no new canonical writer |
 
-Use `ledger transact --operation capture` for writes; use definition-bound
-`record`, `recent`, `recall`, `search`, `reconciliation-index`, and
-`memory-note` projections for reads. Treat the returned `lrn-*` identity as
-canonical. Do not open or hand-edit the store. An unbound current-format store
-requires the explicit one-shot `bind-existing` transaction. When an
-authoritative external transport such as Git advances the valid store while a
-local binding remains stale, use the separate `rebind-existing` transaction.
-Both routes validate the complete current store and otherwise fail closed;
-there is no alternate-path reader.
+Do not admit every capture to memory. Canonical writes and derived admission
+remain separate outcomes; admission failure cannot undo a successful canonical
+write. A no-op, duplicate, or source-memory failure alone does not invalidate
+object-level delivery. Follow enclosing read-only/effect authority on every route.
 
-Rows should preserve `id`, `captured_at`, `status`, `learning`, `evidence`, `application`, `source`, `fingerprint`, `context`, `tags`, `related_ids`, and `supersedes_id`.
-
-Standalone recall, browse, and source-local capture remain Learnings operations.
-No aggregate coordinator or sibling fan-out is required. At a material
-execution boundary, evaluate the capture gate directly and retain the
-source-owned disposition.
+<a id="canonical-store"></a>
+Canonical Store: [store.md](store.md#canonical-store).
+<a id="write-workflow"></a>
+Write Workflow: [capture.md](capture.md#write-workflow).
+<a id="recall-workflow"></a>
+Recall Workflow: [recall.md](recall.md#recall-workflow).
+<a id="memory-admission-gate"></a>
+Memory Admission Gate: [memory-admission.md](memory-admission.md#memory-admission-gate).
+<a id="definition-projection-and-admission"></a>
+Definition projection and admission: [memory-admission.md](memory-admission.md#definition-projection-and-admission).
+<a id="admission-proof"></a>
+Admission Proof: [memory-admission.md](memory-admission.md#admission-proof).
+<a id="supersession-and-withdrawal"></a>
+Supersession and Withdrawal: [memory-admission.md](memory-admission.md#supersession-and-withdrawal).
 
 ## Capture Gate
 
@@ -100,150 +106,6 @@ Evaluation is mandatory once the source is materially activated; append is
 conditional. Do not claim Learnings closeout without a disposition. Keep
 `no-op` and `duplicate-skip` internal unless the user asks, while `blocked` is
 user-visible when it affects delivery.
-
-## Write Workflow
-
-1. Verify the git root:
-
-   ```bash
-   git rev-parse --show-toplevel
-   ```
-
-2. Fail closed when either retired Learnings path exists without the canonical
-   store. Do not create a parallel store or read the retired path:
-
-   ```bash
-   if [ ! -f .ledger/learnings/events.jsonl ] &&
-      { [ -e .ledger/learnings/learnings.jsonl ] || [ -e .learnings.jsonl ]; }; then
-     printf '%s\n' 'blocked: retired Learnings store requires explicit owner-authorized recovery' >&2
-     exit 1
-   fi
-   ```
-
-3. Run the definition-bound doctor:
-
-   ```bash
-   ledger doctor \
-     --definition "$learnings_definition" \
-     --repo "<repo-root>" \
-     --format json
-   ```
-
-   Append only when the store is `current` or absent. For an unbound
-   current-format store, run the explicit `bind-existing` operation once after
-   full validation. For `StoreBindingRevisionMismatch` or
-   `StoreBindingRecordCountMismatch` after authoritative external transport,
-   run `rebind-existing`; it must validate the complete current store, replace
-   only stale Ledger binding metadata, and leave event bytes unchanged. Stop on
-   every invalid row; do not skip or reinterpret it.
-4. Gather exact evidence and changed paths.
-5. Distill objective, inflection, proof, and transferable rule.
-6. Author `learning.json` as one `submission.record` packet, then append from
-   the verified repo root:
-
-   ```bash
-   ledger transact \
-     --definition "$learnings_definition" \
-     --operation capture \
-     --repo "<repo-root>" \
-     --input submission=learning.json \
-     --format json
-   ```
-
-7. Retain the appended learning ID, rerun definition-bound doctor, and use a
-   focused `record` or `recall` projection to verify readability.
-8. Before any Codex-made commit, inspect the current learning through the
-   `record` projection. Do not read the store directly.
-9. Retain exactly one canonical learning proof line in working evidence. Include
-   source-memory proof in the final user-facing reply only when it changed
-   repo-visible state, needs user action, explains a blocker/error, or the user
-   explicitly asks.
-
-Use the disposition invariant above as the internal proof line.
-
-## Recall Workflow
-
-```bash
-ledger project \
-  --definition "$learnings_definition" \
-  --projection recall \
-  --repo "<repo-root>" \
-  --param "query=<focused component failure objective terms>" \
-  --param "now=$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
-  --param search_limit=5 \
-  --param drop_superseded=true \
-  --format json
-```
-
-Do not use `recall` as a substitute for current artifact inspection.
-
-## Memory Admission Gate
-
-A learning becomes a custom memory-source note only when all four checks pass:
-
-1. the canonical row exists and its ID is known;
-2. evidence is inspectable and embedded in a bounded snapshot;
-3. scope and future behavior are clear;
-4. Phase 2 consideration would plausibly reduce future steering, retries, or search.
-
-At least one must also hold:
-
-- status is `codify_now`;
-- the same theme appears at least three times;
-- the user explicitly asks to remember/promote it;
-- it captures a stable cross-task preference or operating default;
-- it is an unusually high-impact failure shield, repo map, verification path, or stop rule;
-- it proves a repeatable procedure suitable for a memory-root skill.
-
-Do not admit every `do_more` row, raw chronology, weak `review_later` candidates, failed-hypothesis exclusions better owned by `negative-ledger`, operating-correction events better handled as standing policy, or synesthetic mappings.
-
-## Definition projection and admission
-
-After the source owner accepts admission, load `$memory-source-notes` and pass
-the deterministic definition projection to the general writer:
-
-```bash
-ledger project \
-  --definition "$learnings_definition" \
-  --projection memory-note \
-  --repo "<repo-root>" \
-  --param id=lrn-... \
-  --payload-only \
-  --format json |
-  run_memory_note_tool append \
-    --extension learnings \
-    --kind learning-admission \
-    --json -
-```
-
-Do not reconstruct the payload from prose, `recent`, or query output. The
-projection validates the canonical store and fails closed for a missing or
-incomplete row; it does not decide admission eligibility.
-
-## Admission Proof
-
-When admission is user-visible or actionable, report canonical and admission
-outcomes separately:
-
-```text
-appended: id=lrn-...
-memory-note: id=MSN-... extension=learnings kind=learning-admission status=created
-```
-
-If the CLI is unavailable:
-
-```text
-appended: id=lrn-...
-memory-note: not-attempted: cli unavailable
-```
-
-A failed memory admission must never roll back or invalidate the canonical learning append.
-
-## Supersession and Withdrawal
-
-When a canonical learning is superseded or withdrawn from memory relevance, append the new canonical row, create a `learning-supersession` or `learning-withdrawal` note, reference the previous memory-source note ID when known, and let Phase 2 update compiled memory surgically.
-
-Never edit or delete prior admission notes.
 
 ## Memory Digest
 

--- a/codex/skills/learnings/capture.md
+++ b/codex/skills/learnings/capture.md
@@ -1,0 +1,61 @@
+# Write Workflow
+
+## Write Workflow
+
+1. Verify the git root:
+
+   ```bash
+   git rev-parse --show-toplevel
+   ```
+
+2. Fail closed when either retired Learnings path exists without the canonical
+   store. Do not create a parallel store or read the retired path:
+
+   ```bash
+   if [ ! -f .ledger/learnings/events.jsonl ] &&
+      { [ -e .ledger/learnings/learnings.jsonl ] || [ -e .learnings.jsonl ]; }; then
+     printf '%s\n' 'blocked: retired Learnings store requires explicit owner-authorized recovery' >&2
+     exit 1
+   fi
+   ```
+
+3. Run the definition-bound doctor:
+
+   ```bash
+   ledger doctor \
+     --definition "$learnings_definition" \
+     --repo "<repo-root>" \
+     --format json
+   ```
+
+   Append only when the store is `current` or absent. For an unbound
+   current-format store, run the explicit `bind-existing` operation once after
+   full validation. For `StoreBindingRevisionMismatch` or
+   `StoreBindingRecordCountMismatch` after authoritative external transport,
+   run `rebind-existing`; it must validate the complete current store, replace
+   only stale Ledger binding metadata, and leave event bytes unchanged. Stop on
+   every invalid row; do not skip or reinterpret it.
+4. Gather exact evidence and changed paths.
+5. Distill objective, inflection, proof, and transferable rule.
+6. Author `learning.json` as one `submission.record` packet, then append from
+   the verified repo root:
+
+   ```bash
+   ledger transact \
+     --definition "$learnings_definition" \
+     --operation capture \
+     --repo "<repo-root>" \
+     --input submission=learning.json \
+     --format json
+   ```
+
+7. Retain the appended learning ID, rerun definition-bound doctor, and use a
+   focused `record` or `recall` projection to verify readability.
+8. Before any Codex-made commit, inspect the current learning through the
+   `record` projection. Do not read the store directly.
+9. Retain exactly one canonical learning proof line in working evidence. Include
+   source-memory proof in the final user-facing reply only when it changed
+   repo-visible state, needs user action, explains a blocker/error, or the user
+   explicitly asks.
+
+Use the [disposition invariant](SKILL.md#disposition-invariant) as the internal proof line.

--- a/codex/skills/learnings/memory-admission.md
+++ b/codex/skills/learnings/memory-admission.md
@@ -1,0 +1,69 @@
+# Memory Admission Gate
+
+## Memory Admission Gate
+
+A learning becomes a custom memory-source note only when all four checks pass:
+
+1. the canonical row exists and its ID is known;
+2. evidence is inspectable and embedded in a bounded snapshot;
+3. scope and future behavior are clear;
+4. Phase 2 consideration would plausibly reduce future steering, retries, or search.
+
+At least one must also hold:
+
+- status is `codify_now`;
+- the same theme appears at least three times;
+- the user explicitly asks to remember/promote it;
+- it captures a stable cross-task preference or operating default;
+- it is an unusually high-impact failure shield, repo map, verification path, or stop rule;
+- it proves a repeatable procedure suitable for a memory-root skill.
+
+Do not admit every `do_more` row, raw chronology, weak `review_later` candidates, failed-hypothesis exclusions better owned by `negative-ledger`, operating-correction events better handled as standing policy, or synesthetic mappings.
+
+## Definition projection and admission
+
+After the source owner accepts admission, load `$memory-source-notes` and pass
+the deterministic definition projection to the general writer:
+
+```bash
+ledger project \
+  --definition "$learnings_definition" \
+  --projection memory-note \
+  --repo "<repo-root>" \
+  --param id=lrn-... \
+  --payload-only \
+  --format json |
+  run_memory_note_tool append \
+    --extension learnings \
+    --kind learning-admission \
+    --json -
+```
+
+Do not reconstruct the payload from prose, `recent`, or query output. The
+projection validates the canonical store and fails closed for a missing or
+incomplete row; it does not decide admission eligibility.
+
+## Admission Proof
+
+When admission is user-visible or actionable, report canonical and admission
+outcomes separately:
+
+```text
+appended: id=lrn-...
+memory-note: id=MSN-... extension=learnings kind=learning-admission status=created
+```
+
+If the CLI is unavailable:
+
+```text
+appended: id=lrn-...
+memory-note: not-attempted: cli unavailable
+```
+
+A failed memory admission must never roll back or invalidate the canonical learning append.
+
+## Supersession and Withdrawal
+
+When a canonical learning is superseded or withdrawn from memory relevance, append the new canonical row, create a `learning-supersession` or `learning-withdrawal` note, reference the previous memory-source note ID when known, and let Phase 2 update compiled memory surgically.
+
+Never edit or delete prior admission notes.

--- a/codex/skills/learnings/recall.md
+++ b/codex/skills/learnings/recall.md
@@ -1,0 +1,17 @@
+# Recall Workflow
+
+## Recall Workflow
+
+```bash
+ledger project \
+  --definition "$learnings_definition" \
+  --projection recall \
+  --repo "<repo-root>" \
+  --param "query=<focused component failure objective terms>" \
+  --param "now=$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+  --param search_limit=5 \
+  --param drop_superseded=true \
+  --format json
+```
+
+Do not use `recall` as a substitute for current artifact inspection.

--- a/codex/skills/learnings/store.md
+++ b/codex/skills/learnings/store.md
@@ -1,0 +1,29 @@
+# Canonical Store
+
+## Canonical Store
+
+Before the first native Ledger command in this workflow, load `$ledger` and
+complete `$ledger ensure`. Require Ledger 1.0.3 or newer within major version 1
+and `ledger-artifact-abi/v1`.
+Set:
+
+```bash
+learnings_definition="$(realpath "${CODEX_HOME:-$HOME/.codex}/skills/learnings/definitions/ledger/learnings-protocol.json")"
+```
+
+Use `ledger transact --operation capture` for writes; use definition-bound
+`record`, `recent`, `recall`, `search`, `reconciliation-index`, and
+`memory-note` projections for reads. Treat the returned `lrn-*` identity as
+canonical. Do not open or hand-edit the store. An unbound current-format store
+requires the explicit one-shot `bind-existing` transaction. When an
+authoritative external transport such as Git advances the valid store while a
+local binding remains stale, use the separate `rebind-existing` transaction.
+Both routes validate the complete current store and otherwise fail closed;
+there is no alternate-path reader.
+
+Rows should preserve `id`, `captured_at`, `status`, `learning`, `evidence`, `application`, `source`, `fingerprint`, `context`, `tags`, `related_ids`, and `supersedes_id`.
+
+Standalone recall, browse, and source-local capture remain Learnings operations.
+No aggregate coordinator or sibling fan-out is required. At a material
+execution boundary, evaluate the capture gate directly and retain the
+source-owned disposition.

--- a/codex/skills/plan/SKILL.md
+++ b/codex/skills/plan/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: plan
-description: "Govern candidate specifications against user authority and repository evidence, then produce one self-contained, architecture-aware execution specification. Bare `$plan` defaults to spec-to-plan and human output, without EPG or Ledger. Use `$plan direct` only for accepted decision-complete intent, and `$plan revise` for an existing plan identity. Export EPG-v1 only for explicit machine-readable output or EPG persistence. Implicitly invoke for detailed specifications, execution plans, migrations, proof/rollback planning, and plan revision; never seize implementation, debugging, review, explanation, or divergent options."
+description: "Produce or revise a self-contained execution specification from an objective or candidate spec, including migration, proof, and rollback planning. Not implementation, debugging, generic review, explanation, or divergent options."
 ---
 
 # Plan
@@ -76,7 +76,9 @@ bypasses. Files and layers are not automatically the semantic factorization.
 Ask only for material user judgment, private constraints, irreversible approval,
 or an authority conflict that artifacts cannot resolve.
 
-Read [specification-governance.md](references/specification-governance.md). Recover
+For `spec-to-plan` or `revise`, read [specification-governance.md](references/specification-governance.md)
+before governing the candidate. `direct` skips that front-end procedure, not the
+following obligations. Recover
 requirements, non-goals, compatibility, fixed decisions, proof bar, and rollback;
 distinguish selected means and defaults. Repair affected derivations or reconstruct
 an unsound organization without losing valid requirements or failed evidence.

--- a/codex/skills/review-fold/tests/test-counterexample-admission.mjs
+++ b/codex/skills/review-fold/tests/test-counterexample-admission.mjs
@@ -198,7 +198,8 @@ if (args.length === 1 && args[0] === '--list') {
   assert.match(fold,/that passed Counterexample admission/);
   assert.match(fold,/reported_claim:[\s\S]*observed_fact: # established only/);
   assert.match(read('../references/counterexample-corpus.md'),/Counterexample admission established validity and current Goal relevance/);
-  assert.match(read('../../actuating/SKILL.md'),/review-fold\/SKILL\.md#counterexample-admission/);
+  assert.match(read('../../actuating/SKILL.md'),/\[counterexamples\.md\]\(counterexamples\.md\)/);
+  assert.match(read('../../actuating/counterexamples.md'),/review-fold\/SKILL\.md#counterexample-admission/);
   assert.match(read('../agents/openai.yaml'),/Apply Counterexample admission to each proposed witness/);
   const normalized = admission.replace(/\s+/g,' ');
   for (const rule of [

--- a/codex/skills/ship/SKILL.md
+++ b/codex/skills/ship/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ship
-description: "Finalize validated work into proof-backed public state without merging, and return immutable Ship-owned publication evidence without taking architecture, review, or closure authority. Use for $ship, opening or updating a PR, promoting a draft, or read-only observing and adopting an exact already-public subject through an Actuating handoff."
+description: "Create, update, or promote a pull request for validated work without merging. Also observe or adopt an exact already-public subject when Actuating explicitly hands off that route."
 ---
 
 # Ship
@@ -32,6 +32,26 @@ Only an explicit Actuating handoff may select `observe-existing` or
 Do not use Ship when the user wants merge/landing, implementation is incomplete
 without an accepted draft reason, validation failure lacks an accepted caveat,
 or no publication/readback was requested.
+
+## Selected guidance
+
+For `pull-request`, read [pull-request.md](pull-request.md) before any push or PR
+effect. It owns readiness, managed-body preservation, mutation order, and readback.
+For an explicit Actuating `observe-existing` or `adopt-existing` handoff, read
+[existing-publication.md](existing-publication.md); these routes remain read-only.
+All routes retain Input, Receipts, Guardrails, and Output below. Do not load the
+other route's procedure just because it shares this package.
+
+<a id="pull-request-route"></a>
+Pull-request route: [pull-request.md](pull-request.md#pull-request-route).
+<a id="managed-body"></a>
+Managed body: [pull-request.md](pull-request.md#managed-body).
+<a id="public-mutation-and-readback"></a>
+Public mutation and readback: [pull-request.md](pull-request.md#public-mutation-and-readback).
+<a id="existing-publication-observation"></a>
+Existing-publication observation: [existing-publication.md](existing-publication.md#existing-publication-observation).
+<a id="existing-publication-adoption"></a>
+Existing-publication adoption: [existing-publication.md](existing-publication.md#existing-publication-adoption).
 
 ## Input
 
@@ -81,116 +101,6 @@ Direct shipping omits `actuation`. For Actuating input, exact repository,
 base/head, validation, task state, and Goal context are mandatory. Ship copies
 the Actuating binding into its receipt but never interprets it as architecture,
 review, mutation, or closure authority.
-
-## Pull-request route
-
-Keep operation and final state separate:
-
-```yaml
-pr_decision:
-  operation: create | update | update-and-promote | blocked
-  final_state: ready | draft | preserve
-```
-
-Default to `ready` when validation is complete and no task remains blocked,
-deferred, or open. Draft requires explicit user intent, incomplete or
-accepted-caveat validation, open work, or repository policy.
-
-For an existing exact repository/base/head PR, update rather than duplicate it.
-Preserve its ready/draft state unless current authority permits a transition.
-Promotion is `update-and-promote`: update proof first, then mark ready.
-
-Read [pr-readiness-policy.md](references/pr-readiness-policy.md).
-
-## Managed body
-
-Only replace content between:
-
-```text
-<!-- ship-proof:start -->
-<!-- ship-proof:end -->
-```
-
-Preserve human-authored content outside the markers byte-for-byte. Duplicated,
-nested, reversed, or unbalanced markers block mutation.
-
-Read [pr-body-proof.md](references/pr-body-proof.md).
-
-## Public mutation and readback
-
-Before any PR effect:
-
-1. Verify repository, remote, base/head branches and SHAs, worktree scope, task
-   state, and validation.
-2. Inspect live PRs for the exact repository/base/head tuple.
-3. Determine `pr_decision` and build the complete managed proof block.
-4. Push the exact intended committed head when required.
-5. Create, update, or update then promote.
-6. Read back repository, base/head refs and SHAs, URL, open/draft state, and the
-   managed proof block.
-
-A zero exit status is not publication proof. If mutation succeeds but readback
-fails, report the partial public effect and block; re-read live state before
-retrying.
-
-Return immutable `SHIP-v1` for the exact publication epoch.
-
-## Existing-publication observation
-
-`observe-existing` is Actuating-only and read-only.
-
-Require:
-
-- the supplied head ref is the provider's current default branch;
-- the supplied head SHA equals the live default-branch tip;
-- base and head differ and base is an ancestor;
-- base and head refs normalize to the same default-branch ref;
-- no open exact repository/base/head PR exists;
-- release input is null.
-
-Return immutable `SHIP-OBSERVATION-v2` with:
-
-```text
-repository
-canonical default-branch ref
-base SHA
-head SHA
-provider readback
-goal context digest
-review contract digest
-observed time
-mutation_performed = false
-```
-
-Actuating computes the receipt digest and includes it in the review context and
-every CAS request fingerprint before dispatch. The echoed CAS workflow binding
-therefore proves that this exact observation existed before review.
-
-No Actuating event ordering or wall-clock comparison is needed.
-
-## Existing-publication adoption
-
-`adopt-existing` is Actuating-only and read-only.
-
-Require a non-null `publication_observation_ref` resolving to the exact
-`SHIP-OBSERVATION-v2` used in the current review context. Exact-match:
-
-- repository and canonical default-branch ref;
-- immutable base and reviewed head;
-- Goal context digest and Review Contract digest;
-- current provider branch readback;
-- CAS review-context binding supplied by Actuating.
-
-If the exact observation was not bound before the current review, do not adopt a
-historical campaign. Obtain a fresh observation and run a fresh review wave.
-
-For an optional release, require current provider state `published`,
-`draft: false`, tag target equal to the adopted head, unique asset names, equal
-cardinality and exact set equality with the live inventory, and exact asset
-name, size, and SHA-256 digest matches.
-
-Return immutable `SHIP-ADOPTION-v2`. It ratifies current public state; it does
-not manufacture publication history or decide Actuating closure.
 
 ## Receipts
 

--- a/codex/skills/ship/existing-publication.md
+++ b/codex/skills/ship/existing-publication.md
@@ -1,0 +1,58 @@
+# Existing-publication observation
+
+## Existing-publication observation
+
+`observe-existing` is Actuating-only and read-only.
+
+Require:
+
+- the supplied head ref is the provider's current default branch;
+- the supplied head SHA equals the live default-branch tip;
+- base and head differ and base is an ancestor;
+- base and head refs normalize to the same default-branch ref;
+- no open exact repository/base/head PR exists;
+- release input is null.
+
+Return immutable `SHIP-OBSERVATION-v2` with:
+
+```text
+repository
+canonical default-branch ref
+base SHA
+head SHA
+provider readback
+goal context digest
+review contract digest
+observed time
+mutation_performed = false
+```
+
+Actuating computes the receipt digest and includes it in the review context and
+every CAS request fingerprint before dispatch. The echoed CAS workflow binding
+therefore proves that this exact observation existed before review.
+
+No Actuating event ordering or wall-clock comparison is needed.
+
+## Existing-publication adoption
+
+`adopt-existing` is Actuating-only and read-only.
+
+Require a non-null `publication_observation_ref` resolving to the exact
+`SHIP-OBSERVATION-v2` used in the current review context. Exact-match:
+
+- repository and canonical default-branch ref;
+- immutable base and reviewed head;
+- Goal context digest and Review Contract digest;
+- current provider branch readback;
+- CAS review-context binding supplied by Actuating.
+
+If the exact observation was not bound before the current review, do not adopt a
+historical campaign. Obtain a fresh observation and run a fresh review wave.
+
+For an optional release, require current provider state `published`,
+`draft: false`, tag target equal to the adopted head, unique asset names, equal
+cardinality and exact set equality with the live inventory, and exact asset
+name, size, and SHA-256 digest matches.
+
+Return immutable `SHIP-ADOPTION-v2`. It ratifies current public state; it does
+not manufacture publication history or decide Actuating closure.

--- a/codex/skills/ship/pull-request.md
+++ b/codex/skills/ship/pull-request.md
@@ -1,0 +1,54 @@
+# Pull-request route
+
+## Pull-request route
+
+Keep operation and final state separate:
+
+```yaml
+pr_decision:
+  operation: create | update | update-and-promote | blocked
+  final_state: ready | draft | preserve
+```
+
+Default to `ready` when validation is complete and no task remains blocked,
+deferred, or open. Draft requires explicit user intent, incomplete or
+accepted-caveat validation, open work, or repository policy.
+
+For an existing exact repository/base/head PR, update rather than duplicate it.
+Preserve its ready/draft state unless current authority permits a transition.
+Promotion is `update-and-promote`: update proof first, then mark ready.
+
+Read [pr-readiness-policy.md](references/pr-readiness-policy.md).
+
+## Managed body
+
+Only replace content between:
+
+```text
+<!-- ship-proof:start -->
+<!-- ship-proof:end -->
+```
+
+Preserve human-authored content outside the markers byte-for-byte. Duplicated,
+nested, reversed, or unbalanced markers block mutation.
+
+Read [pr-body-proof.md](references/pr-body-proof.md).
+
+## Public mutation and readback
+
+Before any PR effect:
+
+1. Verify repository, remote, base/head branches and SHAs, worktree scope, task
+   state, and validation.
+2. Inspect live PRs for the exact repository/base/head tuple.
+3. Determine `pr_decision` and build the complete managed proof block.
+4. Push the exact intended committed head when required.
+5. Create, update, or update then promote.
+6. Read back repository, base/head refs and SHAs, URL, open/draft state, and the
+   managed proof block.
+
+A zero exit status is not publication proof. If mutation succeeds but readback
+fails, report the partial public effect and block; re-read live state before
+retrying.
+
+Return immutable `SHIP-v1` for the exact publication epoch.

--- a/codex/skills/tune/SKILL.md
+++ b/codex/skills/tune/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tune
-description: "Create, directly edit, or evidence-tune Codex skill packages. Use for new skills, explicit skill surgery, regressions, or intended-vs-observed skill behavior. Infer create, edit, or tune mode; preserve progressive disclosure and stable contracts; select the semantically weakest valid intervention before minimizing the diff; and mutate or publish only with corresponding authority."
+description: "Create, edit, or diagnose Codex skill packages, including activation failures, regressions, and intended-versus-observed behavior. Use for skill-package work, not ordinary application code changes."
 ---
 
 # Tune
@@ -81,6 +81,39 @@ PR      -> explicit PR intent
 
 Report a concrete blocker when requested publication cannot complete.
 
+## Selected guidance
+
+After selecting intent and authority, read only [create.md](create.md),
+[edit.md](edit.md), or [tuning.md](tuning.md) for that mode. Read
+[authoring.md](authoring.md) before selecting or realizing a package intervention,
+including proposal-only surgery; it owns disclosure, intervention selection,
+package integrity, and the fresh-eyes pass. A tune diagnosis ending in `no-change`
+need not load authoring procedure merely to report that result.
+
+Follow the selected guide through its authorized validation and publication.
+An available implementation or another skill is not a reason to stop short of
+the requested package change. Continue independent authorized work when one
+claim or effect is blocked.
+
+<a id="progressive-disclosure"></a>
+Progressive disclosure: [authoring.md](authoring.md#progressive-disclosure).
+<a id="cognitive-compilation"></a>
+Cognitive compilation: [authoring.md](authoring.md#cognitive-compilation).
+<a id="intervention-selection"></a>
+Intervention selection: [authoring.md](authoring.md#intervention-selection).
+<a id="decision-instrumentation"></a>
+Decision instrumentation: [authoring.md](authoring.md#decision-instrumentation).
+<a id="package-rules"></a>
+Package rules: [authoring.md](authoring.md#package-rules).
+<a id="fresh-eyes-pass"></a>
+Fresh-eyes pass: [authoring.md](authoring.md#fresh-eyes-pass).
+<a id="create-mode"></a>
+Create mode: [create.md](create.md#create-mode).
+<a id="edit-mode"></a>
+Edit mode: [edit.md](edit.md#edit-mode).
+<a id="tune-mode"></a>
+Tune mode: [tuning.md](tuning.md#tune-mode).
+
 ## Common kernel
 
 1. Resolve the skill root, target, and mode.
@@ -120,203 +153,6 @@ observed activation, recurrence, influence, or outcomes.
 If materially new evidence invalidates the frozen delta or selected intervention,
 return to step 4. Do not silently broaden the diagnosis during editing.
 
-## Progressive disclosure
-
-The package must place knowledge at the cheapest sufficient layer:
-
-```text
-frontmatter description  activation cues
-SKILL.md                  always-required authority, routing, safety, and stops
-references/               conditional knowledge loaded at a named decision
-scripts/                  substantive deterministic operations
-assets/                   output resources, not hidden policy
-```
-
-Before completion, prove:
-
-- metadata carries every activation cue without claiming neighboring skills;
-- `SKILL.md` contains every always-required rule;
-- each deeper resource is linked beside the condition that requires it;
-- a common-path probe reaches its outcome with the kernel and common resources,
-  without requiring the consumer to reconstruct internal routing or choreography;
-- a conditional-path probe loads only resources whose condition holds, without
-  hiding an always-required obligation in an optional reference;
-- a near-miss prompt does not activate.
-
-Keep `SKILL.md` under 500 lines. Move detail only when doing so improves
-progressive disclosure rather than hiding governing policy. In those same probes,
-name what the consumer can stop knowing or coordinating and test a relevant change
-for locality. Merely moving text to references or exposing it through configuration
-does not deepen the skill. Retain specialized vocabulary only when it compresses a
-stable distinction the consumer can recover; private terminology is not capability.
-
-## Create mode
-
-1. Search for a skill already covering the intent.
-2. Collect two or three realistic trigger prompts and at least one near miss.
-3. State the problem, success criterion, and non-trigger boundary.
-4. Classify the skill as `decision`, `execution`, `evidence`, `orchestration`, or
-   `mixed` only when the classification affects design or observability.
-5. Map activation metadata, the always-required kernel, common resources, and
-   each conditional resource.
-6. Scaffold when useful:
-   ```bash
-   uv run --with pyyaml -- python3 \
-     codex/skills/.system/skill-creator/scripts/init_skill.py \
-     <skill-name> --path codex/skills
-   ```
-7. Author the smallest operative package.
-8. Evaluate decision instrumentation; do not add it by default.
-9. Align `agents/openai.yaml`.
-10. Remove redundant doctrine, examples, and generated ceremony.
-
-If an existing skill already owns the intent, prefer extending it or report
-`no-change`; do not create a synonym package.
-
-## Edit mode
-
-Use for direct user-authorized surgery when the desired change is already known.
-
-- Preserve unrelated behavior and files.
-- Preserve stable decision-contract IDs.
-- Update only affected clauses and linked surfaces.
-- Keep frontmatter, package paths, links, and `agents/openai.yaml` aligned.
-- Do not manufacture historical evidence, tuning packets, or receipts.
-- Escalate to tune mode only when deciding *whether* or *how* the skill should
-  change requires behavioral evidence.
-
-## Tune mode
-
-Tune compares intended behavior with observed decision episodes and outcomes.
-
-```text
-activation evidence asks: was the skill present?
-decision evidence asks: what changed because of it?
-outcome evidence asks: was that change useful?
-```
-
-These implications are invalid:
-
-```text
-mention -> activation
-activation -> decision influence
-decision influence -> outcome causality
-successful outcome -> skill effectiveness
-```
-
-Read [tuning-evidence.md](references/tuning-evidence.md) when historical,
-provided, mixed, or attribution-sensitive evidence is needed. Use the passive Seq
-definition there for bounded historical reconstruction.
-
-For every material episode preserve the trigger, activation evidence, decision
-question, selected route, rejected routes actually observed, exercised clauses,
-decision effect, evidence strength, downstream signal, and counterevidence.
-Do not invent unobserved alternatives.
-
-Classify the smallest useful gap:
-
-```text
-activation | interpretation | workflow | tooling | resource
-metadata | boundary | source-scope | decision-contract | observability
-outcome | ceremony | overconstraint
-```
-
-Produce at most one dominant expected delta per cycle. Preserve denominators,
-counterevidence, scope, and limitations. If no consequential decision,
-execution, proof, lifecycle, or outcome relation should change, stop with
-`no-change`.
-
-Regression is an evidence shape, not a mode. Bind the prior failure, involved
-trigger/clause/route, expected future behavior, and a reproduction query. Repair
-the witnessed failure class without installing an unsupported global ban.
-
-## Cognitive compilation
-
-When creating or changing how a target agent frames, searches, explains,
-constructs, selects, reduces, or turns a selected route into action, read
-[cognitive-compilation.md](references/cognitive-compilation.md) before selecting
-the intervention. Skip this reference for mechanical routing, authority,
-tooling, transport, or formatting edits that do not change cognition.
-
-Translate the requested or evidenced weakness into the target's native trigger,
-operation, shadow-risk guard, stopping condition, observable route delta, and
-positive, near-miss, and shadow-failure probes. Reuse an equivalent native rule;
-prefer `no-change` when no material delta is justified.
-
-This is conditional authoring knowledge, not another public mode, runtime
-dispatcher, handoff, or receipt. Tune's selection and authority gates still
-govern. Do not redefine canonical verbatim skills or gate their independent
-entry points through the operator taxonomy.
-
-## Intervention selection
-
-Select by semantic weakness, then realize by physical minimality.
-
-Read [weakness-selection.md](references/weakness-selection.md) when candidates
-differ in semantic scope, a short edit would introduce a broad rule, or a
-regression guard risks overfitting.
-
-A candidate is valid only when it:
-
-- produces the expected delta;
-- preserves protected contracts and valid near misses;
-- stays inside the authorized package surface;
-- introduces no contradiction, prohibited route, or unowned authority;
-- leaves its claimed effect observable.
-
-Among valid candidates, reject a semantically stronger candidate when a provably
-weaker valid candidate permits every behavior the stronger candidate permits
-while avoiding at least one unnecessary restriction. Preserve genuine
-incomparability; never invent a numeric weakness score.
-
-Select one dominant intervention route:
-
-```text
-no-change
-trigger-or-boundary
-decision-or-routing
-workflow-or-tooling
-artifact-or-resource
-metadata-or-observability
-consolidate-or-delete
-blocked
-```
-
-One intervention may touch several files when they jointly realize one rule,
-such as `SKILL.md` plus the matching decision-contract clause and agent prompt.
-
-After semantic selection, minimize physical realization:
-
-```text
-1. no edit
-2. delete or consolidate
-3. clarify an existing trigger, rule, route, or stop
-4. repair an existing artifact or operation
-5. add one conditional reference
-6. add a substantive operation
-7. add a consequential contract clause or receipt
-```
-
-## Decision instrumentation
-
-Read
-[decision-instrumentation.md](references/decision-instrumentation.md)
-before adding or materially changing a decision contract or receipt.
-
-Create `references/decision-contract.json` only when stable consequential
-decision rules need future clause-level evidence. Add an SDR-v1 receipt only when
-the decision cannot otherwise be recovered proportionately.
-
-When a contract exists:
-
-- preserve stable trigger, route, and clause IDs;
-- never renumber for formatting;
-- synchronize changed routes with `SKILL.md`;
-- preserve superseded IDs when historical evidence depends on them;
-- update the source fingerprint after the final package state is known.
-
-Structural validation proves shape, not correctness, usefulness, or authority.
-
 ## Outcome observation
 
 Run a current behavioral observation when the evidence can exist now. Otherwise
@@ -324,37 +160,6 @@ retain the exact future query and state what remains unproved.
 
 A text edit proves only that the package changed. It does not prove improved
 activation, decision quality, execution fidelity, or outcomes.
-
-## Package rules
-
-- Make the smallest sufficient package, not merely the fewest changed lines.
-- Default frontmatter to `name` and `description`.
-- Use a hyphen-case name of at most 64 characters matching the folder.
-- Keep the description under 1024 characters.
-- Do not add README, INSTALL, or CHANGELOG files inside a skill package.
-- Do not add scripts that merely grade prose.
-- Do not add network dependencies, secrets, hidden global state, or
-  nondeterminism.
-- Preserve concurrent and unrelated work.
-- Do not delegate edits to a system-managed optimizer.
-- Root owns all skill-package mutation.
-
-## Fresh-eyes pass
-
-Before completing a non-trivial creation or edit, reread the result as both user
-and router:
-
-- Did the description become too broad, narrow, or duplicative?
-- Does body workflow conflict with frontmatter or another skill's ownership?
-- Did evidence, authority, privacy, publication, or stopping rules weaken?
-- Did paths, names, links, contract IDs, or `agents/openai.yaml` drift?
-- Would the result cause false, missed, ceremonial, or partial activation?
-- Did the change add protocol where direct capability would suffice?
-- For cognitive edits, did the native decision procedure change rather than just
-  its register, without duplicating a handler or widening authority?
-
-Fix a material finding before completion. Otherwise retain
-`fresh_eyes_delta: none` internally.
 
 ## Report
 

--- a/codex/skills/tune/authoring.md
+++ b/codex/skills/tune/authoring.md
@@ -1,0 +1,174 @@
+# Skill authoring
+
+## Progressive disclosure
+
+The package must place knowledge at the cheapest sufficient layer:
+
+```text
+frontmatter description  activation cues
+SKILL.md                  always-required authority, routing, safety, and stops
+workflow guides/references  conditional knowledge loaded at a named decision
+scripts/                  substantive deterministic operations
+assets/                   output resources, not hidden policy
+```
+
+Before completion, prove:
+
+- metadata carries every activation cue without claiming neighboring skills;
+- `SKILL.md` contains every always-required rule;
+- each deeper resource is linked beside the condition that requires it;
+- a common-path probe reaches its outcome with the kernel and common resources,
+  without requiring the consumer to reconstruct internal routing or choreography;
+- a conditional-path probe loads only resources whose condition holds, without
+  hiding an always-required obligation in an optional reference;
+- a near-miss prompt does not activate.
+
+Treat the 500-line body and 1024-character description limits as ceilings, not
+quality targets. Front-load the task that distinguishes the skill from its
+nearest neighbors. Descriptions are routing metadata, not miniature workflows:
+keep necessary activation and near-miss cues there; put authority inventories,
+procedures, internal modes, and output details in the selected body.
+
+For multiple workflows, select the route before reading its procedures. Keep
+shared obligations in the entry and link each required module at the decision
+or effect it governs. Moving the whole manual behind an unconditional link is
+not progressive disclosure; nor is hiding a mandatory rule in an optional read.
+A common route must finish without reading unselected workflows.
+
+During an authorized catalog-level change, inspect the actual rendered catalog,
+including installed/system skills when accessible. Test neighboring descriptions
+together for collisions and missed activation; do not infer truncation from
+this repository alone. Record unavailable runtime/catalog evidence as a limit,
+not a fabricated pass. This is change validation, not a new startup ritual.
+
+Move detail only when doing so improves
+progressive disclosure rather than hiding governing policy. In those same probes,
+name what the consumer can stop knowing or coordinating and test a relevant change
+for locality. Merely moving text to references or exposing it through configuration
+does not deepen the skill. Retain specialized vocabulary only when it compresses a
+stable distinction the consumer can recover; private terminology is not capability.
+
+Separate content-preserving relocation from behavioral ablation. Preserve
+required reviews, authority, stopping rules, canonical writers, and claim strength
+unless their change is itself authorized and evidence-backed. Check positive,
+near-miss, and shadow-failure cases on the selected read path. Distinguish static
+reachability and byte preservation from observed model behavior; fewer loaded
+bytes or a passing structural check alone does not prove efficacy.
+
+## Cognitive compilation
+
+When creating or changing how a target agent frames, searches, explains,
+constructs, selects, reduces, or turns a selected route into action, read
+[cognitive-compilation.md](references/cognitive-compilation.md) before selecting
+the intervention. Skip this reference for mechanical routing, authority,
+tooling, transport, or formatting edits that do not change cognition.
+
+Translate the requested or evidenced weakness into the target's native trigger,
+operation, shadow-risk guard, stopping condition, observable route delta, and
+positive, near-miss, and shadow-failure probes. Reuse an equivalent native rule;
+prefer `no-change` when no material delta is justified.
+
+This is conditional authoring knowledge, not another public mode, runtime
+dispatcher, handoff, or receipt. Tune's selection and authority gates still
+govern. Do not redefine canonical verbatim skills or gate their independent
+entry points through the operator taxonomy.
+
+## Intervention selection
+
+Select by semantic weakness, then realize by physical minimality.
+
+Read [weakness-selection.md](references/weakness-selection.md) when candidates
+differ in semantic scope, a short edit would introduce a broad rule, or a
+regression guard risks overfitting.
+
+A candidate is valid only when it:
+
+- produces the expected delta;
+- preserves protected contracts and valid near misses;
+- stays inside the authorized package surface;
+- introduces no contradiction, prohibited route, or unowned authority;
+- leaves its claimed effect observable.
+
+Among valid candidates, reject a semantically stronger candidate when a provably
+weaker valid candidate permits every behavior the stronger candidate permits
+while avoiding at least one unnecessary restriction. Preserve genuine
+incomparability; never invent a numeric weakness score.
+
+Select one dominant intervention route:
+
+```text
+no-change
+trigger-or-boundary
+decision-or-routing
+workflow-or-tooling
+artifact-or-resource
+metadata-or-observability
+consolidate-or-delete
+blocked
+```
+
+One intervention may touch several files when they jointly realize one rule,
+such as `SKILL.md` plus the matching decision-contract clause and agent prompt.
+
+After semantic selection, minimize physical realization:
+
+```text
+1. no edit
+2. delete or consolidate
+3. clarify an existing trigger, rule, route, or stop
+4. repair an existing artifact or operation
+5. add one conditional reference
+6. add a substantive operation
+7. add a consequential contract clause or receipt
+```
+
+## Decision instrumentation
+
+Read
+[decision-instrumentation.md](references/decision-instrumentation.md)
+before adding or materially changing a decision contract or receipt.
+
+Create `references/decision-contract.json` only when stable consequential
+decision rules need future clause-level evidence. Add an SDR-v1 receipt only when
+the decision cannot otherwise be recovered proportionately.
+
+When a contract exists:
+
+- preserve stable trigger, route, and clause IDs;
+- never renumber for formatting;
+- synchronize changed routes with `SKILL.md`;
+- preserve superseded IDs when historical evidence depends on them;
+- update the source fingerprint after the final package state is known.
+
+Structural validation proves shape, not correctness, usefulness, or authority.
+
+## Package rules
+
+- Make the smallest sufficient package, not merely the fewest changed lines.
+- Default frontmatter to `name` and `description`.
+- Use a hyphen-case name of at most 64 characters matching the folder.
+- Keep the description under 1024 characters.
+- Do not add README, INSTALL, or CHANGELOG files inside a skill package.
+- Do not add scripts that merely grade prose.
+- Do not add network dependencies, secrets, hidden global state, or
+  nondeterminism.
+- Preserve concurrent and unrelated work.
+- Do not delegate edits to a system-managed optimizer.
+- Root owns all skill-package mutation.
+
+## Fresh-eyes pass
+
+Before completing a non-trivial creation or edit, reread the result as both user
+and router:
+
+- Did the description become too broad, narrow, or duplicative?
+- Does body workflow conflict with frontmatter or another skill's ownership?
+- Did evidence, authority, privacy, publication, or stopping rules weaken?
+- Did paths, names, links, contract IDs, or `agents/openai.yaml` drift?
+- Would the result cause false, missed, ceremonial, or partial activation?
+- Did the change add protocol where direct capability would suffice?
+- For cognitive edits, did the native decision procedure change rather than just
+  its register, without duplicating a handler or widening authority?
+
+Fix a material finding before completion. Otherwise retain
+`fresh_eyes_delta: none` internally.

--- a/codex/skills/tune/create.md
+++ b/codex/skills/tune/create.md
@@ -1,0 +1,24 @@
+# Create mode
+
+## Create mode
+
+1. Search for a skill already covering the intent.
+2. Collect two or three realistic trigger prompts and at least one near miss.
+3. State the problem, success criterion, and non-trigger boundary.
+4. Classify the skill as `decision`, `execution`, `evidence`, `orchestration`, or
+   `mixed` only when the classification affects design or observability.
+5. Map activation metadata, the always-required kernel, common resources, and
+   each conditional resource.
+6. Scaffold when useful:
+   ```bash
+   uv run --with pyyaml -- python3 \
+     codex/skills/.system/skill-creator/scripts/init_skill.py \
+     <skill-name> --path codex/skills
+   ```
+7. Author the smallest operative package.
+8. Evaluate decision instrumentation; do not add it by default.
+9. Align `agents/openai.yaml`.
+10. Remove redundant doctrine, examples, and generated ceremony.
+
+If an existing skill already owns the intent, prefer extending it or report
+`no-change`; do not create a synonym package.

--- a/codex/skills/tune/edit.md
+++ b/codex/skills/tune/edit.md
@@ -1,0 +1,13 @@
+# Edit mode
+
+## Edit mode
+
+Use for direct user-authorized surgery when the desired change is already known.
+
+- Preserve unrelated behavior and files.
+- Preserve stable decision-contract IDs.
+- Update only affected clauses and linked surfaces.
+- Keep frontmatter, package paths, links, and `agents/openai.yaml` aligned.
+- Do not manufacture historical evidence, tuning packets, or receipts.
+- Escalate to tune mode only when deciding *whether* or *how* the skill should
+  change requires behavioral evidence.

--- a/codex/skills/tune/tuning.md
+++ b/codex/skills/tune/tuning.md
@@ -1,0 +1,46 @@
+# Tune mode
+
+## Tune mode
+
+Tune compares intended behavior with observed decision episodes and outcomes.
+
+```text
+activation evidence asks: was the skill present?
+decision evidence asks: what changed because of it?
+outcome evidence asks: was that change useful?
+```
+
+These implications are invalid:
+
+```text
+mention -> activation
+activation -> decision influence
+decision influence -> outcome causality
+successful outcome -> skill effectiveness
+```
+
+Read [tuning-evidence.md](references/tuning-evidence.md) when historical,
+provided, mixed, or attribution-sensitive evidence is needed. Use the passive Seq
+definition there for bounded historical reconstruction.
+
+For every material episode preserve the trigger, activation evidence, decision
+question, selected route, rejected routes actually observed, exercised clauses,
+decision effect, evidence strength, downstream signal, and counterevidence.
+Do not invent unobserved alternatives.
+
+Classify the smallest useful gap:
+
+```text
+activation | interpretation | workflow | tooling | resource
+metadata | boundary | source-scope | decision-contract | observability
+outcome | ceremony | overconstraint
+```
+
+Produce at most one dominant expected delta per cycle. Preserve denominators,
+counterevidence, scope, and limitations. If no consequential decision,
+execution, proof, lifecycle, or outcome relation should change, stop with
+`no-change`.
+
+Regression is an evidence shape, not a mode. Bind the prior failure, involved
+trigger/clause/route, expected future behavior, and a reproduction query. Repair
+the witnessed failure class without installing an unsupported global ban.

--- a/codex/skills/universalist/SKILL.md
+++ b/codex/skills/universalist/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: universalist
-description: "Use when current work must decide or reconsider an owned code boundary: introducing, removing, migrating, bypassing, or materially changing its semantic owner, admitted domain, representation, composition, compatibility, effects, failure semantics, or proof; or when repeated implementations distribute one law across owners. Skip routine implementation, validation, review closure, rebasing, Ship, and Land against an accepted architecture unless new evidence fires an invalidator. In Actuating, nominate only when architecture reconsideration is live. Explicit invocation always runs. Team mode requires explicit request."
+description: "Choose or reconsider a semantic code boundary when ownership, representation, composition, or required laws are in question. Also use for distributed implementations of one law or invalidated decisions. Not routine work under an accepted architecture."
 ---
 
 # Universalist
@@ -73,9 +73,10 @@ Team/subagent mode remains explicit-request only.
 
 ## Common path
 
-The common path must complete without loading any deeper reference. Inside
-Actuating, use the composition handoff below instead of also emitting the
-standalone disposition template; the same applicable obligations remain.
+The standalone ordinary/preserve path must complete without loading any deeper
+reference. Inside Actuating, read [actuating-composition.md](actuating-composition.md)
+instead of also emitting the standalone disposition template; the same applicable
+obligations remain.
 
 1. Attribute the trigger evidence. If no implicit trigger condition is
    evidenced, stop without a disposition.
@@ -152,7 +153,7 @@ the whole reference corpus to search for a reason to escalate.
 | One ordinary artifact clearly closes the seam | nothing | compact `ordinary` nomination and transition |
 | Repeated obligations, an imminent constrained variant, or a grounded law-derived challenger needs discrimination | `references/latent-structure-recognition.md` | encoding relation, false friend, discriminator, dividend, transition need |
 | At least two plausible routes materially differ | `references/consequential-boundary.md` | context-relative comparison and Boundary Artifact Contract candidate |
-| A specific typed hole survives ordinary comparison | `references/artifact-selection-by-unknown-location.md`, then the matching registry card fragment only | evidence-bound card disposition |
+| A specific typed hole survives ordinary comparison | `advanced-mechanics.md`, then its selected registry fragment only | evidence-bound card disposition |
 | One advanced card remains live | only that card's `theory_refs` | effective repository-native lowering and proof profile |
 | A consequential decision must remain independently durable outside Actuating | `references/durable-decision.md` | one Ledger-addressed plan and, after standalone adjudication, one root receipt |
 | User explicitly requests Universalist subagents/team mode | `references/workflow/team-routing.md`, `references/workflow/subagent-packet-contract.md`, and `references/workflow/subagent-orchestration.md` | bounded read-only packets and one root synthesis |
@@ -201,29 +202,9 @@ interest do not establish consequentiality.
 
 ### Advanced-mechanics gate
 
-Advanced mechanics are selected by a concrete typed hole, not by browsing for
-an attractive theorem.
-
-After the ordinary candidate and consequential comparison:
-
-1. read `references/artifact-selection-by-unknown-location.md`;
-2. consult `references/universal-construction-registry.yaml`;
-3. inspect at most three nearby cards, including the ordinary alternative;
-4. classify each relevant card as `selected`, `rejected`, `contradicted`, or
-   `unresolved`;
-5. read only the selected or still-material card's exact `theory_refs`;
-6. lower any retained card into one repository-native boundary artifact.
-
-Match proof to the actual claim: a lawful structure needs its laws and
-interpretation, not an invented universal property. Mediation and uniqueness
-apply only to a named universal construction with specified competitors and maps.
-Opacity, one public interpreter, and passing examples alone establish neither.
-A bounded approximation states its domain, losses, and evidence limits. A route
-name never upgrades claim strength.
-
-Signals, registry order, `diagnostic_order`, evidence count, and theorem
-sophistication never prove prerequisites or select a route. Ordinary dominance
-is a successful advanced-mechanics rejection, not a failed analysis.
+When a specific typed hole survives ordinary and consequential comparison,
+read [advanced-mechanics.md](advanced-mechanics.md) before registry selection.
+Select by the hole, not theorem appeal; the route name never upgrades proof.
 
 ### Durability gate (`UNI-DURABLE`)
 
@@ -263,92 +244,18 @@ together.
 
 ## Actuating composition
 
-Inside `$actuating`, Universalist is a nominator only. Actuating owns the
-invocation point and calls Universalist only after architecture reconsideration
-is live. Do not run a duplicate root or worker pass merely because Actuating
-will cross a boundary while realizing an already selected architecture.
-
-Return `candidate`, `preserve-incumbent`, `unresolved`, or `obstructed` with the smallest
-code-bound argument that changes Actuating's decision: trigger evidence, owner
-and operation, required law/observations, discriminator, and material migration,
-residual, or invalidation consequences. For counterexample-driven work, identify
-the enabling freedom removed or lawfully controlled. Reuse supplied facts and proof references. No fixed field projection
-or second Working Set report is required.
-
-Return `unresolved` when evidence is missing or adequate candidates remain
-incomparable; name that reason and the smallest available discriminator. This
-is a supporting result, not a new route or mode. Do not convert uncertainty into
-`obstructed`, preserve an unjustified incumbent, or invent a winner. Actuating
-owns any authorized experiment outside an open review epoch and blocks only the
-affected decision. Obstruction still requires the evidence specified below.
-
-An ordinary nomination can be direct: derive the receipt subject from the
-execution-owned evidence instead of accepting both independently; retire the
-unchecked constructor, migrate callers, and identify the mismatch witness and
-required-valid counterpart. This nominates work; it is not proof of a successor.
-Admission, preservation under permitted operations, and sanctioned-path coverage
-remain distinct obligations. Adequate native evidence may discharge them without
-a duplicate topology account. When route or migration coverage needs explicit
-accounting, return the relevant source-derived topology obligations to Actuating.
-
-A candidate may improve the causal explanation. Return the material delta and
-its discriminator for Actuating's existing selection decision; do not silently
-redefine the family or require a separate co-refinement pass. The family is not
-just its observed examples, and a local correction may still be the adequate
-construction.
-
-When a candidate changes the comparison domain, quotients distinctions, or
-conservatively approximates behavior, justify total interpretation over that
-domain, reflection of every concrete violation, exclusion of invalid behavior,
-and preservation of required valid behaviors and observations at an explicit
-evidence strength. Do not underapproximate danger or erase required distinctions.
-Report any optional safe behavior excluded by a conservative approximation;
-diagnostic exactness is separate from safety. Do not invent these transformations
-or their reporting fields for a candidate that does not use them.
-
-Keep primary enforcement distinct from derived trust-boundary, compatibility,
-observability, and compensating guards. Do not nominate a construction as adequate
-while a sanctioned escape or permitted transition still admits its claimed family.
-
-Universalist never selects or reopens Actuating's target, adjudicates its causal
-alternatives, grants mutation or closure, allocates a plan/root receipt, or persists
-an Actuating architecture artifact. Actuating alone adjudicates the nomination
-and any interpretation delta in its active Working Set. Git and actual proof own
-the realized result. Standalone selection remains subject to its applicable
-consequential and durability contracts.
+Inside Actuating, load [actuating-composition.md](actuating-composition.md) before
+nominating. Actuating owns the invocation point, selection, mutation, and closure;
+Universalist returns `candidate`, `preserve-incumbent`, `unresolved`, or `obstructed`.
+Never load standalone durability mechanics in this composition.
 
 ## Execution-time reclassification (`UNI-RECLASSIFY`)
 
-Treat every compact disposition, nomination, or durable decision as a proof
-lease over current evidence.
-
-Reclassify before the next affected mutation only when new evidence may
-materially change the owner, requirements, observations, compatibility,
-effects, resources, axis, typed hole, law, falsifier, enforcement, residuals,
-route, or seam decomposition. Routine refinement under the same owner, axis,
-law, falsifier, route, obligations, and invalidators reuses the current proof
-lease silently.
-
-Record:
-
-```text
-Prior disposition or decision:
-New evidence:
-Material semantic delta:
-Outcome: retain / split / escalate / obstruct
-Invalidated artifacts: receipt / plan / proof lease / none
-Successor packets: owner + axis + seam / none
-```
-
-- **retain** — the same owner, axis, law, falsifier, route, and obligations hold;
-- **split** — independently governed owners or axes appeared;
-- **escalate** — the route materially changed; repeat consequential analysis;
-- **obstruct** — no honest current route is representable or authorized.
-
-Before Actuating selects a target architecture, revise the nomination in
-place. After implementation begins, return material evidence to Actuating;
-Universalist must not reopen the target directly. Never overwrite an existing
-root receipt.
+Reuse an unchanged disposition silently. When new evidence may materially change
+its owner, requirements, observations, compatibility, effects, resources, axis,
+typed hole, law, falsifier, enforcement, residuals, route, or decomposition, read
+[reclassification.md](reclassification.md) before the next affected mutation.
+Do not reopen Actuating's target or overwrite a root receipt.
 
 ## Evidence and obstruction
 

--- a/codex/skills/universalist/actuating-composition.md
+++ b/codex/skills/universalist/actuating-composition.md
@@ -1,0 +1,57 @@
+# Actuating composition
+
+## Actuating composition
+
+Inside `$actuating`, Universalist is a nominator only. Actuating owns the
+invocation point and calls Universalist only after architecture reconsideration
+is live. Do not run a duplicate root or worker pass merely because Actuating
+will cross a boundary while realizing an already selected architecture.
+
+Return `candidate`, `preserve-incumbent`, `unresolved`, or `obstructed` with the smallest
+code-bound argument that changes Actuating's decision: trigger evidence, owner
+and operation, required law/observations, discriminator, and material migration,
+residual, or invalidation consequences. For counterexample-driven work, identify
+the enabling freedom removed or lawfully controlled. Reuse supplied facts and proof references. No fixed field projection
+or second Working Set report is required.
+
+Return `unresolved` when evidence is missing or adequate candidates remain
+incomparable; name that reason and the smallest available discriminator. This
+is a supporting result, not a new route or mode. Do not convert uncertainty into
+`obstructed`, preserve an unjustified incumbent, or invent a winner. Actuating
+owns any authorized experiment outside an open review epoch and blocks only the
+affected decision. Obstruction still requires the [evidence specified in the entry](SKILL.md#evidence-and-obstruction).
+
+An ordinary nomination can be direct: derive the receipt subject from the
+execution-owned evidence instead of accepting both independently; retire the
+unchecked constructor, migrate callers, and identify the mismatch witness and
+required-valid counterpart. This nominates work; it is not proof of a successor.
+Admission, preservation under permitted operations, and sanctioned-path coverage
+remain distinct obligations. Adequate native evidence may discharge them without
+a duplicate topology account. When route or migration coverage needs explicit
+accounting, return the relevant source-derived topology obligations to Actuating.
+
+A candidate may improve the causal explanation. Return the material delta and
+its discriminator for Actuating's existing selection decision; do not silently
+redefine the family or require a separate co-refinement pass. The family is not
+just its observed examples, and a local correction may still be the adequate
+construction.
+
+When a candidate changes the comparison domain, quotients distinctions, or
+conservatively approximates behavior, justify total interpretation over that
+domain, reflection of every concrete violation, exclusion of invalid behavior,
+and preservation of required valid behaviors and observations at an explicit
+evidence strength. Do not underapproximate danger or erase required distinctions.
+Report any optional safe behavior excluded by a conservative approximation;
+diagnostic exactness is separate from safety. Do not invent these transformations
+or their reporting fields for a candidate that does not use them.
+
+Keep primary enforcement distinct from derived trust-boundary, compatibility,
+observability, and compensating guards. Do not nominate a construction as adequate
+while a sanctioned escape or permitted transition still admits its claimed family.
+
+Universalist never selects or reopens Actuating's target, adjudicates its causal
+alternatives, grants mutation or closure, allocates a plan/root receipt, or persists
+an Actuating architecture artifact. Actuating alone adjudicates the nomination
+and any interpretation delta in its active Working Set. Git and actual proof own
+the realized result. Standalone selection remains subject to its applicable
+consequential and durability contracts.

--- a/codex/skills/universalist/advanced-mechanics.md
+++ b/codex/skills/universalist/advanced-mechanics.md
@@ -1,0 +1,27 @@
+# Advanced mechanics
+
+### Advanced-mechanics gate
+
+Advanced mechanics are selected by a concrete typed hole, not by browsing for
+an attractive theorem.
+
+After the ordinary candidate and consequential comparison:
+
+1. read `references/artifact-selection-by-unknown-location.md`;
+2. consult `references/universal-construction-registry.yaml`;
+3. inspect at most three nearby cards, including the ordinary alternative;
+4. classify each relevant card as `selected`, `rejected`, `contradicted`, or
+   `unresolved`;
+5. read only the selected or still-material card's exact `theory_refs`;
+6. lower any retained card into one repository-native boundary artifact.
+
+Match proof to the actual claim: a lawful structure needs its laws and
+interpretation, not an invented universal property. Mediation and uniqueness
+apply only to a named universal construction with specified competitors and maps.
+Opacity, one public interpreter, and passing examples alone establish neither.
+A bounded approximation states its domain, losses, and evidence limits. A route
+name never upgrades claim strength.
+
+Signals, registry order, `diagnostic_order`, evidence count, and theorem
+sophistication never prove prerequisites or select a route. Ordinary dominance
+is a successful advanced-mechanics rejection, not a failed analysis.

--- a/codex/skills/universalist/reclassification.md
+++ b/codex/skills/universalist/reclassification.md
@@ -1,0 +1,34 @@
+# Execution-time reclassification
+
+## Execution-time reclassification (`UNI-RECLASSIFY`)
+
+Treat every compact disposition, nomination, or durable decision as a proof
+lease over current evidence.
+
+Reclassify before the next affected mutation only when new evidence may
+materially change the owner, requirements, observations, compatibility,
+effects, resources, axis, typed hole, law, falsifier, enforcement, residuals,
+route, or seam decomposition. Routine refinement under the same owner, axis,
+law, falsifier, route, obligations, and invalidators reuses the current proof
+lease silently.
+
+Record:
+
+```text
+Prior disposition or decision:
+New evidence:
+Material semantic delta:
+Outcome: retain / split / escalate / obstruct
+Invalidated artifacts: receipt / plan / proof lease / none
+Successor packets: owner + axis + seam / none
+```
+
+- **retain** — the same owner, axis, law, falsifier, route, and obligations hold;
+- **split** — independently governed owners or axes appeared;
+- **escalate** — the route materially changed; repeat consequential analysis;
+- **obstruct** — no honest current route is representable or authorized.
+
+Before Actuating selects a target architecture, revise the nomination in
+place. After implementation begins, return material evidence to Actuating;
+Universalist must not reopen the target directly. Never overwrite an existing
+root receipt.


### PR DESCRIPTION
## Purpose

Apply the session's recommendations based on [Rethinking skills and prompts for GPT-6 Astra](https://developers.openai.com/blog/rethinking-skills-and-prompts-for-gpt-6-astra): preserve specialized engineering knowledge while reducing the instructions eagerly loaded for unrelated workflows.

Built on `3b9fbf6a594c561123ec8ec349ad59e98ea37254`, including the merged design work already present on main. This is a loading/routing refactor, not a reduction in review rigor or categorical reasoning.

## Changes

- Shorten task-discriminating descriptions in eight packages: Actuating, Universalist, Codebase Doctrine, Tune, Plan, CAS, Ship, and Learnings.
- Select workflows before loading their detailed procedures. Keep shared authority, proof, routing, and stopping obligations in the entry document; require the selected guide before its governed decision or effect.
- Separate Actuating's counterexample, architecture, recurrence, and review-closeout guidance. Local implementation retains its proof bar without acquiring an initial review campaign or publication obligation.
- Preserve Universalist's common categorical recognizer and first-use law-derived alternatives while loading advanced mechanics, Actuating composition, and reclassification only when needed. Keep Church/fold reasoning, required-valid preservation, and uncertainty-versus-obstruction distinctions.
- Retain Codebase Doctrine's complete induction workflow, but distinguish fresh discovery from targeted refresh and task-context projection.
- Update Tune's authoring guidance so concise routing metadata and selected-path disclosure remain the authoring default. Keep create/edit/evidence-tuning procedures separate and distinguish structural checks from model-effectiveness evidence.
- Keep Learnings' mandatory delivery-time evaluation, but allow its no-op decision before loading store/admission procedures or bootstrapping Ledger. Preserve conditional capture and canonical-versus-derived ownership.
- Consolidate duplicate source-memory procedure in AGENTS.md while retaining global invariants, source-specific triggers, exact-applicability negative routing, and the non-gating delivery policy.
- Adapt two existing Actuating source-contract tests to relocated sections. Repair a pre-existing stale footgun-review blob pin to the already-merged #285 bytes; the lens itself is unchanged.

The 23 new Markdown files are conditional guides inside existing packages, not new public skills. They sit beside SKILL.md so existing relative references remain valid. Forwarding anchors preserve moved entry-section links.

## Protected behavior

The public Actuating routes, both review scheduling modes, five-standard-clean convergence, auxiliary review inventory, frozen-subject rules, proof obligations, and effect authority remain intact. Four protected Actuating section bodies still match their original SHA-256 pins. Review-policy JSON and review-lens source files are unchanged.

Canonical Metanoetic, Glaze, and First-principles bodies, custom agents, stores, schemas, and runtime helpers are unchanged. No new workflow engine, durable store, public skill, or runtime script is introduced.

## Entry size observations

Measured UTF-8 bytes in SKILL.md only; conditional knowledge is retained elsewhere. These are not token counts or measured runtime savings.

| Entry | Before | After | Reduction |
|---|---:|---:|---:|
| Actuating | 23,597 | 13,975 | 40.8% |
| Universalist | 20,784 | 15,282 | 26.5% |
| Codebase Doctrine | 16,890 | 9,608 | 43.1% |
| Tune | 14,398 | 6,541 | 54.6% |
| CAS | 8,215 | 4,609 | 43.9% |
| Learnings | 10,174 | 5,604 | 44.9% |
| Ship | 7,825 | 5,139 | 34.3% |
| Plan | 9,570 | 9,307 | 2.7% |

AGENTS.md decreases from 9,980 to 8,930 bytes.

<!-- ship-proof:start -->
## Summary
Preserve specialized skill guidance while loading procedures for the selected workflow. Landing validation repaired one stale admission-test reference; it now verifies the entry routing link and the relocated guidance.

## Proof
- Complete `sh codex/skills/actuating/tests/test-reconciler-contract.sh`: PASS, including composition contracts, protected review-policy and lens identities, executable scenario suites, and Review Fold/Ledger integration.
- `uv run python3 -m unittest discover -s codex/skills/plan/tests -v`: PASS, 21 tests.
- Eight edited skill frontmatters and 104 relative Markdown file links: PASS in the complete checkout.
- Shell syntax, admission-test JavaScript syntax, and `git diff --check`: PASS.

## Scope
- Repository: `tkersey/dotfiles`
- Branch: `codex/astra-progressive-disclosure`
- Head: `032102deb3d04de03a80ef52b0cf89ddabfb77f8`
- Base: `main` at `3b9fbf6a594c561123ec8ec349ad59e98ea37254`

## Risks
Contract checks do not establish model routing effectiveness, latency, or quality improvements. Live model ablations, CAS review campaigns, and unrelated repository suites were not run. No efficacy or review-convergence claim is made.

## Follow-ups
No implementation work remains for this publication. Model efficacy remains unproved and outside this landing's claims.

## Readiness
- Operation: update-and-promote
- Final state: ready
- SHIP-v1 compatibility mode: promote-draft
- Reason: Complete contract and Ledger integration checks now pass; user requested shipping and landing.
- Caveats: Model efficacy is unmeasured; repository policy requires no status checks or approvals.
<!-- ship-proof:end -->