### PR TITLE
Ablate redundant AGENTS.md scaffolding for Astra

### DIFF
--- a/codex/AGENTS.md
+++ b/codex/AGENTS.md
@@ -2,11 +2,8 @@
 
 ## Capability primacy — reject process porn
 
-- Bring capability, not ceremony. Start from the requested object-level outcome; analysis exists to expose the causal mechanism and direct change, then stop and act. Never let plans, governance, workflow design, meta-architecture, or analysis displace the requested capability, correctness, performance, or product behavior. For action requests, continue through required verification and authorized delivery.
-- Do not answer missing functionality with machinery for eventually producing it. Meta-work is admissible only when a concrete witnessed failure makes it indispensable to the current result and no smaller direct fix exists; hypothetical future drift, scale, coordination, rigor, or reuse is insufficient. If it unlocks no object-level delta, delete it.
-- Deep means downward into code, data, behavior, invariants, performance, and failure causality—not sideways into audits, governance, or process systems. Even when the subject is a process artifact, make the smallest behavior-changing edit and report only findings that change what should be built or fixed.
-- Prefer working capability, direct correction, deletion, and behavioral proof over comprehensive prose and ceremonial confidence. Tokens, elapsed time, and user attention must buy object-level progress. “Overengineered” or “process porn” is an immediate stop signal: abandon the meta-layer, recover the goal, and take the smallest direct route; never defend, refine, or replace discarded ceremony.
-- Resolve routine choices from repository evidence and conversation context; use reasonable reversible defaults within authorized scope. Ask only when missing information or authority blocks a necessary action, and continue independent authorized work. Reversibility does not authorize external or destructive effects.
+- Prioritize the requested result over unsolicited process infrastructure. Ground analysis in relevant mechanisms and evidence; do not substitute planning or governance for delivery. Prefer the smallest sufficient solution, including redesign or deletion when warranted. When the user identifies overengineering or process porn, discard unnecessary process and return to the requested result.
+- For action requests, complete required verification and authorized delivery. Resolve routine choices from repository and conversation evidence; make reasonable reversible assumptions within authorized scope. Ask only when missing information or authority blocks necessary action, and continue independent work. Reversibility alone does not authorize external or destructive effects.
 
 ## Editing Constraints Override
 
@@ -15,15 +12,14 @@
 
 ## Metanoetic intelligence-escalation mandate
 
-- `$metanoetic` is a selective one-pass generative interrupt over a concrete incumbent, not a default pass. Invoke it before adjudication only when a skill-owned escalation pressure is evidenced: contradiction; repeated same-surface repair or review accretion; a high-regret or difficult-to-reverse commitment; a plausible owner, model, representation, or solution-class error; an incumbent-generated burden another mechanism could eliminate; or a coherent but merely adequate local optimum with a materially different candidate still plausible. Mere substantiveness or consequentiality is insufficient.
-- Before invocation, bind the incumbent and any challenger to the original objective, target observation, acceptance criterion, or discriminator and current evidence; structured workflows reuse their native fields, including a falsifier when their own contract requires one. For explicit invocation, infer the bindings from context and return `blocked` only when no concrete antecedent or comparison surface exists. For implicit invocation, skip an unbounded pass.
-- Run the canonical Metanoetic line exactly once per unchanged decision surface. It generates candidates only; the receiving workflow owns materiality, admissibility, disposition, evidence, selection, mutation, and closure, and may adopt, modify, reject, or retain the incumbent. Skip terse acknowledgements, mechanical lookups, trivial or already-dispositive work, weakly grounded symptoms, and divergence outside accepted scope or authority.
+- Invoke `$metanoetic` before adjudication for a concrete incumbent when its skill description's escalation pressures are evidenced, or when explicitly requested. Substantiveness or consequentiality alone is insufficient.
+- Bind the incumbent and challengers to the original objective, target observation, acceptance criterion, or discriminator and current evidence. Reuse native workflow fields and any required falsifier. For explicit invocation, infer bindings from context; return `blocked` only without a concrete antecedent or comparison surface. Skip implicit invocation without a bounded comparison.
+- Run the canonical line verbatim exactly once per unchanged decision surface, within accepted scope and authority. It generates candidates only; the receiving workflow owns adjudication, evidence, selection, mutation, and closure, and may adopt, modify, reject, or retain the incumbent.
 
 ## Universalist architecture-decision mandate
 
-- `$universalist` owns its detailed trigger semantics in `SKILL.md` and the machine-readable decision contract. Invoke it when current evidence makes an owned boundary a live semantic decision, reveals one law distributed across owners, or fires an invalidator of a prior boundary disposition; explicit invocation always runs.
-- Boundary presence, crossing, preservation, validation, publication, merge, or mechanical transport is insufficient. Skip routine implementation, review bookkeeping, rebasing, `$ship`, `$land`, and direct owner-local repair under an unchanged architecture unless new semantic boundary evidence appears.
-- When `$actuating` is active, Actuating owns the Universalist invocation point during architecture reconsideration; do not run a duplicate root pass. Universalist team/subagent mode remains explicit-request only.
+- Invoke `$universalist` for an evidenced live semantic boundary decision, a law distributed across owners, an invalidated prior boundary disposition, or an explicit request. Its skill and machine-readable decision contract own detailed semantics. For implicit use, skip routine work under accepted architecture without new semantic boundary evidence.
+- Within `$actuating`, Actuating owns the invocation point during architecture reconsideration; never run a duplicate root pass. Team/subagent mode remains explicit-request only.
 
 ## Tooling standards
 
@@ -33,8 +29,7 @@
 
 - Prefix `git merge --continue` and `git rebase --continue` with `GIT_EDITOR=true`.
 - Do not force-add paths matching `.git/info/exclude` unless explicitly asked.
-- Before `git commit`, run a final narrow status check for session-owned `.ledger/*` changes; if publishable, stage the current-turn/session-owned rows before committing.
-- Review the diff before final response or commit.
+- Before `git commit`, run a final narrow status check for session-owned `.ledger/*` changes; if publishable, stage the current-turn/session-owned rows with the work they explain.
 
 ### Python
 
@@ -58,22 +53,20 @@
   or `$synesthesia` go through `$memory-source-notes` in the same turn. The
   `memory-note` CLI remains the sole immutable writer, not a skill or bypass.
 - Before any Codex-made commit, PR creation, or implementation handoff after
-  material implementation, invoke `$learnings` exactly once and evaluate its
-  capture gate. Evaluate from task evidence before loading store procedures or
-  bootstrapping tools when no canonical operation is needed. Capture is
-  conditional; no-op, duplicate-skip, or failure to append alone never delays or
-  invalidates delivery.
+  material implementation, invoke `$learnings` exactly once. Its skill owns the
+  evidence-first capture gate and disposition. Evaluation is mandatory; capture
+  is conditional. No-op, duplicate-skip, or failure to append alone never delays
+  or invalidates delivery.
 - Activate sibling sources only for their own evidence: `$negative-ledger` for a
   witnessed failed/no-effect/regressed/reverted/abandoned route or a request about
   prior attempts; `$synesthesia` for explicit sensory intent, documented
   representational ambiguity, or a durable mapping/boundary event. No aggregate
   packet, forced sibling evaluation, or source-memory delivery gate.
-- Each material activation retains one owner-defined disposition. Inspect canonical
-  appends/transitions and publish session-owned, publishable `.ledger/*` rows with
-  the work they explain. Canonical writes are independent; derived note/digest or
-  Phase 2 failures never roll them back. Keep no-ops internal; report writes,
-  actionable non-durable proposals, admission degradation, and blockers only when
-  they affect the user, repository state, or requested proof.
+- Inspect canonical appends/transitions. Canonical writes are independent;
+  derived note/digest or Phase 2 failures never roll them back. Keep no-ops
+  internal; report writes, actionable non-durable proposals, admission
+  degradation, and blockers only when they affect the user, repository state,
+  or requested proof.
 
 ### Negative-evidence routing
 
@@ -81,8 +74,6 @@
   and use its current definition-bound `route-gate`. A recalled learning can
   trigger this check, not suppress the route. Only active, witnessed, exact-enough,
   currently artifact-applicable exclusions may block selection.
-- Evaluate capture at a material strategy pivot, regression-confirmed revert, or
-  implementation/review closeout leaving a failed route likely to recur. Transient
-  red tests, syntax errors, first incomplete attempts, and typos are `no-op` unless
-  they expose a durable route-shaping failed hypothesis. The owning skill supplies
-  disposition and lifecycle mechanics; do not run tools to manufacture a no-op.
+- Evaluate capture at material strategy pivots, regression-confirmed reverts,
+  or closeout leaving a failed route likely to recur. The skill owns durable route-shaping capture
+  criteria, disposition, and lifecycle; do not run tools to manufacture a no-op.


### PR DESCRIPTION
## Summary

Apply the requested AGENTS.md ablations for Astra-only development on top of current `main` (`1708eec`, including #287).

Only `codex/AGENTS.md` changes: **1,192 → 876 words**, removing **316 words (26.5%)**. No skill implementations, subagents, review contracts, installation links, tooling, or persistent tests are changed.

## Changes

- **Capability Primacy:** replace five overlapping bullets with two. Remove the universal stop-and-act framing, the witnessed-failure prerequisite for process work, and the smallest-behavior-changing-edit instruction. Prefer the **smallest sufficient solution**, explicitly allowing redesign or deletion, while preserving authorized completion and the limit on external/destructive effects.
- **Metanoetic:** remove the repeated escalation inventory and long exclusion list. Preserve objective/evidence binding, native workflow fields and falsifiers, contextual inference for explicit invocation, bounded implicit use, the verbatim once-per-unchanged-surface pass, and candidate-only authority under the receiving workflow. The canonical skill text is untouched.
- **Universalist:** retain a compact semantic router and Actuating composition rules; defer detailed semantics to the existing skill and machine-readable contract. The routine-work exclusion is explicitly limited to implicit use, so explicit invocation remains effective. Category-theoretic recognition and proof obligations are untouched.
- **Memory and Git:** defer source-owned capture/disposition procedures rather than duplicating them in the root. Keep mandatory Learnings evaluation with conditional capture, source ownership, same-turn accepted-admission transport, exact/applicable negative route gating, sibling isolation, and canonical/derived failure independence. Consolidate publication wording into the existing session-owned Ledger staging check. Remove the generic diff-review instruction triggered by every final response or commit; active workflow checks remain binding.

## Preserved boundaries

Concurrency reconciliation, review counts/reset rules and the verification-expansion limit, Python/`uv` guidance, `jaq` with `jq` fallback, Git editor/exclusion preferences, canonical Ledger access/recovery, compiled-memory ownership, and negative route-gate applicability remain intact. No automatic skill routing or mandatory Learnings evaluation is removed. Existing links continue to use this shared instruction source; this does not introduce model-specific copies.

## Verification

- Confirmed the local baseline exactly matches fetched GitHub blob `b91d464533745f0675a225a5311f2105b3f51f18`.
- `git diff --check` passed.
- **39 temporary static source checks passed**, covering unchanged sections, retained boundary text, requested removals, skill-reference scope, formatting, and the one-file diff. These are textual/source-preservation checks, not model-behavior tests; no test framework or test files were added to the repository.
- Reviewed the shortened instructions against the current Metanoetic, Universalist, Learnings, and Negative Ledger skill contracts.
- Confirmed the published content blob `8b3d01e3d644657acd72215e2a1eec37146601e7` matches the checked local file. GitHub comparison confirms one commit and one changed file: 20 insertions, 29 deletions.

**Not run:** a live Astra baseline-versus-candidate behavioral comparison or the full repository test suite. This is a source-level ablation, not a claim of measured latency, token, or task-success improvement.

<!-- ship-proof:start -->
## Summary
Shorten shared AGENTS.md instructions while retaining the documented authority and tooling boundaries.

## Proof
- `git diff --check 1708eec53d0791b77bbceefc9e727c42da3e8271 3045b2097037ee9949d058a447e8715a2397e5bb`: pass.
- Exact-head diff reviewed: only `codex/AGENTS.md` changes; scope matches the PR description.
- Build, lint suite, runtime tests, and live model comparison: not run for this instruction-only change. Earlier static checks are documented above.

## Scope
- repository: tkersey/dotfiles
- branch: codex/agents-astra-ablation-20260912
- head: 3045b2097037ee9949d058a447e8715a2397e5bb
- base: main
- base SHA: 1708eec53d0791b77bbceefc9e727c42da3e8271

## Risks
Behavioral efficacy and performance are unmeasured.

## Follow-ups
None required for the requested source ablation.

## Readiness
- Operation: update-and-promote
- Final state: ready
- SHIP-v1 compatibility mode: promote-draft
- Reason: scoped instruction change complete and reviewed.
- Caveats: validation is source-level only.
<!-- ship-proof:end -->
