### PR TITLE
Clarify grill-me async question lifecycle

### DIFF
--- a/codex/skills/grill-me/SKILL.md
+++ b/codex/skills/grill-me/SKILL.md
@@ -72,6 +72,10 @@ material consequence
 status: unresolved | locked | defaulted | observation-needed | pruned
 ```
 
+Mark a delivered question awaiting a reply as pending on its existing decision node,
+retaining the sent question context. Pending is delivery metadata: the decision
+status remains `unresolved`. A confirmed delivery failure does not mark the question pending.
+
 Do not create a universal lane matrix, readiness receipt, or parallel summary state.
 
 ## Workflow
@@ -121,6 +125,9 @@ rollout, rollback, or operational ownership
 
 The current frontier contains only unresolved user-owned decisions whose prerequisites are settled.
 
+Pending questions remain in that frontier and block dependent decisions, but are
+not eligible to be sent again. Select only questions without a pending delivery.
+
 Do not ask a question that depends on another unresolved answer. Lock the prerequisite first, then recompute the graph.
 
 When the frontier contains more than three decisions, ask the one to three with the greatest downstream fanout, irreversibility, risk if wrong, or ability to prune descendants.
@@ -132,18 +139,38 @@ Read [references/question-interface.md](references/question-interface.md) only w
 Questions must be:
 
 - atomic and identified by a stable `snake_case` id;
-- limited to one to three per round;
+- limited to one to three per round, counting already pending questions toward
+  a maximum of three outstanding and respecting stricter host per-call or per-turn limits;
 - bounded when honest options can represent the answer space;
 - explicit about the consequence of each option;
 - accompanied by only enough local context to explain why the question is next and what it decides.
 
 Recommend an option only when evidence or already locked priorities justify the recommendation independently of the missing answer. Do not manufacture a recommendation for a genuinely normative choice.
 
+Delivery acknowledgment, silence, and UI preselection do not lock or default a
+decision, grant approval, or start another question round. While a reply is
+pending, continue only independent authorized work; hold conclusions and effects
+that depend on it. For standalone clarification, that means research and evidence
+gathering, not planning or implementation.
+
+When no independent work remains, yield through the host or caller's supported
+mechanism with the unresolved dependency visible. Do not poll, resend the
+question, invent busywork, or report clarification complete.
+
 ### 6. Recompute after every answer
 
-Update locked decisions, detect newly introduced scope or dependencies, prune subsumed branches, and expose the next dependency-ready frontier.
+Match each reply to its conceptual decision and sent question context, not
+arrival order. Reconcile it against the latest authoritative ask before updating
+the graph. Partial replies leave unanswered decisions pending. Clear the pending
+marker when the reply is reconciled or the question is superseded or pruned. A
+late reply to an obsolete question must not silently restore old scope or settle
+a different decision.
 
-Use the same question id when re-asking the same conceptual decision.
+Then update locked decisions, detect newly introduced scope or dependencies, prune
+subsumed branches, and expose the next dependency-ready frontier.
+
+Reuse the same conceptual id only when a material unresolved answer needs
+clarification; do not re-ask merely because a reply has not arrived.
 
 Apply an explicit user change to the target, scope, constraints, or authority and
 recompute affected decisions without asking the user to confirm the same choice.
@@ -176,6 +203,9 @@ Suspend that branch. Do not keep rephrasing the question, solicit a guess, or si
 
 ### 9. Close when the frontier is empty
 
+An empty set of questions eligible to send is not an empty judgment frontier.
+A still-applicable material question awaiting an answer prevents closure.
+
 Closure requires:
 
 - no unresolved material user-owned decision has settled prerequisites;
@@ -188,7 +218,10 @@ Use a final confirmation only when the synthesis changed or reframed the authori
 
 ## Composition and output ownership
 
-When another workflow invokes `$grill-me`, that workflow owns persistence, schemas, receipts, readiness, continuation, and terminal output. Return the locked judgments and observation-bound branches in the caller's native state, then relinquish control.
+When another workflow invokes `$grill-me`, that workflow owns persistence, schemas,
+receipts, readiness, continuation, and terminal output. Return locked judgments,
+observation-bound branches, and any pending dependencies in the caller's native state. Yielding with pending dependencies is not closure;
+the caller may continue independent authorized work without treating them as settled.
 
 `$grill-me` never asserts `plan_allowed`, emits a universal decision packet, or translates into a second competing handoff artifact.
 

--- a/codex/skills/grill-me/references/question-interface.md
+++ b/codex/skills/grill-me/references/question-interface.md
@@ -14,10 +14,12 @@ Are all prerequisites settled?
 Can conversation honestly settle it?
 Is it one conceptual decision?
 Has it not already been answered?
+Is no equivalent question already pending?
 Can the consequence of each live option be explained?
 ```
 
-Otherwise research, decide, default, defer to observation, or prune.
+If an equivalent question is pending, do not send another. Otherwise research,
+decide, default, defer to observation, or prune as appropriate.
 
 ## Local context
 
@@ -41,20 +43,37 @@ work continues. Use `request_user_input` only for questions the current mode per
 it to carry. If a required answer cannot use either tool, ask one concise,
 self-contained plain-text question. Do not turn a missing answer into approval.
 
-For `request_user_input`, send one to three questions.
+Keep the skill's small question budget across deliveries, not just within one
+call. The live schema is authoritative; do not transfer fields between tools.
 
-Each question contains:
+### Synchronous questions
 
-- `id`: stable `snake_case` conceptual identifier;
-- `header`: short human-readable label, at most 12 characters;
-- `question`: one atomic sentence;
-- `options`: two or three mutually exclusive choices when the answer space can be represented honestly.
+For `request_user_input`, use the live question fields: `id`, `header`, `question`,
+and `options` containing `label`/`description` objects. Keep the conceptual id stable,
+the header short, and the question atomic. State each option's consequence in its
+description.
 
-Each option description states its consequence or trade-off. Put a recommended option first and suffix it with ` (Recommended)` only when the recommendation is independently supported by evidence or locked priorities.
+This Codex tool requires nonempty options; use two or three honest, mutually
+exclusive choices. The interface supplies an Other/free-text escape alongside
+those choices, so do not add a duplicate Other or placeholder option. That escape
+does not make a free-text-only request with omitted or empty options valid.
 
-Do not add an `Other` option or a free-text placeholder; the interface supplies
-free-text input. Use free-text input when the live choices cannot honestly fit
-the tool's option schema.
+### Asynchronous questions
+
+For `request_user_input_async`, the `questions` entries use a `title` and optional
+string `options`, not synchronous `id`, `header`, `question`, or option objects.
+Keep conceptual ids internally. Make each title self-contained, including the
+context needed to decide; put consequences in the title or concise option strings.
+Omit `options` for a free-text-only question rather than fabricating choices. When
+async is not permitted for that question, use the plain-text fallback.
+
+The immediate `{"accepted":true}` response acknowledges delivery, not the user's
+decision. Replies arrive later as new user messages. Keep the question pending in
+the existing judgment graph until reconciled under the skill's answer lifecycle.
+A preselected first option is not a submitted answer.
+
+In either channel, put a recommended option first and suffix it with
+` (Recommended)` only when evidence or locked priorities independently justify it.
 
 ## Fallback
 
@@ -64,7 +83,12 @@ banner. Keep the conceptual ID internally if the decision must be re-asked.
 
 ## Answer handling
 
-- Treat selected labels and `user_note:` text as user-provided evidence.
+- Interpret actual user responses: selected labels and `user_note:` text when
+  supplied by the synchronous tool, or later user messages for async questions.
+  The async tool result itself is not an answer.
+- Use question context or host-provided correlation to match delayed replies.
+  When a reply cannot be matched unambiguously, clarify only the material
+  ambiguity; do not guess or settle unrelated pending decisions.
 - Strip ` (Recommended)` before interpreting the selected label.
 - Mine notes for scope changes, dependencies, constraints, risks, and new decisions.
 - A missing answer remains unresolved only when the question is still material.


### PR DESCRIPTION
## Summary

Make `$grill-me`'s existing async question support explicit without redesigning its judgment graph or expanding its authority.

- Keep pending delivery metadata on the existing decision node. The decision remains unresolved, blocks its dependents, is excluded from repeat dispatch, and counts toward the outstanding-question budget. Delivery acknowledgments, silence, and preselected options cannot settle it.
- Reconcile partial, delayed, and out-of-order replies against the sent question context and latest authoritative ask. Superseded or pruned questions cannot silently restore old scope. Yielding with pending dependencies is not clarification closure.
- Distinguish synchronous and asynchronous Codex payloads and answer delivery. Correct free-text-only routing: the synchronous tool requires options; async can omit them when permitted, otherwise use the plain-text fallback. The live host contract remains authoritative.

Independent authorized work may continue while answers are pending. Dependent conclusions and effects remain blocked, and clarification-only use does not authorize planning or implementation.

## Scope

Only these files change:

- `codex/skills/grill-me/SKILL.md`
- `codex/skills/grill-me/references/question-interface.md`

No new helper, queue, ledger, subagent, persistence format, installation change, or caller-workflow change. Existing frontmatter, activation rules, authority boundaries, observation handling, and reference targets are preserved. No additional `AGENTS.md` update is justified; the specific rule belongs in the skill and its interface reference.

## Validation

- `git diff --check` passed.
- Confirmed exactly two modified paths and source blob identities against the repository snapshot.
- Parsed YAML frontmatter and verified it is unchanged; checked balanced Markdown fences and unchanged reference targets.
- Manually reviewed acknowledgment-without-answer, outstanding-question limits, independent versus dependent work, partial/out-of-order replies, stale scope, free-text channel selection, and yielding without premature closure.

The tool-contract guidance was checked against the released `openai/codex` `rust-v0.154.0` handlers. No live Codex session or full repository test suite was run; the scenario review is not an executable behavioral test.

<!-- ship-proof:start -->
## Publication proof

- Documentation-only update to the pending-question lifecycle and tool interface guidance.
- Validation: `git diff --check 9df123dbd5489ba4f14a53f916adc0e4c9373206 ca99480e52b823bffc3aa58937ec1385610ca4e2` passed; exact two-file scope, unchanged frontmatter/reference targets, and balanced Markdown fences verified. Reviewed pending delivery, dependent-work blocking, partial/stale replies, closure, and tool schema guidance.
- Build/tests: not run; no executable code changes. Static and scenario review does not prove live agent behavior.
- Repository: `tkersey/dotfiles`; base: `main` at `9df123dbd5489ba4f14a53f916adc0e4c9373206`; branch: `codex/grill-me-async-lifecycle`; head: `ca99480e52b823bffc3aa58937ec1385610ca4e2`.
- Readiness: update existing ready PR; preserve ready state. No deferred implementation work.
<!-- ship-proof:end -->
